### PR TITLE
docs(obs): correct three comments that mislead about streaming

### DIFF
--- a/crates/aisix-obs/src/access_log.rs
+++ b/crates/aisix-obs/src/access_log.rs
@@ -1,34 +1,43 @@
-//! Structured one-line access log. Called by the proxy handler once per
-//! request (success or error). Keeping the call explicit rather than inside
-//! a tower layer means the handler can attach `provider`, `model`,
-//! `api_key_id`, and `tokens` — fields the layer couldn't see.
+//! Structured one-line access log — one line per request, success or error.
+//! Keeping the call explicit rather than inside a tower layer means the
+//! caller can attach `provider`, `model`, `api_key_id`, and `tokens` —
+//! fields the layer couldn't see.
 //!
 //! # When the line is written, and what that costs
 //!
-//! WHEN differs by response type, and it decides which fields can be filled
-//! at all. The handler calls this on its way out, so:
+//! WHEN differs by path, and it decides which fields can be filled at all.
+//! Four cases, and only the first is "at the end of the request":
 //!
-//! - **Non-streamed**: at the end of the request. Everything the handler
-//!   resolved is available.
-//! - **Streamed**: when the SSE body is handed to the server, before a
-//!   single frame is polled. The upstream has produced nothing yet, so the
-//!   token counts and `provider_request_id` are necessarily absent, and
-//!   `status` is the response-OPEN status — a stream that later aborts, or
-//!   whose consumer walks away, still logged `200` here.
+//! - **Non-streamed response** — from the handler, on its way out, with
+//!   everything it resolved available.
+//! - **Streamed response** — from the handler too, but when the SSE body is
+//!   handed to the server, BEFORE a single frame is polled. The upstream has
+//!   produced nothing yet, so the token counts and `provider_request_id` are
+//!   necessarily absent, and `status` is the response-OPEN status: a stream
+//!   that later aborts, or whose consumer walks away, still logged `200`.
+//! - **`/v1/realtime`** — the opposite extreme. The handler returns the
+//!   WebSocket upgrade immediately; the line is written by `run_session` on
+//!   a detached task once the session closes, so it carries the close status
+//!   and the session's real token totals.
+//! - **Caller hung up before the response head** — written from
+//!   `ClientCancelGuard::drop`, with no handler involved. Status is `499`
+//!   and every resolved field is `None`, because the handler future was
+//!   dropped before it could fill any of them.
 //!
-//! Do not add a field whose value only exists after the upstream responds
-//! and expect it on a streamed line; it will be silently empty there. The
-//! completion-time figures for a streamed request live on the per-attempt
-//! `UsageEvent` (and, for the provider response id, on the
-//! `provider call completed` line `UsageSink::try_emit` writes), keyed by
-//! the same `request_id`.
+//! So do not add a field whose value only exists once the upstream has
+//! responded and expect it on every line: it is silently empty on the
+//! streamed and cancelled ones. A streamed request's completion-time figures
+//! live on the per-attempt `UsageEvent` (and, for the provider response id,
+//! on the `provider call completed` line `UsageSink::try_emit` writes),
+//! keyed by the same `request_id`.
 
 use std::time::Duration;
 
-/// Canonical access-log fields. Constructed by the handler on its way out of
-/// a request and passed to [`log_access`] — see the module docs for what
-/// "on its way out" means for a streamed response, and which fields that
-/// leaves empty.
+/// Canonical access-log fields, passed to [`log_access`].
+///
+/// Constructed at the point a request's outcome becomes known — which is not
+/// the same moment, nor even the same caller, on every path. See the module
+/// docs before assuming a field is available here.
 #[derive(Debug, Clone)]
 pub struct AccessLog<'a> {
     pub method: &'a str,

--- a/crates/aisix-obs/src/access_log.rs
+++ b/crates/aisix-obs/src/access_log.rs
@@ -1,12 +1,34 @@
 //! Structured one-line access log. Called by the proxy handler once per
