### PR TITLE
bench(onthebench): verify that the process being measured is the one this run started

### DIFF
--- a/bench/onthebench/lib.sh
+++ b/bench/onthebench/lib.sh
@@ -144,15 +144,57 @@ wait_http_200() { # wait_http_200 <url> <label> [max_s]
     return 1
 }
 
+# An HTTP 200 says something is listening; it does not say the thing that is
+# listening is the thing this run started. A process that loses the bind race
+# exits, a stale listener from an earlier run keeps answering, and every
+# window afterwards measures a stranger with fail=0 throughout. Two checks,
+# because neither covers the other:
+#
+#   liveness    our own process is still up. This is the one that catches a
+#               lost bind race whatever the other listener is, since the
+#               loser exits on "Address already in use".
+#   ownership   the listener on the port is our pid. This catches a process
+#               that is alive but bound elsewhere, or answering from an
+#               earlier run of itself.
+#
+# Ownership degrades to a warning when ss cannot report the pid (a listener
+# owned by another user needs privilege to attribute); liveness never does.
+#
+# Response-shape fingerprinting deliberately not used: a stand-in mock built
+# from the same semantics answers byte-identically, so a fingerprint cannot
+# tell the two apart. The listening pid can.
+assert_listener() { # assert_listener <port> <pid> <label>
+    local port="$1" want="$2" label="$3" owners p
+    [ -d "/proc/$want" ] ||
+        { echo "FATAL: $label (pid $want) is not running after readiness - it likely lost the bind race on :$port; something else answered the readiness probe" >&2
+          exit 1; }
+    owners=$(ss -ltnpH "sport = :$port" 2>/dev/null | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u)
+    if [ -z "$owners" ]; then
+        echo "WARNING: cannot attribute the listener on :$port; $label identity unverified (liveness passed)" >&2
+        return 0
+    fi
+    grep -qx "$want" <<<"$owners" && return 0
+    # A launcher that forks the real listener is legitimate; a stranger is not.
+    for p in $owners; do
+        [ "$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')" = "$want" ] && return 0
+    done
+    echo "FATAL: :$port is held by pid $(echo "$owners" | paste -sd, -), not the $label this run started (pid $want) - measuring it would measure a foreign process" >&2
+    exit 1
+}
+
 start_mock() { # start_mock <ttft_ms>
     [ -n "$MOCK_PID" ] && { kill "$MOCK_PID" 2>/dev/null || true; wait "$MOCK_PID" 2>/dev/null || true; }
     MOCK_TTFT_MS="$1" taskset -c "$MOCK_CORES" "$TOOLS/mock" -port "$MOCK_PORT" \
         >> "$OUT/mock.log" 2>&1 &
     MOCK_PID=$!
     wait_http_200 "http://127.0.0.1:$MOCK_PORT$REQ_PATH" "mock (ttft=${1}ms)"
+    assert_listener "$MOCK_PORT" "$MOCK_PID" "mock"
     # A mock that ignores MOCK_TTFT_MS would make the delayed leg silently
     # measure a 0-delay upstream with fail=0 throughout; assert the delay is
-    # actually in effect before any window runs against it.
+    # actually in effect before any window runs against it. Note this only
+    # runs on a delayed tier: a grid trimmed to 0-delay points has no such
+    # assertion, which is exactly why the identity check above is
+    # unconditional rather than a side effect of running a delay tier.
     if [ "$1" -gt 0 ]; then
         local ttfb
         ttfb=$(curl -s --max-time 2 -o /dev/null -w '%{time_starttransfer}' -X POST \

--- a/bench/onthebench/lib.sh
+++ b/bench/onthebench/lib.sh
@@ -147,39 +147,65 @@ wait_http_200() { # wait_http_200 <url> <label> [max_s]
 # An HTTP 200 says something is listening; it does not say the thing that is
 # listening is the thing this run started. A process that loses the bind race
 # exits, a stale listener from an earlier run keeps answering, and every
-# window afterwards measures a stranger with fail=0 throughout. Two checks,
-# because neither covers the other:
+# window afterwards measures a stranger with fail=0 throughout.
 #
-#   liveness    our own process is still up. This is the one that catches a
-#               lost bind race whatever the other listener is, since the
-#               loser exits on "Address already in use".
-#   ownership   the listener on the port is our pid. This catches a process
-#               that is alive but bound elsewhere, or answering from an
-#               earlier run of itself.
-#
-# Ownership degrades to a warning when ss cannot report the pid (a listener
-# owned by another user needs privilege to attribute); liveness never does.
+#   ownership   the listener on the port is ours. This is the load-bearing
+#               check: readiness returns on the first 200, which a foreign
+#               listener answers in well under a millisecond, while a losing
+#               process takes milliseconds to reach its bind() and exit - so
+#               at this point the loser is usually still alive and liveness
+#               alone would wave it through.
+#   liveness    our own process is still up - the backstop for a target that
+#               died between launch and readiness for any other reason.
 #
 # Response-shape fingerprinting deliberately not used: a stand-in mock built
 # from the same semantics answers byte-identically, so a fingerprint cannot
 # tell the two apart. The listening pid can.
 assert_listener() { # assert_listener <port> <pid> <label>
-    local port="$1" want="$2" label="$3" owners p
+    local port="$1" want="$2" label="$3" listing owners p anc hops mine
     [ -d "/proc/$want" ] ||
         { echo "FATAL: $label (pid $want) is not running after readiness - it likely lost the bind race on :$port; something else answered the readiness probe" >&2
           exit 1; }
-    owners=$(ss -ltnpH "sport = :$port" 2>/dev/null | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u)
+    # `|| true` on both stages: under set -euo pipefail an ss that prints
+    # nothing, or a grep that matches nothing, fails the pipeline and the
+    # assignment aborts the runner with no message at all - which would turn
+    # every branch below into a silent exit. `,fd=` anchors the pid so a
+    # process whose own name contains "pid=" cannot inject a phantom owner.
+    listing=$(ss -ltnpH "sport = :$port" 2>/dev/null || true)
+    owners=$(printf '%s\n' "$listing" | grep -oE 'pid=[0-9]+,fd=' | cut -d= -f2 | cut -d, -f1 | sort -u || true)
+
+    # ss attributes any socket owned by our own uid, so for a target this
+    # harness started an empty owner set is not "unknown" - readiness proved
+    # something answered, and this proves that something is not ours. Degrade
+    # only when the target itself is out of reach: a containerized entrant's
+    # pid and its published port both belong to another user, and neither can
+    # be attributed without privilege.
     if [ -z "$owners" ]; then
-        echo "WARNING: cannot attribute the listener on :$port; $label identity unverified (liveness passed)" >&2
+        [ -r "/proc/$want/fd" ] &&
+            { echo "FATAL: nothing this user owns is listening on :$port, yet the readiness probe was answered - the responder is not the $label this run started (pid $want)" >&2
+              exit 1; }
+        echo "WARNING: the listener on :$port and $label (pid $want) both belong to another user; identity unverified (liveness passed)" >&2
         return 0
     fi
-    grep -qx "$want" <<<"$owners" && return 0
-    # A launcher that forks the real listener is legitimate; a stranger is not.
+
+    # Every owner must be us or a descendant, not merely "we are among them":
+    # under SO_REUSEPORT a stale instance co-binds instead of losing the race,
+    # and the kernel then splits the load between it and us.
     for p in $owners; do
-        [ "$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')" = "$want" ] && return 0
+        [ "$p" = "$want" ] && continue
+        mine=0; hops=0
+        anc=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ' || true)
+        while [ -n "$anc" ] && [ "$anc" != 0 ] && [ "$hops" -lt 10 ]; do
+            [ "$anc" = "$want" ] && { mine=1; break; }
+            anc=$(ps -o ppid= -p "$anc" 2>/dev/null | tr -d ' ' || true); hops=$((hops + 1))
+        done
+        [ "$mine" = 1 ] ||
+            { echo "FATAL: :$port is held by pid $(echo "$owners" | paste -sd, -), not (only) the $label this run started (pid $want) - measuring it would measure a foreign process" >&2
+              exit 1; }
+        # Same hazard run-entrant.sh already warns about for child processes:
+        # CPU% and RSS are sampled on GW_PID, not on the serving process.
+        echo "WARNING: :$port is served by pid $p, a descendant of $label (pid $want); CPU%/RSS cover pid $want only" >&2
     done
-    echo "FATAL: :$port is held by pid $(echo "$owners" | paste -sd, -), not the $label this run started (pid $want) - measuring it would measure a foreign process" >&2
-    exit 1
 }
 
 start_mock() { # start_mock <ttft_ms>

--- a/bench/onthebench/rig-setup.sh
+++ b/bench/onthebench/rig-setup.sh
@@ -27,10 +27,15 @@ sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -q
 # build deps would silently drop ALL of them and fail much later in the build.
 sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
     git curl build-essential pkg-config libssl-dev protobuf-compiler \
-    python3 linux-tools-common
+    python3 linux-tools-common iproute2 procps
 sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -q "linux-tools-$(uname -r)" ||
     sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -q linux-tools-aws
 perf --version
+# The harness asserts that the process it measures is the one it started, and
+# that assertion reads ss and ps; without them the check degrades to a warning
+# nobody reads and the guard is silently off. Verify like perf above.
+command -v ss >/dev/null || { echo "FATAL: iproute2 (ss) missing"; exit 1; }
+command -v ps >/dev/null || { echo "FATAL: procps (ps) missing"; exit 1; }
 
 echo "== rust toolchain =="
 # Pinned, checksum-verified rustup-init instead of the curl|sh installer: the

--- a/bench/onthebench/run-baseline.sh
+++ b/bench/onthebench/run-baseline.sh
@@ -76,6 +76,7 @@ start_gateway() {
         > "$OUT/gateway.log" 2>&1 &
     GW_PID=$!
     wait_http_200 "http://127.0.0.1:$GW_PORT$REQ_PATH" "gateway"
+    assert_listener "$GW_PORT" "$GW_PID" "gateway"
     sleep 3
     RSS_IDLE=$(rss_kb "$GW_PID")
     TPC_WORKERS=$(ps -T -p "$GW_PID" | grep -c 'tpc-' || true)

--- a/bench/onthebench/run-entrant.sh
+++ b/bench/onthebench/run-entrant.sh
@@ -89,6 +89,7 @@ start_target() {
     [ -n "$GW_PID" ] && [ -d "/proc/$GW_PID" ] ||
         { echo "FATAL: entrant_start did not leave a live pid in GW_PID"; exit 1; }
     wait_http_200 "http://127.0.0.1:$GW_PORT$REQ_PATH" "$ENTRANT_NAME"
+    assert_listener "$GW_PORT" "$GW_PID" "$ENTRANT_NAME"
     sleep 3
     RSS_IDLE=$(rss_kb "$GW_PID")
     THREADS=$(ps -T -p "$GW_PID" 2>/dev/null | tail -n +2 | wc -l) || THREADS=0


### PR DESCRIPTION
## What

After the readiness probe, assert two things for the mock, the gateway and
every entrant:

- **liveness** — our own process is still running
- **ownership** — the listener on the port is our pid (or a child of it, for
  a launcher that forks)

## Why

`wait_http_200` accepts any HTTP 200 on the port. It does not check who
answered. When a process loses the bind race — a stale mock from an
interrupted run, a concurrent session on a shared box — the loser exits on
`Address already in use`, and every window afterwards measures a stranger
with `fail=0` throughout and nothing in the log to suggest otherwise.

This has bitten the performance program three times:

1. A leftover mock on the rig answered a whole scene; the floor read 270K
   instead of ~640K and the scene was scrapped.
2. A sibling harness spent a full batch driving load at another session's
   mock. Its own mock had logged `Address already in use` 81 times and never
   bound once.
3. In that same batch, the poisoned floor then **mis-fired the headroom
   criterion**: two legs were judged instrument-bound at 1.67–1.80× headroom
   and re-measured on a different core count, when the true headroom was
   11–12×. That round of work chased a problem that did not exist.

Point 3 is the reason this is worth a guard rather than a note. The
headroom criterion is correct; its *input* was poisoned. A correct
criterion fed a poisoned input produces confident wrong answers, which is
worse than having no criterion. Identity has to be established before
anything derived from the floor is trusted.

## Two checks, because neither covers the other

| | catches |
|---|---|
| liveness | the lost bind race, whatever the other listener is |
| ownership | a process alive but bound elsewhere, or answering from an earlier run of itself |

Ownership degrades to a warning when `ss` cannot attribute the socket (a
listener owned by another user needs privilege to attribute). Liveness never
degrades.

## Why not fingerprint the response

The stand-in mock in incident 2 answers **byte-identically** to ours — same
message body, same completion id — because it was written from the same
semantics. A response fingerprint cannot separate them. The listening pid
can. (This was my first suggestion to the affected session; their
measurement disproved it.)

## Why unconditional

The harness already asserts that a delayed mock actually delays, which would
have caught an impostor — but only on a grid that has a delay tier, and the
batch that went wrong had trimmed its grid to a single `0:128` point. **A
trimmed grid should cost coverage, not an assertion.** So the identity check
does not hang off a delay tier.

(The finale scene for the closing report had the same blind spot in its
flamegraph re-capture leg, which also ran `0:128` — it produced no
throughput numbers, so nothing was affected, but the gap was the same one.)

## Verification

Built the three failure modes and checked the guard's verdict on each:

| scenario | expected | result |
|---|---|---|
| listener is our own process | pass | pass |
| foreign listener holds the port, our process alive elsewhere | fatal | fatal |
| our process exited after losing the bind race | fatal | fatal |

The third is the exact shape of incident 2.