### PR TITLE
perf(server): set TCP_NODELAY on accepted downstream connections

### DIFF
--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -1477,24 +1477,30 @@ fn background_check_interval(snapshot: &aisix_core::AisixSnapshot) -> std::time:
     std::time::Duration::from_secs(min_interval.max(1))
 }
 
-/// Completes when the process receives SIGINT or SIGTERM (best-effort on
-/// Windows — Ctrl+C only) OR when another part of the system has already
-/// flipped the cancel channel.
 /// Set on every connection the gateway accepts from a client.
 ///
-/// Nagle's algorithm holds a small write back until the previous one has
-/// been acknowledged. A buffered answer leaves as one write and never
-/// notices — which is why this is invisible in a throughput benchmark —
-/// but a streamed one writes a frame at a time, and a frame that lands
-/// while an earlier one is still unacknowledged waits out the client's
-/// delayed ACK (up to 40ms on Linux) before it leaves the box. That is a
-/// latency tax on exactly the responses users watch arrive.
+/// Nagle's algorithm holds a small segment back until the previous one
+/// has been acknowledged. A short buffered answer leaves in a single
+/// segment and never notices — which is why this is invisible in the
+/// throughput benchmark — but a streamed one writes a frame at a time,
+/// and a frame that lands while an earlier one is still unacknowledged
+/// waits out the client's delayed ACK (up to 40ms on Linux) before it
+/// leaves the box. HTTP/2 control frames and the WebSocket surfaces run
+/// on the same accepted socket and inherit the option.
 ///
 /// `axum_server` accepts with the option off, and the gateway had never
 /// turned it on. reqwest already sets it on the upstream side.
+///
+/// A `set_nodelay` failure fails that connection: on Linux the option
+/// carries no socket-state precondition and cannot fail, and elsewhere
+/// it reports a peer that has already gone away — a connection that was
+/// not answerable regardless.
 const DOWNSTREAM_NODELAY: axum_server::accept::NoDelayAcceptor =
     axum_server::accept::NoDelayAcceptor;
 
+/// Completes when the process receives SIGINT or SIGTERM (best-effort on
+/// Windows — Ctrl+C only) OR when another part of the system has already
+/// flipped the cancel channel.
 /// Serve `router` on `addr`, choosing HTTPS when `tls` is configured and
 /// plain HTTP otherwise. Both variants honour the shared `cancel` watch for
 /// graceful shutdown so the proxy/admin surfaces stop in lockstep with the
@@ -2332,19 +2338,33 @@ models:
     /// surface away. A listener wired without the acceptor fails in the
     /// way nothing catches: it serves correctly, benchmarks identically,
     /// and only pays the delayed-ACK tax on streamed responses.
