### PR TITLE
[dont merge me!] fix(gateway): stop following upstream redirects on dispatched requests

### DIFF
--- a/crates/aisix-gateway/src/lib.rs
+++ b/crates/aisix-gateway/src/lib.rs
@@ -51,7 +51,7 @@ pub use upstream_headers::{
     RESERVED_UPSTREAM_HEADERS,
 };
 pub use upstream_http::{
-    client_builder, dispatch_client_builder, error_with_causes, transport_error_message,
-    UpstreamHttpConfig,
+    client_builder, dispatch_client_builder, dispatch_client_fallback, error_with_causes,
+    transport_error_message, UpstreamHttpConfig,
 };
 pub use upstream_tls::TlsSettings;

--- a/crates/aisix-gateway/src/lib.rs
+++ b/crates/aisix-gateway/src/lib.rs
@@ -51,6 +51,7 @@ pub use upstream_headers::{
     RESERVED_UPSTREAM_HEADERS,
 };
 pub use upstream_http::{
-    client_builder, error_with_causes, transport_error_message, UpstreamHttpConfig,
+    client_builder, dispatch_client_builder, error_with_causes, transport_error_message,
+    UpstreamHttpConfig,
 };
 pub use upstream_tls::TlsSettings;

--- a/crates/aisix-gateway/src/upstream_http.rs
+++ b/crates/aisix-gateway/src/upstream_http.rs
@@ -173,13 +173,31 @@ pub fn client_builder() -> reqwest::ClientBuilder {
 /// the redirect turns the upstream's 3xx into the 502 the error path
 /// already describes.
 ///
-/// Scoped to inference dispatch on purpose. The other outbound clients
-/// have callers for which a redirect is ordinary — an OpenAPI document
-/// fetched for the MCP surface, a telemetry endpoint behind a rewrite —
-/// and the ones for which it is not (JWKS, OAuth token, A2A) already
-/// refuse it at their own construction site.
+/// The same reasoning covers the guardrail vendors: an inspection call
+/// POSTs the caller's prompt to an operator-configured endpoint under a
+/// vendor credential header (`Ocp-Apim-Subscription-Key`, and the rest),
+/// none of which reqwest strips on a cross-host hop either.
+///
+/// Not applied to every outbound client. The remaining ones either
+/// already refuse redirects at their own construction site (JWKS/OIDC
+/// discovery, MCP OAuth token, MCP OpenAPI tool calls, A2A) or talk to
+/// an operator's own collector, where an endpoint behind a rewrite is
+/// ordinary (telemetry, heartbeat, OTLP export).
 pub fn dispatch_client_builder() -> reqwest::ClientBuilder {
     client_builder().redirect(reqwest::redirect::Policy::none())
+}
+
+/// The client to fall back to when [`dispatch_client_builder`] fails to
+/// build — a malformed deployment CA, say.
+///
+/// The connection settings are lost either way; what must not be lost is
+/// the redirect refusal, which `reqwest::Client::new()` would silently
+/// restore. Builds from a policy alone, which cannot fail.
+pub fn dispatch_client_fallback() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("a client with only a redirect policy always builds")
 }
 
 /// Layer the outbound trust decision onto a builder. Split out so the
@@ -300,6 +318,50 @@ mod tests {
         assert!(client.is_ok(), "{:?}", client.err());
     }
 
+    /// Both dispatch clients hand a 3xx back to the caller instead of
+    /// following it — including the fallback, which is reached when the
+    /// deployment's TLS material fails to apply and which
+    /// `reqwest::Client::new()` would have quietly restored to
+    /// following-by-default.
+    #[tokio::test]
+    async fn dispatch_clients_hand_back_a_redirect_instead_of_following_it() {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let server = std::thread::spawn(move || {
+            for _ in 0..2 {
+                let (mut socket, _) = listener.accept().expect("accept");
+                let mut buf = [0u8; 1024];
+                let _ = socket.read(&mut buf);
+                let _ = socket.write_all(
+                    b"HTTP/1.1 301 Moved Permanently\r\n\
+                      Location: http://127.0.0.1:1/elsewhere\r\n\
+                      Content-Length: 0\r\nConnection: close\r\n\r\n",
+                );
+            }
+        });
+
+        for (label, client) in [
+            (
+                "dispatch_client_builder",
+                dispatch_client_builder().build().expect("builds"),
+            ),
+            ("dispatch_client_fallback", dispatch_client_fallback()),
+        ] {
+            let res = client
+                .post(format!("http://{addr}/v1/chat/completions"))
+                .body("{}")
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("{label}: {e}"));
+            // Following it would have dialed port 1, where nothing
+            // listens, and surfaced as a transport error instead.
+            assert_eq!(res.status(), 301, "{label} followed the redirect");
+        }
+        server.join().expect("server thread");
+    }
+
     /// Every outbound HTTP client in the workspace must be built from
     /// [`client_builder`], or it silently keeps reqwest's defaults — no
     /// connect timeout, TCP keepalive off, and a 90s pooled-connection
