### PR TITLE
perf(gateway): cache endpoint URLs on the A2A, Vertex and Azure bridges

### DIFF
--- a/crates/aisix-a2a/src/bridge.rs
+++ b/crates/aisix-a2a/src/bridge.rs
@@ -278,6 +278,10 @@ pub trait A2aBridge: Send + Sync {
 #[derive(Debug)]
 pub struct HttpBridge {
     upstream: A2aUpstream,
+    /// The agent's JSON-RPC endpoint, parsed once process-wide instead of
+    /// by reqwest on every call. A bridge is built per request, so this
+    /// is one cache lookup per request in place of one `Url` parse.
+    endpoint: aisix_gateway::url_cache::EndpointUrl,
     client: reqwest::Client,
 }
 
@@ -287,6 +291,7 @@ impl HttpBridge {
     /// per-request, so a shared client does not lose the per-agent deadline.
     pub fn new(upstream: A2aUpstream) -> Self {
         Self {
+            endpoint: aisix_gateway::url_cache::cached_url(&upstream.url),
             upstream,
             client: shared_client(),
         }
@@ -402,8 +407,9 @@ impl A2aBridge for HttpBridge {
     async fn send(&self, request: &serde_json::Value) -> Result<serde_json::Value, A2aError> {
         let resp = self
             .prepare(
-                self.client
-                    .post(&self.upstream.url)
+                self.endpoint
+                    .clone()
+                    .post_on(&self.client)
                     .timeout(self.upstream.timeout)
                     .json(request),
             )
@@ -438,8 +444,9 @@ impl A2aBridge for HttpBridge {
         let resp = tokio::time::timeout(
             self.upstream.timeout,
             self.prepare(
-                self.client
-                    .post(&self.upstream.url)
+                self.endpoint
+                    .clone()
+                    .post_on(&self.client)
                     .header(reqwest::header::ACCEPT, SSE_CONTENT_TYPE)
                     .json(request),
             )

--- a/crates/aisix-a2a/src/bridge.rs
+++ b/crates/aisix-a2a/src/bridge.rs
@@ -324,8 +324,19 @@ impl HttpBridge {
     /// A registered URL that is already at the origin yields the origin
     /// candidates alone — the two bases coincide and probing twice is waste.
     fn agent_card_urls(&self) -> Result<Vec<reqwest::Url>, A2aError> {
-        let base = reqwest::Url::parse(&self.upstream.url)
-            .map_err(|e| A2aError::Connect(format!("invalid upstream url: {e}")))?;
+        // The same parse the POST path uses, so card discovery and the
+        // JSON-RPC call can never disagree about the agent's endpoint.
+        let base = match &self.endpoint {
+            aisix_gateway::url_cache::EndpointUrl::Parsed(url) => url.clone(),
+            aisix_gateway::url_cache::EndpointUrl::Unparsed(raw) => {
+                // `Unparsed` means the parse already failed; re-run it
+                // only to render the same message this returned before.
+                let cause = reqwest::Url::parse(raw)
+                    .err()
+                    .map_or_else(|| "not a valid URL".to_string(), |e| e.to_string());
+                return Err(A2aError::Connect(format!("invalid upstream url: {cause}")));
+            }
+        };
         let prefix = base.path().trim_end_matches('/').to_string();
         let mut urls = Vec::with_capacity(AGENT_CARD_PATHS.len() * 2);
         for path in AGENT_CARD_PATHS {

--- a/crates/aisix-gateway/src/url_cache.rs
+++ b/crates/aisix-gateway/src/url_cache.rs
@@ -151,6 +151,34 @@ thread_local! {
         const { std::cell::RefCell::new(String::new()) };
 }
 
+/// Parse `raw` once, for a caller whose URL *is* a configured string with
+/// nothing derived from the request — an A2A agent's JSON-RPC endpoint.
+///
+/// No resource id and no fingerprint: the string is its own identity, so
+/// an edited agent simply lands on a different row and a renamed or
+/// deleted one leaves a dead row behind, bounded by [`MAX_PARSED_URLS`].
+/// Callers whose URL is *built* from configuration want
+/// [`cached_endpoint_url`] instead, which revalidates against the inputs.
+pub fn cached_url(raw: &str) -> EndpointUrl {
+    static PARSED: OnceLock<DashMap<Box<str>, Url>> = OnceLock::new();
+    let cache = PARSED.get_or_init(DashMap::new);
+    if let Some(hit) = cache.get(raw) {
+        return EndpointUrl::Parsed(hit.clone());
+    }
+    let Ok(url) = Url::parse(raw) else {
+        return EndpointUrl::Unparsed(raw.to_string());
+    };
+    if cache.len() >= MAX_PARSED_URLS {
+        cache.clear();
+    }
+    cache.insert(Box::from(raw), url.clone());
+    EndpointUrl::Parsed(url)
+}
+
+/// Upper bound on [`cached_url`] rows, on the same reasoning as
+/// [`MAX_RESOURCES`].
+const MAX_PARSED_URLS: usize = 8192;
+
 /// This resource's rows, creating them on first sight. `None` means the
 /// caller passed no id and wants the cache bypassed.
 fn rows_for(resource_id: &str) -> Option<Arc<EndpointRows>> {

--- a/crates/aisix-gateway/src/url_cache.rs
+++ b/crates/aisix-gateway/src/url_cache.rs
@@ -1,43 +1,70 @@
-//! Per-ProviderKey cache of parsed upstream endpoint URLs.
+//! Per-resource cache of parsed upstream endpoint URLs.
 //!
 //! Every bridge dispatch used to rebuild its endpoint URL per request —
 //! base resolution (trim + suffix scan + allocation), a `format!`, and a
 //! full `Url` parse inside reqwest's `IntoUrl` when the request builder
-//! receives a string. The URL is a pure function of the ProviderKey's
+//! receives a string. The URL is a pure function of the owning resource's
 //! configuration and the endpoint, so it is parsed once here and handed
 //! back as a cloned `Url` — which reqwest accepts by value without
 //! re-parsing.
 //!
-//! Correctness model: a cached row stores the *fingerprint* of the
-//! inputs the URL was built from (the raw `api_base` plus a per-bridge
-//! second component such as the vendor or the Azure deployment). A hit
-//! whose fingerprint differs from the caller's current inputs rebuilds,
-//! so an edited ProviderKey takes effect on the next request with no
-//! invalidation hook. A ProviderKey id names one etcd resource, so a
-//! deleted-and-recreated key either reuses the id (fingerprint decides)
-//! or leaves a dead row behind (bounded by [`MAX_PROVIDER_KEYS`]).
+//! Correctness model: a cached row stores the *fingerprint* of the inputs
+//! the URL was built from (the raw `api_base` plus whatever else the
+//! bridge derives the URL from). A hit whose fingerprint differs from the
+//! caller's current inputs rebuilds, so an edited resource takes effect on
+//! the next request with no invalidation hook. A resource id names one
+//! etcd resource, so a deleted-and-recreated resource either reuses the id
+//! (fingerprint decides) or leaves a dead row behind (bounded by
+//! [`MAX_RESOURCES`]).
+//!
+//! Two row shapes, because two kinds of URL exist:
+//!
+//! - **Per endpoint** ([`cached_endpoint_url`]) — the URL depends only on
+//!   the resource's configuration. One row per endpoint.
+//! - **Per endpoint and upstream model** ([`cached_model_endpoint_url`]) —
+//!   the URL embeds the upstream model id, as the Vertex model path and the
+//!   Azure deployment segment do. These *must* use the model-keyed form:
+//!   folding the model into the fingerprint instead would give one row per
+//!   endpoint that every model in turn invalidates, so a key serving more
+//!   than one model would miss and rebuild on every request — worse than
+//!   not caching at all.
 
 use dashmap::DashMap;
 use reqwest::Url;
 use std::sync::{Arc, OnceLock};
 
-/// Outer map: ProviderKey id → that key's endpoint URLs. Two levels so
+/// Outer map: resource id → that resource's endpoint URLs. Two levels so
 /// the hit path looks up by `&str` (no per-request key allocation).
-type Cache = DashMap<String, Arc<DashMap<&'static str, CachedUrl>>>;
+type Cache = DashMap<String, Arc<EndpointRows>>;
+
+/// One resource's rows, keyed by the endpoint literal or, for
+/// model-dependent URLs, by `endpoint \x1f upstream_model`.
+type EndpointRows = DashMap<Box<str>, CachedUrl>;
 
 static URL_CACHE: OnceLock<Cache> = OnceLock::new();
 
 struct CachedUrl {
     /// The inputs this URL was built from; compared on every hit.
-    fingerprint: (String, String),
+    fingerprint: Box<[Box<str>]>,
     url: Url,
 }
 
-/// Upper bound on distinct ProviderKey ids the cache will hold. Rows for
-/// deleted keys are never individually evicted (matching the TLS client
-/// cache's model); this cap turns unbounded admin-churn growth into a
-/// full reset, after which live keys re-parse once each.
-const MAX_PROVIDER_KEYS: usize = 8192;
+/// Joins the endpoint and the upstream model into one row key. A control
+/// byte no upstream model id contains, so two (endpoint, model) pairs
+/// cannot collide on one row; a model that does contain it skips the
+/// cache rather than risk aliasing.
+const KEY_SEP: char = '\x1f';
+
+/// Upper bound on distinct resource ids the cache will hold. Rows for
+/// deleted resources are never individually evicted (matching the TLS
+/// client cache's model); this cap turns unbounded admin-churn growth
+/// into a full reset, after which live resources re-parse once each.
+const MAX_RESOURCES: usize = 8192;
+
+/// Upper bound on rows for one resource. Endpoints are a fixed literal
+/// set, but the model-keyed rows scale with the models configured against
+/// one Provider Key, so this bounds the worst case the same way.
+const MAX_ROWS_PER_RESOURCE: usize = 1024;
 
 /// A ready-to-post endpoint URL.
 #[derive(Clone, Debug)]
@@ -61,51 +88,96 @@ impl EndpointUrl {
     }
 }
 
-/// Resolve the parsed URL for (`provider_key_id`, `endpoint`), building
-/// it with `build` only on the first request or after the key's
+/// Resolve the parsed URL for (`resource_id`, `endpoint`), building it
+/// with `build` only on the first request or after the resource's
 /// configuration changed.
 ///
 /// - `endpoint` must be a bridge-namespaced literal (e.g.
-///   `"openai/chat"`) so two bridges can never collide on one key.
-/// - `fingerprint` is the pair of raw inputs the URL is derived from;
-///   pass every input that can change the result (`api_base` and, where
-///   applicable, vendor or deployment).
-/// - An empty `provider_key_id` (contexts built without snapshot ids,
-///   e.g. tests) bypasses the cache entirely.
+///   `"openai/chat"`) so two bridges can never collide on one resource.
+/// - `fingerprint` is every raw input the URL is derived from — the
+///   `api_base` and, where applicable, the vendor, the project, the
+///   region. An input left out is an edit the cache will not notice.
+/// - An empty `resource_id` (contexts built without snapshot ids, e.g.
+///   tests) bypasses the cache entirely.
 /// - `build` errors pass through untouched; nothing is cached on error.
 pub fn cached_endpoint_url<E>(
-    provider_key_id: &str,
+    resource_id: &str,
     endpoint: &'static str,
-    fingerprint: (&str, &str),
+    fingerprint: &[&str],
     build: impl FnOnce() -> Result<String, E>,
 ) -> Result<EndpointUrl, E> {
-    if provider_key_id.is_empty() {
+    let Some(rows) = rows_for(resource_id) else {
         return Ok(parse_or_raw(build()?));
-    }
-    let cache = URL_CACHE.get_or_init(DashMap::new);
-
-    // Clone the inner Arc out of the outer guard so no outer shard lock
-    // is held while reading, building, or parsing.
-    let known = cache.get(provider_key_id).map(|g| Arc::clone(&g));
-    let per_key = match known {
-        Some(per_key) => per_key,
-        None => {
-            // First sighting of this key: bound the outer map before
-            // inserting. `len()` walks shards, but only key-creation
-            // (admin-rate) pays it.
-            if cache.len() >= MAX_PROVIDER_KEYS {
-                cache.clear();
-            }
-            cache
-                .entry(provider_key_id.to_string())
-                .or_insert_with(|| Arc::new(DashMap::new()))
-                .clone()
-        }
     };
-    build_into(&per_key, endpoint, fingerprint, build)
+    resolve(&rows, endpoint, fingerprint, build)
 }
 
-/// Parse without caching (empty-id bypass path).
+/// [`cached_endpoint_url`] for a URL that also embeds the request's
+/// upstream model id — a Vertex `publishers/…/models/<model>:method`
+/// path, an Azure `deployments/<deployment>/…` segment.
+///
+/// `upstream_model` is the operator-configured upstream id
+/// (`model.model_name`), not a caller-supplied string, so the row set is
+/// bounded by the configuration rather than by traffic.
+pub fn cached_model_endpoint_url<E>(
+    resource_id: &str,
+    endpoint: &'static str,
+    upstream_model: &str,
+    fingerprint: &[&str],
+    build: impl FnOnce() -> Result<String, E>,
+) -> Result<EndpointUrl, E> {
+    let Some(rows) = rows_for(resource_id) else {
+        return Ok(parse_or_raw(build()?));
+    };
+    if upstream_model.contains(KEY_SEP) {
+        // Cannot be keyed without risking a collision with another
+        // (endpoint, model) pair. Same URL, uncached.
+        return Ok(parse_or_raw(build()?));
+    }
+    ROW_KEY.with(|buf| {
+        let mut buf = buf.borrow_mut();
+        buf.clear();
+        buf.push_str(endpoint);
+        buf.push(KEY_SEP);
+        buf.push_str(upstream_model);
+        resolve(&rows, &buf, fingerprint, build)
+    })
+}
+
+thread_local! {
+    /// Reused row-key buffer, so the model-keyed hit path allocates
+    /// nothing; only a miss allocates the stored `Box<str>`.
+    static ROW_KEY: std::cell::RefCell<String> =
+        const { std::cell::RefCell::new(String::new()) };
+}
+
+/// This resource's rows, creating them on first sight. `None` means the
+/// caller passed no id and wants the cache bypassed.
+fn rows_for(resource_id: &str) -> Option<Arc<EndpointRows>> {
+    if resource_id.is_empty() {
+        return None;
+    }
+    let cache = URL_CACHE.get_or_init(DashMap::new);
+    // Clone the inner Arc out of the outer guard so no outer shard lock
+    // is held while reading, building, or parsing.
+    if let Some(rows) = cache.get(resource_id) {
+        return Some(Arc::clone(&rows));
+    }
+    // First sighting of this resource: bound the outer map before
+    // inserting. `len()` walks shards, but only resource creation
+    // (admin-rate) pays it.
+    if cache.len() >= MAX_RESOURCES {
+        cache.clear();
+    }
+    Some(
+        cache
+            .entry(resource_id.to_string())
+            .or_insert_with(|| Arc::new(DashMap::new()))
+            .clone(),
+    )
+}
+
+/// Parse without caching (bypass paths).
 fn parse_or_raw(raw: String) -> EndpointUrl {
     match Url::parse(&raw) {
         Ok(url) => EndpointUrl::Parsed(url),
@@ -113,29 +185,48 @@ fn parse_or_raw(raw: String) -> EndpointUrl {
     }
 }
 
-/// Hit-check, and on miss build/parse/cache — single-flight per
-/// (key, endpoint): the row's shard guard is held across the build, so
-/// concurrent cold requests (or requests racing a fingerprint change)
-/// serialize and the build closure runs once per transition. The
-/// closure is pure CPU (string assembly), so holding the inner shard
-/// lock across it is bounded and touches no other lock.
-fn build_into<E>(
-    per_key: &DashMap<&'static str, CachedUrl>,
-    endpoint: &'static str,
-    fingerprint: (&str, &str),
+fn fingerprint_matches(stored: &[Box<str>], current: &[&str]) -> bool {
+    stored.len() == current.len() && stored.iter().zip(current).all(|(a, b)| a.as_ref() == *b)
+}
+
+fn own(fingerprint: &[&str]) -> Box<[Box<str>]> {
+    fingerprint.iter().map(|s| Box::from(*s)).collect()
+}
+
+/// Hit-check under a read guard, and on miss build/parse/cache under the
+/// row's write guard — single-flight per row: that guard is held across
+/// the build, so concurrent cold requests (or requests racing a
+/// fingerprint change) serialize and the build closure runs once per
+/// transition. The closure is pure CPU (string assembly), so holding the
+/// shard lock across it is bounded and touches no other lock.
+fn resolve<E>(
+    rows: &EndpointRows,
+    row: &str,
+    fingerprint: &[&str],
     build: impl FnOnce() -> Result<String, E>,
 ) -> Result<EndpointUrl, E> {
-    match per_key.entry(endpoint) {
+    if let Some(hit) = rows.get(row) {
+        if fingerprint_matches(&hit.fingerprint, fingerprint) {
+            return Ok(EndpointUrl::Parsed(hit.url.clone()));
+        }
+    }
+    // Miss or stale row. Bound this resource's rows here, where no guard
+    // is held and where only a row transition (not a hit) pays `len()`.
+    if rows.len() > MAX_ROWS_PER_RESOURCE {
+        rows.clear();
+    }
+    match rows.entry(Box::from(row)) {
         dashmap::mapref::entry::Entry::Occupied(mut occupied) => {
-            let hit = occupied.get();
-            if hit.fingerprint.0 == fingerprint.0 && hit.fingerprint.1 == fingerprint.1 {
-                return Ok(EndpointUrl::Parsed(hit.url.clone()));
+            // Re-checked under the write guard: another thread may have
+            // rebuilt this row since the read above.
+            if fingerprint_matches(&occupied.get().fingerprint, fingerprint) {
+                return Ok(EndpointUrl::Parsed(occupied.get().url.clone()));
             }
             let raw = build()?;
             match Url::parse(&raw) {
                 Ok(url) => {
                     occupied.insert(CachedUrl {
-                        fingerprint: (fingerprint.0.to_string(), fingerprint.1.to_string()),
+                        fingerprint: own(fingerprint),
                         url: url.clone(),
                     });
                     Ok(EndpointUrl::Parsed(url))
@@ -148,7 +239,7 @@ fn build_into<E>(
             match Url::parse(&raw) {
                 Ok(url) => {
                     vacant.insert(CachedUrl {
-                        fingerprint: (fingerprint.0.to_string(), fingerprint.1.to_string()),
+                        fingerprint: own(fingerprint),
                         url: url.clone(),
                     });
                     Ok(EndpointUrl::Parsed(url))
@@ -178,13 +269,13 @@ mod tests {
     #[test]
     fn caches_per_key_and_endpoint_until_fingerprint_changes() {
         let n = AtomicUsize::new(0);
-        let fp = ("https://api.example.com", "vendor-a");
+        let fp = ["https://api.example.com", "vendor-a"];
 
         // First call builds…
         let u1 = cached_endpoint_url(
             "pk-url-1",
             "test/chat",
-            fp,
+            &fp,
             build_counted(&n, "https://api.example.com/v1/chat"),
         )
         .unwrap();
@@ -195,7 +286,7 @@ mod tests {
         let u2 = cached_endpoint_url(
             "pk-url-1",
             "test/chat",
-            fp,
+            &fp,
             build_counted(&n, "https://api.example.com/v1/chat"),
         )
         .unwrap();
@@ -209,7 +300,7 @@ mod tests {
         cached_endpoint_url(
             "pk-url-1",
             "test/embeddings",
-            fp,
+            &fp,
             build_counted(&n, "https://api.example.com/v1/embeddings"),
         )
         .unwrap();
@@ -219,7 +310,7 @@ mod tests {
         let u4 = cached_endpoint_url(
             "pk-url-1",
             "test/chat",
-            ("https://eu.example.com", "vendor-a"),
+            &["https://eu.example.com", "vendor-a"],
             build_counted(&n, "https://eu.example.com/v1/chat"),
         )
         .unwrap();
@@ -228,20 +319,145 @@ mod tests {
             EndpointUrl::Parsed(u) => assert_eq!(u.as_str(), "https://eu.example.com/v1/chat"),
             _ => panic!("expected parsed URL"),
         }
+
+        // A fingerprint that gained a component is a change too — a
+        // prefix comparison would call this a hit.
+        cached_endpoint_url(
+            "pk-url-1",
+            "test/chat",
+            &["https://eu.example.com", "vendor-a", "project-x"],
+            build_counted(&n, "https://eu.example.com/v1/chat"),
+        )
+        .unwrap();
+        assert_eq!(n.load(Ordering::Relaxed), 4);
+    }
+
+    /// The failure the Azure deployment audit found on the first
+    /// version of this cache: when the URL embeds the upstream model,
+    /// one row per endpoint means every model invalidates the previous
+    /// one, so a key serving several models rebuilds on every request.
+    #[test]
+    fn model_keyed_rows_do_not_evict_each_other() {
+        let n = AtomicUsize::new(0);
+        let fp = ["https://vertex.example.com", "proj", "us-central1"];
+
+        for _ in 0..3 {
+            for model in ["gemini-2.0-flash", "gemini-1.5-pro"] {
+                cached_model_endpoint_url(
+                    "pk-vertex-1",
+                    "test/generate",
+                    model,
+                    &fp,
+                    build_counted(&n, &format!("https://vertex.example.com/{model}:generate")),
+                )
+                .unwrap();
+            }
+        }
+        assert_eq!(
+            n.load(Ordering::Relaxed),
+            2,
+            "one build per model, not one per request",
+        );
+
+        // Each model still gets its own URL back.
+        let u = cached_model_endpoint_url(
+            "pk-vertex-1",
+            "test/generate",
+            "gemini-1.5-pro",
+            &fp,
+            build_counted(&n, "https://wrong.example.com/should-not-build"),
+        )
+        .unwrap();
+        match u {
+            EndpointUrl::Parsed(u) => {
+                assert_eq!(
+                    u.as_str(),
+                    "https://vertex.example.com/gemini-1.5-pro:generate"
+                )
+            }
+            _ => panic!("expected parsed URL"),
+        }
+
+        // A model-keyed row and a plain row on the same endpoint name
+        // are distinct rows, not one row two callers fight over.
+        cached_endpoint_url(
+            "pk-vertex-1",
+            "test/generate",
+            &fp,
+            build_counted(&n, "https://vertex.example.com/shim"),
+        )
+        .unwrap();
+        assert_eq!(n.load(Ordering::Relaxed), 3);
+    }
+
+    /// An edited `api_base` has to reach the model-keyed rows too, or a
+    /// re-pointed Provider Key keeps dispatching to the old host for
+    /// every model that was already warm.
+    #[test]
+    fn model_keyed_rows_follow_a_fingerprint_change() {
+        let n = AtomicUsize::new(0);
+        let build = |host: &str| format!("https://{host}/gemini-2.0-flash:generate");
+
+        cached_model_endpoint_url(
+            "pk-vertex-2",
+            "test/generate",
+            "gemini-2.0-flash",
+            &["https://a.example.com", "proj", "us-central1"],
+            build_counted(&n, &build("a.example.com")),
+        )
+        .unwrap();
+        let after_edit = cached_model_endpoint_url(
+            "pk-vertex-2",
+            "test/generate",
+            "gemini-2.0-flash",
+            &["https://b.example.com", "proj", "us-central1"],
+            build_counted(&n, &build("b.example.com")),
+        )
+        .unwrap();
+        assert_eq!(n.load(Ordering::Relaxed), 2);
+        match after_edit {
+            EndpointUrl::Parsed(u) => assert_eq!(u.host_str(), Some("b.example.com")),
+            _ => panic!("expected parsed URL"),
+        }
+    }
+
+    /// A model id carrying the row separator must not be able to answer
+    /// for a different (endpoint, model) pair.
+    #[test]
+    fn a_model_id_containing_the_separator_bypasses_the_cache() {
+        let n = AtomicUsize::new(0);
+        for _ in 0..2 {
+            cached_model_endpoint_url(
+                "pk-sep",
+                "test/generate",
+                "evil\u{1f}other",
+                &["https://x.example.com"],
+                build_counted(&n, "https://x.example.com/evil"),
+            )
+            .unwrap();
+        }
+        assert_eq!(n.load(Ordering::Relaxed), 2, "must not be cached");
     }
 
     #[test]
     fn empty_key_bypasses_cache_and_malformed_url_stays_raw() {
         let n = AtomicUsize::new(0);
         for _ in 0..2 {
-            cached_endpoint_url("", "test/chat", ("b", ""), build_counted(&n, "https://x/y"))
-                .unwrap();
+            cached_endpoint_url("", "test/chat", &["b"], build_counted(&n, "https://x/y")).unwrap();
+            cached_model_endpoint_url(
+                "",
+                "test/chat",
+                "m",
+                &["b"],
+                build_counted(&n, "https://x/y"),
+            )
+            .unwrap();
         }
-        assert_eq!(n.load(Ordering::Relaxed), 2, "empty id must never cache");
+        assert_eq!(n.load(Ordering::Relaxed), 4, "empty id must never cache");
 
         // Malformed URL: handed back raw (reqwest will surface its usual
         // builder error), and never cached.
-        let bad = cached_endpoint_url("pk-url-2", "test/chat", ("b", ""), || {
+        let bad = cached_endpoint_url("pk-url-2", "test/chat", &["b"], || {
             Ok::<_, ()>("not a url".to_string())
         })
         .unwrap();
@@ -249,7 +465,7 @@ mod tests {
             EndpointUrl::Unparsed(raw) => assert_eq!(raw, "not a url"),
             _ => panic!("malformed URL must stay raw"),
         }
-        let again = cached_endpoint_url("pk-url-2", "test/chat", ("b", ""), || {
+        let again = cached_endpoint_url("pk-url-2", "test/chat", &["b"], || {
             Ok::<_, ()>("https://fixed.example.com/v1".to_string())
         })
         .unwrap();
@@ -269,7 +485,7 @@ mod tests {
             for _ in 0..8 {
                 scope.spawn(|| {
                     barrier.wait();
-                    let u = cached_endpoint_url("pk-url-sf", "test/chat", ("b", ""), || {
+                    let u = cached_endpoint_url("pk-url-sf", "test/chat", &["b"], || {
                         n.fetch_add(1, Ordering::Relaxed);
                         Ok::<_, ()>("https://sf.example.com/v1".to_string())
                     })
@@ -284,12 +500,35 @@ mod tests {
     #[test]
     fn build_errors_pass_through_and_cache_nothing() {
         let r: Result<EndpointUrl, &'static str> =
-            cached_endpoint_url("pk-url-3", "test/chat", ("b", ""), || Err("boom"));
+            cached_endpoint_url("pk-url-3", "test/chat", &["b"], || Err("boom"));
         assert_eq!(r.err(), Some("boom"));
-        let ok = cached_endpoint_url("pk-url-3", "test/chat", ("b", ""), || {
+        let ok = cached_endpoint_url("pk-url-3", "test/chat", &["b"], || {
             Ok::<_, &'static str>("https://ok.example.com/v1".to_string())
         })
         .unwrap();
         assert!(matches!(ok, EndpointUrl::Parsed(_)));
+    }
+
+    /// One resource's rows cannot grow without bound: a key configured
+    /// with more models than the cap resets rather than accumulating.
+    #[test]
+    fn rows_for_one_resource_are_bounded() {
+        let n = AtomicUsize::new(0);
+        for i in 0..(MAX_ROWS_PER_RESOURCE + 2) {
+            cached_model_endpoint_url(
+                "pk-bound",
+                "test/generate",
+                &format!("model-{i}"),
+                &["https://x.example.com"],
+                build_counted(&n, "https://x.example.com/m"),
+            )
+            .unwrap();
+        }
+        let rows = rows_for("pk-bound").expect("rows");
+        assert!(
+            rows.len() <= MAX_ROWS_PER_RESOURCE,
+            "rows grew to {} past the {MAX_ROWS_PER_RESOURCE} cap",
+            rows.len(),
+        );
     }
 }

--- a/crates/aisix-gateway/src/url_cache.rs
+++ b/crates/aisix-gateway/src/url_cache.rs
@@ -134,14 +134,19 @@ pub fn cached_model_endpoint_url<E>(
         // (endpoint, model) pair. Same URL, uncached.
         return Ok(parse_or_raw(build()?));
     }
-    ROW_KEY.with(|buf| {
-        let mut buf = buf.borrow_mut();
-        buf.clear();
-        buf.push_str(endpoint);
-        buf.push(KEY_SEP);
-        buf.push_str(upstream_model);
-        resolve(&rows, &buf, fingerprint, build)
-    })
+    // Taken out of the cell rather than borrowed across `resolve`: a
+    // future `build` closure that reaches back into this cache would
+    // otherwise panic on the re-borrow, in the request path. Taking
+    // leaves an empty `String` behind, so a re-entrant call allocates
+    // its own buffer and this one is put back afterwards.
+    let mut buf = ROW_KEY.with(|cell| cell.take());
+    buf.clear();
+    buf.push_str(endpoint);
+    buf.push(KEY_SEP);
+    buf.push_str(upstream_model);
+    let resolved = resolve(&rows, &buf, fingerprint, build);
+    ROW_KEY.with(|cell| cell.replace(buf));
+    resolved
 }
 
 thread_local! {
@@ -240,8 +245,17 @@ fn resolve<E>(
     }
     // Miss or stale row. Bound this resource's rows here, where no guard
     // is held and where only a row transition (not a hit) pays `len()`.
-    if rows.len() > MAX_ROWS_PER_RESOURCE {
-        rows.clear();
+    //
+    // At the cap, serve this row uncached rather than evicting: a
+    // configuration that sits above the cap would otherwise clear every
+    // warm row each time a new one is asked for, so the next round
+    // rebuilds them all and clears again — a permanent 100% miss rate,
+    // plus a `len()` shard walk on every request. That is the exact
+    // failure this cache exists to remove, and it would be worse than
+    // not caching at all. Refusing the new row instead keeps the rows
+    // that are already warm, bounded and monotonic.
+    if rows.len() >= MAX_ROWS_PER_RESOURCE && !rows.contains_key(row) {
+        return Ok(parse_or_raw(build()?));
     }
     match rows.entry(Box::from(row)) {
         dashmap::mapref::entry::Entry::Occupied(mut occupied) => {
@@ -537,12 +551,77 @@ mod tests {
         assert!(matches!(ok, EndpointUrl::Parsed(_)));
     }
 
-    /// One resource's rows cannot grow without bound: a key configured
-    /// with more models than the cap resets rather than accumulating.
+    /// A dispatch site that builds its URL inline and posts the string
+    /// re-parses it on every request — the cost this module exists to
+    /// remove — and nothing else notices: the request succeeds, the
+    /// tests pass, and the site is simply absent from the cache.
+    ///
+    /// The bridges are a family, and #945 shipped with three of them
+    /// unwired for exactly this reason. Posting a `url` variable is the
+    /// shape that regresses, so it is the shape this refuses.
     #[test]
-    fn rows_for_one_resource_are_bounded() {
+    fn no_dispatch_site_posts_an_unparsed_url_variable() {
+        fn rust_sources(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    if path.file_name().is_some_and(|n| n == "target") {
+                        continue;
+                    }
+                    rust_sources(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+
+        let crates_dir = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/.."));
+        let mut files = Vec::new();
+        rust_sources(crates_dir, &mut files);
+        let mut offenders = Vec::new();
+        for file in files {
+            let path = file.to_string_lossy().replace('\\', "/");
+            if !(path.contains("/aisix-provider-") || path.contains("/aisix-proxy/")) {
+                continue;
+            }
+            let src = std::fs::read_to_string(&file).expect("read source");
+            let production = src
+                .split("\n#[cfg(test)]\nmod ")
+                .next()
+                .expect("production half");
+            for (n, line) in production.lines().enumerate() {
+                if line.trim_start().starts_with("//") {
+                    continue;
+                }
+                if line.contains(".post(&url)") || line.contains(".post(url)") {
+                    offenders.push(format!("{}:{}", file.display(), n + 1));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "these dispatch on a URL string, so reqwest re-parses it on \
+             every request; resolve it through `url_cache` and post it \
+             with `EndpointUrl::post_on`:\n{}",
+            offenders.join("\n"),
+        );
+    }
+
+    /// One resource's rows cannot grow without bound — and past the cap
+    /// the rows that are already warm must keep serving.
+    ///
+    /// Evicting instead (clearing the map to make room) turns a
+    /// configuration above the cap into a permanent 100% miss rate: each
+    /// new row wipes the warm ones, the next round rebuilds them all, and
+    /// the round after that wipes them again. That is worse than not
+    /// caching, so the row past the cap is served uncached instead.
+    #[test]
+    fn rows_past_the_cap_are_served_uncached_and_do_not_evict_warm_rows() {
         let n = AtomicUsize::new(0);
-        for i in 0..(MAX_ROWS_PER_RESOURCE + 2) {
+        for i in 0..MAX_ROWS_PER_RESOURCE {
             cached_model_endpoint_url(
                 "pk-bound",
                 "test/generate",
@@ -553,10 +632,40 @@ mod tests {
             .unwrap();
         }
         let rows = rows_for("pk-bound").expect("rows");
-        assert!(
-            rows.len() <= MAX_ROWS_PER_RESOURCE,
-            "rows grew to {} past the {MAX_ROWS_PER_RESOURCE} cap",
+        assert_eq!(rows.len(), MAX_ROWS_PER_RESOURCE);
+        let builds_at_cap = n.load(Ordering::Relaxed);
+
+        // Rows past the cap build every time…
+        for _ in 0..3 {
+            cached_model_endpoint_url(
+                "pk-bound",
+                "test/generate",
+                "one-model-too-many",
+                &["https://x.example.com"],
+                build_counted(&n, "https://x.example.com/m"),
+            )
+            .unwrap();
+        }
+        assert_eq!(n.load(Ordering::Relaxed), builds_at_cap + 3);
+        assert_eq!(
             rows.len(),
+            MAX_ROWS_PER_RESOURCE,
+            "the cap must hold without evicting",
+        );
+
+        // …and the warm rows are still warm.
+        cached_model_endpoint_url(
+            "pk-bound",
+            "test/generate",
+            "model-0",
+            &["https://x.example.com"],
+            build_counted(&n, "https://x.example.com/m"),
+        )
+        .unwrap();
+        assert_eq!(
+            n.load(Ordering::Relaxed),
+            builds_at_cap + 3,
+            "a warm row was evicted to make room for one past the cap",
         );
     }
 }

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -282,10 +282,10 @@ impl Bridge for AnthropicBridge {
         let url = cached_endpoint_url(
             &ctx.provider_key_id,
             "anthropic/messages",
-            (
+            &[
                 ctx.provider_key.api_base.as_deref().unwrap_or(""),
                 &ctx.provider_key.provider,
-            ),
+            ],
             || Ok(format!("{}/v1/messages", resolve_base(ctx)?)),
         )?;
         let client = self.client_for(ctx);
@@ -334,10 +334,10 @@ impl Bridge for AnthropicBridge {
         let url = cached_endpoint_url(
             &ctx.provider_key_id,
             "anthropic/messages",
-            (
+            &[
                 ctx.provider_key.api_base.as_deref().unwrap_or(""),
                 &ctx.provider_key.provider,
-            ),
+            ],
             || Ok(format!("{}/v1/messages", resolve_base(ctx)?)),
         )?;
         let client = self.client_for(ctx);

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -115,12 +115,35 @@ impl AzureOpenAiBridge {
     /// Resolve the URL the bridge will POST to. Returns
     /// `upstream.chat_completions_url()` in production; tests can
     /// override via [`Self::with_url_override`].
-    fn resolve_url(&self, upstream: &AzureUpstreamRef) -> String {
+    ///
+    /// Cached per (Provider Key, deployment): the URL embeds the
+    /// deployment name, so a key fronting several deployments needs a row
+    /// each — keying only by Provider Key would make every deployment
+    /// invalidate the previous one's row and rebuild on every request.
+    /// The fingerprint is the raw `api_base`, the one input
+    /// `AzureUpstreamRef::resolve` derives the rest from; the api-version
+    /// is a pinned constant.
+    fn resolve_url(
+        &self,
+        ctx: &BridgeContext,
+        upstream: &AzureUpstreamRef,
+    ) -> aisix_gateway::url_cache::EndpointUrl {
         #[cfg(test)]
         if let Some(u) = &self.url_override {
-            return u.clone();
+            // Uncached, and handed over as a raw string so reqwest
+            // parses it exactly as it always did: the override exists so
+            // wiremock can stand in for a canonical Azure host, and each
+            // test server is a different port under one `api_base`.
+            return aisix_gateway::url_cache::EndpointUrl::Unparsed(u.clone());
         }
-        upstream.chat_completions_url()
+        aisix_gateway::url_cache::cached_model_endpoint_url(
+            &ctx.provider_key_id,
+            "azure/chat",
+            &upstream.deployment,
+            &[ctx.provider_key.api_base.as_deref().unwrap_or("")],
+            || Ok::<_, std::convert::Infallible>(upstream.chat_completions_url()),
+        )
+        .unwrap_or_else(|never| match never {})
     }
 
     /// Test-only seam: rewrite the POST URL so wiremock can stand
@@ -695,13 +718,13 @@ impl Bridge for AzureOpenAiBridge {
             ctx.provider_key.response.as_ref(),
         )?;
         let headers = build_request_headers(&auth, &ctx.request_id, false, &ctx.header_ctx())?;
-        let url = self.resolve_url(&upstream);
+        let url = self.resolve_url(ctx, &upstream);
         let client = self.client_for(ctx);
         let started = Instant::now();
 
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -747,13 +770,12 @@ impl Bridge for AzureOpenAiBridge {
             ctx.provider_key.response.as_ref(),
         )?;
         let headers = build_request_headers(&auth, &ctx.request_id, true, &ctx.header_ctx())?;
-        let url = self.resolve_url(&upstream);
+        let url = self.resolve_url(ctx, &upstream);
         let client = self.client_for(ctx);
         let started = Instant::now();
 
         let resp = with_deadline(ctx.deadline, started, async move {
-            client
-                .post(&url)
+            url.post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -1313,6 +1313,92 @@ mod tests {
         )
     }
 
+    fn model_for_deployment(deployment: &str) -> Arc<Model> {
+        Arc::new(
+            serde_json::from_value(serde_json::json!({
+                "display_name": "my-azure-gpt4",
+                "provider": "openai",
+                "model_name": deployment,
+                "provider_key_id": "11111111-1111-1111-1111-111111111111",
+            }))
+            .unwrap(),
+        )
+    }
+
+    /// One Provider Key fronting two deployments. The URL embeds the
+    /// deployment name, so the endpoint URL cache has to hold a row per
+    /// deployment: keying it by Provider Key alone makes each deployment
+    /// invalidate the previous one's row — every request a miss, plus a
+    /// window in which a stale row answers with the *other* deployment's
+    /// URL.
+    ///
+    /// Deliberately built without `with_url_override`: that seam bypasses
+    /// the cache, so a test using it proves nothing about this. The
+    /// wiremock URI reaches the same code through
+    /// `AzureUpstreamRef::resolve`'s verbatim-override branch.
+    #[tokio::test]
+    async fn url_cache_holds_a_row_per_deployment() {
+        let server = MockServer::start().await;
+        for deployment in ["gpt4o-prod", "gpt4o-mini"] {
+            Mock::given(method("POST"))
+                .and(path(format!(
+                    "/openai/deployments/{deployment}/chat/completions"
+                )))
+                .and(query_param("api-version", "2024-10-21"))
+                .respond_with(CapturingResponder::default())
+                .expect(3)
+                .mount(&server)
+                .await;
+        }
+
+        let bridge = AzureOpenAiBridge::new();
+        let req = ChatFormat::new("my-azure-gpt4", vec![ChatMessage::user("hi")]);
+        for _ in 0..3 {
+            for deployment in ["gpt4o-prod", "gpt4o-mini"] {
+                let ctx = BridgeContext::new(
+                    "req-azure-1",
+                    model_for_deployment(deployment),
+                    sample_pk(Some(&server.uri())),
+                )
+                .with_resource_ids("m-1", "pk-azure-rows");
+                bridge.chat(&req, &ctx).await.unwrap();
+            }
+        }
+        // Each `.expect(3)` is verified when the server drops; a row
+        // keyed without the deployment cross-serves and fails both.
+    }
+
+    /// An edited `api_base` has to reach the deployment-keyed rows: a
+    /// cached URL that outlives the edit keeps sending the key's
+    /// credential to the host the operator just re-pointed away from.
+    #[tokio::test]
+    async fn url_cache_follows_an_api_base_edit_for_the_same_key_id() {
+        async fn mount(server: &MockServer) {
+            Mock::given(method("POST"))
+                .and(path("/openai/deployments/gpt4o-prod/chat/completions"))
+                .respond_with(CapturingResponder::default())
+                .expect(1)
+                .mount(server)
+                .await;
+        }
+        let first = MockServer::start().await;
+        let second = MockServer::start().await;
+        mount(&first).await;
+        mount(&second).await;
+
+        let bridge = AzureOpenAiBridge::new();
+        let req = ChatFormat::new("my-azure-gpt4", vec![ChatMessage::user("hi")]);
+        for host in [&first, &second] {
+            let ctx = BridgeContext::new(
+                "req-azure-1",
+                model_for_deployment("gpt4o-prod"),
+                sample_pk(Some(&host.uri())),
+            )
+            .with_resource_ids("m-1", "pk-azure-repoint");
+            bridge.chat(&req, &ctx).await.unwrap();
+        }
+    }
+
     #[test]
     fn build_request_headers_uses_api_key_not_bearer() {
         // Critical Azure-vs-OpenAI distinction: the auth header is

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -402,10 +402,10 @@ impl Bridge for OpenAiBridge {
         let url = cached_endpoint_url(
             &ctx.provider_key_id,
             "openai/chat",
-            (
+            &[
                 ctx.provider_key.api_base.as_deref().unwrap_or(""),
                 &ctx.provider_key.provider,
-            ),
+            ],
             || Ok(format!("{}/chat/completions", self.resolve_base(ctx)?)),
         )?;
         let client = self.client_for(ctx);
@@ -455,10 +455,10 @@ impl Bridge for OpenAiBridge {
         let url = cached_endpoint_url(
             &ctx.provider_key_id,
             "openai/embeddings",
-            (
+            &[
                 ctx.provider_key.api_base.as_deref().unwrap_or(""),
                 &ctx.provider_key.provider,
-            ),
+            ],
             || Ok(format!("{}/embeddings", self.resolve_base(ctx)?)),
         )?;
         let client = self.client_for(ctx);
@@ -514,10 +514,10 @@ impl Bridge for OpenAiBridge {
         let url = cached_endpoint_url(
             &ctx.provider_key_id,
             "openai/completions",
-            (
+            &[
                 ctx.provider_key.api_base.as_deref().unwrap_or(""),
                 &ctx.provider_key.provider,
-            ),
+            ],
             || Ok(format!("{}/completions", self.resolve_base(ctx)?)),
         )?;
         let client = self.client_for(ctx);
@@ -571,10 +571,10 @@ impl Bridge for OpenAiBridge {
         let url = cached_endpoint_url(
             &ctx.provider_key_id,
             "openai/images",
-            (
+            &[
                 ctx.provider_key.api_base.as_deref().unwrap_or(""),
                 &ctx.provider_key.provider,
-            ),
+            ],
             || Ok(format!("{}/images/generations", self.resolve_base(ctx)?)),
         )?;
         let client = self.client_for(ctx);
@@ -619,10 +619,10 @@ impl Bridge for OpenAiBridge {
         let url = cached_endpoint_url(
             &ctx.provider_key_id,
             "openai/chat",
-            (
+            &[
                 ctx.provider_key.api_base.as_deref().unwrap_or(""),
                 &ctx.provider_key.provider,
-            ),
+            ],
             || Ok(format!("{}/chat/completions", self.resolve_base(ctx)?)),
         )?;
         let client = self.client_for(ctx);

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -186,6 +186,23 @@ impl VertexBridge {
     /// operator sees an actionable message instead of a silent
     /// fall-through-to-canonical (which is what the original #390 bug
     /// was — exactly what we don't want to bring back).
+    /// The id this request's endpoint URLs are cached under, or `""` to
+    /// bypass the cache.
+    ///
+    /// The test-only `api_base_override` shadows `provider_key.api_base`
+    /// inside [`Self::resolve_api_base`] without being one of the
+    /// fingerprint inputs, so a row built under one override could answer
+    /// under another — a wiremock port belonging to a server an earlier
+    /// test already dropped. Bypassing keeps the seam invisible to the
+    /// cache, the way the Azure bridge's URL override does.
+    fn url_cache_key<'a>(&self, ctx: &'a BridgeContext) -> &'a str {
+        #[cfg(test)]
+        if self.api_base_override.is_some() {
+            return "";
+        }
+        &ctx.provider_key_id
+    }
+
     fn resolve_api_base(
         &self,
         region: &str,
@@ -714,7 +731,7 @@ impl Bridge for VertexBridge {
         validate_url_token("upstream_id", upstream_id)?;
 
         let url = aisix_gateway::url_cache::cached_model_endpoint_url(
-            &ctx.provider_key_id,
+            self.url_cache_key(ctx),
             "vertex/google-predict",
             upstream_id,
             &[
@@ -839,7 +856,7 @@ impl VertexBridge {
         validate_url_token("upstream_id", upstream_id)?;
 
         let url = aisix_gateway::url_cache::cached_model_endpoint_url(
-            &ctx.provider_key_id,
+            self.url_cache_key(ctx),
             "vertex/gemini-generate",
             upstream_id,
             &[
@@ -945,7 +962,7 @@ impl VertexBridge {
         validate_url_token("upstream_id", upstream_id)?;
 
         let url = aisix_gateway::url_cache::cached_model_endpoint_url(
-            &ctx.provider_key_id,
+            self.url_cache_key(ctx),
             "vertex/anthropic-rawpredict",
             upstream_id,
             &[
@@ -1042,7 +1059,7 @@ impl VertexBridge {
         validate_url_token("upstream_id", upstream_id)?;
 
         let url = aisix_gateway::url_cache::cached_model_endpoint_url(
-            &ctx.provider_key_id,
+            self.url_cache_key(ctx),
             "vertex/anthropic-stream-rawpredict",
             upstream_id,
             &[
@@ -1185,7 +1202,7 @@ impl VertexBridge {
         validate_url_token("region", &creds.region)?;
 
         let url = aisix_gateway::url_cache::cached_endpoint_url(
-            &ctx.provider_key_id,
+            self.url_cache_key(ctx),
             "vertex/openai-shim",
             &[
                 ctx.provider_key.api_base.as_deref().unwrap_or(""),
@@ -1246,7 +1263,7 @@ impl VertexBridge {
         validate_url_token("region", &creds.region)?;
 
         let url = aisix_gateway::url_cache::cached_endpoint_url(
-            &ctx.provider_key_id,
+            self.url_cache_key(ctx),
             "vertex/openai-shim",
             &[
                 ctx.provider_key.api_base.as_deref().unwrap_or(""),
@@ -1377,7 +1394,7 @@ impl VertexBridge {
             ))
         })?;
         let url = aisix_gateway::url_cache::cached_model_endpoint_url(
-            &ctx.provider_key_id,
+            self.url_cache_key(ctx),
             "vertex/partner-rawpredict",
             upstream_id,
             &[
@@ -1457,7 +1474,7 @@ impl VertexBridge {
             ))
         })?;
         let url = aisix_gateway::url_cache::cached_model_endpoint_url(
-            &ctx.provider_key_id,
+            self.url_cache_key(ctx),
             "vertex/partner-stream-rawpredict",
             upstream_id,
             &[
@@ -1571,7 +1588,7 @@ impl VertexBridge {
         validate_url_token("upstream_id", upstream_id)?;
 
         let url = aisix_gateway::url_cache::cached_model_endpoint_url(
-            &ctx.provider_key_id,
+            self.url_cache_key(ctx),
             "vertex/gemini-stream-generate",
             upstream_id,
             &[

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -713,13 +713,26 @@ impl Bridge for VertexBridge {
         validate_url_token("region", &creds.region)?;
         validate_url_token("upstream_id", upstream_id)?;
 
-        let base = self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
-        let url = format!(
-            "{base}/v1/projects/{project}/locations/{region}/publishers/google/models/{model}:predict",
-            project = creds.project,
-            region = creds.region,
-            model = upstream_id,
-        );
+        let url = aisix_gateway::url_cache::cached_model_endpoint_url(
+            &ctx.provider_key_id,
+            "vertex/google-predict",
+            upstream_id,
+            &[
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &creds.project,
+                &creds.region,
+            ],
+            || {
+                let base =
+                    self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
+                Ok::<_, BridgeError>(format!(
+                    "{base}/v1/projects/{project}/locations/{region}/publishers/google/models/{model}:predict",
+                    project = creds.project,
+                    region = creds.region,
+                    model = upstream_id,
+                ))
+            },
+        )?;
 
         let instances: Vec<serde_json::Value> = req
             .input
@@ -739,8 +752,8 @@ impl Bridge for VertexBridge {
         let model_echo = req.model.clone();
 
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -825,13 +838,26 @@ impl VertexBridge {
         validate_url_token("region", &creds.region)?;
         validate_url_token("upstream_id", upstream_id)?;
 
-        let base = self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
-        let url = format!(
-            "{base}/v1/projects/{project}/locations/{region}/publishers/google/models/{model}:generateContent",
-            project = creds.project,
-            region = creds.region,
-            model = upstream_id,
-        );
+        let url = aisix_gateway::url_cache::cached_model_endpoint_url(
+            &ctx.provider_key_id,
+            "vertex/gemini-generate",
+            upstream_id,
+            &[
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &creds.project,
+                &creds.region,
+            ],
+            || {
+                let base =
+                    self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
+                Ok::<_, BridgeError>(format!(
+                    "{base}/v1/projects/{project}/locations/{region}/publishers/google/models/{model}:generateContent",
+                    project = creds.project,
+                    region = creds.region,
+                    model = upstream_id,
+                ))
+            },
+        )?;
 
         let typed = build_gemini_request(req);
         // Audit LOW-4: Gemini requires `contents` to be a non-empty
@@ -863,8 +889,8 @@ impl VertexBridge {
         let started = Instant::now();
 
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -918,13 +944,26 @@ impl VertexBridge {
         validate_url_token("region", &creds.region)?;
         validate_url_token("upstream_id", upstream_id)?;
 
-        let base = self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
-        let url = format!(
-            "{base}/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:rawPredict",
-            project = creds.project,
-            region = creds.region,
-            model = upstream_id,
-        );
+        let url = aisix_gateway::url_cache::cached_model_endpoint_url(
+            &ctx.provider_key_id,
+            "vertex/anthropic-rawpredict",
+            upstream_id,
+            &[
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &creds.project,
+                &creds.region,
+            ],
+            || {
+                let base =
+                    self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
+                Ok::<_, BridgeError>(format!(
+                    "{base}/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:rawPredict",
+                    project = creds.project,
+                    region = creds.region,
+                    model = upstream_id,
+                ))
+            },
+        )?;
 
         // Build the Anthropic Messages body via the shared serializer,
         // then shape it for Vertex (strip model + stream, add the
@@ -955,8 +994,8 @@ impl VertexBridge {
         let started = Instant::now();
 
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&body_value)
                 .send()
@@ -1002,13 +1041,26 @@ impl VertexBridge {
         validate_url_token("region", &creds.region)?;
         validate_url_token("upstream_id", upstream_id)?;
 
-        let base = self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
-        let url = format!(
-            "{base}/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:streamRawPredict",
-            project = creds.project,
-            region = creds.region,
-            model = upstream_id,
-        );
+        let url = aisix_gateway::url_cache::cached_model_endpoint_url(
+            &ctx.provider_key_id,
+            "vertex/anthropic-stream-rawpredict",
+            upstream_id,
+            &[
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &creds.project,
+                &creds.region,
+            ],
+            || {
+                let base =
+                    self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
+                Ok::<_, BridgeError>(format!(
+                    "{base}/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:streamRawPredict",
+                    project = creds.project,
+                    region = creds.region,
+                    model = upstream_id,
+                ))
+            },
+        )?;
 
         // Same Anthropic Messages body as the non-stream path, but built
         // with stream=true and — unlike `:rawPredict` — `stream` is KEPT
@@ -1039,8 +1091,7 @@ impl VertexBridge {
         let started = Instant::now();
 
         let resp = with_deadline(ctx.deadline, started, async move {
-            client
-                .post(&url)
+            url.post_on(&client)
                 .headers(headers)
                 .json(&body_value)
                 .send()
@@ -1133,7 +1184,16 @@ impl VertexBridge {
         validate_url_token("project", &creds.project)?;
         validate_url_token("region", &creds.region)?;
 
-        let url = self.openai_shim_url(&creds, ctx.provider_key.api_base.as_deref())?;
+        let url = aisix_gateway::url_cache::cached_endpoint_url(
+            &ctx.provider_key_id,
+            "vertex/openai-shim",
+            &[
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &creds.project,
+                &creds.region,
+            ],
+            || self.openai_shim_url(&creds, ctx.provider_key.api_base.as_deref()),
+        )?;
 
         let messages = openai_messages_from(req);
         let typed = build_openai_request(req, upstream_id, &messages, false);
@@ -1150,8 +1210,8 @@ impl VertexBridge {
         let started = Instant::now();
 
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -1185,7 +1245,16 @@ impl VertexBridge {
         validate_url_token("project", &creds.project)?;
         validate_url_token("region", &creds.region)?;
 
-        let url = self.openai_shim_url(&creds, ctx.provider_key.api_base.as_deref())?;
+        let url = aisix_gateway::url_cache::cached_endpoint_url(
+            &ctx.provider_key_id,
+            "vertex/openai-shim",
+            &[
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &creds.project,
+                &creds.region,
+            ],
+            || self.openai_shim_url(&creds, ctx.provider_key.api_base.as_deref()),
+        )?;
 
         let messages = openai_messages_from(req);
         let typed = build_openai_request(req, upstream_id, &messages, true);
@@ -1203,8 +1272,7 @@ impl VertexBridge {
         let started = Instant::now();
 
         let resp = with_deadline(ctx.deadline, started, async move {
-            client
-                .post(&url)
+            url.post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -1308,12 +1376,25 @@ impl VertexBridge {
                 "vertex publisher {publisher:?} has no URL segment for the :rawPredict rail"
             ))
         })?;
-        let url = self.partner_rawpredict_url(
-            &creds,
-            ctx.provider_key.api_base.as_deref(),
-            segment,
+        let url = aisix_gateway::url_cache::cached_model_endpoint_url(
+            &ctx.provider_key_id,
+            "vertex/partner-rawpredict",
             upstream_id,
-            "rawPredict",
+            &[
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &creds.project,
+                &creds.region,
+                segment,
+            ],
+            || {
+                self.partner_rawpredict_url(
+                    &creds,
+                    ctx.provider_key.api_base.as_deref(),
+                    segment,
+                    upstream_id,
+                    "rawPredict",
+                )
+            },
         )?;
 
         // OpenAI chat-completions body — same serializer the OpenAI-shim
@@ -1333,8 +1414,8 @@ impl VertexBridge {
         let started = Instant::now();
 
         with_deadline(ctx.deadline, started, async move {
-            let resp = client
-                .post(&url)
+            let resp = url
+                .post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -1375,12 +1456,25 @@ impl VertexBridge {
                 "vertex publisher {publisher:?} has no URL segment for the :streamRawPredict rail"
             ))
         })?;
-        let url = self.partner_rawpredict_url(
-            &creds,
-            ctx.provider_key.api_base.as_deref(),
-            segment,
+        let url = aisix_gateway::url_cache::cached_model_endpoint_url(
+            &ctx.provider_key_id,
+            "vertex/partner-stream-rawpredict",
             upstream_id,
-            "streamRawPredict",
+            &[
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &creds.project,
+                &creds.region,
+                segment,
+            ],
+            || {
+                self.partner_rawpredict_url(
+                    &creds,
+                    ctx.provider_key.api_base.as_deref(),
+                    segment,
+                    upstream_id,
+                    "streamRawPredict",
+                )
+            },
         )?;
 
         let messages = openai_messages_from(req);
@@ -1399,8 +1493,7 @@ impl VertexBridge {
         let started = Instant::now();
 
         let resp = with_deadline(ctx.deadline, started, async move {
-            client
-                .post(&url)
+            url.post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -1477,13 +1570,26 @@ impl VertexBridge {
         validate_url_token("region", &creds.region)?;
         validate_url_token("upstream_id", upstream_id)?;
 
-        let base = self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
-        let url = format!(
-            "{base}/v1/projects/{project}/locations/{region}/publishers/google/models/{model}:streamGenerateContent?alt=sse",
-            project = creds.project,
-            region = creds.region,
-            model = upstream_id,
-        );
+        let url = aisix_gateway::url_cache::cached_model_endpoint_url(
+            &ctx.provider_key_id,
+            "vertex/gemini-stream-generate",
+            upstream_id,
+            &[
+                ctx.provider_key.api_base.as_deref().unwrap_or(""),
+                &creds.project,
+                &creds.region,
+            ],
+            || {
+                let base =
+                    self.resolve_api_base(&creds.region, ctx.provider_key.api_base.as_deref())?;
+                Ok::<_, BridgeError>(format!(
+                    "{base}/v1/projects/{project}/locations/{region}/publishers/google/models/{model}:streamGenerateContent?alt=sse",
+                    project = creds.project,
+                    region = creds.region,
+                    model = upstream_id,
+                ))
+            },
+        )?;
 
         let typed = build_gemini_request(req);
         if typed.contents.is_empty() {
@@ -1507,8 +1613,7 @@ impl VertexBridge {
         let started = Instant::now();
 
         let resp = with_deadline(ctx.deadline, started, async move {
-            client
-                .post(&url)
+            url.post_on(&client)
                 .headers(headers)
                 .json(&body)
                 .send()
@@ -3536,6 +3641,79 @@ mod tests {
         let req = ChatFormat::new("my-gemini", vec![ChatMessage::user("hi")]);
         let chat = bridge.chat(&req, &ctx).await.unwrap();
         assert_eq!(chat.message.content_str(), "hello from gemini");
+    }
+
+    /// The Vertex URL carries the upstream model in its path, so the
+    /// endpoint URL cache has to hold a row per model. Keying it by
+    /// Provider Key alone would make each model invalidate the previous
+    /// one's row — every request a miss, and a window in which a stale
+    /// row answers for the wrong model.
+    ///
+    /// Two models on one key id, alternating, three rounds: each must
+    /// land on its own path every time.
+    #[tokio::test]
+    async fn url_cache_holds_a_row_per_upstream_model() {
+        let server = MockServer::start().await;
+        for model in ["gemini-1.5-pro", "gemini-2.0-flash"] {
+            Mock::given(method("POST"))
+                .and(path(format!(
+                    "/v1/projects/my-proj/locations/us-central1/publishers/google/models/{model}:generateContent"
+                )))
+                .respond_with(CapturingResponder::default())
+                .expect(3)
+                .mount(&server)
+                .await;
+        }
+
+        let bridge = VertexBridge::new();
+        let req = ChatFormat::new("my-gemini", vec![ChatMessage::user("hi")]);
+        for _ in 0..3 {
+            for model in ["gemini-1.5-pro", "gemini-2.0-flash"] {
+                let ctx = BridgeContext::new(
+                    "req-1",
+                    sample_model_with(model),
+                    sample_pk_with_secret_and_api_base(valid_secret_json(), &server.uri()),
+                )
+                .with_resource_ids("m-1", "pk-vertex-rows");
+                bridge.chat(&req, &ctx).await.unwrap();
+            }
+        }
+        // Each `.expect(3)` is verified when the server drops.
+    }
+
+    /// An edited `api_base` has to reach the model-keyed rows too: a
+    /// cached URL that outlives the edit keeps dispatching to the host
+    /// the operator just re-pointed away from.
+    #[tokio::test]
+    async fn url_cache_follows_an_api_base_edit_for_the_same_key_id() {
+        async fn mount(server: &MockServer) {
+            Mock::given(method("POST"))
+                .and(path(
+                    "/v1/projects/my-proj/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent",
+                ))
+                .respond_with(CapturingResponder::default())
+                .expect(1)
+                .mount(server)
+                .await;
+        }
+        let first = MockServer::start().await;
+        let second = MockServer::start().await;
+        mount(&first).await;
+        mount(&second).await;
+
+        let bridge = VertexBridge::new();
+        let req = ChatFormat::new("my-gemini", vec![ChatMessage::user("hi")]);
+        for host in [&first, &second] {
+            let ctx = BridgeContext::new(
+                "req-1",
+                sample_model_with("gemini-1.5-pro"),
+                sample_pk_with_secret_and_api_base(valid_secret_json(), &host.uri()),
+            )
+            .with_resource_ids("m-1", "pk-vertex-repoint");
+            bridge.chat(&req, &ctx).await.unwrap();
+        }
+        // Each `.expect(1)` fails on drop if the second request stayed
+        // on the first host.
     }
 
     /// Same as above but exercises the trailing-slash trim — a

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -698,10 +698,10 @@ async fn multipart_dispatch(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         url_cache_key,
-        (
+        &[
             pk_entry.value.api_base.as_deref().unwrap_or(""),
             upstream_path,
-        ),
+        ],
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(
@@ -1202,7 +1202,7 @@ async fn speech_dispatch(
     let speech_url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/audio/speech",
-        (pk_entry.value.api_base.as_deref().unwrap_or(""), ""),
+        &[pk_entry.value.api_base.as_deref().unwrap_or("")],
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -407,7 +407,7 @@ async fn count_tokens_to_target(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/messages/count_tokens",
-        (pk_entry.value.api_base.as_deref().unwrap_or(""), ""),
+        &[pk_entry.value.api_base.as_deref().unwrap_or("")],
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_anthropic_url(

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1064,7 +1064,7 @@ async fn anthropic_passthrough_dispatch(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         pk_id,
         "proxy/messages",
-        (pk_value.api_base.as_deref().unwrap_or(""), ""),
+        &[pk_value.api_base.as_deref().unwrap_or("")],
         || {
             let base = crate::dispatch::resolve_base_url(pk_value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_anthropic_url(

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -400,10 +400,10 @@ async fn dispatch(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/rerank",
-        (
+        &[
             pk_entry.value.api_base.as_deref().unwrap_or(""),
             &provider_label,
-        ),
+        ],
         || {
             let base = match pk_entry.value.api_base.as_deref() {
                 Some(b) if !b.trim().is_empty() => b.trim_end_matches('/').to_string(),

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1058,7 +1058,7 @@ async fn responses_to_target(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/responses",
-        (pk_entry.value.api_base.as_deref().unwrap_or(""), ""),
+        &[pk_entry.value.api_base.as_deref().unwrap_or("")],
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(


### PR DESCRIPTION
## What

Extends the per-ProviderKey endpoint URL cache (`aisix_gateway::url_cache`, #945) to the dispatch paths the first pass left out, so every bridge that rebuilt a URL per request now parses it once.

Fixes #942.

## Measurement

No same-rig A/B is attached, and one is structurally impossible for this change: the benchmark harness drives `/v1/chat/completions` against an OpenAI-shaped mock upstream, so the Vertex, Azure and A2A code paths this PR touches never execute in it. The same mechanism on the half that *is* benchmarked (#945, chat family) came out at +1.32µs — the unfavourable direction, inside a ±1.5µs single-leg resolution — and shipped with the mechanism pinned by tests instead.

What can be measured is the work removed per affected request. Microbenchmark, 200k iterations per leg, release build, idle x86 dev box (**not** the Graviton rig), on the Vertex Gemini URL shape (~120 chars, the longest of the three):

| | ns/op |
|---|---|
| build + `Url::parse` (today) | 817.3 |
| cache hit (two-level lookup + `Url::clone`) | 100.3 |
| **saved** | **717.0** |

Caliber, so this is not over-read: it is a microbenchmark, not a request-level A/B; the cached leg allocates a row-key `String` per iteration where production reuses a thread-local one, so it is pessimistic on the cache side; the Azure URL is shorter and saves less; and the absolute numbers are x86, not the aarch64 rig.

~0.72µs is roughly 0.7% of the gateway's ~102µs CPU per request, on endpoints that also pay a token lookup, a JSON serialization, and a provider round trip. Worth having, invisible in any throughput number. (Issue #942 estimated <0.2µs — the measured figure is ~3.5× that, the same direction of under-estimate the program has seen before when reading costs off frame shares.)

## Why these were left out, and what each needed

**A2A** (3 sites) posts to the agent's configured endpoint — a string with nothing derived from the request. The string is therefore its own identity, so this needs no fingerprint: `cached_url` parses it once process-wide. An `HttpBridge` is constructed per request, so this turns a `Url` parse per request into a map lookup. Agent-card discovery reuses the same parsed endpoint, so discovery and dispatch cannot disagree about the agent's URL.

**Vertex** (9 sites) splits two ways. Seven embed the upstream model in the path (`publishers/<vendor>/models/<model>:<method>`); two — the OpenAI-compat shim rail — do not, because the shim keys off the body's `model` field. The seven take a row per (endpoint, model); the two shim sites take a plain per-endpoint row. The fingerprint is `api_base` + project + region, which is every input `resolve_api_base` and the path template read.

**Azure** (2 sites) is the case #945's audit pulled back on. The URL embeds the deployment name, so keying by ProviderKey alone made each deployment invalidate the previous one's row: a key fronting several deployments would miss and rebuild on *every* request — measurably slower than not caching. It now takes a row per deployment.

## The cache change that makes the model dimension possible

Folding the model into the fingerprint is exactly the Azure failure above, so rows are keyed by `endpoint \x1f upstream_model` instead. Three supporting changes, no behavior change for the existing callers:

- Rows are keyed by `Box<str>` rather than a `&'static str` literal, and the hit path reads under a **shared** guard (`get`) before reaching for the row's write guard — so a hit now takes a read lock where it previously took the shard's write lock.
- The fingerprint is a slice rather than a pair. Vertex's URL is derived from three inputs; the old two-slot tuple could not express that, and concatenating inputs to fit is how a cache starts missing edits.
- The model-keyed row key is assembled in a reused thread-local buffer (the same trick `aisix-obs`'s handle cache uses for label keys), so **the row key** allocates nothing on a hit. (The returned `Url` is cloned, which does allocate — that is the copy reqwest takes by value instead of re-parsing.) A model id containing the separator byte skips the cache rather than risk aliasing another row.

Rows per resource are bounded: the model dimension makes the row count scale with configured models rather than with the fixed endpoint set. A row past the cap is served **uncached** rather than evicting to make room — clearing would leave an above-cap configuration at a permanent 100% miss rate plus a `len()` shard walk per request, which is worse than not caching at all. Checked only on the miss path.

## Not wired, deliberately

The videos, jobs and realtime paths. They are cold — one URL per long-running operation or per WebSocket session, not per inference request — and the jobs URLs concatenate the forwarded client query string, which would have to become part of the cache key. Stated here rather than left as an unexplained gap.

## Tests

- `url_cache_holds_a_row_per_upstream_model` (Vertex) and `url_cache_holds_a_row_per_deployment` (Azure) — one Provider Key alternating between two models / two deployments, three rounds, each request must land on its own path. Both mutation-verified: dropping the model or deployment from the row key fails them on the mock's request-count expectations.
- `url_cache_follows_an_api_base_edit_for_the_same_key_id`, on both bridges — a re-pointed `api_base` must reach the model/deployment-keyed rows, not keep serving the host it was moved away from. Mutation-verified by removing `api_base` from the fingerprint.
- The Azure tests deliberately avoid `with_url_override`: that seam bypasses the cache, so a test using it proves nothing about this. A wiremock URI reaches the production path through `AzureUpstreamRef::resolve`'s verbatim-override branch.
- `no_dispatch_site_posts_an_unparsed_url_variable` — guard test: no production dispatch site in the provider or proxy crates may post a URL string. That is the shape that re-parses per request, and it is how three bridges stayed unwired through #945.
- `url_cache` unit tests: model rows do not evict each other, a model-keyed row and a plain row on the same endpoint name are distinct, a separator-carrying model id bypasses the cache, a fingerprint that gains a component counts as a change, and rows past the cap are served uncached without evicting warm ones.
- `cargo test --workspace --no-fail-fast`: all green except `aisix-mcp connect_timeout_bounds_an_unreachable_upstream`, which fails identically on unmodified `main` in this sandbox and is not reachable from this change.

Source: perf program AISIX-Cloud#1259 (todo 8 deferred list).