### PR TITLE
fix(realtime): attribute post-auth refusals to the resolved caller

### DIFF
--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -933,6 +933,7 @@ mod tests {
         snap: AisixSnapshot,
     ) -> (
         std::net::SocketAddr,
+        crate::ProxyState,
         tokio::sync::mpsc::Receiver<ObsUsageEvent>,
     ) {
         let (tx, rx) = tokio::sync::mpsc::channel::<ObsUsageEvent>(16);
@@ -941,7 +942,7 @@ mod tests {
         let state = crate::ProxyState::new(handle, hub, &cfg())
             .without_cache()
             .with_usage_sink(UsageSink::new(tx));
-        let app = crate::build_router(state);
+        let app = crate::build_router(state.clone());
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
@@ -949,7 +950,7 @@ mod tests {
                 .await
                 .unwrap();
         });
-        (addr, rx)
+        (addr, state, rx)
     }
 
     /// Scripted mock upstream: accepts ONE WebSocket, records the request
@@ -1014,7 +1015,7 @@ mod tests {
     async fn relays_frames_and_emits_aggregated_usage_event() {
         let (up_addr, handshake, frames) = spawn_upstream().await;
         let snap = snapshot(&format!("http://{up_addr}/v1"), "openai", "openai");
-        let (addr, mut rx) = serve(snap).await;
+        let (addr, _state, mut rx) = serve(snap).await;
 
         let mut req = format!("ws://{addr}/v1/realtime?model=rt-model")
             .into_client_request()
@@ -1077,7 +1078,7 @@ mod tests {
     async fn subprotocol_key_authenticates_and_realtime_is_echoed() {
         let (up_addr, _handshake, _frames) = spawn_upstream().await;
         let snap = snapshot(&format!("http://{up_addr}/v1"), "openai", "openai");
-        let (addr, _rx) = serve(snap).await;
+        let (addr, _state, _rx) = serve(snap).await;
 
         let mut req = format!("ws://{addr}/v1/realtime?model=rt-model")
             .into_client_request()
@@ -1105,7 +1106,7 @@ mod tests {
     #[tokio::test]
     async fn missing_auth_rejects_the_handshake() {
         let snap = snapshot("http://127.0.0.1:9/v1", "openai", "openai");
-        let (addr, _rx) = serve(snap).await;
+        let (addr, _state, _rx) = serve(snap).await;
 
         let req = format!("ws://{addr}/v1/realtime?model=rt-model")
             .into_client_request()
@@ -1120,7 +1121,7 @@ mod tests {
     #[tokio::test]
     async fn missing_model_param_rejects_with_400() {
         let snap = snapshot("http://127.0.0.1:9/v1", "openai", "openai");
-        let (addr, mut rx) = serve(snap).await;
+        let (addr, _state, mut rx) = serve(snap).await;
 
         let mut req = format!("ws://{addr}/v1/realtime")
             .into_client_request()
@@ -1148,7 +1149,7 @@ mod tests {
     #[tokio::test]
     async fn non_realtime_capable_adapter_is_rejected() {
         let snap = snapshot("http://127.0.0.1:9", "anthropic", "anthropic");
-        let (addr, _rx) = serve(snap).await;
+        let (addr, _state, _rx) = serve(snap).await;
 
         let mut req = format!("ws://{addr}/v1/realtime?model=rt-model")
             .into_client_request()
@@ -1169,7 +1170,7 @@ mod tests {
         let k_json = format!(r#"{{"key_hash":"{CALLER_HASH}","allowed_models":["other-model"]}}"#);
         let k: ApiKey = serde_json::from_str(&k_json).unwrap();
         snap.apikeys.insert(ResourceEntry::new("k-1", k, 2));
-        let (addr, mut rx) = serve(snap).await;
+        let (addr, state, mut rx) = serve(snap).await;
 
         let mut req = format!("ws://{addr}/v1/realtime?model=rt-model")
             .into_client_request()
@@ -1191,6 +1192,14 @@ mod tests {
         assert_eq!(
             ev.api_key_id, "k-1",
             "a post-auth refusal must attribute the resolved key"
+        );
+
+        // Second surface of the same fix: the request-rate metric label
+        // set names the caller instead of `unknown`.
+        let scrape = state.metrics.render();
+        assert!(
+            scrape.contains(r#"api_key_id="k-1""#),
+            "the refusal metric must carry the caller label, got: {scrape}"
         );
     }
 
@@ -1244,8 +1253,9 @@ mod tests {
         let event = rx.try_recv().expect("the refusal is recorded");
         assert_eq!(event.status_code, 400);
         assert_eq!(event.inbound_protocol, "realtime");
-        // Auth runs inside prepare(), which a rejected upgrade never
-        // reaches — no key is attributed; the requested model rides along.
+        // The handler authenticates only after the upgrade is accepted
+        // as upgradable, so a rejected upgrade never reaches auth — no
+        // key is attributed; the requested model rides along.
         assert_eq!(event.api_key_id, "");
         assert_eq!(event.requested_model, "probe-model");
 

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -94,7 +94,7 @@ pub(crate) async fn realtime(
     method: Method,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
-    client: ClientContext,
+    mut client: ClientContext,
     ws: Result<WebSocketUpgrade, axum::extract::ws::rejection::WebSocketUpgradeRejection>,
 ) -> Response {
     let request_id = client.request_id.clone();
@@ -107,14 +107,32 @@ pub(crate) async fn realtime(
     // collected (#885). Map it into this endpoint's normal error arm,
     // keeping axum's own status classification (400 / 426 / 405) and its
     // per-variant diagnostic.
+    //
+    // Auth runs here rather than through the extractor (the browser flow
+    // carries the credential in a subprotocol item), so a failure between
+    // auth and dispatch must hand the resolved key back for attribution —
+    // pre-#932 those errors were emitted as if anonymous.
     let outcome = match ws {
-        Ok(ws) => prepare(&state, &params, &headers, &client)
-            .await
-            .map(|prep| (ws, prep)),
-        Err(rejection) => Err(crate::error::ProxyError::WebSocketUpgradeRequired {
-            status: rejection.status(),
-            detail: rejection.body_text(),
-        }),
+        Ok(ws) => match authenticate(&state, &headers, &client).await {
+            Ok(auth) => {
+                // Every other family gets `client.jwt` published by the
+                // auth extractor; do the same here so the session clone
+                // and the error emits below attribute the JWT identity.
+                client.jwt = auth.jwt.clone();
+                prepare(&state, &params, &client, auth.clone())
+                    .await
+                    .map(|prep| (ws, prep))
+                    .map_err(|err| (Some(auth), err))
+            }
+            Err(err) => Err((None, err)),
+        },
+        Err(rejection) => Err((
+            None,
+            crate::error::ProxyError::WebSocketUpgradeRequired {
+                status: rejection.status(),
+                detail: rejection.body_text(),
+            },
+        )),
     };
 
     match outcome {
@@ -134,13 +152,15 @@ pub(crate) async fn realtime(
                 .instrument(span)
             })
         }
-        Err(err) => {
+        Err((auth, err)) => {
             let status = err.status().as_u16();
+            let api_key_id = auth.as_ref().map(|a| a.entry.id.as_str());
             emit_access_log(
                 &method,
                 status,
                 started.elapsed(),
                 &request_id,
+                api_key_id,
                 None,
                 Some(&err),
             );
@@ -148,11 +168,14 @@ pub(crate) async fn realtime(
             // (unresolved labels, same as `reject_before_dispatch`) — logs
             // and the request-rate metrics must not disagree about whether
             // these requests exist. Authentication may not have run, so the
-            // caller is attributed only when a key was resolved.
+            // caller is attributed only when a key was resolved (#932).
             crate::request_metrics::record(
                 &state,
                 "/v1/realtime",
-                crate::request_metrics::Caller::unattributed(None),
+                match auth.as_ref() {
+                    Some(a) => crate::request_metrics::Caller::new(a),
+                    None => crate::request_metrics::Caller::unattributed(None),
+                },
                 crate::request_metrics::Upstream {
                     model: crate::usage_attr::UNRESOLVED_MODEL_LABEL,
                     ..Default::default()
@@ -166,7 +189,7 @@ pub(crate) async fn realtime(
                 "realtime",
                 &request_id,
                 params.get("model").map(String::as_str).unwrap_or(""),
-                "",
+                api_key_id.unwrap_or(""),
                 status,
                 err.kind(),
                 &client,
@@ -190,11 +213,9 @@ struct Prepared {
 async fn prepare(
     state: &ProxyState,
     params: &HashMap<String, String>,
-    headers: &HeaderMap,
     client: &ClientContext,
+    auth: AuthenticatedKey,
 ) -> Result<Prepared, ProxyError> {
-    let auth = authenticate(state, headers, client).await?;
-
     let requested_model = params
         .get("model")
         .map(String::as_str)
@@ -494,6 +515,7 @@ async fn run_session(
                 502,
                 started.elapsed(),
                 &request_id,
+                Some(&auth.entry.id),
                 Some((&provider_label, &requested_model)),
                 Some(&connect_err),
             );
@@ -687,6 +709,7 @@ async fn run_session(
         close_status,
         elapsed,
         &request_id,
+        Some(&auth.entry.id),
         Some((&provider_label, &requested_model)),
         session_error.as_ref(),
     );
@@ -824,6 +847,7 @@ fn emit_access_log(
     status: u16,
     elapsed: Duration,
     request_id: &str,
+    api_key_id: Option<&str>,
     target: Option<(&str, &str)>,
     error: Option<&ProxyError>,
 ) {
@@ -841,7 +865,7 @@ fn emit_access_log(
         latency: elapsed,
         provider: target.map(|(p, _)| p).filter(|p| !p.is_empty()),
         model: target.map(|(_, m)| m),
-        api_key_id: None,
+        api_key_id,
         prompt_tokens: None,
         completion_tokens: None,
         total_tokens: None,
@@ -1145,7 +1169,7 @@ mod tests {
         let k_json = format!(r#"{{"key_hash":"{CALLER_HASH}","allowed_models":["other-model"]}}"#);
         let k: ApiKey = serde_json::from_str(&k_json).unwrap();
         snap.apikeys.insert(ResourceEntry::new("k-1", k, 2));
-        let (addr, _rx) = serve(snap).await;
+        let (addr, mut rx) = serve(snap).await;
 
         let mut req = format!("ws://{addr}/v1/realtime?model=rt-model")
             .into_client_request()
@@ -1156,6 +1180,18 @@ mod tests {
             .await
             .expect_err("handshake must fail on model ACL");
         assert!(err.to_string().contains("403"), "got: {err}");
+
+        // Auth succeeded before the ACL refused, so the error event must
+        // name the caller — pre-#932 it was emitted as if anonymous.
+        let ev = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("the refusal must emit an error UsageEvent")
+            .expect("sink closed");
+        assert_eq!(ev.status_code, 403);
+        assert_eq!(
+            ev.api_key_id, "k-1",
+            "a post-auth refusal must attribute the resolved key"
+        );
     }
 
     /// State + router + usage receiver for driving the endpoint's

--- a/tests/e2e/src/cases/realtime-ws-e2e.test.ts
+++ b/tests/e2e/src/cases/realtime-ws-e2e.test.ts
@@ -102,7 +102,8 @@ describe("realtime e2e: /v1/realtime WebSocket relay (#721)", () => {
     etcdReachable = await etcd.ping();
     if (!etcdReachable) return;
 
-    app = await spawnApp();
+    // The access log emits at `info` (asserted by the #932 case below).
+    app = await spawnApp({ logLevel: "info" });
     seed = new SeedClient(etcd, app.etcdPrefix);
     upstream = await startRealtimeUpstream();
     idp = await startMockIdp();
@@ -310,6 +311,20 @@ describe("realtime e2e: /v1/realtime WebSocket relay (#721)", () => {
     expect(span.attributes["aisix.jwt_subject"]).toBe("rt-alice");
     expect(span.attributes["aisix.jwt_provider"]).toBe("rt-idp");
     expect(span.attributes["aisix.jwt_claim_mapping"]).toBe("rt-dept");
+
+    // Third surface of the same fix: the refusal's access-log line must
+    // name the caller (the realtime access log carried no api_key_id on
+    // any path before #932).
+    const logLine = app
+      .output()
+      .split("\n")
+      .find(
+        (l) =>
+          l.includes("proxy request completed") &&
+          l.includes(refusal.requestId),
+      );
+    expect(logLine, "access log line for the refusal").toBeTruthy();
+    expect(logLine).toContain(restrictedKey.id);
   });
 
   test("bad credentials reject the upgrade handshake", async (ctx) => {

--- a/tests/e2e/src/cases/realtime-ws-e2e.test.ts
+++ b/tests/e2e/src/cases/realtime-ws-e2e.test.ts
@@ -1,14 +1,22 @@
 import { createHash } from "node:crypto";
 import { WebSocket } from "undici";
-import { WebSocketServer, type WebSocket as WsSocket } from "ws";
+import {
+  WebSocket as WsClient,
+  WebSocketServer,
+  type WebSocket as WsSocket,
+} from "ws";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
+  agentClaims,
   EtcdClient,
   SeedClient,
   spawnApp,
+  startMockIdp,
   waitConfigPropagation,
+  type MockIdp,
   type SpawnedApp,
 } from "../harness/index.js";
+import { startMockOtlp, type MockOtlp } from "../harness/otlp-mock.js";
 
 // E2E: /v1/realtime WebSocket relay (#721, AISIX-Cloud#873 §⑤) against a
 // real `aisix` binary. Verifies with a live WS handshake what unit tests
@@ -84,6 +92,9 @@ describe("realtime e2e: /v1/realtime WebSocket relay (#721)", () => {
   let app: SpawnedApp | undefined;
   let seed: SeedClient | undefined;
   let upstream: RealtimeUpstream | undefined;
+  let idp: MockIdp | undefined;
+  let otlp: MockOtlp | undefined;
+  let restrictedKey: { id: string } | undefined;
   let etcdReachable = false;
 
   beforeAll(async () => {
@@ -94,6 +105,8 @@ describe("realtime e2e: /v1/realtime WebSocket relay (#721)", () => {
     app = await spawnApp();
     seed = new SeedClient(etcd, app.etcdPrefix);
     upstream = await startRealtimeUpstream();
+    idp = await startMockIdp();
+    otlp = await startMockOtlp();
 
     await seed.createApiKey({
       key_hash: CALLER_KEY_HASH,
@@ -111,6 +124,39 @@ describe("realtime e2e: /v1/realtime WebSocket relay (#721)", () => {
       provider_key_id: pk.id,
     });
 
+    // JWT identity resolving (via a claim mapping) to a key that may NOT
+    // use the realtime model — drives the post-auth refusal attribution
+    // test (#932). The OTLP receiver is how that test reads the error
+    // usage event.
+    await seed.createObservabilityExporter({
+      name: "rt-otlp",
+      kind: "otlp_http",
+      endpoint: otlp.url,
+    });
+    await seed.createOidcProvider({
+      name: "rt-idp",
+      issuer: idp.url,
+      audiences: ["aisix-gateway"],
+      jwks_uri: idp.jwksUrl,
+    });
+    restrictedKey = await seed.createApiKey({
+      key_hash: createHash("sha256").update("sk-rt-restricted").digest("hex"),
+      allowed_models: ["some-other-model"],
+    });
+    await seed.createClaimMapping({
+      name: "rt-dept",
+      jwt_provider: "rt-idp",
+      match: [{ claim: "department", op: "exact", values: ["realtime"] }],
+      resolve: { api_key_id: restrictedKey.id },
+    });
+    // Readiness probe seeded LAST: watch events apply in revision order,
+    // so this key authenticating implies every earlier seed is live (same
+    // pattern as claim-mapping-e2e).
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update("sk-rt-ready-probe").digest("hex"),
+      allowed_models: [],
+    });
+
     // Gate on the DP snapshot via /v1/models — the WS upgrade below
     // authenticates against the same snapshot, and a handshake fired
     // before the caller key propagates is rejected outright.
@@ -122,11 +168,20 @@ describe("realtime e2e: /v1/realtime WebSocket relay (#721)", () => {
       const body = (await res.json()) as { data?: Array<{ id?: string }> };
       return (body.data ?? []).some((m) => m.id === "realtime-e2e-model");
     });
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: "Bearer sk-rt-ready-probe" },
+      });
+      await res.text();
+      return res.status === 200;
+    });
   });
 
   afterAll(async () => {
     await app?.exit();
     await upstream?.close();
+    await idp?.close();
+    await otlp?.close();
   });
 
   test("browser-flow subprotocol auth + bidirectional relay + upstream credential swap", async (ctx) => {
@@ -193,6 +248,68 @@ describe("realtime e2e: /v1/realtime WebSocket relay (#721)", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error?: { type?: string } };
     expect(body.error?.type).toBe("websocket_upgrade_required");
+  });
+
+  test("a post-auth refusal attributes the caller and JWT identity (#932)", async (ctx) => {
+    if (!etcdReachable || !app || !idp || !otlp || !restrictedKey) {
+      ctx.skip();
+      return;
+    }
+    // JWT auth resolves (through the `rt-dept` claim mapping) to a key
+    // that may not use the realtime model, so auth succeeds and the
+    // model ACL then refuses — the error usage event must carry the
+    // resolved key and the JWT identity, not an anonymous shape.
+    const token = idp.sign(
+      agentClaims(idp.url, { sub: "rt-alice", department: "realtime" }),
+    );
+    const wsUrl = `${app.proxyUrl.replace("http://", "ws://")}/v1/realtime?model=realtime-e2e-model`;
+    // The `ws` client can set headers (undici's browser-style client
+    // cannot), which also makes this the header-auth coverage for the
+    // endpoint — every other case rides the subprotocol flow.
+    const refusal = await new Promise<{ status: number; requestId: string }>(
+      (resolve, reject) => {
+        const c = new WsClient(wsUrl, {
+          headers: { authorization: `Bearer ${token}` },
+        });
+        c.on("unexpected-response", (_req, res) => {
+          res.resume();
+          resolve({
+            status: res.statusCode ?? 0,
+            requestId: String(res.headers["x-aisix-request-id"] ?? ""),
+          });
+          c.terminate();
+        });
+        c.on("open", () => {
+          c.terminate();
+          reject(new Error("handshake must fail on model ACL"));
+        });
+        c.on("error", (e) => reject(e));
+      },
+    );
+    expect(refusal.status).toBe(403);
+    expect(refusal.requestId).not.toBe("");
+
+    // The error event fans out to OTLP exporters like every other usage
+    // event; poll the mock for the span keyed on the handshake's id.
+    let span;
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      span = otlp.spans.find(
+        (s) => s.attributes["aisix.request_id"] === refusal.requestId,
+      );
+      if (span) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    if (!span) {
+      throw new Error(
+        `no usage span for request_id=${refusal.requestId} ` +
+          `(spans=${otlp.spans.length}, parse failures=${otlp.parseFailures.length})`,
+      );
+    }
+    expect(span.attributes["aisix.api_key_id"]).toBe(restrictedKey.id);
+    expect(span.attributes["aisix.jwt_subject"]).toBe("rt-alice");
+    expect(span.attributes["aisix.jwt_provider"]).toBe("rt-idp");
+    expect(span.attributes["aisix.jwt_claim_mapping"]).toBe("rt-dept");
   });
 
   test("bad credentials reject the upgrade handshake", async (ctx) => {


### PR DESCRIPTION
## Problem

`/v1/realtime` authenticates inside the handler (the browser flow carries the credential in a `sec-websocket-protocol` item, so the `AuthenticatedKey` extractor can't run). When a request failed **after** authentication succeeded — model ACL, rate limit, virtual-router refusal — the refusal was emitted as if anonymous:

- the error usage event carried an empty `api_key_id` and none of the JWT identity fields (`jwt_subject` / `jwt_provider` / `jwt_claim_mapping`),
- request metrics counted the refusal as `unattributed`,
- the realtime access log hardcoded `api_key_id: None` on every path (success included).

The success-path usage event was already attributed correctly.

## Fix

The handler now authenticates before `prepare()` and hands the resolved `AuthenticatedKey` back alongside any post-auth error:

- the error arm stamps the usage event, request metrics (`Caller::new`), and access log from the resolved key; pre-auth refusals stay unattributed as before;
- `client.jwt` is published right after auth — the same thing the auth extractor does for every other handler family — so the session clone and the upstream-connect-failure emit inside `run_session` carry the JWT identity too;
- `emit_access_log` gains an `api_key_id` parameter, stamped on all three call sites (post-auth error, upstream connect failure, session end).

## Tests

- Unit: `model_acl_rejects_unauthorized_key` now asserts the 403 usage event names the resolved key (`api_key_id = "k-1"`) — fails on the previous implementation, passes with the fix.
- E2E (`realtime-ws-e2e.test.ts`): new case authenticates with a JWT resolved through a claim mapping to a key that may not use the realtime model, then asserts the OTLP error span carries `aisix.api_key_id`, `aisix.jwt_subject`, `aisix.jwt_provider`, and `aisix.jwt_claim_mapping`. Also the first header-auth (`Authorization: Bearer`) coverage on this endpoint — the existing cases all ride the subprotocol flow.

Fixes #932


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime WebSocket authentication and validation before session setup.
  * ACL-denied connections now return consistent HTTP 403 responses with request IDs.
  * Authentication failures and rejected requests now retain API key attribution in access logs, usage records, and metrics.
  * Session and activity records now include the authenticated key identity.
* **Tests**
  * Added end-to-end coverage for JWT authentication, model access restrictions, request handling, usage attribution, and access logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->