### PR TITLE
bench(onthebench): pin the dwarf stack dump and flag flamegraphs that did not unwind

### DIFF
--- a/bench/onthebench/README.md
+++ b/bench/onthebench/README.md
@@ -72,14 +72,17 @@ Every method knob is a `BENCH_*` environment variable (defaults in `lib.sh`
 match the #891 grid exactly): `BENCH_GRID` (`"ttft_ms:conc ..."`, e.g.
 `"20:1536 20:2048"` for an added delay tier, `"0:128"` for a spot-check),
 `BENCH_REPS`, `BENCH_WINDOW`, `BENCH_WARMUP`, `BENCH_MAX_TRIES`,
-`BENCH_FLOOR_REPS`, `BENCH_FLAMEGRAPH`. `bench.sh` forwards them to the rig.
+`BENCH_FLOOR_REPS`, `BENCH_FLAMEGRAPH`, `BENCH_PERF_STACK`. `bench.sh` forwards
+them to the rig.
 A changed knob is recorded in `meta.json`, so a non-default run can never
 pass silently as the standard grid.
 
 Values are validated at startup and nonsense refuses to run: grid entries
 must be `ttft_ms:conc` with a positive concurrency; window, reps, max tries
 and floor reps must be positive integers (warmup may be `0`);
-`BENCH_FLAMEGRAPH` is `0` or `1`.
+`BENCH_FLAMEGRAPH` is `0` or `1`. `BENCH_PERF_STACK` is the per-sample stack
+perf copies for dwarf unwinding (default 32768; a multiple of 8 up to 65528) -
+raise it if a capture reports a high unresolved-stack share.
 
 ## Measuring another target ("entrant")
 

