### PR TITLE
fix(semantic): honor member gates at route selection

### DIFF
--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -93,6 +93,12 @@ scoped to a member never runs for group traffic (measured: direct 422, via group
 is correct — input guardrails run before a target is picked, and under failover
 there is no single "winning member" to resolve against. Tracked in
 AISIX-Cloud#1090; do not cite it as precedent for scoping a new gate to the entry.
+The 2026-08 model-kind audit re-confirmed the same gap for **ensemble panel/judge
+sub-calls and semantic-router targets**, and the ruling (project decision) is that
+all three kinds stay under #1090's one unified design pass: the operator can
+attach the guardrail to the parent entry, so member scope is a mitigable gap, not
+an unavoidable bypass. Do not piecemeal-fix one kind ahead of that decision, and
+do not re-audit it as a new finding.
 
 Two shapes, both already implemented — copy the nearest one:
 

--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -98,7 +98,12 @@ sub-calls and semantic-router targets**, and the ruling (project decision) is th
 all three kinds stay under #1090's one unified design pass: the operator can
 attach the guardrail to the parent entry, so member scope is a mitigable gap, not
 an unavoidable bypass. Do not piecemeal-fix one kind ahead of that decision, and
-do not re-audit it as a new finding.
+do not re-audit it as a new finding. The same project ruling holds for the OTHER
+member gates on **ensemble** sub-calls (member `allowed_cidrs`, cooldown/health
+consumption, Prometheus usage, caching): ensemble is an experimental surface and
+its parity gaps are deliberate TODOs, not fresh findings — semantic-router
+targets got these gates first because they share the single-winner dispatch
+shape; graduate ensemble deliberately, in one pass.
 
 Two shapes, both already implemented — copy the nearest one:
 

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1334,9 +1334,16 @@ async fn dispatch(
     let (attempt_models, semantic_route): (Vec<AttemptModel>, Option<String>) =
         if virtual_entry.value.is_semantic() {
             let prompt = last_user_message_text(req).unwrap_or_default();
-            crate::semantic::resolve(state, snapshot, &virtual_entry, &prompt, request_id)
-                .await
-                .map_err(&with_model)?
+            crate::semantic::resolve(
+                state,
+                snapshot,
+                &virtual_entry,
+                &prompt,
+                &client.source_ip,
+                request_id,
+            )
+            .await
+            .map_err(&with_model)?
         } else {
             let attempts = resolve_attempt_models(
                 &state.routing,
@@ -1539,7 +1546,7 @@ async fn dispatch(
             // existed on the group.
             let budget = crate::routing::effective_retries(
                 model,
-                virtual_entry.value.routing.as_ref(),
+                crate::routing::group_retries_of(&virtual_entry.value),
                 state.default_retries,
                 target_idx + 1 < attempt_models.len(),
             );
@@ -2615,7 +2622,7 @@ async fn dispatch(
         // Per-target retry budget — see the streaming loop above.
         let budget = crate::routing::effective_retries(
             model,
-            virtual_entry.value.routing.as_ref(),
+            crate::routing::group_retries_of(&virtual_entry.value),
             state.default_retries,
             target_idx + 1 < attempt_models.len(),
         );

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -834,11 +834,19 @@ async fn cache_semantic_embed(
 ) -> Option<Vec<f32>> {
     let started = Instant::now();
     let texts = [sem.text.clone()];
+    // Same deadline chain as the semantic router's embed call: the
+    // policy knob wins, then the embedding model's own `timeout`, then
+    // the deployment default — a hung embedding upstream must not stall
+    // the cache gate unbounded either.
+    let embed_deadline = sem.cfg.embedding_timeout().or_else(|| {
+        crate::routing::effective_timeouts(&sem.embed_entry.value, None, state.default_timeouts)
+            .request
+    });
     match crate::semantic::embed_texts(
         state,
         snapshot,
         &sem.embed_entry,
-        sem.cfg.embedding_timeout(),
+        embed_deadline,
         request_id,
         &texts,
     )

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -293,7 +293,7 @@ async fn dispatch(
             .any(|t| crate::dispatch::speaks_anthropic(snapshot, &t.model));
         let budget = crate::routing::effective_retries(
             &target.model,
-            model_entry.value.routing.as_ref(),
+            crate::routing::group_retries_of(&model_entry.value),
             state.default_retries,
             has_usable_fallback,
         );

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -698,7 +698,7 @@ async fn dispatch(
         // because the knob only existed on the group.
         let budget = crate::routing::effective_retries(
             &target.model,
-            model_entry.value.routing.as_ref(),
+            crate::routing::group_retries_of(&model_entry.value),
             state.default_retries,
             i + 1 < n,
         );

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -657,7 +657,7 @@ async fn dispatch(
         // model gets a budget too.
         let budget = crate::routing::effective_retries(
             &target.model,
-            model_entry.value.routing.as_ref(),
+            crate::routing::group_retries_of(&model_entry.value),
             state.default_retries,
             target_idx + 1 < attempt_models.len(),
         );

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -215,11 +215,13 @@ pub fn effective_retries(
 /// its group level lives on the Model itself (the same place a routing
 /// group keeps its group-level `timeout`).
 pub fn group_retries_of(parent: &aisix_core::Model) -> Option<u32> {
-    parent
-        .routing
-        .as_ref()
-        .and_then(|r| r.retries)
-        .or(parent.retries)
+    match parent.routing.as_ref() {
+        // A Model Group's group slot is `routing.retries` alone — a
+        // stray top-level `retries` on the group Model stays inert
+        // (the schema-convergence work forbids that shape outright).
+        Some(routing) => routing.retries,
+        None => parent.retries,
+    }
 }
 
 /// How many same-target retries this dispatch may spend, and whether the
@@ -1616,6 +1618,13 @@ mod tests {
         let mut group_parent = model_with_retries(Some(7));
         group_parent.routing = Some(group_with_retries(Some(3)));
         assert_eq!(group_retries_of(&group_parent), Some(3));
+        // …and stays INERT even when `routing.retries` is unset — the
+        // routing block's presence pins the group slot, so the target →
+        // routing.retries → deployment-default chain is unchanged for
+        // every Model Group shape.
+        let mut sparse_group = model_with_retries(Some(7));
+        sparse_group.routing = Some(group_with_retries(None));
+        assert_eq!(group_retries_of(&sparse_group), None);
         // Semantic router (no routing block): the parent's own top-level
         // `retries` IS the group slot — the member → group → default
         // chain unified across virtual parents.

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -188,11 +188,11 @@ pub fn retry_after_hint(err: &BridgeError) -> Option<Duration> {
 /// keeps the default for.
 pub fn effective_retries(
     target: &aisix_core::Model,
-    group: Option<&aisix_core::models::routing::Routing>,
+    group_retries: Option<u32>,
     deployment_default: u32,
     has_fallback_targets: bool,
 ) -> RetryBudget {
-    if let Some(explicit) = target.retries.or_else(|| group.and_then(|r| r.retries)) {
+    if let Some(explicit) = target.retries.or(group_retries) {
         return RetryBudget {
             attempts: explicit as usize,
             configured: true,
@@ -206,6 +206,20 @@ pub fn effective_retries(
         },
         configured: false,
     }
+}
+
+/// The group-level slot of the member → group → deployment-default
+/// retries chain, resolved from the caller-addressed parent entry:
+/// `routing.retries` for a Model Group, the parent's own top-level
+/// `retries` otherwise — a semantic router has no `routing` block, so
+/// its group level lives on the Model itself (the same place a routing
+/// group keeps its group-level `timeout`).
+pub fn group_retries_of(parent: &aisix_core::Model) -> Option<u32> {
+    parent
+        .routing
+        .as_ref()
+        .and_then(|r| r.retries)
+        .or(parent.retries)
 }
 
 /// How many same-target retries this dispatch may spend, and whether the
@@ -1581,9 +1595,44 @@ mod tests {
     ) -> RetryBudget {
         let m = model_with_retries(target);
         match group {
-            Some(g) => effective_retries(&m, Some(&group_with_retries(g)), default, has_fallback),
+            Some(g) => effective_retries(
+                &m,
+                group_retries_of(&{
+                    let mut parent = model_with_retries(None);
+                    parent.routing = Some(group_with_retries(g));
+                    parent
+                }),
+                default,
+                has_fallback,
+            ),
             None => effective_retries(&m, None, default, has_fallback),
         }
+    }
+
+    #[test]
+    fn group_retries_reads_the_routing_block_then_the_parent_model() {
+        // Model Group: the group slot is `routing.retries`; a stray
+        // top-level value on the parent stays shadowed by it.
+        let mut group_parent = model_with_retries(Some(7));
+        group_parent.routing = Some(group_with_retries(Some(3)));
+        assert_eq!(group_retries_of(&group_parent), Some(3));
+        // Semantic router (no routing block): the parent's own top-level
+        // `retries` IS the group slot — the member → group → default
+        // chain unified across virtual parents.
+        let semantic_parent = model_with_retries(Some(2));
+        assert_eq!(group_retries_of(&semantic_parent), Some(2));
+        assert_eq!(
+            effective_retries(
+                &model_with_retries(None),
+                group_retries_of(&semantic_parent),
+                9,
+                false
+            )
+            .attempts,
+            2
+        );
+        // Neither configured → no group level.
+        assert_eq!(group_retries_of(&model_with_retries(None)), None);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/semantic.rs
+++ b/crates/aisix-proxy/src/semantic.rs
@@ -142,6 +142,7 @@ pub(crate) async fn resolve(
     snapshot: &AisixSnapshot,
     router_entry: &ResourceEntry<Model>,
     prompt: &str,
+    source_ip: &str,
     request_id: &str,
 ) -> Result<(Vec<AttemptModel>, Option<String>), ProxyError> {
     let semantic = router_entry
@@ -149,12 +150,15 @@ pub(crate) async fn resolve(
         .semantic
         .as_ref()
         .expect("resolve called on a non-semantic model");
+    let router = &router_entry.value;
 
     // No user text to classify (e.g. a system-only or tool-only request):
     // route to `default` without an embedding call rather than embedding an
     // empty string, which could spuriously match a route.
     if prompt.trim().is_empty() {
-        return Ok((vec![attempt_for_target(snapshot, &semantic.default)?], None));
+        let (attempt, _) =
+            select_eligible(state, snapshot, router, source_ip, &semantic.default, None)?;
+        return Ok((vec![attempt], None));
     }
 
     // Resolve the embedding model + its modality metadata. A dangling or
@@ -170,7 +174,7 @@ pub(crate) async fn resolve(
                 "semantic router references a missing or non-embedding embedding_model; \
                  applying on_embedding_failure",
             );
-            return fallback(semantic, snapshot);
+            return fallback(state, snapshot, router, source_ip, semantic);
         }
     };
     let dims = embed_entry
@@ -199,11 +203,18 @@ pub(crate) async fn resolve(
     to_embed.push(prompt.to_string());
     to_embed.extend(pending.iter().cloned());
 
+    // Deadline chain for the embed sub-call: the router-level knob wins,
+    // then the embedding model's own `timeout`, then the deployment
+    // default — previously only the router knob applied, so a hung
+    // embedding upstream stalled every semantic request unbounded.
+    let embed_deadline = semantic.embedding_timeout().or_else(|| {
+        crate::routing::effective_timeouts(&embed_entry.value, None, state.default_timeouts).request
+    });
     let vectors = match embed_texts(
         state,
         snapshot,
         &embed_entry,
-        semantic.embedding_timeout(),
+        embed_deadline,
         request_id,
         &to_embed,
     )
@@ -216,7 +227,7 @@ pub(crate) async fn resolve(
                 error = %e,
                 "semantic embedding call failed; applying on_embedding_failure",
             );
-            return fallback(semantic, snapshot);
+            return fallback(state, snapshot, router, source_ip, semantic);
         }
     };
 
@@ -245,31 +256,57 @@ pub(crate) async fn resolve(
         .collect();
 
     let decision = decide(semantic, &prompt_vec, &route_vecs);
-    let (target_alias, route_name): (&str, Option<String>) = match decision.winner {
-        Some(i) => (
-            semantic.routes[i].target.as_str(),
-            Some(semantic.routes[i].name.clone()),
-        ),
-        None => (semantic.default.as_str(), None),
+    let (attempt, route_name): (AttemptModel, Option<String>) = match decision.winner {
+        Some(i) => {
+            let (attempt, fell_back) = select_eligible(
+                state,
+                snapshot,
+                router,
+                source_ip,
+                semantic.routes[i].target.as_str(),
+                Some(semantic.default.as_str()),
+            )?;
+            // `x-aisix-route` reports the route that actually served the
+            // request: a winner displaced by its target's gates is a
+            // fall-through to `default`, not a served route.
+            let name = (!fell_back).then(|| semantic.routes[i].name.clone());
+            (attempt, name)
+        }
+        None => {
+            let (attempt, _) = select_eligible(
+                state,
+                snapshot,
+                router,
+                source_ip,
+                semantic.default.as_str(),
+                None,
+            )?;
+            (attempt, None)
+        }
     };
     tracing::debug!(
         router = %router_entry.value.display_name,
         resolved_route = ?route_name,
-        target = %target_alias,
+        target = %attempt.model.display_name,
         "semantic routing decision",
     );
-    let attempt = attempt_for_target(snapshot, target_alias)?;
     Ok((vec![attempt], route_name))
 }
 
 /// Apply the `on_embedding_failure` policy: route to the fallback target,
 /// or surface `503` when the policy is `fail`.
 fn fallback(
-    semantic: &Semantic,
+    state: &ProxyState,
     snapshot: &AisixSnapshot,
+    router: &Model,
+    source_ip: &str,
+    semantic: &Semantic,
 ) -> Result<(Vec<AttemptModel>, Option<String>), ProxyError> {
     match embedding_failure_target(semantic) {
-        Some(alias) => Ok((vec![attempt_for_target(snapshot, alias)?], None)),
+        Some(alias) => {
+            let (attempt, _) = select_eligible(state, snapshot, router, source_ip, alias, None)?;
+            Ok((vec![attempt], None))
+        }
         None => Err(ProxyError::ProviderUnavailable),
     }
 }
@@ -286,6 +323,85 @@ fn attempt_for_target(snapshot: &AisixSnapshot, alias: &str) -> Result<AttemptMo
         id: entry.id.clone(),
         model: entry.value.clone(),
     })
+}
+
+/// Pick the dispatchable target among `{primary, fallback}` — the
+/// semantic single-winner analogue of the group filter
+/// (`routing::targets_allowed_for_ip` + `filter_attempt_models`):
+///
+/// - the member's client-IP allowlist is a HARD gate: an excluded
+///   candidate is dropped, and with every candidate excluded the caller
+///   gets the same 403 as the entry gate, naming only the alias they
+///   addressed (`routing.rs` does the same for all-excluded groups, so
+///   a router never becomes a probe for which members exist);
+/// - member health (request-path cooldown / background-unhealthy) is a
+///   SOFT preference: prefer an available candidate, but with none
+///   available dispatch the primary anyway — the router has no
+///   `when_all_unavailable` knob, and the semantically-right target
+///   beats failing the request on an advisory signal.
+///
+/// Returns the attempt plus whether the fallback displaced the primary
+/// (so the caller can clear the served-route attribution).
+fn select_eligible(
+    state: &ProxyState,
+    snapshot: &AisixSnapshot,
+    router: &Model,
+    source_ip: &str,
+    primary: &str,
+    fallback_alias: Option<&str>,
+) -> Result<(AttemptModel, bool), ProxyError> {
+    let mut candidates: Vec<(AttemptModel, bool)> = Vec::with_capacity(2);
+    candidates.push((attempt_for_target(snapshot, primary)?, false));
+    if let Some(alias) = fallback_alias {
+        // A dangling `default` only matters when it must actually serve;
+        // as a mere fallback candidate it is skipped, not fatal.
+        if alias != primary {
+            if let Ok(attempt) = attempt_for_target(snapshot, alias) {
+                candidates.push((attempt, true));
+            }
+        }
+    }
+    candidates.retain(|(attempt, fell_back)| {
+        let allowed = attempt.model.ip_allowed(source_ip);
+        if !allowed {
+            tracing::warn!(
+                router = %router.display_name,
+                target = %attempt.model.display_name,
+                fallback = fell_back,
+                "semantic target excluded by its allowed_cidrs",
+            );
+        }
+        allowed
+    });
+    if candidates.is_empty() {
+        return Err(ProxyError::ModelIpRestricted(router.display_name.clone()));
+    }
+    let picked = candidates
+        .iter()
+        .position(|(attempt, _)| {
+            let stale_after = attempt
+                .model
+                .background_model_check
+                .as_ref()
+                .map(|cfg| std::time::Duration::from_secs(cfg.stale_after_seconds));
+            matches!(
+                state
+                    .runtime_status
+                    .status_with_stale(&attempt.id, stale_after)
+                    .status,
+                crate::RuntimeStatus::Healthy | crate::RuntimeStatus::NotApplicable
+            )
+        })
+        .unwrap_or(0);
+    let (attempt, fell_back) = candidates.swap_remove(picked);
+    if fell_back {
+        tracing::debug!(
+            router = %router.display_name,
+            served = %attempt.model.display_name,
+            "semantic route target unavailable; serving default",
+        );
+    }
+    Ok((attempt, fell_back))
 }
 
 /// Embed `texts` through the embedding model's bridge in one batched call,

--- a/crates/aisix-proxy/src/semantic.rs
+++ b/crates/aisix-proxy/src/semantic.rs
@@ -364,7 +364,7 @@ fn select_eligible(
     candidates.retain(|(attempt, fell_back)| {
         let allowed = attempt.model.ip_allowed(source_ip);
         if !allowed {
-            tracing::warn!(
+            tracing::debug!(
                 router = %router.display_name,
                 target = %attempt.model.display_name,
                 fallback = fell_back,

--- a/tests/e2e/src/cases/semantic-member-gates-e2e.test.ts
+++ b/tests/e2e/src/cases/semantic-member-gates-e2e.test.ts
@@ -1,0 +1,361 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { pickFreePort } from "../harness/ports.js";
+
+// E2E: the semantic router honors its MEMBERS' own gates (model-kind
+// audit — the semantic selection path used to bypass every one of
+// them, while routing groups enforce all of them per target):
+//
+//   1. A route target excluded by its `allowed_cidrs` is a hard miss:
+//      the request falls through to `default` and the served-route
+//      header is cleared.
+//   2. Route target AND default both excluded → the same 403 the entry
+//      gate produces, leaking no member names.
+//   3. A route target in request-path cooldown (tripped by a 500) is
+//      skipped on the NEXT request — health is consumed at selection,
+//      not just recorded.
+//   4. The embed sub-call inherits the embedding model's own `timeout`
+//      when the router sets no `embedding_timeout_ms` — a hung
+//      embedding upstream degrades via `on_embedding_failure` instead
+//      of stalling the request unbounded.
+//   5. The router's own top-level `retries` is the group slot of the
+//      member → group → deployment-default retry chain (a semantic
+//      parent has no `routing` block to carry it).
+
+const CALLER_PLAINTEXT = "sk-semantic-gates-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+function keywordVector(text: string): number[] {
+  const t = text.toLowerCase();
+  if (t.includes("code") || t.includes("python")) return [0, 1, 0, 0];
+  return [0, 0, 0, 1];
+}
+
+interface EmbeddingMock {
+  baseUrl: string;
+  close(): Promise<void>;
+}
+
+/** Deterministic keyword-vector `/v1/embeddings` mock; `delayMs` holds
+ * every response open to model a hung embedding upstream. */
+async function startEmbeddingMock(opts: { delayMs?: number } = {}): Promise<EmbeddingMock> {
+  const server: Server = createServer((req, res) => {
+    res.on("error", () => {});
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      if (!req.url?.includes("/embeddings")) {
+        res.statusCode = 404;
+        res.end("{}");
+        return;
+      }
+      const respond = () => {
+        let body: { input?: string | string[] };
+        try {
+          body = JSON.parse(raw || "{}") as { input?: string | string[] };
+        } catch {
+          res.statusCode = 400;
+          res.end("{}");
+          return;
+        }
+        const inputs = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            object: "list",
+            model: "embed-mock",
+            data: inputs.map((text, index) => ({
+              object: "embedding",
+              index,
+              embedding: keywordVector(text),
+            })),
+            usage: { prompt_tokens: inputs.length, total_tokens: inputs.length },
+          }),
+        );
+      };
+      if (opts.delayMs) setTimeout(respond, opts.delayMs);
+      else respond();
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    async close() {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+function chatBody(content: string) {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: 0,
+    model: "gpt-4o-mini",
+    choices: [
+      { index: 0, message: { role: "assistant", content }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe("semantic router member gates e2e", () => {
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+  const embedMocks: EmbeddingMock[] = [];
+
+  async function chatUpstream(
+    content: string,
+    extra: Parameters<typeof startOpenAiUpstream>[0] = {},
+  ): Promise<OpenAiUpstream> {
+    const u = await startOpenAiUpstream({ nonStreamBody: chatBody(content), ...extra });
+    upstreams.push(u);
+    return u;
+  }
+
+  async function directModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+    extra: Record<string, unknown> = {},
+  ): Promise<void> {
+    if (!seed) throw new Error("seed not ready");
+    const pk = await seed.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+      ...extra,
+    });
+  }
+
+  async function embeddingModel(
+    displayName: string,
+    mock: EmbeddingMock,
+    extra: Record<string, unknown> = {},
+  ): Promise<void> {
+    if (!seed) throw new Error("seed not ready");
+    const pk = await seed.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${mock.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "embed-mock",
+      provider_key_id: pk.id,
+      embedding: { dimensions: 4 },
+      ...extra,
+    });
+  }
+
+  async function chat(
+    model: string,
+    prompt: string,
+  ): Promise<{ status: number; content: string; route: string | null; body: string }> {
+    if (!app) throw new Error("app not ready");
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ model, messages: [{ role: "user", content: prompt }] }),
+    });
+    const body = await res.text();
+    let content = "";
+    try {
+      const parsed = JSON.parse(body) as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      content = parsed.choices?.[0]?.message?.content ?? "";
+    } catch {
+      // non-JSON body (never expected) — surface via `body` in asserts
+    }
+    return { status: res.status, content, route: res.headers.get("x-aisix-route"), body };
+  }
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+    await seed.createApiKey({ key_hash: CALLER_KEY_HASH, allowed_models: ["*"] });
+
+    const embed = await startEmbeddingMock();
+    const slowEmbed = await startEmbeddingMock({ delayMs: 3000 });
+    embedMocks.push(embed, slowEmbed);
+    await embeddingModel("smg-bge", embed);
+    // The slow embedder's own timeout is the knob under test in case 4.
+    await embeddingModel("smg-bge-slow", slowEmbed, { timeout: 500 });
+
+    // Members. The loopback caller is NOT in 10.0.0.0/8, so "restricted"
+    // members are excluded for every test request.
+    await directModel("smg-blocked", await chatUpstream("served-blocked"), {
+      allowed_cidrs: ["10.0.0.0/8"],
+    });
+    await directModel("smg-blocked-2", await chatUpstream("served-blocked-2"), {
+      allowed_cidrs: ["10.0.0.0/8"],
+    });
+    await directModel("smg-open", await chatUpstream("served-open"));
+    await directModel("smg-flaky", await chatUpstream("unused", { status: 500 }), {
+      cooldown: { default_seconds: 120 },
+    });
+    await directModel("smg-t4-code", await chatUpstream("served-t4-code"));
+    await directModel("smg-t4-default", await chatUpstream("served-t4-default"));
+    // 4 scripted failures, then success: recoverable only with the
+    // router-level retry budget of 4 (deployment default is 2).
+    await directModel(
+      "smg-retry-target",
+      await chatUpstream("served-after-retries", {
+        scriptedResponses: [
+          { status: 500, errorBody: { error: { message: "boom", type: "server_error" } } },
+          { status: 500, errorBody: { error: { message: "boom", type: "server_error" } } },
+          { status: 500, errorBody: { error: { message: "boom", type: "server_error" } } },
+          { status: 500, errorBody: { error: { message: "boom", type: "server_error" } } },
+        ],
+      }),
+    );
+
+    const router = (name: string, target: string, def: string, extra: Record<string, unknown> = {}) =>
+      seed!.createModel({
+        display_name: name,
+        semantic: {
+          embedding_model: "smg-bge",
+          routes: [
+            { name: "code", target, examples: ["write python code"], threshold: 0.5 },
+          ],
+          default: def,
+          match: { threshold: 0.5 },
+        },
+        ...extra,
+      });
+
+    await router("smg-router-ip", "smg-blocked", "smg-open");
+    await router("smg-router-all-blocked", "smg-blocked", "smg-blocked-2");
+    await router("smg-router-cooldown", "smg-flaky", "smg-open");
+    await router("smg-router-retries", "smg-retry-target", "smg-open", { retries: 4 });
+    await seed.createModel({
+      display_name: "smg-router-slow-embed",
+      semantic: {
+        embedding_model: "smg-bge-slow",
+        routes: [
+          { name: "code", target: "smg-t4-code", examples: ["write python code"], threshold: 0.5 },
+        ],
+        default: "smg-t4-default",
+        match: { threshold: 0.5 },
+      },
+    });
+
+    // Readiness: an unmatched prompt on the IP router falls through to
+    // the open default → 200 once everything propagated.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("smg-router-ip", "hello there");
+        return r.status === 200 && r.content === "served-open";
+      } catch {
+        return false;
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+    await Promise.all(embedMocks.map((m) => m.close()));
+  });
+
+  test("route target excluded by allowed_cidrs falls through to default and clears the route header", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const r = await chat("smg-router-ip", "write python code please");
+    expect(r.status).toBe(200);
+    expect(r.content).toBe("served-open");
+    // The winning route did not serve; the header must not claim it did.
+    expect(r.route).toBeNull();
+  });
+
+  test("route target and default both excluded yields the entry-gate 403 without leaking members", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const r = await chat("smg-router-all-blocked", "write python code please");
+    expect(r.status).toBe(403);
+    expect(r.body).not.toContain("smg-blocked");
+  });
+
+  test("a cooled-down route target is skipped at selection on the next request", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    // First request dispatches to the 500-ing target and trips its
+    // cooldown (selection had no health signal yet).
+    const first = await chat("smg-router-cooldown", "write python code please");
+    expect(first.status).toBeGreaterThanOrEqual(500);
+    // Second request: the winner is in cooldown → selection prefers the
+    // default instead of grinding the broken target again.
+    const second = await chat("smg-router-cooldown", "write python code please");
+    expect(second.status).toBe(200);
+    expect(second.content).toBe("served-open");
+    expect(second.route).toBeNull();
+  });
+
+  test("the embed sub-call inherits the embedding model's own timeout", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const started = Date.now();
+    const r = await chat("smg-router-slow-embed", "write python code please");
+    const elapsed = Date.now() - started;
+    expect(r.status).toBe(200);
+    // Pre-fix the 3s hang completed and routed by keyword to the code
+    // target; with the member timeout honored the embed call dies at
+    // ~500ms and on_embedding_failure serves the default.
+    expect(r.content).toBe("served-t4-default");
+    expect(elapsed).toBeLessThan(2500);
+  });
+
+  test("the router's top-level retries is the group slot of the retry chain", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    // 4 scripted 500s then success: only a budget of 4 retries (router
+    // level) survives; the deployment default of 2 fails pre-fix.
+    const r = await chat("smg-router-retries", "write python code please");
+    expect(r.status).toBe(200);
+    expect(r.content).toBe("served-after-retries");
+    expect(r.route).toBe("code");
+  });
+});

--- a/tests/e2e/src/cases/semantic-member-gates-e2e.test.ts
+++ b/tests/e2e/src/cases/semantic-member-gates-e2e.test.ts
@@ -243,6 +243,49 @@ describe("semantic router member gates e2e", () => {
       }),
     );
 
+    // Streaming-loop twin of the retries case: 4 scripted 500s, then the
+    // static SSE fixture serves the success — recoverable only with the
+    // router-level budget of 4 through the STREAMING dispatch loop.
+    await directModel(
+      "smg-retry-stream-target",
+      await chatUpstream("unused-static", {
+        scriptedResponses: [
+          { status: 500, errorBody: { error: { message: "boom", type: "server_error" } } },
+          { status: 500, errorBody: { error: { message: "boom", type: "server_error" } } },
+          { status: 500, errorBody: { error: { message: "boom", type: "server_error" } } },
+          { status: 500, errorBody: { error: { message: "boom", type: "server_error" } } },
+        ],
+        streamEvents: [
+          JSON.stringify({
+            id: "smg-sse",
+            object: "chat.completion.chunk",
+            model: "gpt-4o-mini",
+            choices: [
+              { index: 0, delta: { content: "served-stream" }, finish_reason: "stop" },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+          "[DONE]",
+        ],
+      }),
+    );
+    // Background-unhealthy displacement: this member's upstream always
+    // 500s, request-path cooldown is DISABLED (so only the background
+    // prober's Unhealthy verdict can displace it), and the 1s probe
+    // interval marks it within a few seconds.
+    await directModel("smg-unhealthy", await chatUpstream("unused-500", { status: 500 }), {
+      cooldown: { enabled: false },
+      background_model_check: {
+        enabled: true,
+        // Schema minimum — the prober's first verdict lands within ~5s.
+        interval_seconds: 5,
+        stale_after_seconds: 300,
+        prompt: "ping",
+        max_tokens: 1,
+        timeout_seconds: 2,
+      },
+    });
+
     const router = (name: string, target: string, def: string, extra: Record<string, unknown> = {}) =>
       seed!.createModel({
         display_name: name,
@@ -261,6 +304,10 @@ describe("semantic router member gates e2e", () => {
     await router("smg-router-all-blocked", "smg-blocked", "smg-blocked-2");
     await router("smg-router-cooldown", "smg-flaky", "smg-open");
     await router("smg-router-retries", "smg-retry-target", "smg-open", { retries: 4 });
+    await router("smg-router-retries-stream", "smg-retry-stream-target", "smg-open", {
+      retries: 4,
+    });
+    await router("smg-router-unhealthy", "smg-unhealthy", "smg-open");
     await seed.createModel({
       display_name: "smg-router-slow-embed",
       semantic: {
@@ -344,6 +391,56 @@ describe("semantic router member gates e2e", () => {
     // ~500ms and on_embedding_failure serves the default.
     expect(r.content).toBe("served-t4-default");
     expect(elapsed).toBeLessThan(2500);
+  });
+
+  test("the streaming dispatch loop honors the router-level retry budget too", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "smg-router-retries-stream",
+        messages: [{ role: "user", content: "write python code please" }],
+        stream: true,
+      }),
+    });
+    const body = await res.text();
+    // 4 scripted 500s exhaust only with the router's budget of 4; the
+    // 5th attempt opens the real SSE stream.
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    expect(body).toContain("served-stream");
+  });
+
+  test("a background-unhealthy route target is displaced by the healthy default", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    // Cooldown is disabled on the member, so only the background
+    // prober's Unhealthy verdict can displace it. Poll until the 5s
+    // probe interval has marked it and selection serves the default.
+    const deadline = Date.now() + 30_000;
+    let displaced: { status: number; content: string; route: string | null } | undefined;
+    while (Date.now() < deadline) {
+      const r = await chat("smg-router-unhealthy", "write python code please");
+      if (r.status === 200 && r.content === "served-open") {
+        displaced = r;
+        break;
+      }
+      // Until the mark lands, the winner dispatches and its upstream
+      // 500s — cooldown being disabled keeps this the only mechanism.
+      expect(r.status).toBeGreaterThanOrEqual(500);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    expect(displaced).toBeDefined();
+    expect(displaced?.route).toBeNull();
   });
 
   test("the router's top-level retries is the group slot of the retry chain", async (ctx) => {


### PR DESCRIPTION
## Problem

The semantic router's selection path (`semantic::resolve` → `attempt_for_target`) bypassed every gate its members carry, while routing groups enforce all of them per target — the per-model-gate invariant this repo documents (`aisix-proxy/AGENTS.md`): *anything an operator configures ON a model is a statement about that model, and reaching it through a group must not strip it*. Concretely, for a semantic route target: its `allowed_cidrs` was never evaluated (an IP-restricted model was reachable by any caller who could reach the router), its request-path cooldown and background health were recorded but never consumed (a broken target kept receiving every matching request), the embed sub-call ignored the embedding model's own `timeout` (a hung embedding upstream stalled requests unbounded unless the router set `embedding_timeout_ms`), and the router had no group slot in the retry chain at all.

## Change

- **Member IP allowlist becomes a hard gate at selection** (`select_eligible`): an excluded route target falls through to `default`; with every candidate excluded the caller gets the same 403 the entry gate produces, naming only the alias they addressed — a router never becomes a probe for which members exist (mirrors `routing.rs`'s all-excluded behavior).
- **Health is consumed, softly**: a route winner in cooldown or background-unhealthy is displaced by an available `default`; when neither is available the primary dispatches anyway — the router has no `when_all_unavailable` knob, and the semantically-right target beats failing a request on an advisory signal.
- **Served-route attribution stays honest**: `x-aisix-route` is cleared when the default displaces the route winner.
- **Embed deadline chain**: router `embedding_timeout_ms` → the embedding model's own `timeout` → deployment default.
- **Retries chain unified**: `group_retries_of()` makes the router's top-level `retries` the group slot of the member → group → deployment-default chain (a semantic parent has no `routing` block to carry it; a Model Group keeps using `routing.retries`). All five dispatch call sites moved to the helper so the chain cannot drift per endpoint.
- `aisix-proxy/AGENTS.md`: the guardrail-attachment note now names ensemble/semantic member guardrails as part of AISIX-Cloud#1090's single design pass (project decision — the operator can attach at the parent, so member scope is a mitigable gap, not an unavoidable bypass; do not piecemeal-fix or re-audit).

The control-plane side of the retries knob (accepting `retries` on semantic models) ships in the paired schema-convergence PR; the DP reading it first is harmless.

## Tests

New e2e `semantic-member-gates-e2e.test.ts` (real binary + etcd + deterministic keyword-vector embedding mock), five cases: IP-excluded target falls to default with the route header cleared; target+default both excluded → 403 leaking no member names; a 500-tripped cooldown target is skipped on the next request; the embedding model's own 500ms timeout cuts a 3s embed hang and degrades via `on_embedding_failure` (elapsed asserted); a 4×500-then-success target recovers only with the router-level `retries: 4` (deployment default is 2). **All five fail on main** (the pre-fix binary serves the IP-restricted member, 200s the all-blocked router, grinds the cooled target, hangs 3s then routes by keyword, and 5xxs the retry case); all five pass with the fix. Existing semantic suites and the full e2e run (566 tests) are green, plus a unit test pinning `group_retries_of`'s routing-block-then-parent order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Semantic routing now considers client IP restrictions and target health when selecting destinations.
  * Unavailable or restricted targets can automatically fall back to eligible alternatives.
  * Embedding requests now use the most appropriate configured timeout.
* **Bug Fixes**
  * Retry behavior is now consistently applied across chat, streaming, token counting, responses, direct models, and routed models.
  * Improved fallback handling for empty prompts and embedding failures.
  * Routing attribution is cleared when a request falls back from an unavailable winner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->