### PR TITLE
perf(gateway): cache parsed upstream endpoint URLs per ProviderKey

### DIFF
--- a/crates/aisix-gateway/src/lib.rs
+++ b/crates/aisix-gateway/src/lib.rs
@@ -31,6 +31,7 @@ pub mod sse;
 pub mod upstream_headers;
 pub mod upstream_http;
 pub mod upstream_tls;
+pub mod url_cache;
 
 pub use bridge::{
     capture_in_band_error, capture_upstream_error_http, content_type_is_json, parse_retry_after,

--- a/crates/aisix-gateway/src/url_cache.rs
+++ b/crates/aisix-gateway/src/url_cache.rs
@@ -87,24 +87,21 @@ pub fn cached_endpoint_url<E>(
     // Clone the inner Arc out of the outer guard so no outer shard lock
     // is held while reading, building, or parsing.
     let known = cache.get(provider_key_id).map(|g| Arc::clone(&g));
-    if let Some(per_key) = known {
-        if let Some(hit) = per_key.get(endpoint) {
-            if hit.fingerprint.0 == fingerprint.0 && hit.fingerprint.1 == fingerprint.1 {
-                return Ok(EndpointUrl::Parsed(hit.url.clone()));
+    let per_key = match known {
+        Some(per_key) => per_key,
+        None => {
+            // First sighting of this key: bound the outer map before
+            // inserting. `len()` walks shards, but only key-creation
+            // (admin-rate) pays it.
+            if cache.len() >= MAX_PROVIDER_KEYS {
+                cache.clear();
             }
+            cache
+                .entry(provider_key_id.to_string())
+                .or_insert_with(|| Arc::new(DashMap::new()))
+                .clone()
         }
-        return build_into(&per_key, endpoint, fingerprint, build);
-    }
-
-    // First sighting of this key: bound the outer map before inserting.
-    // `len()` walks shards, but only key-creation (admin-rate) pays it.
-    if cache.len() >= MAX_PROVIDER_KEYS {
-        cache.clear();
-    }
-    let per_key = cache
-        .entry(provider_key_id.to_string())
-        .or_insert_with(|| Arc::new(DashMap::new()))
-        .clone();
+    };
     build_into(&per_key, endpoint, fingerprint, build)
 }
 
@@ -116,26 +113,49 @@ fn parse_or_raw(raw: String) -> EndpointUrl {
     }
 }
 
-/// Build, parse, and (on parse success) cache the URL for `endpoint`.
+/// Hit-check, and on miss build/parse/cache — single-flight per
+/// (key, endpoint): the row's shard guard is held across the build, so
+/// concurrent cold requests (or requests racing a fingerprint change)
+/// serialize and the build closure runs once per transition. The
+/// closure is pure CPU (string assembly), so holding the inner shard
+/// lock across it is bounded and touches no other lock.
 fn build_into<E>(
     per_key: &DashMap<&'static str, CachedUrl>,
     endpoint: &'static str,
     fingerprint: (&str, &str),
     build: impl FnOnce() -> Result<String, E>,
 ) -> Result<EndpointUrl, E> {
-    let raw = build()?;
-    match Url::parse(&raw) {
-        Ok(url) => {
-            per_key.insert(
-                endpoint,
-                CachedUrl {
-                    fingerprint: (fingerprint.0.to_string(), fingerprint.1.to_string()),
-                    url: url.clone(),
-                },
-            );
-            Ok(EndpointUrl::Parsed(url))
+    match per_key.entry(endpoint) {
+        dashmap::mapref::entry::Entry::Occupied(mut occupied) => {
+            let hit = occupied.get();
+            if hit.fingerprint.0 == fingerprint.0 && hit.fingerprint.1 == fingerprint.1 {
+                return Ok(EndpointUrl::Parsed(hit.url.clone()));
+            }
+            let raw = build()?;
+            match Url::parse(&raw) {
+                Ok(url) => {
+                    occupied.insert(CachedUrl {
+                        fingerprint: (fingerprint.0.to_string(), fingerprint.1.to_string()),
+                        url: url.clone(),
+                    });
+                    Ok(EndpointUrl::Parsed(url))
+                }
+                Err(_) => Ok(EndpointUrl::Unparsed(raw)),
+            }
         }
-        Err(_) => Ok(EndpointUrl::Unparsed(raw)),
+        dashmap::mapref::entry::Entry::Vacant(vacant) => {
+            let raw = build()?;
+            match Url::parse(&raw) {
+                Ok(url) => {
+                    vacant.insert(CachedUrl {
+                        fingerprint: (fingerprint.0.to_string(), fingerprint.1.to_string()),
+                        url: url.clone(),
+                    });
+                    Ok(EndpointUrl::Parsed(url))
+                }
+                Err(_) => Ok(EndpointUrl::Unparsed(raw)),
+            }
+        }
     }
 }
 
@@ -237,6 +257,28 @@ mod tests {
             matches!(again, EndpointUrl::Parsed(_)),
             "bad URL was cached"
         );
+    }
+
+    #[test]
+    fn concurrent_cold_misses_build_once() {
+        // Single-flight: the row's shard guard is held across the
+        // build, so N racing cold requests produce exactly one build.
+        let n = AtomicUsize::new(0);
+        let barrier = std::sync::Barrier::new(8);
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                scope.spawn(|| {
+                    barrier.wait();
+                    let u = cached_endpoint_url("pk-url-sf", "test/chat", ("b", ""), || {
+                        n.fetch_add(1, Ordering::Relaxed);
+                        Ok::<_, ()>("https://sf.example.com/v1".to_string())
+                    })
+                    .unwrap();
+                    assert!(matches!(u, EndpointUrl::Parsed(_)));
+                });
+            }
+        });
+        assert_eq!(n.load(Ordering::Relaxed), 1, "one build across 8 racers");
     }
 
     #[test]