-//! completed request (success or error). Keeping the call explicit rather
-//! than inside a tower layer means the handler can attach `provider`,
-//! `model`, `api_key_id`, and `tokens` — fields the layer couldn't see.
+//! request (success or error). Keeping the call explicit rather than inside
+//! a tower layer means the handler can attach `provider`, `model`,
+//! `api_key_id`, and `tokens` — fields the layer couldn't see.
+//!
+//! # When the line is written, and what that costs
+//!
+//! WHEN differs by response type, and it decides which fields can be filled
+//! at all. The handler calls this on its way out, so:
+//!
+//! - **Non-streamed**: at the end of the request. Everything the handler
+//!   resolved is available.
+//! - **Streamed**: when the SSE body is handed to the server, before a
+//!   single frame is polled. The upstream has produced nothing yet, so the
+//!   token counts and `provider_request_id` are necessarily absent, and
+//!   `status` is the response-OPEN status — a stream that later aborts, or
+//!   whose consumer walks away, still logged `200` here.
+//!
+//! Do not add a field whose value only exists after the upstream responds
+//! and expect it on a streamed line; it will be silently empty there. The
+//! completion-time figures for a streamed request live on the per-attempt
+//! `UsageEvent` (and, for the provider response id, on the
+//! `provider call completed` line `UsageSink::try_emit` writes), keyed by
+//! the same `request_id`.
 
 use std::time::Duration;
 
-/// Canonical access-log fields. Constructed by the handler at the end of
-/// a request and passed to [`log_access`].
+/// Canonical access-log fields. Constructed by the handler on its way out of
+/// a request and passed to [`log_access`] — see the module docs for what
+/// "on its way out" means for a streamed response, and which fields that
+/// leaves empty.
 #[derive(Debug, Clone)]
 pub struct AccessLog<'a> {
     pub method: &'a str,

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -3,12 +3,19 @@
 //!
 //! Existing compatibility series cover spec §7:
 //! - `aisix_requests_total{provider,model,status,outcome}` — counter
-//!   incremented at the end of every proxy request.
+//!   incremented once per proxy request that produced a response. A request
+//!   the caller abandoned before the response head never reaches it; see
+//!   [`M_PROXY_CLIENT_CANCELLED`].
 //! - `aisix_request_duration_seconds{provider,model,status}` — histogram
-//!   of end-to-end proxy latency.
+//!   of proxy latency, recorded when the response is handed to the client.
+//!   That is the full request for a non-streamed response and only time to
+//!   response START for a streamed one; `aisix_request_e2e_latency_seconds`
+//!   is the series that is end-to-end on both. See `request_metrics`.
 //! - `aisix_ratelimit_rejections_total{scope}` — counter for 429 flows.
 //! - `aisix_tokens_consumed_total{provider,model}` — counter of
-//!   `usage.total_tokens` summed across completed non-streaming calls.
+//!   `usage.total_tokens` summed across completed calls. Streamed calls are
+//!   included: they contribute from the end-of-stream emit, not at response
+//!   open like the two series above.
 //!
 //! Newer AISIX-native series use `aisix_proxy_*` and `aisix_llm_*`
 //! names with bounded, DP-stable labels. They intentionally do not
@@ -60,9 +67,9 @@ pub const M_PROXY_REQUESTS_TOTAL: &str = "aisix_proxy_requests_total";
 pub const M_PROXY_FAILED_REQUESTS_TOTAL: &str = "aisix_proxy_failed_requests_total";
 pub const M_PROXY_REQUEST_DURATION: &str = "aisix_proxy_request_duration_seconds";
 /// Requests the client abandoned before the response head was written.