@@ -331,9 +393,16 @@ mod tests {
                 if sanctioned_rmcp_site && line.contains("rmcp_reqwest::Client::") {
                     continue;
                 }
-                if line.contains("reqwest::Client::builder()")
-                    || line.contains("reqwest::Client::new()")
-                {
+                // Prose about a constructor is not a call to one.
+                if line.trim_start().starts_with("//") {
+                    continue;
+                }
+                // `Client::new()` unqualified, too: every one of these
+                // files imports the type, and the fallback arm of a
+                // failed build is where a bare client hides
+                // (`.unwrap_or_else(|_| Client::new())` gives back
+                // reqwest's defaults, redirect following included).
+                if line.contains("reqwest::Client::builder()") || line.contains("Client::new()") {
                     offenders.push(format!("{}:{}", file.display(), n + 1));
                 }
             }
@@ -494,53 +563,109 @@ mod tests {
     /// the 502 the error path describes instead of a silent hop to
     /// whatever host the `Location` named.
     ///
-    /// Provider bridges are matched by shape rather than listed, so a new
-    /// vendor crate is covered the day its `bridge.rs` lands; the
-    /// gateway's per-worker and per-ProviderKey pools and the proxy's
-    /// passthrough client are named because they have no shape in common.
+    /// Stated as a whitelist rather than a pattern: **every**
+    /// `client_builder()` site in the workspace either builds a dispatch
+    /// client or is named below. A rule shaped the other way — "files
+    /// that look like a bridge must use the dispatch builder" — passes
+    /// silently for a client put in `src/client.rs`, or in
+    /// `src/bridge/mod.rs`, or in a surface nobody thought of, which is
+    /// how the guardrail clients were missed the first time.
     ///
-    /// Deliberately not every outbound client: an OpenAPI document
-    /// fetched for the MCP surface, or a telemetry endpoint behind a
-    /// rewrite, may legitimately redirect. The outbound clients that must
-    /// not (JWKS, OAuth token, A2A) already refuse at their own site.
+    /// Adding an outbound client therefore forces a decision here, and
+    /// the decision it forces is the safe-by-default one.
     #[test]
-    fn every_dispatch_client_refuses_redirects() {
-        fn is_dispatch_site(path: &std::path::Path) -> bool {
-            let p = path.to_string_lossy().replace('\\', "/");
-            (p.contains("/aisix-provider-") && p.ends_with("/src/bridge.rs"))
-                || p.ends_with("aisix-proxy/src/http_client.rs")
-                || p.ends_with("aisix-gateway/src/upstream_tls.rs")
-        }
+    fn every_outbound_client_is_classified_for_redirects() {
+        /// Sites that build a client from [`client_builder`] and are
+        /// *not* dispatch, with why a redirect there is not the same
+        /// question. Everything else must use
+        /// [`dispatch_client_builder`].
+        const NON_DISPATCH: &[(&str, &str)] = &[
+            (
+                "aisix-mcp/src/oauth.rs",
+                "sets `Policy::none()` itself; an OAuth token endpoint never \
+                 legitimately redirects",
+            ),
+            (
+                "aisix-mcp/src/openapi.rs",
+                "sets `Policy::none()` itself, for the generated tool calls",
+            ),
+            (
+                "aisix-proxy/src/jwt.rs",
+                "sets `Policy::none()` itself; a JWKS endpoint never \
+                 legitimately redirects",
+            ),
+            (
+                "aisix-a2a/src/bridge.rs",
+                "sets `Policy::none()` itself; an A2A agent does not redirect \
+                 its JSON-RPC endpoint",
+            ),
+            (
+                "aisix-obs/src/otlp_http_sink.rs",
+                "the operator's own collector; an endpoint behind a rewrite is \
+                 ordinary and carries no vendor credential of ours",
+            ),
+            (
+                "aisix-server/src/heartbeat.rs",
+                "the control plane the deployment is registered with",
+            ),
+            (
+                "aisix-server/src/telemetry.rs",
+                "the control plane the deployment is registered with",
+            ),
+        ];
 
         let crates_dir = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/.."));
-        let mut sites = 0;
+        let mut dispatch_sites = 0;
+        let mut classified = std::collections::HashSet::new();
         let mut offenders = Vec::new();
-        for file in rust_sources(crates_dir)
-            .into_iter()
-            .filter(|f| is_dispatch_site(f))
-        {
+        for file in rust_sources(crates_dir) {
+            // This module defines both builders.
+            if file.ends_with("upstream_http.rs") {
+                continue;
+            }
+            let path = file.to_string_lossy().replace('\\', "/");
             let src = std::fs::read_to_string(&file).expect("read source");
             for (n, line) in production_half(&src).lines().enumerate() {
-                if !line.contains("client_builder()") {
+                // Prose about the builders is not a call to one.
+                if !line.contains("client_builder()") || line.trim_start().starts_with("//") {
                     continue;
                 }
-                sites += 1;
-                if !line.contains("dispatch_client_builder()") {
+                if line.contains("dispatch_client_builder()") {
+                    dispatch_sites += 1;
+                } else if let Some((named, _why)) =
+                    NON_DISPATCH.iter().find(|(f, _)| path.ends_with(f))
+                {
+                    classified.insert(*named);
+                } else {
                     offenders.push(format!("{}:{}", file.display(), n + 1));
                 }
             }
         }
-        assert!(
-            sites >= 6,
-            "found {sites} dispatch client construction sites, expected at \
-             least 6 — the probe no longer matches the code and this test \
-             proves nothing",
-        );
+
         assert!(
             offenders.is_empty(),
-            "these dispatch a caller's request on a client that follows \
-             redirects; build them from `dispatch_client_builder()`:\n{}",
+            "these build an outbound client that follows redirects. If it \
+             carries a caller's payload or a gateway-held credential, build \
+             it from `dispatch_client_builder()`; if a redirect there is \
+             genuinely ordinary, add it to NON_DISPATCH with the reason:\n{}",
             offenders.join("\n"),
+        );
+        assert!(
+            dispatch_sites >= 13,
+            "found {dispatch_sites} dispatch client construction sites, \
+             expected at least 13 — the probe no longer matches the code and \
+             this test proves nothing",
+        );
+        let stale: Vec<_> = NON_DISPATCH
+            .iter()
+            .map(|(f, _)| *f)
+            .filter(|f| !classified.contains(f))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "these NON_DISPATCH entries no longer match a client_builder() \
+             site; drop them so the list keeps meaning something:\n{}",
+            stale.join("\n"),
         );
     }
 

--- a/crates/aisix-gateway/src/upstream_http.rs
+++ b/crates/aisix-gateway/src/upstream_http.rs
@@ -153,6 +153,35 @@ pub fn client_builder() -> reqwest::ClientBuilder {
     apply_tls(b, &cfg.tls)
 }
 
+/// [`client_builder`] for the clients that carry a caller's request to an
+/// AI provider, which additionally refuse to follow redirects.
+///
+/// reqwest follows up to 10 redirects by default, and the gateway had
+/// never opted out. A provider answering a dispatched POST with a `301`
+/// or `302` therefore made reqwest re-issue it as a `GET` against the
+/// `Location` host and hand back that response as the completion; a `307`
+/// or `308` replayed the prompt body there verbatim. Only
+/// `authorization`, `cookie`, and the proxy-auth headers are dropped when
+/// the hop crosses hosts, so the vendor credential schemes that do not
+/// use `authorization` — Azure's `api-key`, Anthropic's `x-api-key` —
+/// were carried to whatever host the `Location` named.
+///
+/// Nothing in the gateway was written for that: a 3xx from an upstream
+/// collapses to a 502 in `BridgeError`, the access log records the
+/// configured endpoint rather than the one that answered, and an operator
+/// who never configured the redirect target has no way to see it. Refusing
+/// the redirect turns the upstream's 3xx into the 502 the error path
+/// already describes.
+///
+/// Scoped to inference dispatch on purpose. The other outbound clients
+/// have callers for which a redirect is ordinary — an OpenAPI document
+/// fetched for the MCP surface, a telemetry endpoint behind a rewrite —
+/// and the ones for which it is not (JWKS, OAuth token, A2A) already
+/// refuse it at their own construction site.
+pub fn dispatch_client_builder() -> reqwest::ClientBuilder {
+    client_builder().redirect(reqwest::redirect::Policy::none())
+}
+
 /// Layer the outbound trust decision onto a builder. Split out so the
 /// per-ProviderKey clients get byte-for-byte the same treatment as the
 /// shared one.
@@ -456,6 +485,61 @@ mod tests {
             "these dispatch clients present a user agent the per-worker \
              pool would replace with `{}`:\n{}",
             crate::upstream_tls::DISPATCH_USER_AGENT,
+            offenders.join("\n"),
+        );
+    }
+
+    /// A client that carries a caller's request to a provider must be
+    /// built from [`dispatch_client_builder`], so an upstream 3xx becomes
+    /// the 502 the error path describes instead of a silent hop to
+    /// whatever host the `Location` named.
+    ///
+    /// Provider bridges are matched by shape rather than listed, so a new
+    /// vendor crate is covered the day its `bridge.rs` lands; the
+    /// gateway's per-worker and per-ProviderKey pools and the proxy's
+    /// passthrough client are named because they have no shape in common.
+    ///
+    /// Deliberately not every outbound client: an OpenAPI document
+    /// fetched for the MCP surface, or a telemetry endpoint behind a
+    /// rewrite, may legitimately redirect. The outbound clients that must
+    /// not (JWKS, OAuth token, A2A) already refuse at their own site.
+    #[test]
+    fn every_dispatch_client_refuses_redirects() {
+        fn is_dispatch_site(path: &std::path::Path) -> bool {
+            let p = path.to_string_lossy().replace('\\', "/");
+            (p.contains("/aisix-provider-") && p.ends_with("/src/bridge.rs"))
+                || p.ends_with("aisix-proxy/src/http_client.rs")
+                || p.ends_with("aisix-gateway/src/upstream_tls.rs")
+        }
+
+        let crates_dir = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/.."));
+        let mut sites = 0;
+        let mut offenders = Vec::new();
+        for file in rust_sources(crates_dir)
+            .into_iter()
+            .filter(|f| is_dispatch_site(f))
+        {
+            let src = std::fs::read_to_string(&file).expect("read source");
+            for (n, line) in production_half(&src).lines().enumerate() {
+                if !line.contains("client_builder()") {
+                    continue;
+                }
+                sites += 1;
+                if !line.contains("dispatch_client_builder()") {
+                    offenders.push(format!("{}:{}", file.display(), n + 1));
+                }
+            }
+        }
+        assert!(
+            sites >= 6,
+            "found {sites} dispatch client construction sites, expected at \
+             least 6 — the probe no longer matches the code and this test \
+             proves nothing",
+        );
+        assert!(
+            offenders.is_empty(),
+            "these dispatch a caller's request on a client that follows \
+             redirects; build them from `dispatch_client_builder()`:\n{}",
             offenders.join("\n"),
         );
     }

--- a/crates/aisix-gateway/src/upstream_tls.rs
+++ b/crates/aisix-gateway/src/upstream_tls.rs
@@ -257,7 +257,7 @@ fn worker_client() -> Option<reqwest::Client> {
     }
     WORKER_CLIENT.with(|cell| {
         cell.get_or_init(|| {
-            match crate::upstream_http::client_builder()
+            match crate::upstream_http::dispatch_client_builder()
                 .user_agent(DISPATCH_USER_AGENT)
                 .build()
             {
@@ -321,7 +321,8 @@ fn build_provider_key_client(tls: &ProviderKeyTls) -> Result<reqwest::Client, St
     // than replacing them: a deployment CA and a per-key CA are both
     // trust roots, and a client presenting the deployment's mTLS
     // identity must keep presenting it.
-    let mut builder = crate::upstream_http::client_builder().user_agent(PROVIDER_KEY_USER_AGENT);
+    let mut builder =
+        crate::upstream_http::dispatch_client_builder().user_agent(PROVIDER_KEY_USER_AGENT);
     if let Some(pem) = tls.ca_cert.as_ref().filter(|p| !p.trim().is_empty()) {
         let roots = reqwest::Certificate::from_pem_bundle(pem.as_bytes())
             .map_err(|e| format!("provider_key.tls.ca_cert: {e}"))?;

--- a/crates/aisix-guardrails/src/aliyun.rs
+++ b/crates/aisix-guardrails/src/aliyun.rs
@@ -106,7 +106,7 @@ impl AliyunTextModerationGuardrail {
         // Same connection-layer settings as every provider call: a bound
         // connect phase, TCP keepalive on, and pooled connections expired
         // before a hop in front of the guardrail service reaps them.
-        let client = aisix_gateway::client_builder()
+        let client = aisix_gateway::dispatch_client_builder()
             .build()
             .expect("guardrail http client builds");
         let endpoint = cfg

--- a/crates/aisix-guardrails/src/aliyun_ai_guardrail.rs
+++ b/crates/aisix-guardrails/src/aliyun_ai_guardrail.rs
@@ -128,7 +128,7 @@ impl AliyunAiGuardrail {
         // Same connection-layer settings as every provider call: a bound
         // connect phase, TCP keepalive on, and pooled connections expired
         // before a hop in front of the guardrail service reaps them.
-        let client = aisix_gateway::client_builder()
+        let client = aisix_gateway::dispatch_client_builder()
             .build()
             .expect("guardrail http client builds");
         let endpoint = cfg

--- a/crates/aisix-guardrails/src/lakera.rs
+++ b/crates/aisix-guardrails/src/lakera.rs
@@ -101,7 +101,7 @@ impl LakeraGuardrail {
         // Same connection-layer settings as every provider call: a bound
         // connect phase, TCP keepalive on, and pooled connections expired
         // before a hop in front of the guardrail service reaps them.
-        let client = aisix_gateway::client_builder()
+        let client = aisix_gateway::dispatch_client_builder()
             .build()
             .expect("guardrail http client builds");
         Self {

--- a/crates/aisix-guardrails/src/openai_moderation.rs
+++ b/crates/aisix-guardrails/src/openai_moderation.rs
@@ -97,7 +97,7 @@ impl OpenaiModerationGuardrail {
         // Same connection-layer settings as every provider call: a bound
         // connect phase, TCP keepalive on, and pooled connections expired
         // before a hop in front of the guardrail service reaps them.
-        let client = aisix_gateway::client_builder()
+        let client = aisix_gateway::dispatch_client_builder()
             .build()
             .expect("guardrail http client builds");
         Self {

--- a/crates/aisix-guardrails/src/presidio.rs
+++ b/crates/aisix-guardrails/src/presidio.rs
@@ -126,7 +126,7 @@ impl PresidioGuardrail {
         // Same connection-layer settings as every provider call: a bound
         // connect phase, TCP keepalive on, and pooled connections expired
         // before a hop in front of the guardrail service reaps them.
-        let client = aisix_gateway::client_builder()
+        let client = aisix_gateway::dispatch_client_builder()
             .build()
             .expect("guardrail http client builds");
         Self {

--- a/crates/aisix-guardrails/src/prompt_shield.rs
+++ b/crates/aisix-guardrails/src/prompt_shield.rs
@@ -101,7 +101,7 @@ impl PromptShieldGuardrail {
         // Per-call timeout is enforced via tokio::time::timeout in
         // call_api(); the connection layer is the shared one, so a pooled
         // connection expires before a hop in front of the service reaps it.
-        let client = aisix_gateway::client_builder()
+        let client = aisix_gateway::dispatch_client_builder()
             .build()
             .expect("guardrail http client builds");
         Self {

--- a/crates/aisix-guardrails/src/text_moderation.rs
+++ b/crates/aisix-guardrails/src/text_moderation.rs
@@ -100,7 +100,7 @@ impl TextModerationGuardrail {
         // Same connection-layer settings as every provider call: a bound
         // connect phase, TCP keepalive on, and pooled connections expired
         // before a hop in front of the guardrail service reaps them.
-        let client = aisix_gateway::client_builder()
+        let client = aisix_gateway::dispatch_client_builder()
             .build()
             .expect("guardrail http client builds");
         Self {

--- a/crates/aisix-mcp/src/bridge.rs
+++ b/crates/aisix-mcp/src/bridge.rs
@@ -58,7 +58,12 @@ pub const DEFAULT_UPSTREAM_TIMEOUT: Duration = Duration::from_secs(30);
 ///   MCP server behind an enterprise CA is exactly as common as a model
 ///   endpoint behind one, and the PEM has to be re-parsed rather than
 ///   reused because rmcp's `Certificate` is a different crate version's
-///   type than the one `upstream_tls` caches for the workspace line.
+///   type than the one `upstream_tls` caches for the workspace line;
+/// - redirects are refused, as they are on every other client that
+///   carries a caller's payload under a gateway-held credential. A
+///   `tools/call` POSTs the caller's arguments under the MCP server's
+///   `x-api-key` or bearer, and reqwest does not strip either on a hop
+///   to whatever host a `Location` names.
 ///
 /// One client for all MCP upstreams = one shared pool, matching how the
 /// provider bridges share theirs (auth is injected per-request by the
@@ -69,6 +74,7 @@ fn shared_http_client() -> rmcp_reqwest::Client {
         .get_or_init(|| {
             let cfg = aisix_gateway::upstream_http::config();
             let mut b = rmcp_reqwest::Client::builder()
+                .redirect(rmcp_reqwest::redirect::Policy::none())
                 .pool_idle_timeout(cfg.pool_idle_timeout)
                 .tcp_keepalive(cfg.tcp_keepalive);
             if let Some(d) = cfg.connect_timeout {
@@ -112,7 +118,15 @@ fn shared_http_client() -> rmcp_reqwest::Client {
             if !cfg.tls.verify {
                 b = b.danger_accept_invalid_certs(true);
             }
-            b.build().unwrap_or_else(|_| rmcp_reqwest::Client::new())
+            // The connection settings are lost if the build fails; the
+            // redirect refusal must not be, which `Client::new()` would
+            // silently give back.
+            b.build().unwrap_or_else(|_| {
+                rmcp_reqwest::Client::builder()
+                    .redirect(rmcp_reqwest::redirect::Policy::none())
+                    .build()
+                    .expect("a client with only a redirect policy always builds")
+            })
         })
         .clone()
 }

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -81,7 +81,7 @@ fn default_client() -> Client {
     aisix_gateway::dispatch_client_builder()
         .user_agent("aisix/0.1")
         .build()
-        .unwrap_or_else(|_| Client::new())
+        .unwrap_or_else(|_| aisix_gateway::dispatch_client_fallback())
 }
 
 /// Path suffixes the Anthropic bridge appends. If an operator

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -78,7 +78,7 @@ impl Default for AnthropicBridge {
 }
 
 fn default_client() -> Client {
-    aisix_gateway::client_builder()
+    aisix_gateway::dispatch_client_builder()
         .user_agent("aisix/0.1")
         .build()
         .unwrap_or_else(|_| Client::new())

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -186,7 +186,7 @@ impl Default for AzureOpenAiBridge {
 }
 
 fn default_client() -> Client {
-    aisix_gateway::client_builder()
+    aisix_gateway::dispatch_client_builder()
         .user_agent("aisix/0.1")
         .build()
         .unwrap_or_else(|_| Client::new())

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -189,7 +189,7 @@ fn default_client() -> Client {
     aisix_gateway::dispatch_client_builder()
         .user_agent("aisix/0.1")
         .build()
-        .unwrap_or_else(|_| Client::new())
+        .unwrap_or_else(|_| aisix_gateway::dispatch_client_fallback())
 }
 
 /// Parsed Azure upstream reference resolved from a provider_key's

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -162,7 +162,7 @@ fn default_client() -> Client {
     aisix_gateway::dispatch_client_builder()
         .user_agent("aisix/0.1")
         .build()
-        .unwrap_or_else(|_| Client::new())
+        .unwrap_or_else(|_| aisix_gateway::dispatch_client_fallback())
 }
 
 /// Strip a known endpoint suffix from `base`. Idempotent: if no known

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -159,7 +159,7 @@ impl Default for OpenAiBridge {
 }
 
 fn default_client() -> Client {
-    aisix_gateway::client_builder()
+    aisix_gateway::dispatch_client_builder()
         .user_agent("aisix/0.1")
         .build()
         .unwrap_or_else(|_| Client::new())
@@ -911,6 +911,50 @@ mod tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    /// An upstream 3xx has to surface as an upstream status, which the
+    /// proxy renders as a 502 — the behavior `BridgeError::http_status`
+    /// has always described. reqwest follows up to 10 redirects by
+    /// default and the gateway had never opted out, so a redirected POST
+    /// was silently re-issued as a `GET` against the `Location` host
+    /// (RFC 9110 §15.4.2, as tower-http's follow-redirect middleware
+    /// implements it) and that host's answer came back as the completion.
+    ///
+    /// The second assertion is the one that matters: the redirect target
+    /// must never be dialed at all.
+    #[tokio::test]
+    async fn upstream_redirects_are_not_followed() {
+        let elsewhere = MockServer::start().await;
+        mount_ok(&elsewhere).await;
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(301).insert_header(
+                "location",
+                format!("{}/chat/completions", elsewhere.uri()).as_str(),
+            ))
+            .mount(&server)
+            .await;
+
+        let bridge = OpenAiBridge::new();
+        let ctx = sample_ctx(&server.uri());
+        let err = bridge.chat(&req(), &ctx).await.unwrap_err();
+        assert_eq!(
+            err.http_status(),
+            502,
+            "a redirect the gateway does not follow is 502-worthy: {err:?}",
+        );
+        match err {
+            BridgeError::UpstreamStatus { status, .. } => assert_eq!(status, 301),
+            other => panic!("unexpected: {other:?}"),
+        }
+        assert!(
+            elsewhere.received_requests().await.unwrap().is_empty(),
+            "the redirect target was dialed; the request and the key's \
+             credential left for a host the operator never configured",
+        );
     }
 
     /// Audit fix (PR #323): the [`aisix_gateway::MAX_UPSTREAM_ERROR_BODY_BYTES`]

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -277,7 +277,7 @@ fn default_client() -> Client {
     aisix_gateway::dispatch_client_builder()
         .user_agent("aisix/0.1")
         .build()
-        .unwrap_or_else(|_| Client::new())
+        .unwrap_or_else(|_| aisix_gateway::dispatch_client_fallback())
 }
 
 /// The set of Vertex publishers we dispatch to.

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -274,7 +274,7 @@ impl Default for VertexBridge {
 }
 
 fn default_client() -> Client {
-    aisix_gateway::client_builder()
+    aisix_gateway::dispatch_client_builder()
         .user_agent("aisix/0.1")
         .build()
         .unwrap_or_else(|_| Client::new())

--- a/crates/aisix-proxy/src/http_client.rs
+++ b/crates/aisix-proxy/src/http_client.rs
@@ -17,7 +17,7 @@ pub fn client() -> &'static Client {
         aisix_gateway::dispatch_client_builder()
             .user_agent("aisix/0.1")
             .build()
-            .unwrap_or_else(|_| Client::new())
+            .unwrap_or_else(|_| aisix_gateway::dispatch_client_fallback())
     })
 }
 

--- a/crates/aisix-proxy/src/http_client.rs
+++ b/crates/aisix-proxy/src/http_client.rs
@@ -14,7 +14,7 @@ use std::sync::OnceLock;
 pub fn client() -> &'static Client {
     static CLIENT: OnceLock<Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
-        aisix_gateway::client_builder()
+        aisix_gateway::dispatch_client_builder()
             .user_agent("aisix/0.1")
             .build()
             .unwrap_or_else(|_| Client::new())

--- a/tests/e2e/src/cases/upstream-redirect-not-followed-e2e.test.ts
+++ b/tests/e2e/src/cases/upstream-redirect-not-followed-e2e.test.ts
@@ -1,0 +1,149 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server as HttpServer } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: an upstream that answers a dispatched request with a redirect must
+// not be followed.
+//
+// The configured endpoint is the only host an operator has authorised the
+// gateway to send a caller's prompt and the Provider Key's credential to.
+// A redirect names a different one, chosen by the upstream at request
+// time, and nothing on the caller's side — status, body, or access log —
+// would say the answer came from somewhere else.
+//
+// The scenario: the configured endpoint answers `301` with a `Location`
+// pointing at a second, perfectly healthy OpenAI-shaped upstream. If the
+// gateway follows, the caller gets that second host's completion and the
+// call looks entirely successful. It must instead fail the request as a
+// bad gateway, and the second host must never be dialed.
+
+const CALLER_PLAINTEXT = "sk-redirect-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+describe("upstream redirects are not followed", () => {
+  let app: SpawnedApp | undefined;
+  let elsewhere: OpenAiUpstream | undefined;
+  let redirector: HttpServer | undefined;
+  let redirectorHits = 0;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    // The host the redirect points at: a healthy upstream that would
+    // happily answer, so following the redirect produces a *success*
+    // rather than an error — the failure mode that hides itself.
+    elsewhere = await startOpenAiUpstream();
+
+    const location = `${elsewhere.baseUrl}/v1/chat/completions`;
+    redirector = createServer((req, res) => {
+      redirectorHits += 1;
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(301, { location });
+        res.end();
+      });
+    });
+    await new Promise<void>((resolve) =>
+      redirector!.listen(0, "127.0.0.1", resolve),
+    );
+    const address = redirector.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("redirecting upstream: no listen address");
+    }
+
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "redirect-pk",
+      secret: "sk-mock-redirect",
+      api_base: `http://127.0.0.1:${address.port}/v1`,
+    });
+    await seed.createModel({
+      display_name: "redirect-gpt",
+      provider: "openai",
+      model_name: "gpt-4o",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["redirect-gpt"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await elsewhere?.close();
+    await new Promise<void>((resolve) =>
+      redirector ? redirector.close(() => resolve()) : resolve(),
+    );
+  });
+
+  test("a 301 from the configured endpoint fails the call instead of hopping", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(async () => {
+      try {
+        const models = await fetch(`${app!.proxyUrl}/v1/models`, {
+          headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+        });
+        if (models.status !== 200) return false;
+        const ids =
+          ((await models.json()) as { data?: Array<{ id?: string }> }).data?.map(
+            (m) => m.id,
+          ) ?? [];
+        return ids.includes("redirect-gpt");
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      },
+      body: JSON.stringify({
+        model: "redirect-gpt",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    const body = (await res.json()) as {
+      error?: { message?: string; type?: string };
+      choices?: unknown[];
+    };
+
+    // The upstream gave the gateway nothing it can answer with, which is
+    // what a bad gateway is.
+    expect(res.status, JSON.stringify(body)).toBe(502);
+    expect(body.error, JSON.stringify(body)).toBeDefined();
+    expect(body.choices).toBeUndefined();
+
+    // The point of the case: the prompt and the key's credential never
+    // left for the host the operator did not configure.
+    expect(redirectorHits).toBeGreaterThan(0);
+    expect(
+      elsewhere!.receivedRequests.map((r) => `${r.method} ${r.path}`),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Every client that carries a caller's request to an AI provider is now built from `dispatch_client_builder()` — `client_builder()` plus `redirect(Policy::none())`. An upstream that answers a dispatched request with a 3xx now surfaces as an upstream status instead of being obeyed.

## Why

reqwest follows up to 10 redirects by default and the gateway had never opted out. The error path was written as if it had: `BridgeError::http_status` collapses an upstream 3xx to 502, with the comment *"redirects we don't follow are 502-worthy"* (`crates/aisix-gateway/src/bridge.rs`). The gateway did follow them.

What a followed redirect actually did, per the follow-redirect middleware reqwest 0.12 installs unconditionally (`tower-http-0.6.8/src/follow_redirect/mod.rs:272-290`, implementing RFC 9110 §15.4):

| upstream answers | what the gateway then did |
|---|---|
| `301` / `302` on a POST | rewrote the method to `GET`, dropped the body and the payload headers, and returned the redirect host's answer to that bodyless GET as the completion |
| `303` | same, for any method |
| `307` / `308` | replayed the request body verbatim to the redirect host |

Credential handling makes it worse: `remove_sensitive_headers` (`reqwest-0.12.28/src/redirect.rs:239-250`) strips only `authorization`, `cookie`, `cookie2`, `proxy-authorization`, and `www-authenticate` when the hop crosses hosts. The vendor schemes that do not use `authorization` — Azure's `api-key`, Anthropic's `x-api-key` — travelled to whatever host the `Location` named. And none of it is visible: the access log records the configured endpoint, not the one that answered.

The regression test demonstrates the old behavior exactly. Reverting the one-line builder change makes it fail with `UpstreamStatus { status: 404 }` — the redirect target's answer to a GET it has no route for, returned to the caller as if the configured provider had said it.

## Behavior change (for release notes)

An upstream 3xx on a dispatched request now fails the call with **502** instead of silently following the redirect. AI provider APIs do not redirect POSTed inference calls, so no working deployment should notice; a deployment that had been *relying* on an endpoint redirect (for example an `api_base` pointing at a host that 301s to the real one) will now fail, and the fix is to configure the final URL in the Provider Key's `api_base`.

## Scope

Applied to the clients that dispatch a caller's request:

- the four provider bridges (`openai`, `anthropic`, `azure-openai`, `vertex`)
- the proxy's passthrough client (`/v1/messages`, `/v1/responses`, `count_tokens`, rerank, audio, videos, the jobs surface, the raw tunnel)
- the gateway's per-worker pool and per-ProviderKey TLS-override pool

Deliberately **not** a global default on `client_builder()`. Some outbound clients have callers for which a redirect is ordinary — an OpenAPI document fetched for the MCP surface, a telemetry endpoint behind a rewrite. The outbound clients that must not follow one (JWKS/OIDC discovery, MCP OAuth token, A2A) already refuse at their own construction site, for the same reason.

Bedrock dispatches on the AWS SDK's own hyper client, not reqwest, and is unaffected by this setting.

## Not a performance change

reqwest parses the next URL *before* it consults the policy (`redirect.rs:310` parses `attempt.location()`, then `policy.check(...)`), so refusing redirects saves no per-request CPU. The audit that found this (AISIX-Cloud#1259 todo 3, main table row 9) measured the redirect layer at ~2.25µs/request and concluded it is not recoverable from the application side. Nothing in this PR is expected to move a benchmark.

## Tests

- `upstream_redirects_are_not_followed` (openai bridge) — a `301` whose `Location` points at a second, healthy OpenAI-shaped upstream. Asserts the call fails 502 **and** that the second host is never dialed. Mutation-verified: with the old builder the test fails, and fails by returning the other host's response.
- `every_dispatch_client_refuses_redirects` (source guard) — every dispatch client must be built from `dispatch_client_builder()`. Provider bridges are matched by *shape* (`aisix-provider-*/src/bridge.rs`), so a new vendor crate is covered the day it lands; the gateway pools and the proxy passthrough client are named. Asserts the probe still finds at least six sites so it cannot pass vacuously.
- e2e `upstream-redirect-not-followed-e2e` — drives a real `/v1/chat/completions` through the gateway against a mock upstream that 301s to a healthy second upstream; asserts 502, no `choices`, and zero requests on the redirect target.
- `cargo test --workspace --no-fail-fast`: all green except `aisix-mcp connect_timeout_bounds_an_unreachable_upstream`, which fails identically on unmodified `main` in this sandbox (dial behavior under the local network policy; not reachable from this change, which does not touch the MCP client).
- e2e both serving modes: TPC 194 files / 551 passed; work-stealing 194 files, one file failed on an `etcd put` 503 timeout and passed 12/12 on rerun (known harness flake, not a product failure).

Source: perf program AISIX-Cloud#1259, todo 3 audit (main table row 9, proposal C).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upstream HTTP requests now refuse redirects instead of following them.
  * Redirect behavior is consistently enforced across providers, MCP connections, guardrails, and proxy requests.
  * Requests that encounter redirects now return an appropriate upstream error without contacting the redirect destination.

* **Tests**
  * Added coverage for redirect handling, fallback behavior, and end-to-end gateway scenarios.
  * Added safeguards to detect outbound clients that do not use the standard redirect policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->