--- a/crates/aisix-gateway/src/url_cache.rs
+++ b/crates/aisix-gateway/src/url_cache.rs
@@ -1,0 +1,253 @@
+//! Per-ProviderKey cache of parsed upstream endpoint URLs.
+//!
+//! Every bridge dispatch used to rebuild its endpoint URL per request —
+//! base resolution (trim + suffix scan + allocation), a `format!`, and a
+//! full `Url` parse inside reqwest's `IntoUrl` when the request builder
+//! receives a string. The URL is a pure function of the ProviderKey's
+//! configuration and the endpoint, so it is parsed once here and handed
+//! back as a cloned `Url` — which reqwest accepts by value without
+//! re-parsing.
+//!
+//! Correctness model: a cached row stores the *fingerprint* of the
+//! inputs the URL was built from (the raw `api_base` plus a per-bridge
+//! second component such as the vendor or the Azure deployment). A hit
+//! whose fingerprint differs from the caller's current inputs rebuilds,
+//! so an edited ProviderKey takes effect on the next request with no
+//! invalidation hook. A ProviderKey id names one etcd resource, so a
+//! deleted-and-recreated key either reuses the id (fingerprint decides)
+//! or leaves a dead row behind (bounded by [`MAX_PROVIDER_KEYS`]).
+
+use dashmap::DashMap;
+use reqwest::Url;
+use std::sync::{Arc, OnceLock};
+
+/// Outer map: ProviderKey id → that key's endpoint URLs. Two levels so
+/// the hit path looks up by `&str` (no per-request key allocation).
+type Cache = DashMap<String, Arc<DashMap<&'static str, CachedUrl>>>;
+
+static URL_CACHE: OnceLock<Cache> = OnceLock::new();
+
+struct CachedUrl {
+    /// The inputs this URL was built from; compared on every hit.
+    fingerprint: (String, String),
+    url: Url,
+}
+
+/// Upper bound on distinct ProviderKey ids the cache will hold. Rows for
+/// deleted keys are never individually evicted (matching the TLS client
+/// cache's model); this cap turns unbounded admin-churn growth into a
+/// full reset, after which live keys re-parse once each.
+const MAX_PROVIDER_KEYS: usize = 8192;
+
+/// A ready-to-post endpoint URL.
+#[derive(Clone, Debug)]
+pub enum EndpointUrl {
+    /// Parsed once (possibly cached); reqwest takes `Url` by value
+    /// without re-parsing.
+    Parsed(Url),
+    /// The built string failed to parse. Handed back verbatim so the
+    /// request builder produces exactly the error it always produced
+    /// for a malformed `api_base`; never cached.
+    Unparsed(String),
+}
+
+impl EndpointUrl {
+    /// Start a POST to this URL on `client`.
+    pub fn post_on(self, client: &reqwest::Client) -> reqwest::RequestBuilder {
+        match self {
+            Self::Parsed(url) => client.post(url),
+            Self::Unparsed(raw) => client.post(raw),
+        }
+    }
+}
+
+/// Resolve the parsed URL for (`provider_key_id`, `endpoint`), building
+/// it with `build` only on the first request or after the key's
+/// configuration changed.
+///
+/// - `endpoint` must be a bridge-namespaced literal (e.g.
+///   `"openai/chat"`) so two bridges can never collide on one key.
+/// - `fingerprint` is the pair of raw inputs the URL is derived from;
+///   pass every input that can change the result (`api_base` and, where
+///   applicable, vendor or deployment).
+/// - An empty `provider_key_id` (contexts built without snapshot ids,
+///   e.g. tests) bypasses the cache entirely.
+/// - `build` errors pass through untouched; nothing is cached on error.
+pub fn cached_endpoint_url<E>(
+    provider_key_id: &str,
+    endpoint: &'static str,
+    fingerprint: (&str, &str),
+    build: impl FnOnce() -> Result<String, E>,
+) -> Result<EndpointUrl, E> {
+    if provider_key_id.is_empty() {
+        return Ok(parse_or_raw(build()?));
+    }
+    let cache = URL_CACHE.get_or_init(DashMap::new);
+
+    // Clone the inner Arc out of the outer guard so no outer shard lock
+    // is held while reading, building, or parsing.
+    let known = cache.get(provider_key_id).map(|g| Arc::clone(&g));
+    if let Some(per_key) = known {
+        if let Some(hit) = per_key.get(endpoint) {
+            if hit.fingerprint.0 == fingerprint.0 && hit.fingerprint.1 == fingerprint.1 {
+                return Ok(EndpointUrl::Parsed(hit.url.clone()));
+            }
+        }
+        return build_into(&per_key, endpoint, fingerprint, build);
+    }
+
+    // First sighting of this key: bound the outer map before inserting.
+    // `len()` walks shards, but only key-creation (admin-rate) pays it.
+    if cache.len() >= MAX_PROVIDER_KEYS {
+        cache.clear();
+    }
+    let per_key = cache
+        .entry(provider_key_id.to_string())
+        .or_insert_with(|| Arc::new(DashMap::new()))
+        .clone();
+    build_into(&per_key, endpoint, fingerprint, build)
+}
+
+/// Parse without caching (empty-id bypass path).
+fn parse_or_raw(raw: String) -> EndpointUrl {
+    match Url::parse(&raw) {
+        Ok(url) => EndpointUrl::Parsed(url),
+        Err(_) => EndpointUrl::Unparsed(raw),
+    }
+}
+
+/// Build, parse, and (on parse success) cache the URL for `endpoint`.
+fn build_into<E>(
+    per_key: &DashMap<&'static str, CachedUrl>,
+    endpoint: &'static str,
+    fingerprint: (&str, &str),
+    build: impl FnOnce() -> Result<String, E>,
+) -> Result<EndpointUrl, E> {
+    let raw = build()?;
+    match Url::parse(&raw) {
+        Ok(url) => {
+            per_key.insert(
+                endpoint,
+                CachedUrl {
+                    fingerprint: (fingerprint.0.to_string(), fingerprint.1.to_string()),
+                    url: url.clone(),
+                },
+            );
+            Ok(EndpointUrl::Parsed(url))
+        }
+        Err(_) => Ok(EndpointUrl::Unparsed(raw)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn build_counted<'a>(
+        counter: &'a AtomicUsize,
+        url: &str,
+    ) -> impl FnOnce() -> Result<String, ()> + 'a {
+        let url = url.to_string();
+        move || {
+            counter.fetch_add(1, Ordering::Relaxed);
+            Ok(url)
+        }
+    }
+
+    #[test]
+    fn caches_per_key_and_endpoint_until_fingerprint_changes() {
+        let n = AtomicUsize::new(0);
+        let fp = ("https://api.example.com", "vendor-a");
+
+        // First call builds…
+        let u1 = cached_endpoint_url(
+            "pk-url-1",
+            "test/chat",
+            fp,
+            build_counted(&n, "https://api.example.com/v1/chat"),
+        )
+        .unwrap();
+        assert!(matches!(u1, EndpointUrl::Parsed(_)));
+        assert_eq!(n.load(Ordering::Relaxed), 1);
+
+        // …second call with the same fingerprint hits.
+        let u2 = cached_endpoint_url(
+            "pk-url-1",
+            "test/chat",
+            fp,
+            build_counted(&n, "https://api.example.com/v1/chat"),
+        )
+        .unwrap();
+        match (u1, u2) {
+            (EndpointUrl::Parsed(a), EndpointUrl::Parsed(b)) => assert_eq!(a, b),
+            _ => panic!("expected parsed URLs"),
+        }
+        assert_eq!(n.load(Ordering::Relaxed), 1, "second call must not rebuild");
+
+        // A different endpoint on the same key builds its own row.
+        cached_endpoint_url(
+            "pk-url-1",
+            "test/embeddings",
+            fp,
+            build_counted(&n, "https://api.example.com/v1/embeddings"),
+        )
+        .unwrap();
+        assert_eq!(n.load(Ordering::Relaxed), 2);
+
+        // An edited api_base (fingerprint change) rebuilds on next use.
+        let u4 = cached_endpoint_url(
+            "pk-url-1",
+            "test/chat",
+            ("https://eu.example.com", "vendor-a"),
+            build_counted(&n, "https://eu.example.com/v1/chat"),
+        )
+        .unwrap();
+        assert_eq!(n.load(Ordering::Relaxed), 3);
+        match u4 {
+            EndpointUrl::Parsed(u) => assert_eq!(u.as_str(), "https://eu.example.com/v1/chat"),
+            _ => panic!("expected parsed URL"),
+        }
+    }
+
+    #[test]
+    fn empty_key_bypasses_cache_and_malformed_url_stays_raw() {
+        let n = AtomicUsize::new(0);
+        for _ in 0..2 {
+            cached_endpoint_url("", "test/chat", ("b", ""), build_counted(&n, "https://x/y"))
+                .unwrap();
+        }
+        assert_eq!(n.load(Ordering::Relaxed), 2, "empty id must never cache");
+
+        // Malformed URL: handed back raw (reqwest will surface its usual
+        // builder error), and never cached.
+        let bad = cached_endpoint_url("pk-url-2", "test/chat", ("b", ""), || {
+            Ok::<_, ()>("not a url".to_string())
+        })
+        .unwrap();
+        match bad {
+            EndpointUrl::Unparsed(raw) => assert_eq!(raw, "not a url"),
+            _ => panic!("malformed URL must stay raw"),
+        }
+        let again = cached_endpoint_url("pk-url-2", "test/chat", ("b", ""), || {
+            Ok::<_, ()>("https://fixed.example.com/v1".to_string())
+        })
+        .unwrap();
+        assert!(
+            matches!(again, EndpointUrl::Parsed(_)),
+            "bad URL was cached"
+        );
+    }
+
+    #[test]
+    fn build_errors_pass_through_and_cache_nothing() {
+        let r: Result<EndpointUrl, &'static str> =
+            cached_endpoint_url("pk-url-3", "test/chat", ("b", ""), || Err("boom"));
+        assert_eq!(r.err(), Some("boom"));
+        let ok = cached_endpoint_url("pk-url-3", "test/chat", ("b", ""), || {
+            Ok::<_, &'static str>("https://ok.example.com/v1".to_string())
+        })
+        .unwrap();
+        assert!(matches!(ok, EndpointUrl::Parsed(_)));
+    }
+}

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -14,6 +14,7 @@
 //! Error mapping is identical to OpenAi — the `BridgeError` contract from
 //! PR #6 applies verbatim.
 