-/// Every other proxy series is emitted at the end of a handler, which a
-/// cancelled request never reaches — without this one those requests are
-/// absent from the metrics entirely, not counted as failures.
+/// Every other proxy series needs a handler to produce a response first,
+/// which a cancelled request never does — without this one those requests
+/// are absent from the metrics entirely, not counted as failures.
 ///
 /// The label set is `endpoint` ONLY. A cancelled request has no resolved
 /// model / provider key / team (the body may not even be parsed yet), so

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -194,9 +194,24 @@ pub struct UsageEvent {
     /// HTTP status code the proxy returned to the downstream caller.
     pub status_code: u16,
 
-    /// Provider response `id` — OpenAI's `chat.completion.id` or
-    /// Anthropic's message `id`. Empty when the request never reached
-    /// the upstream (guardrail block / pre-dispatch error).
+    /// Provider response `id` — OpenAI's `chat.completion.id`, Anthropic's
+    /// message `id`, a Responses-API `resp_…`.
+    ///
+    /// Empty does NOT mean the request never reached an upstream. It means
+    /// no id was recorded, which happens on all of:
+    ///
+    /// - the request never reached an upstream (guardrail block,
+    ///   pre-dispatch error), or was served from cache;
+    /// - the attempt failed, so there was no response body to read one from;
+    /// - the endpoint's provider response carries no id at all — embeddings,
+    ///   audio, images, `count_tokens` — or the id it returns is a resource
+    ///   handle rather than a per-call response id (video jobs,
+    ///   files/batches/fine-tuning, the passthrough tunnel), which is
+    ///   deliberately not recorded here (AISIX-Cloud#1289);
+    /// - the upstream simply omitted it.
+    ///
+    /// So a consumer may not infer "reached an upstream" from a non-empty
+    /// value's absence: a successful `/v1/embeddings` call has none.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub provider_request_id: String,
 

--- a/crates/aisix-proxy/src/request_metrics.rs
+++ b/crates/aisix-proxy/src/request_metrics.rs
@@ -1,5 +1,20 @@
 //! The one chokepoint for the per-request outcome metrics every handler
-//! emits at the end of dispatch.
+//! emits once dispatch has produced a response.
+//!
+//! # What `elapsed` measures, and why it is not end-to-end
+//!
+//! Handlers call [`record`] on their way out, so for a **streamed** response
+//! the `elapsed` they pass is time to response START, not the full
+//! generation — the SSE body has not been polled yet. Every duration series
+//! fed from here therefore mixes two scopes: full request time for
+//! non-streamed traffic, time-to-response-start for streamed. `chat.rs`
+//! guards the SLO histogram against exactly this
+//! (`record_request_e2e_latency` is called with the stream's own duration at
+//! completion instead); nothing guards the three families below.
+//!
+//! Read a streaming p99 off `aisix_request_e2e_latency_seconds`, which is
+//! recorded at stream completion. Do not read one off
+//! `aisix_llm_request_duration_seconds` and expect end-to-end.
 //!
 //! Three families ride on a single call:
 //!
@@ -205,7 +220,10 @@ fn is_llm_endpoint(endpoint: &str) -> bool {
     LLM_ENDPOINTS.contains(&endpoint)
 }
 
-/// Terminal request-metric emit, shared by every handler.
+/// The one request-metric emit, shared by every handler.
+///
+/// Called on the handler's way out — see the module docs for why `elapsed`
+/// is NOT the end-to-end figure on a streamed response.
 ///
 /// `endpoint` must be a bounded route template — a literal for the fixed
 /// routes, or [`crate::normalize_endpoint_label`] output for the `:param` /


### PR DESCRIPTION
Three observability comments state something that holds on the non-streamed path, at a definition several modules share. Found by auditing for the shape of the first one after it had already produced a wrong public doc.

Comments only — no behavior change.

## 1. `access_log.rs` — when the line is written

Said the line is written "once per **completed** request" and that the struct is "constructed by the handler **at the end of a request**". True for a non-streamed response; for a streamed one the handler calls `emit_access_log` when the SSE body is handed to the server, before a single frame is polled.

That decides which fields can be filled at all. A streamed line carries no token counts (`Success` is built with `prompt_tokens: None`), no `provider_request_id` (it arrives in the first frame), and a `status` as of response *open* — a stream that later aborts still logged `200` here.

It has already misled: the public logging docs were written from this comment and stated the wrong timing until api7/docs#2073 corrected it. The per-field note added with #1289 said this for `provider_request_id` alone, phrased as that field's quirk rather than a property of the struct, so the next field added would inherit the trap.

## 2. `UsageEvent::provider_request_id` — what empty means

Said "Empty when the request never reached the upstream (guardrail block / pre-dispatch error)". The enumeration was already short, and #935 shortened it further by widening where the field IS populated without revisiting it.

Empty is also what a cache hit, a failed attempt with no response body, an upstream that omitted the id, and every endpoint whose response carries no id produce. So a consumer of `dpmgr_usage_events` cannot read absence as "never reached an upstream" — a successful `/v1/embeddings` call has none. That is the inference the old wording invited, on the DP↔CP contract struct.

## 3. `request_metrics` — what `elapsed` measures

Called itself the "**terminal**" request-metric emit, "at the **end of dispatch**". Handlers call it on their way out, so on a streamed response the `elapsed` it receives is time to response START.

Three duration families are fed from there — `aisix_request_duration_seconds`, `aisix_proxy_request_duration_seconds`, `aisix_llm_request_duration_seconds` — and all three therefore mix full request time (non-streamed) with time-to-response-start (streamed). `chat.rs` knows this and guards the SLO histogram against it in so many words ("`elapsed` for a stream is time-to-response-start"), recording the stream's real duration at completion instead. The chokepoint those twelve modules share said nothing, and "terminal" implied the opposite.

Now documented, with a pointer to `aisix_request_e2e_latency_seconds` as the series that is actually end-to-end.

**The mixed-scope duration series is described here, not changed.** Whether those three families should record a streamed request's full duration is a metric-semantics decision with dashboard and alert consequences, and belongs in its own change. The public metrics reference is separately wrong about this and is being corrected alongside.