### PR TITLE
feat(ratelimit): add a Day variant to PolicyWindow

### DIFF
--- a/crates/aisix-core/src/models/rate_limit_policy.rs
+++ b/crates/aisix-core/src/models/rate_limit_policy.rs
@@ -78,6 +78,7 @@ pub enum PolicyWindow {
     Second,
     Minute,
     Hour,
+    Day,
 }
 
 impl PolicyWindow {
@@ -86,6 +87,7 @@ impl PolicyWindow {
             Self::Second => "second",
             Self::Minute => "minute",
             Self::Hour => "hour",
+            Self::Day => "day",
         }
     }
 }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -2813,11 +2813,12 @@ mod tests {
 
     #[test]
     fn rate_limit_policy_rejects_unknown_window() {
+        // "day" graduated into the enum (#771); "week" stays out.
         let v = json!({
             "name": "bad",
             "scope": "team",
             "scope_ref": "x",
-            "window": "day",
+            "window": "week",
             "max_requests": 10
         });
         assert!(validate_rate_limit_policy(&v).is_err());

--- a/crates/aisix-core/tests/resource_schema_characterization.rs
+++ b/crates/aisix-core/tests/resource_schema_characterization.rs
@@ -233,9 +233,14 @@ fn rate_limit_policy_corpus() {
                 json!({"name": "q", "scope": "region", "scope_ref": "t1", "window": "minute", "max_requests": 1}),
             ),
             (
+                "team + day window token quota (#771)",
+                true,
+                json!({"name": "q", "scope": "team", "scope_ref": "t1", "window": "day", "max_tokens": 100}),
+            ),
+            (
                 "unknown window enum",
                 false,
-                json!({"name": "q", "scope": "team", "scope_ref": "t1", "window": "day", "max_requests": 1}),
+                json!({"name": "q", "scope": "team", "scope_ref": "t1", "window": "week", "max_requests": 1}),
             ),
             (
                 "max_requests below minimum (0)",

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -275,6 +275,14 @@ fn classic_rate_limit(policy: &RateLimitPolicy) -> Option<RateLimit> {
                 );
             }
         }
+        PolicyWindow::Day => {
+            // Both counters are native (`token_dims`, `KeyState`, and
+            // the Redis scripts handle `tpd` already) — day is the one
+            // window where a token cap on a team-capable policy was
+            // previously inexpressible (#771).
+            rl.rpd = policy.max_requests;
+            rl.tpd = policy.max_tokens;
+        }
     }
     Some(rl)
 }
@@ -721,6 +729,19 @@ mod tests {
             "hour window MUST NOT populate tpd (would 24× the cap)"
         );
         // tph intentionally deferred — see ai-gateway#396.
+    }
+
+    #[test]
+    fn day_maps_to_rpd_tpd() {
+        // #771: day is the one window whose token counter (`tpd`) is
+        // already native end to end, so both limits wire through.
+        let rl = classic_rate_limit(&make_policy("day", Some(10000), Some(2000000))).unwrap();
+        assert_eq!(rl.rpd, Some(10000));
+        assert_eq!(rl.tpd, Some(2000000));
+        assert!(rl.rpm.is_none());
+        assert!(rl.tpm.is_none());
+        assert!(rl.rps.is_none());
+        assert!(rl.rph.is_none());
     }
 
     #[test]

--- a/schemas/resources/rate_limit_policy.schema.json
+++ b/schemas/resources/rate_limit_policy.schema.json
@@ -236,7 +236,8 @@
       "enum": [
         "second",
         "minute",
-        "hour"
+        "hour",
+        "day"
       ],
       "type": "string"
     },

