### PR TITLE
fix(wildcard): key gates and telemetry on the wildcard row, not caller-minted aliases

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -481,7 +481,7 @@ pub async fn speech(
                 "/v1/audio/speech",
                 crate::request_metrics::Caller::new(&auth),
                 crate::request_metrics::Upstream {
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     ..Default::default()
                 },
                 status,

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -859,7 +859,7 @@ async fn multipart_dispatch(
             Err(err) => return Err(ProxyError::Bridge(err)),
         };
 
-    state.health.record_success(&model_name);
+    state.health.record_success(&model_entry.value.display_name);
     state.runtime_status.mark_healthy(&model_entry.id);
 
     // Parse the response body best-effort for a `usage` token block
@@ -1283,7 +1283,7 @@ async fn speech_dispatch(
             Err(err) => return Err(ProxyError::Bridge(err)),
         };
 
-    state.health.record_success(&model_name);
+    state.health.record_success(&model_entry.value.display_name);
     state.runtime_status.mark_healthy(&model_entry.id);
 
     // #911 [21]: speech synthesis (TTS) reports no token usage — it is billed

--- a/crates/aisix-proxy/src/background.rs
+++ b/crates/aisix-proxy/src/background.rs
@@ -38,12 +38,13 @@ pub async fn run_background_model_check_once(
         if model.is_routing() {
             continue;
         }
-        // A wildcard alias row has no concrete upstream id of its own —
-        // probing would send the `*` template verbatim, burn real quota
-        // every interval, and pin the row permanently Unhealthy.
-        if model.display_name.contains('*')
-            || model.model_name.as_deref().is_some_and(|m| m.contains('*'))
-        {
+        // A wildcard alias row whose upstream TEMPLATE is itself a glob
+        // has no concrete model id to probe — the `*` would go upstream
+        // verbatim, burn real quota every interval, and pin the row
+        // permanently Unhealthy. A wildcard alias pinned to a concrete
+        // template (`gpt-*` → `gpt-4o`) probes that template safely and
+        // keeps its configured check.
+        if model.model_name.as_deref().is_none_or(|m| m.contains('*')) {
             continue;
         }
         let Some(cfg) = model.background_model_check.as_ref() else {

--- a/crates/aisix-proxy/src/background.rs
+++ b/crates/aisix-proxy/src/background.rs
@@ -25,6 +25,19 @@ use crate::health::ModelRuntimeStatusTracker;
 /// accounts) is dampened.
 const MAX_CONCURRENT_BACKGROUND_CHECKS: usize = 4;
 
+/// Whether a direct model's upstream id is a concrete string the prober
+/// can send. A wildcard alias row whose `model_name` template is itself a
+/// glob (`openai/*` → `"*"`) or absent has no concrete id — probing would
+/// send the `*` verbatim, burn real quota every interval, and pin the row
+/// permanently Unhealthy. A wildcard alias pinned to a concrete template
+/// (`gpt-*` → `gpt-4o`) probes that template safely and keeps its check.
+fn upstream_template_is_probeable(model: &aisix_core::Model) -> bool {
+    model
+        .model_name
+        .as_deref()
+        .is_some_and(|m| !m.contains('*'))
+}
+
 pub async fn run_background_model_check_once(
     snapshot: Arc<AisixSnapshot>,
     hub: Arc<Hub>,
@@ -38,13 +51,7 @@ pub async fn run_background_model_check_once(
         if model.is_routing() {
             continue;
         }
-        // A wildcard alias row whose upstream TEMPLATE is itself a glob
-        // has no concrete model id to probe — the `*` would go upstream
-        // verbatim, burn real quota every interval, and pin the row
-        // permanently Unhealthy. A wildcard alias pinned to a concrete
-        // template (`gpt-*` → `gpt-4o`) probes that template safely and
-        // keeps its configured check.
-        if model.model_name.as_deref().is_none_or(|m| m.contains('*')) {
+        if !upstream_template_is_probeable(model) {
             continue;
         }
         let Some(cfg) = model.background_model_check.as_ref() else {
@@ -164,6 +171,29 @@ mod tests {
     use reqwest::Client;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn upstream_template_probeability() {
+        let model = |model_name: Option<&str>| -> aisix_core::Model {
+            let mut v = serde_json::json!({
+                "display_name": "d",
+                "provider": "openai",
+                "provider_key_id": "pk",
+            });
+            if let Some(m) = model_name {
+                v["model_name"] = serde_json::json!(m);
+            }
+            serde_json::from_value(v).unwrap()
+        };
+        // Concrete template probes safely — including a wildcard ALIAS
+        // pinned to a concrete upstream (`gpt-*` → `gpt-4o`).
+        assert!(upstream_template_is_probeable(&model(Some("gpt-4o"))));
+        // A glob template would send `*` verbatim — skip.
+        assert!(!upstream_template_is_probeable(&model(Some("*"))));
+        assert!(!upstream_template_is_probeable(&model(Some("gpt-*"))));
+        // No upstream id at all — skip.
+        assert!(!upstream_template_is_probeable(&model(None)));
+    }
 
     fn openai_test_bridge() -> OpenAiBridge {
         let client = Client::builder()

--- a/crates/aisix-proxy/src/background.rs
+++ b/crates/aisix-proxy/src/background.rs
@@ -38,6 +38,14 @@ pub async fn run_background_model_check_once(
         if model.is_routing() {
             continue;
         }
+        // A wildcard alias row has no concrete upstream id of its own —
+        // probing would send the `*` template verbatim, burn real quota
+        // every interval, and pin the row permanently Unhealthy.
+        if model.display_name.contains('*')
+            || model.model_name.as_deref().is_some_and(|m| m.contains('*'))
+        {
+            continue;
+        }
         let Some(cfg) = model.background_model_check.as_ref() else {
             continue;
         };

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1810,8 +1810,14 @@ async fn dispatch(
         let model_for_metrics = req.model.clone();
         // Latency histograms label with the BOUNDED model (emit-chokepoint
         // rule): a wildcard-served alias must not mint per-suffix series.
-        let bounded_model_for_metrics =
-            crate::usage_attr::metric_model_label(snapshot, &req.model).into_owned();
+        let (bounded_model_for_metrics, bounded_upstream_for_metrics) = {
+            let (m, u) = crate::usage_attr::metric_model_label_pair(
+                snapshot,
+                &req.model,
+                model.upstream_model().unwrap_or("unknown"),
+            );
+            (m.into_owned(), u.into_owned())
+        };
         // #890 req-4: normalised inbound client type, captured for the
         // streaming on_complete metric emission (mirrors the non-streaming
         // `record_success` path).
@@ -2026,7 +2032,7 @@ async fn dispatch(
                     crate::request_metrics::Upstream {
                         provider: &provider_for_metrics,
                         model: &model_for_metrics,
-                        upstream_model: &upstream_model_for_metrics,
+                        upstream_model: &bounded_upstream_for_metrics,
                         pk: pk.labels(),
                         stream: true,
                         // The serving target is fixed once the stream
@@ -2067,8 +2073,8 @@ async fn dispatch(
                         endpoint: "/v1/chat/completions",
                         inbound_protocol: "openai",
                         provider: &provider_for_metrics,
-                        model: &model_for_metrics,
-                        upstream_model: &upstream_model_for_metrics,
+                        model: &bounded_model_for_metrics,
+                        upstream_model: &bounded_upstream_for_metrics,
                         provider_key_id: pk.labels().id(),
                         provider_key_name: pk.labels().name(),
                         api_key_id: &api_key_id_for_telem,

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -404,7 +404,7 @@ pub async fn chat_completions(
                 "/v1/chat/completions",
                 crate::request_metrics::Caller::new(&auth),
                 crate::request_metrics::Upstream {
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     stream: req.is_streaming(),
                     is_fallback: routing.fallback_count() > 0,
                     ..Default::default()
@@ -415,7 +415,7 @@ pub async fn chat_completions(
             state.metrics.record_request_e2e_latency(
                 LatencyLabels {
                     endpoint: "/v1/chat/completions",
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     provider: "unknown",
                     status,
                     streaming: req.is_streaming(),
@@ -1808,6 +1808,10 @@ async fn dispatch(
         let user_id_for_metrics = auth.key().user_id.clone();
         let provider_for_metrics = provider.to_ascii_lowercase();
         let model_for_metrics = req.model.clone();
+        // Latency histograms label with the BOUNDED model (emit-chokepoint
+        // rule): a wildcard-served alias must not mint per-suffix series.
+        let bounded_model_for_metrics =
+            crate::usage_attr::metric_model_label(snapshot, &req.model).into_owned();
         // #890 req-4: normalised inbound client type, captured for the
         // streaming on_complete metric emission (mirrors the non-streaming
         // `record_success` path).
@@ -2041,7 +2045,7 @@ async fn dispatch(
                 metrics_for_stream.record_request_e2e_latency(
                     LatencyLabels {
                         endpoint: "/v1/chat/completions",
-                        model: &model_for_metrics,
+                        model: &bounded_model_for_metrics,
                         provider: &provider_for_metrics,
                         status: 200,
                         streaming: true,
@@ -2051,7 +2055,7 @@ async fn dispatch(
                 metrics_for_stream.record_request_ttft(
                     LatencyLabels {
                         endpoint: "/v1/chat/completions",
-                        model: &model_for_metrics,
+                        model: &bounded_model_for_metrics,
                         provider: &provider_for_metrics,
                         status: 200,
                         streaming: true,
@@ -3520,6 +3524,8 @@ async fn dispatch_ensemble(
         let state_for_telem = state.clone();
         let request_id_for_telem = request_id.to_string();
         let client_model_for_telem = req.model.clone();
+        let bounded_model_for_telem =
+            crate::usage_attr::metric_model_label(snapshot, &req.model).into_owned();
         let api_key_id_for_telem = api_key_id.to_string();
         let applied_guardrails_for_telem = applied_guardrails.to_vec();
         let client_for_telem = client.clone();
@@ -3689,7 +3695,7 @@ async fn dispatch_ensemble(
                 state_for_telem.metrics.record_request_e2e_latency(
                     LatencyLabels {
                         endpoint: "/v1/chat/completions",
-                        model: &client_model_for_telem,
+                        model: &bounded_model_for_telem,
                         // Matches the legacy series: no single provider
                         // governs an ensemble response.
                         provider: "ensemble",
@@ -3701,7 +3707,7 @@ async fn dispatch_ensemble(
                 state_for_telem.metrics.record_request_ttft(
                     LatencyLabels {
                         endpoint: "/v1/chat/completions",
-                        model: &client_model_for_telem,
+                        model: &bounded_model_for_telem,
                         provider: "ensemble",
                         status: 200,
                         streaming: true,
@@ -4072,10 +4078,11 @@ fn record_success(
     // `elapsed` for a stream is time-to-response-start; the stream's
     // on_complete records the full duration instead.
     if !stream {
+        let bounded_model = crate::usage_attr::metric_model_label(&state.snapshot.load(), model);
         metrics.record_request_e2e_latency(
             LatencyLabels {
                 endpoint: "/v1/chat/completions",
-                model,
+                model: bounded_model.as_ref(),
                 provider,
                 status,
                 streaming: false,

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -399,7 +399,7 @@ async fn dispatch(
         Ok(resp_json) => {
             // #701: clear any cooldown/unhealthy mark now the upstream
             // answered — same recovery signal as rerank/audio/chat.
-            state.health.record_success(model_name);
+            state.health.record_success(&model_entry.value.display_name);
             state.runtime_status.mark_healthy(&model_entry.id);
             // Extract usage BEFORE moving resp_json into the Response
             // so the success struct carries typed counters rather

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -215,7 +215,7 @@ pub async fn completions(
                 "/v1/completions",
                 crate::request_metrics::Caller::new(&auth),
                 crate::request_metrics::Upstream {
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     ..Default::default()
                 },
                 status,

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -148,7 +148,7 @@ pub async fn count_tokens(
                 "/v1/messages/count_tokens",
                 crate::request_metrics::Caller::new(&auth),
                 crate::request_metrics::Upstream {
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     ..Default::default()
                 },
                 status,

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -212,7 +212,7 @@ pub async fn embeddings(
                 "/v1/embeddings",
                 crate::request_metrics::Caller::new(&auth),
                 crate::request_metrics::Upstream {
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     ..Default::default()
                 },
                 status,

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -442,7 +442,7 @@ async fn dispatch(
         Ok(embed_resp) => {
             // #701: clear any cooldown/unhealthy mark now the upstream
             // answered — same recovery signal as rerank/audio/chat.
-            state.health.record_success(&body.model);
+            state.health.record_success(&model_entry.value.display_name);
             state.runtime_status.mark_healthy(&model_entry.id);
             // Token accounting (#226 / AISIX-Cloud#1074). Embeddings are
             // input-only, so `prompt_tokens == total_tokens` on the OpenAI

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -188,7 +188,7 @@ pub async fn image_generations(
                 "/v1/images/generations",
                 crate::request_metrics::Caller::new(&auth),
                 crate::request_metrics::Upstream {
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     ..Default::default()
                 },
                 status,

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -370,7 +370,7 @@ async fn dispatch(
         Ok(resp_json) => {
             // #701: clear any cooldown/unhealthy mark now the upstream
             // answered — same recovery signal as rerank/audio/chat.
-            state.health.record_success(model_name);
+            state.health.record_success(&model_entry.value.display_name);
             state.runtime_status.mark_healthy(&model_entry.id);
             // Extract usage tokens (gpt-image-1 returns a `usage` block;
             // dall-e-3 doesn't) BEFORE moving resp_json into the

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -207,10 +207,12 @@ pub async fn messages(
             // SLO e2e histogram (AISIX-Cloud#1011): non-streaming only —
             // a stream records its full duration at completion instead.
             if !stream_requested {
+                let bounded_model =
+                    crate::usage_attr::metric_model_label(&state.snapshot.load(), &model_name);
                 state.metrics.record_request_e2e_latency(
                     LatencyLabels {
                         endpoint: "/v1/messages",
-                        model: &model_name,
+                        model: bounded_model.as_ref(),
                         provider: &provider_label,
                         status,
                         streaming: false,
@@ -312,7 +314,7 @@ pub async fn messages(
                 "/v1/messages",
                 crate::request_metrics::Caller::new(&auth),
                 crate::request_metrics::Upstream {
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     stream: stream_requested,
                     is_fallback: routing.fallback_count() > 0,
                     ..Default::default()
@@ -323,7 +325,7 @@ pub async fn messages(
             state.metrics.record_request_e2e_latency(
                 LatencyLabels {
                     endpoint: "/v1/messages",
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     provider: "unknown",
                     status,
                     streaming: stream_requested,
@@ -1258,6 +1260,10 @@ async fn anthropic_passthrough_dispatch(
         let api_key_id_c = api_key_id.to_string();
         let provider_c = provider_label.clone();
         let model_name_c = model_name.to_string();
+        // Bounded twin for the latency-histogram label (emit-chokepoint
+        // rule) — usage events keep the raw requested string.
+        let bounded_model_c =
+            crate::usage_attr::metric_model_label(&state.snapshot.load(), model_name).into_owned();
         let provider_key_id_c = pk_id.to_string();
         let upstream_model_c = upstream_model.clone();
         let team_id_c = team_id.clone();
@@ -1361,7 +1367,7 @@ async fn anthropic_passthrough_dispatch(
                 state_c.metrics.record_request_e2e_latency(
                     LatencyLabels {
                         endpoint: "/v1/messages",
-                        model: &model_name_c,
+                        model: &bounded_model_c,
                         provider: &provider_c,
                         status: 200,
                         streaming: true,
@@ -1910,6 +1916,8 @@ async fn cross_provider_dispatch(
         let api_key_id_for_telem = api_key_id.to_string();
         let provider_for_telem = provider_label.clone();
         let model_for_telem = model_name.to_string();
+        let bounded_model_for_telem =
+            crate::usage_attr::metric_model_label(&state.snapshot.load(), model_name).into_owned();
         let provider_key_id_for_telem = provider_key_id.to_string();
         let upstream_model_for_telem = upstream_model.clone();
         let team_id_for_telem = team_id;
@@ -2007,7 +2015,7 @@ async fn cross_provider_dispatch(
                 state_for_telem.metrics.record_request_e2e_latency(
                     LatencyLabels {
                         endpoint: "/v1/messages",
-                        model: &model_for_telem,
+                        model: &bounded_model_for_telem,
                         provider: &provider_for_telem,
                         status: 200,
                         streaming: true,
@@ -2848,10 +2856,11 @@ fn emit_anthropic_usage_event(
         },
     );
     if metrics.upstream_ttft_ms > 0 {
+        let bounded_model = crate::usage_attr::metric_model_label(&state.snapshot.load(), model);
         state.metrics.record_request_ttft(
             LatencyLabels {
                 endpoint: "/v1/messages",
-                model,
+                model: bounded_model.as_ref(),
                 provider,
                 status: status_code,
                 streaming: true,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1905,7 +1905,7 @@ async fn cross_provider_dispatch(
         } else {
             upstream
         };
-        state.health.record_success(model_name);
+        state.health.record_success(&model.display_name);
         state.runtime_status.mark_healthy(model_id);
 
         let message_id = format!("msg_{}", Uuid::new_v4().simple());
@@ -2856,7 +2856,9 @@ fn emit_anthropic_usage_event(
         },
     );
     if metrics.upstream_ttft_ms > 0 {
-        let bounded_model = crate::usage_attr::metric_model_label(&state.snapshot.load(), model);
+        let snap_for_labels = state.snapshot.load();
+        let (bounded_model, bounded_upstream) =
+            crate::usage_attr::metric_model_label_pair(&snap_for_labels, model, upstream_model);
         state.metrics.record_request_ttft(
             LatencyLabels {
                 endpoint: "/v1/messages",
@@ -2872,8 +2874,8 @@ fn emit_anthropic_usage_event(
                 endpoint: "/v1/messages",
                 inbound_protocol: "anthropic",
                 provider,
-                model,
-                upstream_model,
+                model: bounded_model.as_ref(),
+                upstream_model: bounded_upstream.as_ref(),
                 provider_key_id: pk.labels().id(),
                 provider_key_name: pk.labels().name(),
                 api_key_id,

--- a/crates/aisix-proxy/src/model_resolve.rs
+++ b/crates/aisix-proxy/src/model_resolve.rs
@@ -78,6 +78,27 @@ pub(crate) fn wildcard_row_name(snapshot: &AisixSnapshot, requested: &str) -> Op
     best_wildcard_row(snapshot, requested).map(|(entry, _)| entry.value.display_name.clone())
 }
 
+/// The `(display_name, model_name template)` pair of the wildcard row
+/// serving `requested` — the bounded identities for BOTH metric labels:
+/// with `model_name: "*"` the substituted upstream id is caller-derived
+/// too, so `upstream_model` must label as the configured template, not
+/// the capture.
+pub(crate) fn wildcard_row_identity(
+    snapshot: &AisixSnapshot,
+    requested: &str,
+) -> Option<(String, String)> {
+    best_wildcard_row(snapshot, requested).map(|(entry, _)| {
+        (
+            entry.value.display_name.clone(),
+            entry
+                .value
+                .model_name
+                .clone()
+                .unwrap_or_else(|| "*".to_string()),
+        )
+    })
+}
+
 /// Concrete upstream model id for a wildcard match: substitute the captured
 /// segment into the `model_name` template's `*`, keep the template as-is when it
 /// has no `*` (a fixed upstream for every match), or send the captured segment

--- a/crates/aisix-proxy/src/model_resolve.rs
+++ b/crates/aisix-proxy/src/model_resolve.rs
@@ -29,8 +29,23 @@ pub(crate) fn resolve_model(
     if let Some(exact) = snapshot.models.get_by_name(requested) {
         return Some(exact);
     }
-    // Wildcard fallback: the most specific direct Model whose `*`-glob display
-    // name matches the request. Only runs when the exact lookup missed.
+    let (entry, upstream) = best_wildcard_row(snapshot, requested)?;
+    let mut model = entry.value.clone();
+    model.model_name = Some(upstream);
+    Some(Arc::new(ResourceEntry::new(
+        entry.id.clone(),
+        model,
+        entry.revision,
+    )))
+}
+
+/// Wildcard fallback: the most specific direct Model whose `*`-glob
+/// display name matches the request, plus the substituted upstream model
+/// id. Only meaningful when the exact lookup missed.
+fn best_wildcard_row(
+    snapshot: &AisixSnapshot,
+    requested: &str,
+) -> Option<(Arc<ResourceEntry<Model>>, String)> {
     let mut best: Option<(usize, Arc<ResourceEntry<Model>>, String)> = None;
     for entry in snapshot.models.entries() {
         let model = &entry.value;
@@ -52,14 +67,15 @@ pub(crate) fn resolve_model(
             best = Some((specificity, entry.clone(), upstream));
         }
     }
-    let (_, entry, upstream) = best?;
-    let mut model = entry.value.clone();
-    model.model_name = Some(upstream);
-    Some(Arc::new(ResourceEntry::new(
-        entry.id.clone(),
-        model,
-        entry.revision,
-    )))
+    best.map(|(_, entry, upstream)| (entry, upstream))
+}
+
+/// The `display_name` of the wildcard row that would serve `requested`,
+/// for metric-label bounding: successful wildcard traffic must label as
+/// the configured row (`openai/*`), never as the caller-minted concrete
+/// string — the #451 cardinality guard extended to resolvable names.
+pub(crate) fn wildcard_row_name(snapshot: &AisixSnapshot, requested: &str) -> Option<String> {
+    best_wildcard_row(snapshot, requested).map(|(entry, _)| entry.value.display_name.clone())
 }
 
 /// Concrete upstream model id for a wildcard match: substitute the captured
@@ -121,6 +137,24 @@ mod tests {
         // Attribution stays on the wildcard Model; upstream id is the capture.
         assert_eq!(resolved.id, "m-star");
         assert_eq!(resolved.value.model_name.as_deref(), Some("gpt-4o"));
+        // The resolved clone keeps the ROW's display_name — the bounded
+        // identity metric labels and rate-limit buckets key on.
+        assert_eq!(resolved.value.display_name, "openai/*");
+    }
+
+    #[test]
+    fn wildcard_row_name_bounds_caller_minted_aliases() {
+        let snap = snapshot_with(vec![
+            ("m-star", direct_model("openai/*", Some("*"))),
+            ("m-exact", direct_model("openai/gpt-4o", Some("gpt-4o"))),
+        ]);
+        // A caller-minted suffix maps to the serving row's name…
+        assert_eq!(
+            wildcard_row_name(&snap, "openai/anything-i-like").as_deref(),
+            Some("openai/*")
+        );
+        // …and an unservable name maps to nothing.
+        assert_eq!(wildcard_row_name(&snap, "azure/gpt-4o"), None);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -35,6 +35,13 @@ use crate::state::ProxyState;
 /// Optional model rate-limit info resolved by the caller before enforce.
 pub(crate) struct ModelRateLimit {
     pub name: String,
+    /// The resolved entry's `display_name` — the bucket identity. Equal
+    /// to `name` everywhere except a wildcard-served alias, where every
+    /// caller-minted concrete name must land in the wildcard row's ONE
+    /// bucket: keying on `name` there let any caller mint fresh
+    /// full-size buckets per suffix, unbounded-multiplying the declared
+    /// cap (the passthrough gate already keyed on `display_name`).
+    pub bucket_name: String,
     pub entry_id: String,
     pub limits: Option<RateLimit>,
     /// The model's `provider` — the value of the `provider` condition
@@ -60,6 +67,7 @@ impl ModelRateLimit {
             .cloned();
         Self {
             name: model_name.to_owned(),
+            bucket_name: model.display_name.clone(),
             entry_id: model_entry_id.to_owned(),
             limits,
             provider: model.provider.clone(),
@@ -333,7 +341,7 @@ async fn reserve_layers(
     // Layer 2: Model inline rate limit.
     if let Some(mrl) = model_rl {
         if let Some(ref limits) = mrl.limits {
-            let key = format!("model:{}", mrl.name);
+            let key = format!("model:{}", mrl.bucket_name);
             let r = state
                 .limiter
                 .pre_commit(&key, limits)
@@ -546,7 +554,7 @@ pub(crate) async fn reserve_model_only(
     // Inline model rate limit.
     let mrl = ModelRateLimit::from_model(model_name, model_entry_id, model);
     if let Some(ref limits) = mrl.limits {
-        let key = format!("model:{}", mrl.name);
+        let key = format!("model:{}", mrl.bucket_name);
         let r = state
             .limiter
             .pre_commit(&key, limits)
@@ -670,6 +678,7 @@ mod tests {
     fn make_model_rl(name: &str, entry_id: &str, provider: Option<&str>) -> ModelRateLimit {
         ModelRateLimit {
             name: name.to_owned(),
+            bucket_name: name.to_owned(),
             entry_id: entry_id.to_owned(),
             limits: None,
             provider: provider.map(str::to_owned),

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -785,7 +785,10 @@ async fn run_session(
         crate::request_metrics::Caller::new(&auth),
         crate::request_metrics::Upstream {
             provider: &provider_label,
-            model: &model_entry.value.display_name,
+            // The requested string so the emit chokepoint folds a
+            // wildcard-served alias's pair to the row's identities
+            // (non-wildcard: requested == display_name, unchanged).
+            model: &requested_model,
             upstream_model: model_entry.value.upstream_model().unwrap_or("unknown"),
             pk: pk.labels(),
             ..Default::default()

--- a/crates/aisix-proxy/src/request_metrics.rs
+++ b/crates/aisix-proxy/src/request_metrics.rs
@@ -242,6 +242,16 @@ pub(crate) fn record(
     elapsed: Duration,
 ) {
     let outcome = RequestOutcome::from_status(status);
+    // Emit-chokepoint label bounding (#451 class): success paths hand in
+    // the caller's requested string, which for a wildcard-served alias
+    // is caller-minted — collapse it to the configured row's name here
+    // so no handler-family member can mint unbounded series.
+    let snap = state.snapshot.load();
+    let model_label = crate::usage_attr::metric_model_label(&snap, upstream.model);
+    let upstream = Upstream {
+        model: model_label.as_ref(),
+        ..upstream
+    };
     state
         .metrics
         .record_request(upstream.provider, upstream.model, status, outcome, elapsed);
@@ -311,6 +321,13 @@ pub(crate) fn record_usage(
     upstream: Upstream<'_>,
     tokens: Tokens<'_>,
 ) {
+    // Same emit-chokepoint bounding as `record` — see the note there.
+    let snap = state.snapshot.load();
+    let model_label = crate::usage_attr::metric_model_label(&snap, upstream.model);
+    let upstream = Upstream {
+        model: model_label.as_ref(),
+        ..upstream
+    };
     // Legacy compatibility series (provider × model).
     state
         .metrics

--- a/crates/aisix-proxy/src/request_metrics.rs
+++ b/crates/aisix-proxy/src/request_metrics.rs
@@ -247,9 +247,11 @@ pub(crate) fn record(
     // is caller-minted — collapse it to the configured row's name here
     // so no handler-family member can mint unbounded series.
     let snap = state.snapshot.load();
-    let model_label = crate::usage_attr::metric_model_label(&snap, upstream.model);
+    let (model_label, upstream_label) =
+        crate::usage_attr::metric_model_label_pair(&snap, upstream.model, upstream.upstream_model);
     let upstream = Upstream {
         model: model_label.as_ref(),
+        upstream_model: upstream_label.as_ref(),
         ..upstream
     };
     state
@@ -323,9 +325,11 @@ pub(crate) fn record_usage(
 ) {
     // Same emit-chokepoint bounding as `record` — see the note there.
     let snap = state.snapshot.load();
-    let model_label = crate::usage_attr::metric_model_label(&snap, upstream.model);
+    let (model_label, upstream_label) =
+        crate::usage_attr::metric_model_label_pair(&snap, upstream.model, upstream.upstream_model);
     let upstream = Upstream {
         model: model_label.as_ref(),
+        upstream_model: upstream_label.as_ref(),
         ..upstream
     };
     // Legacy compatibility series (provider × model).

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -191,7 +191,7 @@ pub async fn rerank(
                 "/v1/rerank",
                 crate::request_metrics::Caller::new(&auth),
                 crate::request_metrics::Upstream {
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     ..Default::default()
                 },
                 status,

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -517,7 +517,7 @@ async fn dispatch(
             Err(err) => return Err(ProxyError::Bridge(err)),
         };
 
-    state.health.record_success(&model_name);
+    state.health.record_success(&model_entry.value.display_name);
     state.runtime_status.mark_healthy(&model_entry.id);
 
     // Extract usage from the upstream body BEFORE handing the bytes

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -300,10 +300,12 @@ pub async fn responses(
                 // SLO e2e histogram (AISIX-Cloud#1011): recorded even when
                 // the upstream response carried no parseable usage block —
                 // latency observation must not depend on token accounting.
+                let bounded_model =
+                    crate::usage_attr::metric_model_label(&state.snapshot.load(), &model_name);
                 state.metrics.record_request_e2e_latency(
                     LatencyLabels {
                         endpoint: "/v1/responses",
-                        model: &model_name,
+                        model: bounded_model.as_ref(),
                         provider: &success.provider,
                         status,
                         streaming: stream_requested,
@@ -375,7 +377,7 @@ pub async fn responses(
                 "/v1/responses",
                 crate::request_metrics::Caller::new(&auth),
                 crate::request_metrics::Upstream {
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     stream: stream_requested,
                     is_fallback: routing.fallback_count() > 0,
                     ..Default::default()
@@ -386,7 +388,7 @@ pub async fn responses(
             state.metrics.record_request_e2e_latency(
                 LatencyLabels {
                     endpoint: "/v1/responses",
-                    model: metric_model,
+                    model: metric_model.as_ref(),
                     provider: "unknown",
                     status,
                     streaming: stream_requested,
@@ -1444,6 +1446,9 @@ async fn responses_to_target(
         let request_id_c = request_id.to_string();
         let model_id_c = model_id.to_string();
         let requested_model_c = requested_model.to_string();
+        let bounded_model_c =
+            crate::usage_attr::metric_model_label(&state.snapshot.load(), requested_model)
+                .into_owned();
         let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
         let provider_c = provider_label.clone();
@@ -1538,7 +1543,7 @@ async fn responses_to_target(
                 state_c.metrics.record_request_e2e_latency(
                     LatencyLabels {
                         endpoint: "/v1/responses",
-                        model: &requested_model_c,
+                        model: &bounded_model_c,
                         provider: &provider_c,
                         status: 200,
                         streaming: true,
@@ -1944,6 +1949,9 @@ async fn responses_cross_provider_to_target(
         let request_id_c = request_id.to_string();
         let model_id_c = model_id.to_string();
         let requested_model_c = requested_model.to_string();
+        let bounded_model_c =
+            crate::usage_attr::metric_model_label(&state.snapshot.load(), requested_model)
+                .into_owned();
         let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
         let provider_c = provider_label.clone();
@@ -2036,7 +2044,7 @@ async fn responses_cross_provider_to_target(
                 state_c.metrics.record_request_e2e_latency(
                     LatencyLabels {
                         endpoint: "/v1/responses",
-                        model: &requested_model_c,
+                        model: &bounded_model_c,
                         provider: &provider_c,
                         status,
                         streaming: true,

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -227,18 +227,27 @@ pub(crate) const UNRESOLVED_MODEL_LABEL: &str = "unresolved";
 
 /// Bound the `model` metric label to the configured set. A request's `model`
 /// field is arbitrary caller-controlled text until it resolves against the
-/// snapshot; on an error path that can fire *before* resolution (model-not-
-/// found), feeding the raw value into a Prometheus label lets a caller
-/// explode metric cardinality. Return the requested name only when it maps to
-/// a configured model (direct or virtual router — both live in `models`),
-/// else the fixed [`UNRESOLVED_MODEL_LABEL`] sentinel. This is the typed-
-/// endpoint analogue of passthrough's `PASSTHROUGH_MODEL_LABEL` guard (#451),
-/// shared here so the handler family can't drift.
-pub(crate) fn metric_model_label<'a>(snap: &AisixSnapshot, model_name: &'a str) -> &'a str {
+/// snapshot; feeding the raw value into a Prometheus label lets a caller
+/// explode metric cardinality. Three outcomes:
+/// - an exact configured name (direct or virtual router — both live in
+///   `models`) labels as itself;
+/// - a name only a WILDCARD row serves labels as that row's `display_name`
+///   (`openai/*`) — the caller can mint unlimited concrete suffixes, so the
+///   configured row is the only bounded identity, and it keeps success and
+///   failure series for one row under one label;
+/// - anything else is the fixed [`UNRESOLVED_MODEL_LABEL`] sentinel.
+///
+/// This is the typed-endpoint analogue of passthrough's
+/// `PASSTHROUGH_MODEL_LABEL` guard (#451); `request_metrics::record` /
+/// `record_usage` apply it at the emit chokepoint so no handler family
+/// member can drift.
+pub(crate) fn metric_model_label<'a>(snap: &AisixSnapshot, model_name: &'a str) -> Cow<'a, str> {
     if snap.models.get_by_name(model_name).is_some() {
-        model_name
-    } else {
-        UNRESOLVED_MODEL_LABEL
+        return Cow::Borrowed(model_name);
+    }
+    match crate::model_resolve::wildcard_row_name(snap, model_name) {
+        Some(row) => Cow::Owned(row),
+        None => Cow::Borrowed(UNRESOLVED_MODEL_LABEL),
     }
 }
 
@@ -328,6 +337,41 @@ pub(crate) fn emit_error_usage_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn metric_model_label_three_outcomes() {
+        use aisix_core::resource::ResourceEntry;
+        use aisix_core::snapshot::ResourceTable;
+        let table = ResourceTable::default();
+        let wildcard: aisix_core::Model = serde_json::from_value(serde_json::json!({
+            "display_name": "openai/*",
+            "provider": "openai",
+            "model_name": "*",
+            "provider_key_id": "pk-1",
+        }))
+        .unwrap();
+        table.insert(ResourceEntry::new("m-star", wildcard, 1));
+        let snap = AisixSnapshot {
+            models: table,
+            ..Default::default()
+        };
+        // Exact configured name labels as itself (the wildcard row's own
+        // name IS an exact name).
+        assert_eq!(metric_model_label(&snap, "openai/*"), "openai/*");
+        // A caller-minted suffix a wildcard row serves labels as the ROW,
+        // not the unbounded concrete string (#451 class on the success
+        // path).
+        assert_eq!(metric_model_label(&snap, "openai/gpt-4o"), "openai/*");
+        assert_eq!(
+            metric_model_label(&snap, "openai/anything-else"),
+            "openai/*"
+        );
+        // Unservable text stays the sentinel.
+        assert_eq!(
+            metric_model_label(&snap, "no-such/model"),
+            UNRESOLVED_MODEL_LABEL
+        );
+    }
 
     /// AISIX-Cloud#1289: the id is upstream-controlled and reaches a log line
     /// and cp-api's `dpmgr_usage_events`. A newline in it would break the

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -251,6 +251,46 @@ pub(crate) fn metric_model_label<'a>(snap: &AisixSnapshot, model_name: &'a str) 
     }
 }
 
+/// Fixed non-model surface labels the emit chokepoint must pass through
+/// byte-identical: rewriting any of these would silently split every
+/// series that carries it (the `unknown` note below) and merge distinct
+/// surfaces into the `unresolved` bucket. Also an O(1) short-circuit so
+/// the tunnel hot paths (passthrough / MCP / A2A / jobs) never pay the
+/// wildcard scan.
+const FIXED_SURFACE_MODEL_LABELS: &[&str] = &[
+    UNRESOLVED_MODEL_LABEL,
+    "passthrough",
+    "mcp",
+    "a2a",
+    "unknown",
+    "files",
+    "batches",
+    "fine_tuning",
+];
+
+/// The `(model, upstream_model)` label pair for the emit chokepoint —
+/// COLLAPSE-ONLY: a name only a wildcard row serves folds to the row's
+/// `(display_name, model_name template)` (both halves of a wildcard hit
+/// are caller-derived); every other value passes through verbatim.
+/// Sentinel fallbacks stay a HANDLER decision (`metric_model_label` on
+/// the pre-resolution error paths) — the chokepoint must never rewrite
+/// a caller's fixed surface label.
+pub(crate) fn metric_model_label_pair<'a>(
+    snap: &AisixSnapshot,
+    model_name: &'a str,
+    upstream_model: &'a str,
+) -> (Cow<'a, str>, Cow<'a, str>) {
+    if FIXED_SURFACE_MODEL_LABELS.contains(&model_name)
+        || snap.models.get_by_name(model_name).is_some()
+    {
+        return (Cow::Borrowed(model_name), Cow::Borrowed(upstream_model));
+    }
+    match crate::model_resolve::wildcard_row_identity(snap, model_name) {
+        Some((row, template)) => (Cow::Owned(row), Cow::Owned(template)),
+        None => (Cow::Borrowed(model_name), Cow::Borrowed(upstream_model)),
+    }
+}
+
 /// Stamp the five per-PK attribution fields onto an in-progress UsageEvent,
 /// sanitising the operator-controlled tag strings (control-char strip + length
 /// cap) before they hit the wire. One source of truth for the mapping so the
@@ -371,6 +411,23 @@ mod tests {
             metric_model_label(&snap, "no-such/model"),
             UNRESOLVED_MODEL_LABEL
         );
+
+        // The emit-chokepoint pair is COLLAPSE-ONLY: a wildcard hit folds
+        // BOTH halves to the row's configured identities…
+        let (m, u) = metric_model_label_pair(&snap, "openai/gpt-4o", "gpt-4o");
+        assert_eq!((m.as_ref(), u.as_ref()), ("openai/*", "*"));
+        // …an exact hit passes both through…
+        let (m, u) = metric_model_label_pair(&snap, "openai/*", "somemodel");
+        assert_eq!((m.as_ref(), u.as_ref()), ("openai/*", "somemodel"));
+        // …and fixed surface sentinels and unresolvable values are NEVER
+        // rewritten (rewriting `mcp`/`passthrough`/`unknown` would split
+        // every series that carries them).
+        for sentinel in ["passthrough", "mcp", "a2a", "unknown"] {
+            let (m, u) = metric_model_label_pair(&snap, sentinel, "x");
+            assert_eq!((m.as_ref(), u.as_ref()), (sentinel, "x"));
+        }
+        let (m, u) = metric_model_label_pair(&snap, "no-such/model", "raw-upstream");
+        assert_eq!((m.as_ref(), u.as_ref()), ("no-such/model", "raw-upstream"));
     }
 
     /// AISIX-Cloud#1289: the id is upstream-controlled and reaches a log line

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -1566,7 +1566,7 @@ pub async fn create_video(
         Err(err) => {
             let status = err.status().as_u16();
             let metric_model = crate::usage_attr::metric_model_label(&snapshot, &model_name);
-            telemetry.finish(status, "unknown", metric_model, Some(&err));
+            telemetry.finish(status, "unknown", metric_model.as_ref(), Some(&err));
             // #655 parity: failed submits surface in Logs as zero-token
             // events instead of vanishing.
             crate::usage_attr::emit_error_usage_event(
@@ -1706,7 +1706,9 @@ async fn dispatch_create(
     reservation.commit_tokens(0).await;
     let resp = result?;
 
-    state.health.record_success(&body.model);
+    state
+        .health
+        .record_success(&target.model_entry.value.display_name);
     state.runtime_status.mark_healthy(&target.model_entry.id);
 
     let submit = target.provider.parse_submit(&resp)?;

--- a/tests/e2e/src/cases/wildcard-identity-e2e.test.ts
+++ b/tests/e2e/src/cases/wildcard-identity-e2e.test.ts
@@ -85,6 +85,35 @@ describe("wildcard alias identity e2e", () => {
       provider_key_id: pk.id,
       rate_limit: { rpm: 1 },
     });
+    // A second wildcard row with an SSE fixture (the mock picks SSE vs
+    // JSON per FIXTURE): drives the streaming-only TTFT/summary series
+    // so the dump-wide assertions cover that family too.
+    const sse = await startOpenAiUpstream({
+      streamEvents: [
+        JSON.stringify({
+          id: "wid-sse",
+          object: "chat.completion.chunk",
+          model: "gpt-4o-mini",
+          choices: [
+            { index: 0, delta: { content: "served-wid2" }, finish_reason: "stop" },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        "[DONE]",
+      ],
+    });
+    upstreams.push(sse);
+    const pk2 = await seed.createProviderKey({
+      display_name: "wid2-pk",
+      secret: "sk-mock",
+      api_base: `${sse.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "wid2/*",
+      provider: "openai",
+      model_name: "*",
+      provider_key_id: pk2.id,
+    });
 
     // Readiness via a wildcard-served alias: any suffix must resolve.
     // listModels hides wildcard patterns, so probe with a chat call —
@@ -105,7 +134,7 @@ describe("wildcard alias identity e2e", () => {
     await Promise.all(upstreams.map((u) => u.close()));
   });
 
-  test("every caller-minted alias shares the wildcard row's rate-limit bucket, and success metrics label as the row", async (ctx) => {
+  test("every caller-minted alias shares the wildcard row's rate-limit bucket, and success metrics label as the row", { timeout: 150_000 }, async (ctx) => {
     if (!etcdReachable || !app) {
       ctx.skip();
       return;
@@ -135,11 +164,39 @@ describe("wildcard alias identity e2e", () => {
     expect(second.status).toBe(429);
     expect(second.type).toBe("rate_limit_exceeded");
 
+    // Drive a STREAMING request too (fresh window; its own alias): the
+    // TTFT/summary families only emit on streamed completions, and the
+    // dump-wide assertion below must cover them.
+    const streamRes = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "wid2/gamma",
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      }),
+    });
+    const streamBody = await streamRes.text();
+    expect(streamRes.status).toBe(200);
+    expect(streamRes.headers.get("content-type")).toContain("text/event-stream");
+    expect(streamBody).toContain("served-wid2");
+
     // Success + throttle series both label as the configured row; the
     // caller-minted suffixes never become label values.
     const metrics = await (await fetch(`${app.metricsUrl}/metrics`)).text();
     expect(metrics).toContain('model="wid/*"');
     expect(metrics).not.toContain('model="wid/alpha"');
     expect(metrics).not.toContain('model="wid/beta"');
+    expect(metrics).not.toContain('model="wid2/gamma"');
+    expect(metrics).toContain('model="wid2/*"');
+    // The upstream_model label is caller-derived on a wildcard hit too
+    // (the capture substitutes into the template) — it must collapse to
+    // the row's configured template, never the minted suffix.
+    expect(metrics).not.toContain('upstream_model="alpha"');
+    expect(metrics).not.toContain('upstream_model="beta"');
+    expect(metrics).not.toContain('upstream_model="gamma"');
   });
 });

--- a/tests/e2e/src/cases/wildcard-identity-e2e.test.ts
+++ b/tests/e2e/src/cases/wildcard-identity-e2e.test.ts
@@ -89,6 +89,7 @@ describe("wildcard alias identity e2e", () => {
     // JSON per FIXTURE): drives the streaming-only TTFT/summary series
     // so the dump-wide assertions cover that family too.
     const sse = await startOpenAiUpstream({
+      eventDelayMs: 2,
       streamEvents: [
         JSON.stringify({
           id: "wid-sse",

--- a/tests/e2e/src/cases/wildcard-identity-e2e.test.ts
+++ b/tests/e2e/src/cases/wildcard-identity-e2e.test.ts
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  awaitWindowHeadroom,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: a wildcard alias row (`wid/*`) is ONE configured identity, so its
+// gates and telemetry must key on the row, not on whatever concrete
+// suffix a caller mints (model-kind audit):
+//
+//   1. The inline rate_limit bucket is shared across every alias the row
+//      serves — previously each distinct suffix opened a fresh
+//      full-size bucket, letting any caller multiply the declared cap
+//      without bound.
+//   2. The Prometheus `model` label for wildcard-served SUCCESS traffic
+//      is the row's display_name; caller-minted strings must not mint
+//      unbounded series (the #451 cardinality guard, extended to
+//      resolvable names).
+
+const CALLER_PLAINTEXT = "sk-wildcard-identity-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+function chatBody(content: string) {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: 0,
+    model: "gpt-4o-mini",
+    choices: [
+      { index: 0, message: { role: "assistant", content }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe("wildcard alias identity e2e", () => {
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  async function chat(model: string): Promise<{ status: number; type?: string }> {
+    if (!app) throw new Error("app not ready");
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ model, messages: [{ role: "user", content: "hi" }] }),
+    });
+    const body = (await res.json()) as { error?: { type?: string } };
+    return { status: res.status, type: body.error?.type };
+  }
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+    await seed.createApiKey({ key_hash: CALLER_KEY_HASH, allowed_models: ["*"] });
+
+    const upstream = await startOpenAiUpstream({ nonStreamBody: chatBody("served-wid") });
+    upstreams.push(upstream);
+    const pk = await seed.createProviderKey({
+      display_name: "wid-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "wid/*",
+      provider: "openai",
+      model_name: "*",
+      provider_key_id: pk.id,
+      rate_limit: { rpm: 1 },
+    });
+
+    // Readiness via a wildcard-served alias: any suffix must resolve.
+    // listModels hides wildcard patterns, so probe with a chat call —
+    // 404 until the row propagates. The probe consumes the shared rpm
+    // slot, so tests below re-align on a fresh window first.
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await chat("wid/readiness-probe");
+        return r.status === 200 || r.status === 429;
+      } catch {
+        return false;
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("every caller-minted alias shares the wildcard row's rate-limit bucket, and success metrics label as the row", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    await awaitWindowHeadroom(5);
+
+    // The readiness probe already consumed a slot of the SHARED bucket
+    // (itself evidence of the fix), so align by burning `wid/alpha`
+    // until a fresh window admits it — that 200 is alias #1's slot.
+    const deadline = Date.now() + 90_000;
+    let aligned = false;
+    while (Date.now() < deadline) {
+      const r = await chat("wid/alpha");
+      if (r.status === 200) {
+        aligned = true;
+        break;
+      }
+      expect(r.status).toBe(429);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    expect(aligned).toBe(true);
+
+    // A DIFFERENT alias in the same window must land in the same
+    // bucket. Pre-fix each suffix opened its own rpm=1 bucket and this
+    // passed with 200.
+    const second = await chat("wid/beta");
+    expect(second.status).toBe(429);
+    expect(second.type).toBe("rate_limit_exceeded");
+
+    // Success + throttle series both label as the configured row; the
+    // caller-minted suffixes never become label values.
+    const metrics = await (await fetch(`${app.metricsUrl}/metrics`)).text();
+    expect(metrics).toContain('model="wid/*"');
+    expect(metrics).not.toContain('model="wid/alpha"');
+    expect(metrics).not.toContain('model="wid/beta"');
+  });
+});


### PR DESCRIPTION
## Problem

A wildcard alias row (`openai/*`) is ONE configured identity — the resolution layer deliberately keeps the row's entry id and `display_name` on the resolved clone so attribution stays bounded. Three mechanisms ignored that and keyed on the caller-supplied concrete string instead (model-kind audit):

1. **Inline `rate_limit`/`concurrency` buckets fragmented per alias.** The bucket key was `model:<requested string>`, so `openai/*` capped at `rpm: 60` gave every distinct suffix a caller minted its own fresh 60-rpm bucket — the declared cap multiplied without bound by caller-chosen strings. (The passthrough gate already keyed on `display_name`; the typed endpoints now match it.)
2. **Prometheus `model` labels were unbounded on wildcard-served traffic.** The bounded-label guard (#451) only ran on pre-resolution error paths and mapped wildcard-served names to the `unresolved` sentinel, while success paths passed the raw requested string — a caller could mint one new series per invented suffix across the request/token/latency families, and the same row's successes and failures landed under different labels.
3. **The background prober probed wildcard rows as if direct**, dispatching the literal `*` template upstream every interval — guaranteed 4xx, real quota burned, and the row pinned permanently Unhealthy on the admin status view. It now skips them (the jobs surface already did).

Plus one consistency nit: the videos endpoint keyed health-tracker successes by the caller string where every sibling keys by `display_name`.

## Change

- `ModelRateLimit` carries `bucket_name` = the resolved entry's `display_name` (equal to the requested name everywhere except wildcard-served aliases); both inline-bucket sites key on it. Condition inputs keep the requested string, so `model_name` policy matching is unchanged.
- `metric_model_label` gains the wildcard outcome (a name only a wildcard row serves labels as that row's `display_name`) and `request_metrics::record`/`record_usage` apply it at the emit chokepoint, so no handler-family member can drift. The SLO latency histograms — emitted from streaming closures the chokepoint cannot see — get bounded companion labels at each capture site. Usage events keep the raw `requested_model` per their documented contract.
- Background prober skips rows whose `display_name`/`model_name` contains `*`.

## Behavior changes

1. All aliases served by one wildcard row now share that row's inline rate-limit bucket (previously per-alias buckets — the amplification bug).
2. Wildcard-served traffic's metric `model` label becomes the row's `display_name` (previously the raw alias on success and `unresolved` on failure); per-model dashboards for wildcard rows become coherent and bounded.
3. Wildcard rows with `background_model_check.enabled` stop being probed (previously probed with the literal `*` and marked Unhealthy forever).

## Tests

- Unit: `from_model` bucket identity; `metric_model_label` three outcomes (exact / wildcard-served / unresolved); `wildcard_row_name` specificity and misses.
- E2E (`wildcard-identity-e2e.test.ts`, real binary + etcd): a second caller-minted alias 429s inside the same window (**fails on main**: it got 200 on its own fresh bucket), and a full-metrics-dump assertion proves no caller-minted alias appears as any label value while the row's name does — the dump-wide check also caught the latency-histogram family during development, which is why the fix covers it.
- Full workspace tests and the entire e2e suite (197 files / 562 tests) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved telemetry labeling across chat, completions, embeddings, images, messages, responses, reranking, video, and realtime requests.
  * Wildcard model aliases now use consistent configured identities in metrics and rate-limit tracking.
  * Health status reporting now reflects the resolved model’s display name.
  * Background health checks skip wildcard or incomplete model identifiers to avoid invalid probes.
* **Bug Fixes**
  * Improved consistency for streaming, latency, usage, error, and upstream metrics.
  * Added coverage for wildcard identity, throttling, and metric behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->