### PR TITLE
build(deps): drop an unused dependency and narrow unused features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,6 @@ dependencies = [
  "async-trait",
  "axum 0.7.9",
  "futures",
- "http 1.4.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -1078,7 +1077,6 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core 0.4.5",
- "axum-macros",
  "base64 0.22.1",
  "bytes",
  "futures-util",
@@ -1171,17 +1169,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -5205,7 +5192,6 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5265,16 +5251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5284,15 +5260,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -5442,7 +5415,6 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "serde_core",
  "sha1_smol",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,10 @@ tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 async-trait = "0.1"
 
 # HTTP server. axum's `tracing` feature has no API surface — it gates
-# axum's internal logging of extractor rejections; a zero-hit grep is
-# its normal appearance, keep it.
+# axum's internal logging of extractor rejections, so a zero-hit grep is
+# its normal appearance. It is also an axum default feature (defaults
+# stay on here), so the explicit entry documents intent rather than
+# being what enables it.
 axum = { version = "0.7", features = ["ws", "tracing", "multipart"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 tower = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,13 @@ futures = "0.3"
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 async-trait = "0.1"
 
-# HTTP server
-axum = { version = "0.7", features = ["macros", "ws", "tracing", "multipart"] }
+# HTTP server. axum's `tracing` feature has no API surface — it gates
+# axum's internal logging of extractor rejections; a zero-hit grep is
+# its normal appearance, keep it.
+axum = { version = "0.7", features = ["ws", "tracing", "multipart"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["trace", "cors", "limit", "compression-gzip", "set-header"] }
+tower-http = { version = "0.6", features = ["set-header"] }
 http = "1.2"
 http-body-util = "0.1"
 # Trusted-proxy CIDR matching for real-ip resolution (#492)
@@ -113,12 +115,12 @@ yaml-rust2 = "0.8"
 # Time / IDs
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
-uuid = { version = "1.11", features = ["v4", "v5", "serde"] }
+uuid = { version = "1.11", features = ["v4", "v5"] }
 hostname = "0.4"
 
 # Observability
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt", "registry"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
 

--- a/crates/aisix-a2a/Cargo.toml
+++ b/crates/aisix-a2a/Cargo.toml
@@ -22,7 +22,6 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-http.workspace = true
 # A2A has no official Rust SDK (the reference SDKs are Python/JS/Java/Go/.NET),
 # so the JSON-RPC 2.0 + agent-card plumbing is hand-rolled directly on the
 # workspace HTTP client rather than pulled from an SDK.


### PR DESCRIPTION
## What

Dependency-hygiene pass over the workspace manifests: removes the one unused direct dependency and narrows four feature lists to what the code actually uses. No behavior change; every cut is backed by a zero-usage search across `src/` and `tests/` of all crates.

## Changes and evidence

| Change | Evidence | Tree effect |
|---|---|---|
| aisix-a2a: drop direct `http` dependency | zero `http::` references in the crate; its tests use `axum::http` (axum's re-export, not the direct dep). Only `cargo machete` finding in the workspace, manually verified (no cfg-gated / feature-gated / test-only use) | none (http stays in the tree for its real consumers); manifest-only cleanup |
| tower-http: `["trace", "cors", "limit", "compression-gzip", "set-header"]` → `["set-header"]` | `TraceLayer`/`CorsLayer`/`RequestBodyLimitLayer`/`CompressionLayer` have zero hits; body limiting is `axum::extract::DefaultBodyLimit` plus the crate's own `enforce_request_body_limit` (aisix-proxy/src/lib.rs); the only tower-http item in use is `SetResponseHeaderLayer` (server header) | tower-http's trace/cors/limit/compression modules stop compiling. Note: `async-compression` itself stays — reqwest's `gzip` feature (deliberately kept: Accept-Encoding negotiation) enables tower-http's decompression side |
| axum: drop `macros` | no `#[debug_handler]`, no `derive(FromRef)`; `FromRef` appears only as a trait bound, which the feature does not gate | drops the `axum-macros` proc-macro crate |
| uuid: drop `serde` | no `Uuid`-typed field crosses a serde boundary; every call site converts immediately (`to_string()`/`simple()`/`as_u128()`) | declaration-only |
| tracing-subscriber: drop `json` | no `.json()` formatter is constructed and there is no log-format config knob, so the JSON formatter is unreachable at runtime | drops `tracing-serde` |

## Deliberately kept (audited, not cut)

- **axum `tracing`** — has no API surface; it gates axum's internal logging of extractor rejections. It is also an axum default feature (default features stay on), so the explicit entry is documentation of intent rather than what enables it; the manifest comment records both facts so a future sweep does not re-flag it.
- **config `toml` / `json`** — statically zero-hit, but `config::File::from` infers the format from the file extension, so existing `config.toml` / `config.json` deployments depend on them. Removing them would be a breaking operator-facing change.
- **tokio `full`** — only `io-std` and `process` are unused, and both are thin internal tokio modules whose removal compiles out no third-party crate; narrowing buys nothing measurable.
- **reqwest features** — `gzip` (Accept-Encoding negotiation), `multipart` (audio), `stream`/`json` all in use; `rustls-tls-native-roots` is load-bearing (#860); `http2` is enabled by object_store's reqwest dependency either way.

## Verification

- `cargo check --workspace --all-targets --all-features` — clean
- `cargo test --workspace --all-features` — 0 failed
- `cargo clippy --workspace --all-targets --all-features` — no warnings; `cargo fmt --check` clean
- `cargo run -p aisix-core --bin dump-schema` — zero schema diff
- e2e (both serving modes) gated by CI

Stacked on #960: both PRs touch the workspace manifest and lockfile; this one retargets to `main` automatically when #960 merges.