--- a/tests/e2e/src/cases/ratelimit-day-window-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-day-window-e2e.test.ts
@@ -1,0 +1,193 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  ProxyClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for #771: `window: "day"` on a RateLimitPolicy. Day was the one
+// window whose token counter (`tpd`) is native end to end but that
+// `PolicyWindow` did not offer — so a per-day token quota on a TEAM
+// (the only scope kind policies can target and keys cannot) was
+// inexpressible. Pre-#771 a policy row with `window: "day"` failed enum
+// deserialization and the whole row was dropped, so both cases below
+// answered 200 on every call.
+//
+//   1. team scope × day window × max_tokens: two keys on one team share
+//      the day bucket — the first call commits its usage, the second
+//      key's call is rejected once the pool is exhausted.
+//   2. day window × max_requests maps to the native rpd counter (no
+//      upscaling): the second request inside the same day is 429.
+
+const KEY_A_PLAINTEXT = "sk-day-window-a";
+const KEY_B_PLAINTEXT = "sk-day-window-b";
+const KEY_C_PLAINTEXT = "sk-day-window-c";
+const TEAM_ID = "team-day-e2e";
+
+// Upstream-reported usage per call: 16 tokens > the 10-token day pool,
+// so ONE call exhausts it for the whole team.
+const CHAT_BODY = {
+  id: "chatcmpl-mock",
+  object: "chat.completion",
+  created: 0,
+  model: "gpt-4o-mini",
+  choices: [
+    {
+      index: 0,
+      message: { role: "assistant", content: "hi" },
+      finish_reason: "stop",
+    },
+  ],
+  usage: { prompt_tokens: 8, completion_tokens: 8, total_tokens: 16 },
+};
+
+/** Day buckets roll at UTC midnight; a burst that starts seconds before
+ * it would split across two buckets and the 429 assertions would flap. */
+async function awaitDayWindowHeadroom(headroomSecs = 15): Promise<void> {
+  const secsLeft = 86_400 - (Math.floor(Date.now() / 1000) % 86_400);
+  if (secsLeft >= headroomSecs) return;
+  await new Promise((r) => setTimeout(r, secsLeft * 1000 + 100));
+}
+
+describe("rate limit e2e: day window (#771)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({ nonStreamBody: CHAT_BODY });
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "day-window-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "day-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+
+    // Keys A and B pool on one team; the day-token policy targets it.
+    // (The standalone Admin API accepts team_id directly — the CP writes
+    // it when managed.)
+    for (const [plaintext, user] of [
+      [KEY_A_PLAINTEXT, "user-a"],
+      [KEY_B_PLAINTEXT, "user-b"],
+    ] as const) {
+      await seed.createApiKey({
+        key_hash: createHash("sha256").update(plaintext).digest("hex"),
+        allowed_models: ["day-model"],
+        team_id: TEAM_ID,
+        user_id: user,
+      });
+    }
+    await seed.createRateLimitPolicy({
+      name: "team-day-tokens",
+      scope: "team",
+      scope_ref: TEAM_ID,
+      window: "day",
+      max_tokens: 10,
+    });
+
+    // Key C is teamless; its own day policy caps requests, not tokens.
+    // (api_key scope matches on the resource entry id.)
+    const keyC = await seed.createApiKey({
+      key_hash: createHash("sha256").update(KEY_C_PLAINTEXT).digest("hex"),
+      allowed_models: ["day-model"],
+    });
+    await seed.createRateLimitPolicy({
+      name: "key-day-requests",
+      scope: "api_key",
+      scope_ref: keyC.id,
+      window: "day",
+      max_requests: 1,
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  async function chat(plaintext: string): Promise<Response> {
+    return fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${plaintext}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "day-model",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+  }
+
+  test("team day token pool: one member's usage exhausts it for the next", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    // listModels doesn't consume the budget — a safe readiness probe.
+    const probe = new ProxyClient(app.proxyUrl, KEY_A_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === "day-model");
+    });
+    await awaitDayWindowHeadroom();
+
+    // Key A succeeds and commits 16 tokens against the team's 10/day.
+    const first = await chat(KEY_A_PLAINTEXT);
+    expect(first.status).toBe(200);
+
+    // Key B is a DIFFERENT key on the SAME team: the pool is shared, so
+    // the counter (16 >= 10) rejects it. Pre-#771 the policy row was
+    // dropped at load and this returned 200.
+    const second = await chat(KEY_B_PLAINTEXT);
+    expect(second.status).toBe(429);
+  });
+
+  test("day request cap maps to the native rpd counter", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const probe = new ProxyClient(app.proxyUrl, KEY_C_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      return res.status === 200;
+    });
+    await awaitDayWindowHeadroom();
+
+    const first = await chat(KEY_C_PLAINTEXT);
+    expect(first.status).toBe(200);
+
+    const second = await chat(KEY_C_PLAINTEXT);
+    expect(second.status).toBe(429);
+    // Retry-After stays within one day — above 86400 is a unit
+    // confusion, 0 tells SDKs to hammer.
+    const retryAfter = Number.parseInt(
+      second.headers.get("retry-after") ?? "0",
+      10,
+    );
+    expect(retryAfter).toBeGreaterThan(0);
+    expect(retryAfter).toBeLessThanOrEqual(86_400);
+  });
+});

--- a/tests/e2e/src/cases/ratelimit-day-window-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-day-window-e2e.test.ts
@@ -3,7 +3,6 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
   SeedClient,
-  ProxyClient,
   spawnApp,
   startOpenAiUpstream,
   waitConfigPropagation,