--- a/bench/onthebench/README.md
+++ b/bench/onthebench/README.md
@@ -61,10 +61,13 @@ Replicates the published onthebench setup (https://onthebench.ai/gateways/perfor
   VmHWM are in the metadata, alongside commit, binary sha256, instrument
   sha256s, core split, kernel, and the full method parameters.
 - **Flamegraph** — one on-CPU flamegraph at the c=128 saturation point per run
-  (`perf record -F 499 --call-graph dwarf` → inferno), the api7/aisix#847
+  (`perf record -F 499 --call-graph dwarf,32768` → inferno), the api7/aisix#847
   workflow. `rig-setup.sh` sets `kernel.perf_event_paranoid=1` (session-scoped,
   reverts on reboot) so an unprivileged run can sample its own process, and
-  `run-baseline.sh` refuses a stripped binary before wasting a run.
+  `run-baseline.sh` refuses a stripped binary before wasting a run. Every
+  capture reports the share of its stacks that failed to unwind, into both the
+  terminal and the collected `perf.log`; a capture that unwound poorly is
+  called out rather than left to look like a profile.
 
 ## Method overrides
 

--- a/bench/onthebench/bench.sh
+++ b/bench/onthebench/bench.sh
@@ -48,7 +48,7 @@ echo "== run baseline ($RUNID) =="
 # printf %q keeps values with spaces intact through the remote shell.
 ENVPASS="BENCH_SRC_COMMIT=$COMMIT BENCH_SRC_DIRTY=$DIRTY"
 for v in BENCH_GRID BENCH_REPS BENCH_WINDOW BENCH_WARMUP BENCH_MAX_TRIES \
-         BENCH_FLOOR_REPS BENCH_FLAMEGRAPH; do
+         BENCH_FLOOR_REPS BENCH_FLAMEGRAPH BENCH_PERF_STACK; do
     # if, not `[ ] &&`: harmless here, but the && form as a function's last
     # statement is exactly how the grid_concs regression happened once.
     if [ -n "${!v:-}" ]; then ENVPASS="$ENVPASS $v=$(printf %q "${!v}")"; fi

--- a/bench/onthebench/lib.sh
+++ b/bench/onthebench/lib.sh
@@ -19,8 +19,13 @@ MAX_TRIES="${BENCH_MAX_TRIES:-8}"
 GRID="${BENCH_GRID:-0:16 0:32 0:128 10:768}"
 FLOOR_REPS="${BENCH_FLOOR_REPS:-2}"
 FLAMEGRAPH="${BENCH_FLAMEGRAPH:-1}"
-# Bytes of stack perf copies per sample for dwarf unwinding. See
-# flamegraph_point: the 8KB default is too small for this gateway's stacks.
+# Bytes of stack perf copies per sample for dwarf unwinding. perf's 8KB
+# default has produced captures on this rig where 88-96% of the sampled
+# weight unwound to nothing; 32KB has not. The trigger is not isolated to a
+# build profile or a commit - the two worst captures are a thin-LTO build,
+# and one commit produced both a 42% and a 71% capture - so this size is a
+# mitigation, not a diagnosis, and check_symbolization measures every
+# capture rather than trusting it.
 PERF_STACK="${BENCH_PERF_STACK:-32768}"
 
 # Request shape. An entrant overrides these before sourcing when its only
@@ -52,8 +57,10 @@ is_pos_int "$WINDOW" || { echo "FATAL: BENCH_WINDOW must be a positive integer, 
 is_pos_int "$REPS" || { echo "FATAL: BENCH_REPS must be a positive integer, got '$REPS'"; exit 1; }
 is_pos_int "$MAX_TRIES" || { echo "FATAL: BENCH_MAX_TRIES must be a positive integer, got '$MAX_TRIES'"; exit 1; }
 is_pos_int "$FLOOR_REPS" || { echo "FATAL: BENCH_FLOOR_REPS must be a positive integer, got '$FLOOR_REPS'"; exit 1; }
-# perf rejects a non-multiple of 8 and silently caps above 64KB; refuse both
-# here rather than discovering it after a 45s capture window.
+# perf rounds a non-multiple of 8 up (callchain.c get_stack_size) and hard
+# errors above round_down(USHRT_MAX, 8) = 65528. Require the exact value so
+# the size recorded in meta.json is the size perf actually used, and so an
+# out-of-range value fails here rather than after a 45s capture window.
 is_pos_int "$PERF_STACK" && [ $((PERF_STACK % 8)) -eq 0 ] && [ "$PERF_STACK" -le 65528 ] ||
     { echo "FATAL: BENCH_PERF_STACK must be a positive multiple of 8 up to 65528, got '$PERF_STACK'"; exit 1; }
 case "$FLAMEGRAPH" in 0|1) ;; *) echo "FATAL: BENCH_FLAMEGRAPH must be 0 or 1, got '$FLAMEGRAPH'"; exit 1 ;; esac