+use aisix_gateway::url_cache::cached_endpoint_url;
 use aisix_gateway::{
     Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream, ChatFormat, ChatResponse,
     SseDecoder, SseEvent,
@@ -271,7 +272,6 @@ impl Bridge for AnthropicBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatResponse, BridgeError> {
-        let base = resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -279,15 +279,23 @@ impl Bridge for AnthropicBridge {
             split_system(req).map_err(|e| BridgeError::InvalidUpstreamConfig(e.to_string()))?;
         let mut body = build_request(req, upstream, system, messages, false);
         maybe_inject_cache_breakpoints(&mut body, ctx);
-        let url = format!("{base}/v1/messages");
+        let url = cached_endpoint_url(
+            &ctx.provider_key_id,
+            "anthropic/messages",
+            (
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &ctx.provider_key.provider,
+            ),
+            || Ok(format!("{}/v1/messages", resolve_base(ctx)?)),
+        )?;
         let client = self.client_for(ctx);
         let api_version = self.api_version;
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
 
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .header("x-api-key", key)
                 .header("anthropic-version", api_version)
                 .header(header::CONTENT_TYPE, "application/json")
@@ -316,7 +324,6 @@ impl Bridge for AnthropicBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let base = resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -324,15 +331,22 @@ impl Bridge for AnthropicBridge {
             split_system(req).map_err(|e| BridgeError::InvalidUpstreamConfig(e.to_string()))?;
         let mut body = build_request(req, upstream, system, messages, true);
         maybe_inject_cache_breakpoints(&mut body, ctx);
-        let url = format!("{base}/v1/messages");
+        let url = cached_endpoint_url(
+            &ctx.provider_key_id,
+            "anthropic/messages",
+            (
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &ctx.provider_key.provider,
+            ),
+            || Ok(format!("{}/v1/messages", resolve_base(ctx)?)),
+        )?;
         let client = self.client_for(ctx);
         let api_version = self.api_version;
         let started = Instant::now();
         let request_id = ctx.request_id.clone();
 
         let resp = with_deadline(ctx.deadline, started, async move {
-            client
-                .post(&url)
+            url.post_on(&client)
                 .header("x-api-key", key)
                 .header("anthropic-version", api_version)
                 .header(header::CONTENT_TYPE, "application/json")

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -695,13 +695,27 @@ impl Bridge for AzureOpenAiBridge {
             ctx.provider_key.response.as_ref(),
         )?;
         let headers = build_request_headers(&auth, &ctx.request_id, false, &ctx.header_ctx())?;
-        let url = self.resolve_url(&upstream);
+        let url = if cfg!(test) {
+            // Test builds route through the wiremock URL override; skip
+            // the cross-request cache so each test sees its own URL.
+            aisix_gateway::url_cache::EndpointUrl::Unparsed(self.resolve_url(&upstream))
+        } else {
+            aisix_gateway::url_cache::cached_endpoint_url(
+                &ctx.provider_key_id,
+                "azure/chat",
+                (
+                    ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                    deployment,
+                ),
+                || Ok::<_, BridgeError>(self.resolve_url(&upstream)),
+            )?
+        };
         let client = self.client_for(ctx);
         let started = Instant::now();
 
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -747,13 +761,26 @@ impl Bridge for AzureOpenAiBridge {
             ctx.provider_key.response.as_ref(),
         )?;
         let headers = build_request_headers(&auth, &ctx.request_id, true, &ctx.header_ctx())?;
-        let url = self.resolve_url(&upstream);
+        let url = if cfg!(test) {
+            // Test builds route through the wiremock URL override; skip
+            // the cross-request cache so each test sees its own URL.
+            aisix_gateway::url_cache::EndpointUrl::Unparsed(self.resolve_url(&upstream))
+        } else {
+            aisix_gateway::url_cache::cached_endpoint_url(
+                &ctx.provider_key_id,
+                "azure/chat",
+                (
+                    ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                    deployment,
+                ),
+                || Ok::<_, BridgeError>(self.resolve_url(&upstream)),
+            )?
+        };
         let client = self.client_for(ctx);
         let started = Instant::now();
 
         let resp = with_deadline(ctx.deadline, started, async move {
-            client
-                .post(&url)
+            url.post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -695,27 +695,13 @@ impl Bridge for AzureOpenAiBridge {
             ctx.provider_key.response.as_ref(),
         )?;
         let headers = build_request_headers(&auth, &ctx.request_id, false, &ctx.header_ctx())?;
-        let url = if cfg!(test) {
-            // Test builds route through the wiremock URL override; skip
-            // the cross-request cache so each test sees its own URL.
-            aisix_gateway::url_cache::EndpointUrl::Unparsed(self.resolve_url(&upstream))
-        } else {
-            aisix_gateway::url_cache::cached_endpoint_url(
-                &ctx.provider_key_id,
-                "azure/chat",
-                (
-                    ctx.provider_key.api_base.as_deref().unwrap_or(""),
-                    deployment,
-                ),
-                || Ok::<_, BridgeError>(self.resolve_url(&upstream)),
-            )?
-        };
+        let url = self.resolve_url(&upstream);
         let client = self.client_for(ctx);
         let started = Instant::now();
 
         with_deadline(ctx.deadline, started, async move {
-            let resp = url
-                .post_on(&client)
+            let resp = client
+                .post(&url)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -761,26 +747,13 @@ impl Bridge for AzureOpenAiBridge {
             ctx.provider_key.response.as_ref(),
         )?;
         let headers = build_request_headers(&auth, &ctx.request_id, true, &ctx.header_ctx())?;
-        let url = if cfg!(test) {
-            // Test builds route through the wiremock URL override; skip
-            // the cross-request cache so each test sees its own URL.
-            aisix_gateway::url_cache::EndpointUrl::Unparsed(self.resolve_url(&upstream))
-        } else {
-            aisix_gateway::url_cache::cached_endpoint_url(
-                &ctx.provider_key_id,
-                "azure/chat",
-                (
-                    ctx.provider_key.api_base.as_deref().unwrap_or(""),
-                    deployment,
-                ),
-                || Ok::<_, BridgeError>(self.resolve_url(&upstream)),
-            )?
-        };
+        let url = self.resolve_url(&upstream);
         let client = self.client_for(ctx);
         let started = Instant::now();
 
         let resp = with_deadline(ctx.deadline, started, async move {
-            url.post_on(&client)
+            client
+                .post(&url)
                 .headers(headers)
                 .json(&body)
                 .send()

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -20,6 +20,7 @@
 //! - elapsed deadline → `BridgeError::Timeout { elapsed_ms }`
 
 use aisix_core::{RequestOverrides, ResponseOverrides, StreamDoneMarker};
+use aisix_gateway::url_cache::cached_endpoint_url;
 use aisix_gateway::{
     apply_request_headers, Bridge, BridgeContext, BridgeError, ChatChunk, ChatChunkStream,
     ChatFormat, ChatResponse, EmbeddingRequest, EmbeddingResponse, SseDecoder, SseEvent,
@@ -387,7 +388,6 @@ impl Bridge for OpenAiBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatResponse, BridgeError> {
-        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -399,13 +399,21 @@ impl Bridge for OpenAiBridge {
             ctx.provider_key.response.as_ref(),
         )?;
         let headers = build_request_headers(key, &ctx.request_id, false, &ctx.header_ctx())?;
-        let url = format!("{base}/chat/completions");
+        let url = cached_endpoint_url(
+            &ctx.provider_key_id,
+            "openai/chat",
+            (
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &ctx.provider_key.provider,
+            ),
+            || Ok(format!("{}/chat/completions", self.resolve_base(ctx)?)),
+        )?;
         let client = self.client_for(ctx);
         let started = Instant::now();
 
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -431,7 +439,6 @@ impl Bridge for OpenAiBridge {
         req: &EmbeddingRequest,
         ctx: &BridgeContext,
     ) -> Result<EmbeddingResponse, BridgeError> {
-        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -445,12 +452,20 @@ impl Bridge for OpenAiBridge {
             ctx.provider_key.response.as_ref(),
         )?;
         let headers = build_request_headers(key, &ctx.request_id, false, &ctx.header_ctx())?;
-        let url = format!("{base}/embeddings");
+        let url = cached_endpoint_url(
+            &ctx.provider_key_id,
+            "openai/embeddings",
+            (
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &ctx.provider_key.provider,
+            ),
+            || Ok(format!("{}/embeddings", self.resolve_base(ctx)?)),
+        )?;
         let client = self.client_for(ctx);
         let started = Instant::now();
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -476,7 +491,6 @@ impl Bridge for OpenAiBridge {
         body: &serde_json::Value,
         ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -497,12 +511,20 @@ impl Bridge for OpenAiBridge {
         )?;
         let headers = build_request_headers(key, &ctx.request_id, false, &ctx.header_ctx())?;
 
-        let url = format!("{base}/completions");
+        let url = cached_endpoint_url(
+            &ctx.provider_key_id,
+            "openai/completions",
+            (
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &ctx.provider_key.provider,
+            ),
+            || Ok(format!("{}/completions", self.resolve_base(ctx)?)),
+        )?;
         let client = self.client_for(ctx);
         let started = Instant::now();
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&outbound)
                 .send()
@@ -526,7 +548,6 @@ impl Bridge for OpenAiBridge {
         body: &serde_json::Value,
         ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -547,12 +568,20 @@ impl Bridge for OpenAiBridge {
         )?;
         let headers = build_request_headers(key, &ctx.request_id, false, &ctx.header_ctx())?;
 
-        let url = format!("{base}/images/generations");
+        let url = cached_endpoint_url(
+            &ctx.provider_key_id,
+            "openai/images",
+            (
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &ctx.provider_key.provider,
+            ),
+            || Ok(format!("{}/images/generations", self.resolve_base(ctx)?)),
+        )?;
         let client = self.client_for(ctx);
         let started = Instant::now();
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&outbound)
                 .send()
@@ -576,7 +605,6 @@ impl Bridge for OpenAiBridge {
         req: &ChatFormat,
         ctx: &BridgeContext,
     ) -> Result<ChatChunkStream, BridgeError> {
-        let base = self.resolve_base(ctx)?;
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
@@ -588,13 +616,20 @@ impl Bridge for OpenAiBridge {
             ctx.provider_key.response.as_ref(),
         )?;
         let headers = build_request_headers(key, &ctx.request_id, true, &ctx.header_ctx())?;
-        let url = format!("{base}/chat/completions");
+        let url = cached_endpoint_url(
+            &ctx.provider_key_id,
+            "openai/chat",
+            (
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &ctx.provider_key.provider,
+            ),
+            || Ok(format!("{}/chat/completions", self.resolve_base(ctx)?)),
+        )?;
         let client = self.client_for(ctx);
         let started = Instant::now();
 
         let resp = with_deadline(ctx.deadline, started, async move {
-            client
-                .post(&url)
+            url.post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -810,6 +810,56 @@ mod tests {
         ChatFormat::new("my-gpt4", vec![ChatMessage::user("hi")])
     }
 
+    async fn mount_ok(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-1",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(server)
+            .await;
+    }
+
+    /// The URL cache keys on the ProviderKey's resource id; an edited
+    /// `api_base` must take effect on the next request (fingerprint
+    /// revalidation), never serve the previously cached host.
+    #[tokio::test]
+    async fn url_cache_follows_api_base_edit_for_same_key_id() {
+        let s1 = MockServer::start().await;
+        let s2 = MockServer::start().await;
+        mount_ok(&s1).await;
+        mount_ok(&s2).await;
+
+        let bridge = OpenAiBridge::new();
+        let ctx1 = BridgeContext::new("r1", sample_model(), sample_provider_key(&s1.uri()))
+            .with_resource_ids("m-1", "pk-rewire-test");
+        bridge.chat(&req(), &ctx1).await.unwrap();
+
+        // Same resource id, api_base re-pointed at a different host.
+        let ctx2 = BridgeContext::new("r2", sample_model(), sample_provider_key(&s2.uri()))
+            .with_resource_ids("m-1", "pk-rewire-test");
+        bridge.chat(&req(), &ctx2).await.unwrap();
+
+        assert_eq!(
+            s1.received_requests().await.unwrap().len(),
+            1,
+            "first request hits the original host"
+        );
+        assert_eq!(
+            s2.received_requests().await.unwrap().len(),
+            1,
+            "after the edit the request follows the new host — a stale \
+             cached URL would have hit the original again"
+        );
+    }
+
     #[tokio::test]
     async fn non_streaming_happy_path() {
         let server = MockServer::start().await;

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -643,8 +643,27 @@ async fn multipart_dispatch(
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
     let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?;
 
-    let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
-    let url = crate::dispatch::build_openai_url(&base, upstream_path);
+    // Cache key must be `'static`; both callers pass fixed literals.
+    let url_cache_key: &'static str = if upstream_path == "/audio/translations" {
+        "proxy/audio/translations"
+    } else {
+        "proxy/audio/transcriptions"
+    };
+    let url = aisix_gateway::url_cache::cached_endpoint_url(
+        &pk_entry.id,
+        url_cache_key,
+        (
+            pk_entry.value.api_base.as_deref().unwrap_or(""),
+            upstream_path,
+        ),
+        || {
+            let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
+            Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(
+                &base,
+                upstream_path,
+            ))
+        },
+    )?;
     let provider_label = provider.to_ascii_lowercase();
     // Static label for retry tracing — this dispatch serves both audio
     // sub-routes, and logging translations under the transcription label
@@ -726,8 +745,9 @@ async fn multipart_dispatch(
     // the same shape in rerank.rs for why `note_failure` stays per attempt.
     let (upstream_headers, body_bytes) =
         match crate::routing::retrying_dispatch(state, model, retry_endpoint_label, || {
-            let mut req = client
-                .post(&url)
+            let mut req = url
+                .clone()
+                .post_on(&client)
                 .headers(headers.clone())
                 .multipart(build_form());
             // #554/#911: audio transcription/translation is non-streaming; apply
@@ -1080,7 +1100,6 @@ async fn speech_dispatch(
     let pk_entry = crate::dispatch::resolve_provider_key(&snapshot, model)?;
     let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?;
 
-    let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
     let provider_label = provider.to_ascii_lowercase();
 
     // Rewrite model field.
@@ -1134,7 +1153,18 @@ async fn speech_dispatch(
     );
 
     let client = crate::http_client::client_for(pk_entry.value.tls.as_ref());
-    let speech_url = crate::dispatch::build_openai_url(&base, "/audio/speech");
+    let speech_url = aisix_gateway::url_cache::cached_endpoint_url(
+        &pk_entry.id,
+        "proxy/audio/speech",
+        (pk_entry.value.api_base.as_deref().unwrap_or(""), ""),
+        || {
+            let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
+            Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(
+                &base,
+                "/audio/speech",
+            ))
+        },
+    )?;
     let tracker = &state.runtime_status;
     let model_id: &str = &model_entry.id;
     let cooldown_cfg = model.cooldown.as_ref();
@@ -1142,8 +1172,9 @@ async fn speech_dispatch(
     // the same shape in rerank.rs for why `note_failure` stays per attempt.
     let (upstream_headers, body_bytes) =
         match crate::routing::retrying_dispatch(state, model, "/v1/audio/speech", || {
-            let mut req = client
-                .post(speech_url.clone())
+            let mut req = speech_url
+                .clone()
+                .post_on(&client)
                 .headers(headers.clone())
                 .json(&body);
             // #554/#911: speech synthesis is non-streaming; apply the per-model

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -400,8 +400,18 @@ async fn count_tokens_to_target(
     // `build_anthropic_url` tolerates an api_base with or without `/v1` (the
     // Anthropic dashboard placeholder and copy-pasted full URLs both
     // resolve to `…/v1/messages/count_tokens`).
-    let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
-    let url = crate::dispatch::build_anthropic_url(&base, "/messages/count_tokens");
+    let url = aisix_gateway::url_cache::cached_endpoint_url(
+        &pk_entry.id,
+        "proxy/messages/count_tokens",
+        (pk_entry.value.api_base.as_deref().unwrap_or(""), ""),
+        || {
+            let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
+            Ok::<_, crate::error::ProxyError>(crate::dispatch::build_anthropic_url(
+                &base,
+                "/messages/count_tokens",
+            ))
+        },
+    )?;
 
     // Build the outbound HeaderMap explicitly so the PK's
     // `request.default_headers` / `request.forward_client_headers` can
@@ -446,7 +456,7 @@ async fn count_tokens_to_target(
     );
 
     let client = crate::http_client::client_for(pk_entry.value.tls.as_ref());
-    let mut req = client.post(&url).headers(headers).json(&body);
+    let mut req = url.post_on(&client).headers(headers).json(&body);
     // #554: count_tokens is non-streaming; apply the E2E request timeout.
     if let Some(d) = timeouts.request {
         req = req.timeout(d);

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1038,8 +1038,18 @@ async fn anthropic_passthrough_dispatch(
     // where the customer mistakenly puts `/v1` in the Anthropic
     // api_base (the dashboard placeholder uses the OpenAI form, so
     // this is a copy-paste hazard).
-    let base = crate::dispatch::resolve_base_url(pk_value)?;
-    let url = crate::dispatch::build_anthropic_url(&base, "/messages");
+    let url = aisix_gateway::url_cache::cached_endpoint_url(
+        pk_id,
+        "proxy/messages",
+        (pk_value.api_base.as_deref().unwrap_or(""), ""),
+        || {
+            let base = crate::dispatch::resolve_base_url(pk_value)?;
+            Ok::<_, crate::error::ProxyError>(crate::dispatch::build_anthropic_url(
+                &base,
+                "/messages",
+            ))
+        },
+    )?;
 
     // Check if the request wants streaming.
     let is_stream = body
@@ -1083,7 +1093,7 @@ async fn anthropic_passthrough_dispatch(
     );
 
     let client = crate::http_client::client_for(pk_value.tls.as_ref());
-    let mut req_builder = client.post(&url).headers(headers).json(&body);
+    let mut req_builder = url.post_on(&client).headers(headers).json(&body);
     // #554: non-streaming gets the E2E request timeout via reqwest's
     // request-level timeout. Streaming must NOT use it (it would cap the
     // whole stream); the streaming branch below enforces the per-chunk

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -385,12 +385,22 @@ async fn dispatch(
     // gate without an arm in the helper; the audit-trail-friendly
     // default is OpenAI's host (it's a 4xx-from-OpenAI rather than
     // dispatching to a stale legacy domain).
-    let base = match pk_entry.value.api_base.as_deref() {
-        Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
-        _ => default_base_for_provider(&provider_label)
-            .unwrap_or_else(|| "https://api.openai.com".to_string()),
-    };
-    let url = crate::dispatch::build_openai_url(&base, "/rerank");
+    let url = aisix_gateway::url_cache::cached_endpoint_url(
+        &pk_entry.id,
+        "proxy/rerank",
+        (
+            pk_entry.value.api_base.as_deref().unwrap_or(""),
+            &provider_label,
+        ),
+        || {
+            let base = match pk_entry.value.api_base.as_deref() {
+                Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),
+                _ => default_base_for_provider(&provider_label)
+                    .unwrap_or_else(|| "https://api.openai.com".to_string()),
+            };
+            Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(&base, "/rerank"))
+        },
+    )?;
 
     // Build headers explicitly so the PK's `request.default_headers` and
     // `request.forward_client_headers` can inject operator/client headers
@@ -438,7 +448,11 @@ async fn dispatch(
     let cooldown_cfg = model.cooldown.as_ref();
     let (upstream_headers, body_bytes) =
         match crate::routing::retrying_dispatch(state, model, "/v1/rerank", || {
-            let mut req = client.post(&url).headers(headers.clone()).json(body);
+            let mut req = url
+                .clone()
+                .post_on(&client)
+                .headers(headers.clone())
+                .json(body);
             // #554: rerank is non-streaming; apply the E2E request timeout.
             if let Some(d) =
                 crate::routing::effective_timeouts(model, None, state.default_timeouts).request

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1031,8 +1031,18 @@ async fn responses_to_target(
         );
     }
 
-    let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
-    let url = crate::dispatch::build_openai_url(&base, "/responses");
+    let url = aisix_gateway::url_cache::cached_endpoint_url(
+        &pk_entry.id,
+        "proxy/responses",
+        (pk_entry.value.api_base.as_deref().unwrap_or(""), ""),
+        || {
+            let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
+            Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(
+                &base,
+                "/responses",
+            ))
+        },
+    )?;
 
     let is_stream = body
         .get("stream")
@@ -1073,7 +1083,7 @@ async fn responses_to_target(
     );
 
     let client = crate::http_client::client_for(pk_entry.value.tls.as_ref());
-    let mut req = client.post(&url).headers(headers).json(&body);
+    let mut req = url.post_on(&client).headers(headers).json(&body);
     // #554: non-streaming gets the E2E request timeout via reqwest's
     // request-level timeout. Streaming must NOT use it (it would cap the
     // whole stream); the streaming branch below enforces the per-chunk

--- a/tests/e2e/src/cases/provider-key-api-base-repoint-e2e.test.ts
+++ b/tests/e2e/src/cases/provider-key-api-base-repoint-e2e.test.ts
@@ -1,0 +1,160 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: provider_key `api_base` re-point takes effect on the next request.
+//
+// Customer story: an operator migrates an upstream (region move, proxy
+// cut-over, vendor endpoint change) by PUT-ing a new `api_base` onto the
+// existing provider_key — same id, same secret. Every request after the
+// config propagates must dispatch to the NEW host.
+//
+// What this pins: the gateway resolves the upstream URL from the CURRENT
+// provider_key document. Any per-key caching of the resolved/parsed
+// upstream URL must revalidate against the live config — a stale cached
+// URL would keep routing requests (and the upstream credential) to the
+// old host indefinitely, which is the exact regression this test exists
+// to catch.
+//
+// Reference: OpenAI Chat Completions shape
+// (https://platform.openai.com/docs/api-reference/chat).
+
+const CALLER_PLAINTEXT = "sk-repoint-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+function chatBody(id: string, content: string) {
+  return {
+    id,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "gpt-4o-mini",
+    choices: [
+      { index: 0, message: { role: "assistant", content }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe("provider_key api_base re-point reaches the new host", () => {
+  let app: SpawnedApp | undefined;
+  let hostA: OpenAiUpstream | undefined;
+  let hostB: OpenAiUpstream | undefined;
+  let etcd: EtcdClient | undefined;
+  let seed: SeedClient | undefined;
+  let pkId = "";
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    hostA = await startOpenAiUpstream({
+      nonStreamBody: chatBody("cmpl-host-a", "from-a"),
+    });
+    hostB = await startOpenAiUpstream({
+      nonStreamBody: chatBody("cmpl-host-b", "from-b"),
+    });
+
+    app = await spawnApp({ admin: false });
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "repoint-pk",
+      secret: "sk-mock",
+      api_base: `${hostA.baseUrl}/v1`,
+    });
+    pkId = pk.id;
+    await seed.createModel({
+      display_name: "repoint-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["repoint-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await hostA?.close();
+    await hostB?.close();
+  });
+
+  test("requests follow an in-place api_base edit to the new upstream", async (ctx) => {
+    if (!etcdReachable || !app || !hostA || !hostB || !pkId) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Readiness + warm the URL path on host A. Several requests, so any
+    // per-key URL cache is definitely populated before the edit.
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "repoint-model",
+          messages: [{ role: "user", content: "ready" }],
+        });
+        return probe.choices[0]?.message.content === "from-a";
+      } catch {
+        return false;
+      }
+    });
+    for (let i = 0; i < 3; i++) {
+      const r = await client.chat.completions.create({
+        model: "repoint-model",
+        messages: [{ role: "user", content: `warm-${i}` }],
+      });
+      expect(r.choices[0]?.message.content).toBe("from-a");
+    }
+
+    // In-place re-point: same id + secret, api_base moves to host B.
+    await seed!.update("provider_keys", pkId, {
+      provider: "openai",
+      adapter: "openai",
+      display_name: "repoint-pk",
+      secret: "sk-mock",
+      api_base: `${hostB!.baseUrl}/v1`,
+    });
+
+    // After propagation every request must land on host B. A stale
+    // cached URL would keep answering "from-a" forever.
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await client.chat.completions.create({
+          model: "repoint-model",
+          messages: [{ role: "user", content: "moved?" }],
+        });
+        return probe.choices[0]?.message.content === "from-b";
+      } catch {
+        return false;
+      }
+    });
+    for (let i = 0; i < 3; i++) {
+      const r = await client.chat.completions.create({
+        model: "repoint-model",
+        messages: [{ role: "user", content: `post-${i}` }],
+      });
+      expect(r.choices[0]?.message.content).toBe("from-b");
+    }
+  });
+});


### PR DESCRIPTION
# perf(gateway): cache parsed upstream endpoint URLs per ProviderKey

## What

Every bridge dispatch rebuilt its upstream endpoint URL on every
request: base resolution (trim + endpoint-suffix scan + allocations), a
`format!`, and — because the request builder was handed a `&String` — a
full URL parse inside reqwest's `IntoUrl` (`into_url.rs`: a string is
`Url::parse`d on every call; a `Url` value is accepted as-is). The URL
is a pure function of the ProviderKey's configuration and the endpoint,
so this PR parses it once and hands the builder a cloned `Url` value.

New `aisix_gateway::url_cache`:

- Two-level map (ProviderKey id → endpoint literal → parsed `Url`), so
  the hit path performs no allocation for the lookup. Misses are
  single-flight per (key, endpoint): the row's shard guard is held
  across the build, so racing cold requests serialize and the build
  closure runs once per transition.
- **Fingerprint revalidation instead of invalidation hooks**: each row
  stores the raw inputs it was built from (`api_base` + the per-bridge
  second component — vendor for the OpenAI-compatible family, deployment
  for Azure). A hit whose fingerprint differs rebuilds, so an edited
  ProviderKey takes effect on the next request.
- A malformed URL is returned raw and never cached — the request builder
  surfaces exactly the error it always produced for a bad `api_base`.
- Bounded: the outer map caps at 8192 ProviderKey ids and resets on
  overflow. (Like the per-key TLS client cache, rows are never
  individually evicted; unlike it, this cache adds the hard cap.)
- Contexts without a ProviderKey id (tests, standalone constructions)
  bypass the cache entirely.

Wired call sites:

- OpenAI-compatible family bridge: chat, streaming chat, completions,
  embeddings, image generation.
- Anthropic bridge: messages, streaming messages.
- Direct-dispatch proxy paths: native `/v1/messages` passthrough,
  `/v1/responses`, `/v1/rerank` (fingerprint carries the provider
  label — its URL falls back to a per-provider default host),
  `messages/count_tokens`, audio transcription/translation/speech.

Behavior note: on the wired bridge paths, base resolution now runs
inside the build closure (after credential extraction), so a
doubly-misconfigured key (bad base AND bad credential) reports the
credential error first; single-fault configurations are unchanged.

## Out of scope (tracked in #942)

- The A2A bridge: its upstream URL belongs to an agent resource, not a
  ProviderKey, and its bridge is constructed per call.
- Token-minting vendor bridges whose URL embeds per-request material
  beyond the deployment name.
- The Azure bridge (withdrawn after audit): its URL varies per
  deployment while this cache keys per ProviderKey×endpoint, so a key
  serving several deployments would miss every request and pay a
  rebuild+write per request. Needs a deployment-keyed inner level.
- Cold-path direct-dispatch sites (`realtime`, `jobs`, `videos`).

## Numbers (same-rig A/B)

Measured as the final leg increment on the same session as the
zero-config package PR: the step lands at +1.3 us/req, **below the
session's single-leg resolution** (+-1.5 us leg-to-leg noise; the
frame-share estimate for this mechanism was ~0.6 us). The mechanism
itself is verified by unit test — single-flight: the build/parse
closure runs once per (key, endpoint) transition, including under a
barrier-based 8-thread race — rather than by the throughput number. The combined default state (this PR + the
zero-config package) measured 38,983 rps / 102.45 us/req at c=128
(anchor 35,440 / 112.69; fail=0; anchor drift -0.30%), with the full
grid c=16 34,432 / c=32 37,164 / c=768@10ms 33,620.

## Tests

- Unit: four url_cache tests (per-key+endpoint caching with
  fingerprint-change rebuild; empty-id bypass + malformed-URL
  no-caching; build-error passthrough with nothing cached; concurrent
  single-flight under a barrier), plus a bridge-layer test pinning that
  an api_base edit on the SAME resource id reaches the new host on the
  next request. Full workspace suites green.
- E2E (vitest, real gateway + etcd + mocks): new
  `provider-key-api-base-repoint-e2e` — seeds a provider_key, warms the
  URL path against host A, re-points api_base to host B in etcd, and
  asserts every post-propagation request lands on B (the exact
  stale-URL regression this cache must never introduce). Full suite
  green on the combined branch in work-stealing mode; TPC mode green on
  the package branch.