@@ -28,6 +27,7 @@ import {
 const KEY_A_PLAINTEXT = "sk-day-window-a";
 const KEY_B_PLAINTEXT = "sk-day-window-b";
 const KEY_C_PLAINTEXT = "sk-day-window-c";
+const SENTINEL_PLAINTEXT = "sk-day-window-sentinel";
 const TEAM_ID = "team-day-e2e";
 
 // Upstream-reported usage per call: 16 tokens > the 10-token day pool,
@@ -82,6 +82,16 @@ describe("rate limit e2e: day window (#771)", () => {
       provider_key_id: pk.id,
     });
 
+    // The team policy precedes every key so any key authenticating
+    // proves it applied (watch events apply in revision order).
+    await seed.createRateLimitPolicy({
+      name: "team-day-tokens",
+      scope: "team",
+      scope_ref: TEAM_ID,
+      window: "day",
+      max_tokens: 10,
+    });
+
     // Keys A and B pool on one team; the day-token policy targets it.
     // (The standalone Admin API accepts team_id directly — the CP writes
     // it when managed.)
@@ -96,16 +106,10 @@ describe("rate limit e2e: day window (#771)", () => {
         user_id: user,
       });
     }
-    await seed.createRateLimitPolicy({
-      name: "team-day-tokens",
-      scope: "team",
-      scope_ref: TEAM_ID,
-      window: "day",
-      max_tokens: 10,
-    });
 
     // Key C is teamless; its own day policy caps requests, not tokens.
-    // (api_key scope matches on the resource entry id.)
+    // (api_key scope matches on the resource entry id, so the policy
+    // must follow the key.)
     const keyC = await seed.createApiKey({
       key_hash: createHash("sha256").update(KEY_C_PLAINTEXT).digest("hex"),
       allowed_models: ["day-model"],
@@ -116,6 +120,20 @@ describe("rate limit e2e: day window (#771)", () => {
       scope_ref: keyC.id,
       window: "day",
       max_requests: 1,
+    });
+
+    // Readiness sentinel seeded LAST: once it authenticates, every seed
+    // above — both policies included — is live on the DP snapshot.
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update(SENTINEL_PLAINTEXT).digest("hex"),
+      allowed_models: [],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${SENTINEL_PLAINTEXT}` },
+      });
+      await res.text();
+      return res.status === 200;
     });
   });
 
@@ -143,14 +161,7 @@ describe("rate limit e2e: day window (#771)", () => {
       ctx.skip();
       return;
     }
-    // listModels doesn't consume the budget — a safe readiness probe.
-    const probe = new ProxyClient(app.proxyUrl, KEY_A_PLAINTEXT);
-    await waitConfigPropagation(async () => {
-      const res = await probe.listModels();
-      if (res.status !== 200) return false;
-      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
-      return data.some((m) => m.id === "day-model");
-    });
+    // Propagation is gated in beforeAll on the last-seeded sentinel key.
     await awaitDayWindowHeadroom();
 
     // Key A succeeds and commits 16 tokens against the team's 10/day.
@@ -169,11 +180,6 @@ describe("rate limit e2e: day window (#771)", () => {
       ctx.skip();
       return;
     }
-    const probe = new ProxyClient(app.proxyUrl, KEY_C_PLAINTEXT);
-    await waitConfigPropagation(async () => {
-      const res = await probe.listModels();
-      return res.status === 200;
-    });
     await awaitDayWindowHeadroom();
 
     const first = await chat(KEY_C_PLAINTEXT);


### PR DESCRIPTION
## Problem

`RateLimitPolicy` — the only surface that can target a team, member, or team_member — offered `window: second | minute | hour`, with no `day`. The `tpd` counter is already native end to end (`token_dims`, `KeyState`, both Redis Lua scripts), so a per-day token quota worked on a key's own 7-field `rate_limit` but was inexpressible for a team.

## Change

- `PolicyWindow` gains `Day` (`"day"` on the wire; the resource JSON Schema regenerates accordingly).
- `classic_rate_limit` maps it natively: `max_requests → rpd`, `max_tokens → tpd`. No upscaling (the #426 lesson), and — unlike `second`/`hour` — no inert-token warn, because `tpd` is a real counter.

Per-second / per-hour token caps stay excluded (#396 — different counter strategy with a documented correctness reason).

## Tests

- Unit: `day_maps_to_rpd_tpd` pins the native mapping and that nothing leaks into the other window fields; the closed-enum rejection test now uses `"week"` as its unknown example since `"day"` graduated.
- E2E (`ratelimit-day-window-e2e.test.ts`): (1) team scope × day window × `max_tokens` — two keys on one team share the day pool: the first call commits 16 tokens against a 10/day cap, the second key's call is 429; (2) day window × `max_requests` maps to the native rpd counter, with a `Retry-After` ≤ 86400 sanity bound. Both fail on the previous implementation (a `window: "day"` row failed enum deserialization and the whole policy row was dropped, so every call answered 200).

The CP half (cp-admin.yaml `window` enum + `validateRateLimitWindowTokens` `{minute, day}` + dashboard + dpCompatGate entry) follows DP-first in a separate AISIX-Cloud PR.

Fixes #771