+    ///
+    /// The TLS sites also have to wire it with `map`, not `acceptor`:
+    /// `Server::acceptor` *replaces* the acceptor, so
+    /// `from_tcp_rustls(..).acceptor(DOWNSTREAM_NODELAY)` compiles, drops
+    /// the rustls acceptor, and serves plaintext on the TLS port — while
+    /// satisfying a check that only looks for the constant's name.
     #[test]
     fn every_listener_sets_tcp_nodelay() {
         let src = include_str!("main.rs");
         let production = src
-            .split("\n#[cfg(test)]\nmod tests {")
+            .split("\n#[cfg(test)]\nmod ")
             .next()
             .expect("production half");
+        // Spelled out at the call site rather than imported, so this
+        // probe sees every listener. (`use axum_server::…` in production
+        // would hide one from it.)
+        assert!(
+            !production.contains("use axum_server::"),
+            "importing the listener constructor hides the site from this \
+             check; call it as `axum_server::from_tcp…` instead",
+        );
         let lines: Vec<&str> = production.lines().collect();
 
         let mut sites = 0;
         let mut offenders = Vec::new();
         for (n, line) in lines.iter().enumerate() {
-            if !line.contains("axum_server::from_tcp") {
+            if !(line.contains("axum_server::from_tcp") || line.contains("axum_server::bind")) {
                 continue;
             }
             sites += 1;
@@ -2352,14 +2372,23 @@ models:
             // formatter keeps within the next two lines.
             let statement = lines[n..(n + 3).min(lines.len())].join(" ");
             if !statement.contains("DOWNSTREAM_NODELAY") {
-                offenders.push(format!("main.rs:{}", n + 1));
+                offenders.push(format!("main.rs:{}: no TCP_NODELAY acceptor", n + 1));
+            } else if line.contains("_rustls") && !statement.contains(".map(") {
+                offenders.push(format!(
+                    "main.rs:{}: TLS listener must slot the acceptor under rustls with \
+                     `.map(|tls| tls.acceptor(DOWNSTREAM_NODELAY))`; `.acceptor(..)` \
+                     replaces the rustls acceptor and serves plaintext",
+                    n + 1
+                ));
             }
         }
 
         assert!(
             sites >= 4,
             "found {sites} listener construction sites, expected at least 4 — \
-             the probe no longer matches the code and this test proves nothing",
+             the probe no longer matches the code and this test proves nothing. \
+             If the listeners were deliberately consolidated, lower this count \
+             on purpose",
         );
         assert!(
             offenders.is_empty(),

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -1480,6 +1480,21 @@ fn background_check_interval(snapshot: &aisix_core::AisixSnapshot) -> std::time:
 /// Completes when the process receives SIGINT or SIGTERM (best-effort on
 /// Windows — Ctrl+C only) OR when another part of the system has already
 /// flipped the cancel channel.
+/// Set on every connection the gateway accepts from a client.
+///
+/// Nagle's algorithm holds a small write back until the previous one has
+/// been acknowledged. A buffered answer leaves as one write and never
+/// notices — which is why this is invisible in a throughput benchmark —
+/// but a streamed one writes a frame at a time, and a frame that lands
+/// while an earlier one is still unacknowledged waits out the client's
+/// delayed ACK (up to 40ms on Linux) before it leaves the box. That is a
+/// latency tax on exactly the responses users watch arrive.
+///
+/// `axum_server` accepts with the option off, and the gateway had never
+/// turned it on. reqwest already sets it on the upstream side.
+const DOWNSTREAM_NODELAY: axum_server::accept::NoDelayAcceptor =
+    axum_server::accept::NoDelayAcceptor;
+
 /// Serve `router` on `addr`, choosing HTTPS when `tls` is configured and
 /// plain HTTP otherwise. Both variants honour the shared `cancel` watch for
 /// graceful shutdown so the proxy/admin surfaces stop in lockstep with the
@@ -1556,13 +1571,17 @@ async fn serve_http(
     match tls_config {
         None => {
             tracing::info!(%addr, label, "aisix listening (http)");
-            let mut server = axum_server::from_tcp(listener).handle(handle);
+            let mut server = axum_server::from_tcp(listener)
+                .acceptor(DOWNSTREAM_NODELAY)
+                .handle(handle);
             apply_idle_timeout(server.http_builder(), idle_timeout);
             server.serve(make_service).await?;
         }
         Some(tls_config) => {
             tracing::info!(%addr, label, "aisix listening (https)");
-            let mut server = axum_server::from_tcp_rustls(listener, tls_config).handle(handle);
+            let mut server = axum_server::from_tcp_rustls(listener, tls_config)
+                .map(|tls| tls.acceptor(DOWNSTREAM_NODELAY))
+                .handle(handle);
             apply_idle_timeout(server.http_builder(), idle_timeout);
             server.serve(make_service).await?;
         }
@@ -1737,13 +1756,17 @@ fn run_tpc_worker(
         match tls_config {
             None => {
                 tracing::info!(%addr, label, worker, "aisix listening (http, thread-per-core)");
-                let mut server = axum_server::from_tcp(listener).handle(handle);
+                let mut server = axum_server::from_tcp(listener)
+                    .acceptor(DOWNSTREAM_NODELAY)
+                    .handle(handle);
                 apply_idle_timeout(server.http_builder(), idle_timeout);
                 server.serve(make_service).await?;
             }
             Some(tls_config) => {
                 tracing::info!(%addr, label, worker, "aisix listening (https, thread-per-core)");
-                let mut server = axum_server::from_tcp_rustls(listener, tls_config).handle(handle);
+                let mut server = axum_server::from_tcp_rustls(listener, tls_config)
+                    .map(|tls| tls.acceptor(DOWNSTREAM_NODELAY))
+                    .handle(handle);
                 apply_idle_timeout(server.http_builder(), idle_timeout);
                 server.serve(make_service).await?;
             }
@@ -2274,6 +2297,75 @@ models:
             bridge.name(),
             "anthropic",
             "specialized 'anthropic' MUST be `AnthropicBridge::new()` (bridge name 'anthropic')",
+        );
+    }
+
+    /// The acceptor has to leave `TCP_NODELAY` set on the socket the
+    /// gateway will write responses to. Asserted against a real accepted
+    /// connection, including that the option is off beforehand — the
+    /// default this exists to change.
+    #[tokio::test]
+    async fn the_downstream_acceptor_sets_tcp_nodelay() {
+        use axum_server::accept::Accept;
+
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let _client = tokio::net::TcpStream::connect(addr).await.expect("connect");
+        let (accepted, _peer) = listener.accept().await.expect("accept");
+
+        assert!(
+            !accepted.nodelay().expect("read nodelay"),
+            "a plain accepted socket is expected to have Nagle on; if the \
+             platform default changed, this test no longer proves anything",
+        );
+        let (accepted, ()) = DOWNSTREAM_NODELAY
+            .accept(accepted, ())
+            .await
+            .expect("accept");
+        assert!(accepted.nodelay().expect("read nodelay"));
+    }
+
+    /// Four listeners are served — HTTP and HTTPS, on the shared runtime
+    /// and on each thread-per-core worker — and a fifth is one config
+    /// surface away. A listener wired without the acceptor fails in the
+    /// way nothing catches: it serves correctly, benchmarks identically,
+    /// and only pays the delayed-ACK tax on streamed responses.
+    #[test]
+    fn every_listener_sets_tcp_nodelay() {
+        let src = include_str!("main.rs");
+        let production = src
+            .split("\n#[cfg(test)]\nmod tests {")
+            .next()
+            .expect("production half");
+        let lines: Vec<&str> = production.lines().collect();
+
+        let mut sites = 0;
+        let mut offenders = Vec::new();
+        for (n, line) in lines.iter().enumerate() {
+            if !line.contains("axum_server::from_tcp") {
+                continue;
+            }
+            sites += 1;
+            // The acceptor is wired in the same statement, which the
+            // formatter keeps within the next two lines.
+            let statement = lines[n..(n + 3).min(lines.len())].join(" ");
+            if !statement.contains("DOWNSTREAM_NODELAY") {
+                offenders.push(format!("main.rs:{}", n + 1));
+            }
+        }
+
+        assert!(
+            sites >= 4,
+            "found {sites} listener construction sites, expected at least 4 — \
+             the probe no longer matches the code and this test proves nothing",
+        );
+        assert!(
+            offenders.is_empty(),
+            "these listeners accept connections with Nagle left on, which \
+             delays streamed response frames; wire `DOWNSTREAM_NODELAY`:\n{}",
+            offenders.join("\n"),
         );
     }
 }


### PR DESCRIPTION
## What

Wires `axum_server`'s `NoDelayAcceptor` into every listener the gateway serves on, so `TCP_NODELAY` is set on each accepted client connection.

Before this, Nagle's algorithm was on for every downstream connection: `axum_server` accepts with the option off and nothing turned it on — `grep -rn nodelay crates/` had no hits anywhere in the tree. reqwest already sets it on the upstream side, so only the client-facing half was affected.

## Why

Nagle holds a small segment back until the previous one has been acknowledged. A short buffered answer leaves in a single segment and never notices. A streamed response writes a frame at a time, and a frame produced while an earlier one is still unacknowledged is held in the kernel until the client's delayed ACK arrives — up to 40ms on Linux. That is a latency tax on exactly the responses a user watches arrive token by token (SSE chat streams, `/v1/messages` streaming, audio streaming).

HTTP/2 control frames (`WINDOW_UPDATE`, `SETTINGS` ACK) and the WebSocket surfaces run on the same accepted socket and inherit the option, so a large h2 upload no longer risks stalling on a held flow-control frame either.

**This is not a throughput claim.** The saturation benchmark drives non-streaming requests whose response fits a single segment, which Nagle never delays; the change is invisible there. No benchmark leg is attached for that reason.

## Scope

All four listener constructions, which is every socket the process accepts on:

- shared-runtime HTTP and HTTPS (`serve_http`) — proxy, admin, and metrics listeners all route through it
- thread-per-core HTTP and HTTPS (`run_tpc_worker`), one per worker

Under TLS the no-delay acceptor is slotted *beneath* the rustls one (`Server::map` + `RustlsAcceptor::acceptor`), so the socket option is set before the handshake rather than after. Wiring it with `Server::acceptor` instead would *replace* the rustls acceptor and serve plaintext on the TLS port — the guard test rejects that form explicitly.

## Tests

- `the_downstream_acceptor_sets_tcp_nodelay` — accepts a real connection, asserts the option is **off** beforehand (so the test cannot pass vacuously) and set afterwards.
- `every_listener_sets_tcp_nodelay` — source guard over the production half of `main.rs`: every listener construction must wire the acceptor, TLS sites must wire it under rustls with `.map`, no `use axum_server::` may hide a site from the probe, and the probe must still match at least four sites. A listener that misses this serves correctly, benchmarks identically, and only pays the tax on streamed responses, so nothing else would catch the drift. Both rules are mutation-verified.
- `cargo test -p aisix-server`: 92 passed.
- e2e vitest, both serving modes: TPC 193 files / 550 passed / 6 skipped, work-stealing 193 files / 550 passed / 6 skipped, no failures.

## Risk

`TCP_NODELAY` disables write coalescing in the kernel: slightly more small packets on streamed responses, in exchange for not waiting on a delayed ACK. It is the standard setting for a proxy (nginx ships `tcp_nodelay on`; reqwest already defaults it on for the upstream half of this same process), and it is applied unconditionally rather than behind a knob for that reason.

One behavior delta worth naming: the acceptor fails a connection if `set_nodelay` errors. On Linux the option has no socket-state precondition and cannot fail; on BSD-family kernels it can report a peer that has already gone away, and such a connection was not answerable regardless.

Source: perf program AISIX-Cloud#1259, todo 3 audit (main table row 12, proposal B).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved network responsiveness for HTTP and HTTPS connections by enabling TCP_NODELAY on accepted sockets.
  * Applied the optimization consistently across all supported server runtime modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->