@@ -314,41 +321,61 @@ floor_tier() { # floor_tier <ttft>  -> the floor points this tier needs
 # renders, it looks plausible, and every attribution taken from it is wrong.
 # The check is on the collapsed output rather than on perf's exit code
 # because that is where the failure is visible - frames that unwound to
-# nothing come back as [unknown]/[dso] entries with no symbol at any depth.
+# nothing come back as [unknown]/[dso] entries with no symbol.
+#
+# Two shares, because they fail differently. "no symbol at any depth" is the
+# coarse one and can pass a capture whose leaves are nearly all anonymous;
+# the leaf share is what a flamegraph attributes self-time to, and separates
+# this repo's own captures more widely. Both thresholds come from those
+# captures: usable ones measure up to 71% (any-depth) and 72% (leaf), the
+# failed ones start at 88% and 91% respectively.
 check_symbolization() { # check_symbolization <folded-file>
-    local unresolved
-    unresolved=$(awk '
+    local shares any leaf
+    shares=$(awk '
         { n = $NF; total += n
-          # strip the count and the leading thread name, then look for any
-          # frame that carries a real symbol
-          sub(/ [0-9]+$/, ""); split($0, frames, ";")
+          sub(/ [0-9]+$/, ""); nf = split($0, frames, ";")
           resolved = 0
-          for (i = 2; i <= length(frames); i++)
+          # frames[1] is the thread name and always resolves; start past it
+          for (i = 2; i <= nf; i++)
               if (frames[i] !~ /^\[/) { resolved = 1; break }
-          if (!resolved) bad += n }
-        END { if (total > 0) printf "%.1f", bad / total * 100; else print "100.0" }
-    ' "$1")
-    # 80% is where the two populations separate, measured over this repo's
-    # own captures: usable ones run 37-57% unresolved (kernel frames, which
-    # kptr_restrict keeps anonymous, plus stripped system libraries), the
-    # unwind-failure mode lands at 92-96%. A tighter threshold would flag
-    # healthy captures; a looser one would let the failure through.
-    awk -v u="$unresolved" 'BEGIN{exit !(u > 80)}' &&
-        echo "WARNING: $1 is $unresolved% unresolved stacks - unwinding likely failed; do not attribute from this flamegraph (try a larger BENCH_PERF_STACK)" >&2
-    echo "  flamegraph: $unresolved% unresolved stacks" >&2
+          if (!resolved) bad += n
+          if (nf >= 2 && frames[nf] ~ /^\[/) badleaf += n }
+        END { if (total > 0) printf "%.1f %.1f", bad / total * 100, badleaf / total * 100
+              else print "empty empty" }
+    ' "$1") || { echo "WARNING: cannot read $1 for the symbolization check" >&2; return 0; }
+    read -r any leaf <<<"$shares"
+    if [ "$any" = empty ]; then
+        echo "WARNING: $1 has no samples - the capture produced nothing to attribute" >&2
+        return 0
+    fi
+    # Reported into perf.log as well as the terminal: perf.log is collected
+    # off the rig, and the reader who most needs this number is the one
+    # opening the SVG months later, not the operator watching the run.
+    echo "  flamegraph: $any% unresolved stacks, $leaf% unresolved leaves" |
+        tee -a "$OUT/perf.log" >&2
+    awk -v a="$any" -v l="$leaf" 'BEGIN{exit !(a > 80 || l > 85)}' &&
+        echo "WARNING: $1 unwound poorly - do not attribute from this flamegraph (try a larger BENCH_PERF_STACK)" |
+            tee -a "$OUT/perf.log" >&2
+    return 0
 }
 
 flamegraph_point() { # flamegraph_point <conc> <title>  (0-delay mock running)
     local conc="$1" title="$2" load_bg
     echo "== flamegraph (c=$conc, 0-delay) ==" >&2
+    # A 32KB dump writes roughly 4x the perf.data of perf's 8KB default
+    # (~1.5GB over this window); the rig is shared and has run out of disk
+    # before. Warn rather than skip - a capture is worth attempting.
+    local avail_mb
+    avail_mb=$(df -Pm "$OUT" | awk 'NR==2{print $4}')
+    [ "${avail_mb:-0}" -ge 4096 ] ||
+        echo "WARNING: ${avail_mb}MB free at $OUT; a ${PERF_STACK}-byte dump may not fit" >&2
     loadgen "127.0.0.1:$GW_PORT" "$conc" 45 > "$OUT/flamegraph-window.txt" & load_bg=$!
     sleep 5
-    # Explicit stack dump size: perf's 8KB default is smaller than this
-    # gateway's async stacks under a fat-LTO build, and a stack that does not
-    # fit unwinds to nothing - every frame collapses to [unknown] and the SVG
-    # renders as one flat bar. That failure is silent (perf exits 0, inferno
-    # renders happily), which is why the size is pinned here rather than left
-    # to the default, and why the collapse output is checked below.
+    # Explicit stack dump size: a stack that does not fit in the dump unwinds
+    # to nothing - every frame collapses to [unknown] and the SVG renders as
+    # one flat bar. The failure is silent (perf exits 0, inferno renders
+    # happily), which is why the size is pinned here rather than left to the
+    # default, and why the collapsed output is checked below.
     perf record -F 499 --call-graph "dwarf,$PERF_STACK" -p "$GW_PID" -o "$OUT/perf.data" -- sleep 25 \
         >> "$OUT/perf.log" 2>&1 || echo "WARNING: perf record failed" >&2
     wait "$load_bg" || true
@@ -405,7 +432,7 @@ meta_method_json() {
     "grid": "$GRID", "body": $BODY_JSON,
     "path": "$REQ_PATH", "clk_tck": $CLK_TCK, "nofile": $(ulimit -n),
     "loadgen_headers": $HEADERS_JSON,
-    "flamegraph": {"enabled": $([ "$FLAMEGRAPH" = 1 ] && grid_has 0 128 && echo true || echo false), "freq_hz": 499, "callgraph": "dwarf", "window_s": 25, "conc": 128}
+    "flamegraph": {"enabled": $([ "$FLAMEGRAPH" = 1 ] && grid_has 0 128 && echo true || echo false), "freq_hz": 499, "callgraph": "dwarf,$PERF_STACK", "stack_bytes": $PERF_STACK, "window_s": 25, "conc": 128}
   }
 EOF
 }

--- a/bench/onthebench/lib.sh
+++ b/bench/onthebench/lib.sh
@@ -19,6 +19,9 @@ MAX_TRIES="${BENCH_MAX_TRIES:-8}"
 GRID="${BENCH_GRID:-0:16 0:32 0:128 10:768}"
 FLOOR_REPS="${BENCH_FLOOR_REPS:-2}"
 FLAMEGRAPH="${BENCH_FLAMEGRAPH:-1}"
+# Bytes of stack perf copies per sample for dwarf unwinding. See
+# flamegraph_point: the 8KB default is too small for this gateway's stacks.
+PERF_STACK="${BENCH_PERF_STACK:-32768}"
 
 # Request shape. An entrant overrides these before sourcing when its only
 # ingress speaks a different dialect (the pinned loadgen and mock both serve
@@ -49,6 +52,10 @@ is_pos_int "$WINDOW" || { echo "FATAL: BENCH_WINDOW must be a positive integer, 
 is_pos_int "$REPS" || { echo "FATAL: BENCH_REPS must be a positive integer, got '$REPS'"; exit 1; }
 is_pos_int "$MAX_TRIES" || { echo "FATAL: BENCH_MAX_TRIES must be a positive integer, got '$MAX_TRIES'"; exit 1; }
 is_pos_int "$FLOOR_REPS" || { echo "FATAL: BENCH_FLOOR_REPS must be a positive integer, got '$FLOOR_REPS'"; exit 1; }
+# perf rejects a non-multiple of 8 and silently caps above 64KB; refuse both
+# here rather than discovering it after a 45s capture window.
+is_pos_int "$PERF_STACK" && [ $((PERF_STACK % 8)) -eq 0 ] && [ "$PERF_STACK" -le 65528 ] ||
+    { echo "FATAL: BENCH_PERF_STACK must be a positive multiple of 8 up to 65528, got '$PERF_STACK'"; exit 1; }
 case "$FLAMEGRAPH" in 0|1) ;; *) echo "FATAL: BENCH_FLAMEGRAPH must be 0 or 1, got '$FLAMEGRAPH'"; exit 1 ;; esac
 [ -n "$GRID" ] || { echo "FATAL: BENCH_GRID is empty"; exit 1; }
 for _spec in $GRID; do
@@ -303,12 +310,46 @@ floor_tier() { # floor_tier <ttft>  -> the floor points this tier needs
 
 # ---- flamegraph --------------------------------------------------------------
 
+# A flamegraph whose stacks did not unwind is worse than no flamegraph: it
+# renders, it looks plausible, and every attribution taken from it is wrong.
+# The check is on the collapsed output rather than on perf's exit code
+# because that is where the failure is visible - frames that unwound to
+# nothing come back as [unknown]/[dso] entries with no symbol at any depth.
+check_symbolization() { # check_symbolization <folded-file>
+    local unresolved
+    unresolved=$(awk '
+        { n = $NF; total += n
+          # strip the count and the leading thread name, then look for any
+          # frame that carries a real symbol
+          sub(/ [0-9]+$/, ""); split($0, frames, ";")
+          resolved = 0
+          for (i = 2; i <= length(frames); i++)
+              if (frames[i] !~ /^\[/) { resolved = 1; break }
+          if (!resolved) bad += n }
+        END { if (total > 0) printf "%.1f", bad / total * 100; else print "100.0" }
+    ' "$1")
+    # 80% is where the two populations separate, measured over this repo's
+    # own captures: usable ones run 37-57% unresolved (kernel frames, which
+    # kptr_restrict keeps anonymous, plus stripped system libraries), the
+    # unwind-failure mode lands at 92-96%. A tighter threshold would flag
+    # healthy captures; a looser one would let the failure through.
+    awk -v u="$unresolved" 'BEGIN{exit !(u > 80)}' &&
+        echo "WARNING: $1 is $unresolved% unresolved stacks - unwinding likely failed; do not attribute from this flamegraph (try a larger BENCH_PERF_STACK)" >&2
+    echo "  flamegraph: $unresolved% unresolved stacks" >&2
+}
+
 flamegraph_point() { # flamegraph_point <conc> <title>  (0-delay mock running)
     local conc="$1" title="$2" load_bg
     echo "== flamegraph (c=$conc, 0-delay) ==" >&2
     loadgen "127.0.0.1:$GW_PORT" "$conc" 45 > "$OUT/flamegraph-window.txt" & load_bg=$!
     sleep 5
-    perf record -F 499 --call-graph dwarf -p "$GW_PID" -o "$OUT/perf.data" -- sleep 25 \
+    # Explicit stack dump size: perf's 8KB default is smaller than this
+    # gateway's async stacks under a fat-LTO build, and a stack that does not
+    # fit unwinds to nothing - every frame collapses to [unknown] and the SVG
+    # renders as one flat bar. That failure is silent (perf exits 0, inferno
+    # renders happily), which is why the size is pinned here rather than left
+    # to the default, and why the collapse output is checked below.
+    perf record -F 499 --call-graph "dwarf,$PERF_STACK" -p "$GW_PID" -o "$OUT/perf.data" -- sleep 25 \
         >> "$OUT/perf.log" 2>&1 || echo "WARNING: perf record failed" >&2
     wait "$load_bg" || true
     # Rendering must never kill the measurement: perf.data is kept on any
@@ -318,6 +359,7 @@ flamegraph_point() { # flamegraph_point <conc> <title>  (0-delay mock running)
                inferno-collapse-perf > "$OUT/flamegraph-c$conc.folded" 2>> "$OUT/perf.log" &&
            inferno-flamegraph --title "$title" \
                < "$OUT/flamegraph-c$conc.folded" > "$OUT/flamegraph-c$conc.svg" 2>> "$OUT/perf.log"; then
+            check_symbolization "$OUT/flamegraph-c$conc.folded"
             rm -f "$OUT/perf.data"
         else
             echo "WARNING: flamegraph rendering failed; perf.data kept" >&2

--- a/bench/onthebench/lib.sh
+++ b/bench/onthebench/lib.sh
@@ -380,16 +380,23 @@ flamegraph_point() { # flamegraph_point <conc> <title>  (0-delay mock running)
         >> "$OUT/perf.log" 2>&1 || echo "WARNING: perf record failed" >&2
     wait "$load_bg" || true
     # Rendering must never kill the measurement: perf.data is kept on any
-    # failure so the SVG can be produced off-rig.
+    # failure so the SVG can be produced off-rig. Collapse and render are
+    # separate steps because the symbolization check reads the folded file:
+    # a capture that collapsed but failed to render still has a share worth
+    # reporting, and gating the check on the SVG would lose exactly the
+    # diagnostic that explains why the capture is worth nothing.
     if [ -s "$OUT/perf.data" ]; then
         if perf script -i "$OUT/perf.data" 2>> "$OUT/perf.log" |
-               inferno-collapse-perf > "$OUT/flamegraph-c$conc.folded" 2>> "$OUT/perf.log" &&
-           inferno-flamegraph --title "$title" \
-               < "$OUT/flamegraph-c$conc.folded" > "$OUT/flamegraph-c$conc.svg" 2>> "$OUT/perf.log"; then
+               inferno-collapse-perf > "$OUT/flamegraph-c$conc.folded" 2>> "$OUT/perf.log"; then
             check_symbolization "$OUT/flamegraph-c$conc.folded"
-            rm -f "$OUT/perf.data"
+            if inferno-flamegraph --title "$title" \
+                   < "$OUT/flamegraph-c$conc.folded" > "$OUT/flamegraph-c$conc.svg" 2>> "$OUT/perf.log"; then
+                rm -f "$OUT/perf.data"
+            else
+                echo "WARNING: flamegraph rendering failed; perf.data kept" >&2
+            fi
         else
-            echo "WARNING: flamegraph rendering failed; perf.data kept" >&2
+            echo "WARNING: perf script or collapse failed; perf.data kept" >&2
         fi
     fi
 }


### PR DESCRIPTION
## What

Two changes to the rig harness, both about the same failure: a flamegraph
that renders fine and is entirely wrong.

1. **Pin the per-sample stack dump** to 32KB (`BENCH_PERF_STACK`, validated
   like the other `BENCH_*` knobs, forwarded to the rig by `bench.sh`).
2. **Check the collapsed output** after rendering and warn when the capture
   is unusable.

## Why

While taking the closing census for the performance program, a c=128
capture on a fat-LTO build came back with **95.5% of its stacks collapsed
to `[unknown]`**. perf's default dump is 8KB, which is smaller than this
gateway's async stacks under fat LTO, so libunwind had nothing to walk.

The failure is silent in every layer: `perf record` exits 0, `perf script`
produces output, inferno renders an SVG, and the picture reads as "the
kernel is 94% of the time". A re-capture of the same commit reproduced it
at 91.7%, so it is not a fluke. Attribution taken from such a graph is
wrong in a way that looks authoritative.

Same build, same load, after the fix:

| | before | after |
|---|---|---|
| collapsed stacks | 529 | 1876 |
| resolved user-space share | ~5% | 48.4% |

## The threshold is measured, not picked

The check warns above **80% unresolved**. That number comes from this
repo's own captures, not from judgement:

| capture | unresolved | verdict |
|---|---|---|
| old rig, thin LTO + glibc | 0.0% | usable |
| this rig, thin LTO + glibc | 37.0% | usable |
| this rig, fat LTO, 32KB dump | 51.1% | usable |
| this rig, fat LTO (earlier scene) | 56.6% | usable |
| this rig, fat LTO, 8KB dump | 91.7% | **failed** |
| this rig, fat LTO, 8KB dump | 95.5% | **failed** |

The two populations separate cleanly. A tighter threshold flags healthy
captures (the 57% one is a real, usable profile); a looser one lets the
failure through.

Verified by running the check against all six captures plus an empty file:
warns on exactly the two failed ones and the degenerate input, silent on
the four usable ones.

## Why warn instead of abort

A bad flamegraph does not invalidate a run's throughput numbers - they come
from the measured windows, not from perf. Aborting a 15-minute measurement
over an auxiliary artifact would be the wrong trade. The share is printed
on every capture either way, so a run's log always states how much of its
own profile is trustworthy.

## Note for anyone reading older profiles

Captures taken before this change were subject to the same effect. The two
at 92-96% are unusable outright; the ones in the 51-57% band are fine, but
their "kernel" share is an upper bound - deep stacks that failed to unwind
land in the same bucket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable perf stack sizing for benchmark flamegraph captures.
  * Added validation for stack size values, including range and alignment requirements.
  * Added warnings when flamegraph stack symbols cannot be resolved reliably.
  * Documented the new benchmark override and its default constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->