### PR TITLE
perf(server): enable jemalloc background purge thread + post-load RSS decay leg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "serde_json",
  "socket2 0.5.10",
  "tempfile",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
  "tracing",
@@ -4862,6 +4863,17 @@ dependencies = [
  "lazy_static",
  "regex",
  "rustc-hash",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/bench/onthebench/README.md
+++ b/bench/onthebench/README.md
@@ -101,10 +101,30 @@ part of this repository; flamegraphs default off for entrants because shipped
 release binaries are usually stripped (a stripped target skips the flamegraph
 with a warning rather than failing the run).
 
+## Post-load decay leg (`run-decay.sh`)
+
+`run-decay.sh <aisix-src-dir> <out-dir>` measures the axis the load grid
+cannot see: what happens to gateway RSS *after* the load stops
+(api7/aisix#968). One saturating burst of large bodies (default: c=64 for 60s,
+~120 KiB legal chat-completions requests standing in for inline-base64
+multimodal payloads), then 120s of idle sampling — VmRSS/VmHWM at ~2 Hz plus
+`smaps_rollup` Pss/LazyFree at ~1 Hz, because pages an allocator returns with
+`MADV_FREE` stay in VmRSS until the kernel reclaims them, and the corrected
+series `rss - lazyfree` is the residency an OOM limit actually enforces.
+Deliberately a separate runner: the large bodies drive VmHWM far above the
+baseline grid's, so sharing a process lifetime with `run-baseline.sh` would
+poison `rss_hwm_kb` against every historical baseline. Knobs:
+`BENCH_DECAY_CONC`, `BENCH_DECAY_BURST_S`, `BENCH_DECAY_S`,
+`BENCH_DECAY_BODY_KB` (≤126: the body travels as one argv string under
+Linux's 128 KiB `MAX_ARG_STRLEN`). A burst window with any failed request is
+recorded, marked invalid, and produces no decay curve; a curve cut short by a
+dead gateway exits nonzero like any incomplete run.
+
 ## Output
 
 One directory per run: `results.jsonl` (one JSON object per measured window,
-`kind` gateway/floor, `entrant` naming the measured target), `meta.json`, the
+`kind` gateway/floor — or decay_anchor/decay_burst/decay/decay_summary from
+the decay runner, `entrant` naming the measured target), `meta.json`, the
 generated config files, and the gateway/mock logs. `flamegraph-c128.svg` is
 present when Inferno rendering succeeded; on a rendering failure the run
 keeps `perf.data` instead, so the SVG can be produced off-rig.

--- a/bench/onthebench/lib.sh
+++ b/bench/onthebench/lib.sh
@@ -348,6 +348,123 @@ run_point() { # run_point <ttft> <conc>
           HARNESS_RC=1; }
 }
 
+# ---- decay leg ---------------------------------------------------------------
+
+# Post-load RSS decay (api7/aisix#968): one saturating burst of large bodies,
+# then sample the idle process's memory for a fixed window. VmRSS alone cannot
+# answer "did the allocator hand the pages back" — pages released with
+# MADV_FREE stay resident until the kernel reclaims them, so a pure VmRSS
+# curve reads "already reclaimable" as "never returned". Every 1s sample
+# therefore also reads smaps_rollup's Pss and LazyFree; rss_kb - lazyfree_kb
+# is the residency that memory pressure cannot take back for free — the
+# OOM-relevant series. smaps_rollup walks the VMA list (~ms per read), which
+# is why it must never run inside a measured load window; the decay phase is
+# idle by definition, so there it costs nothing.
+
+status_mem_kb() { # status_mem_kb <pid>  -> "rss_kb hwm_kb" (or "null null")
+    awk '/^VmRSS:/{r=$2} /^VmHWM:/{h=$2}
+         END{print (r==""?"null":r), (h==""?"null":h)}' \
+        "/proc/$1/status" 2>/dev/null || echo "null null"
+}
+
+smaps_mem_kb() { # smaps_mem_kb <pid>  -> "pss_kb lazyfree_kb" (or "null null")
+    # LazyFree missing but Pss present is an old kernel without the field,
+    # not a read failure: report 0, the corrected series then equals VmRSS.
+    awk '/^Pss:/{p=$2} /^LazyFree:/{l=$2}
+         END{if (p=="") print "null null"; else print p, (l==""?0:l)}' \
+        "/proc/$1/smaps_rollup" 2>/dev/null || echo "null null"
+}
+
+decay_leg() { # decay_leg <conc> <burst_s> <decay_s>  (0-delay mock + gateway up)
+    local conc="$1" burst_s="$2" decay_s="$3"
+    local rssfile="$OUT/.rss-decay.$$" line rss0 hwm0 pss0 lz0 rss_peak
+    local rps fail ok p50 p99 rigref budget spawn valid t_end t_now t_s
+    local rss hwm pss lz i corrected delta
+
+    echo "== decay leg (c=$conc, burst=${burst_s}s, decay=${decay_s}s, body=${#BODY}B) ==" >&2
+
+    read -r rss0 hwm0 <<<"$(status_mem_kb "$GW_PID")"
+    read -r pss0 lz0 <<<"$(smaps_mem_kb "$GW_PID")"
+    printf '{"kind":"decay_anchor","entrant":"%s","conc":%s,"burst_s":%s,"decay_s":%s,"body_bytes":%s,"rss_kb":%s,"hwm_kb":%s,"pss_kb":%s,"lazyfree_kb":%s}\n' \
+        "$ENTRANT_NAME" "$conc" "$burst_s" "$decay_s" "${#BODY}" "$rss0" "$hwm0" "$pss0" "$lz0" >> "$RESULTS"
+
+    # The burst, with the same peak-RSS sampler and validity policy as
+    # measured_window. An invalid burst (any failed request) is recorded and
+    # marked but produces no decay curve: a refusal or a 413 means the heap
+    # was never driven to the state the curve would claim to describe.
+    ( max=0; while [ -d "/proc/$GW_PID" ]; do
+          v=$(awk '/VmRSS/{print $2}' "/proc/$GW_PID/status" 2>/dev/null || true)
+          v="${v:-0}"
+          if [ "$v" -gt "$max" ]; then max="$v"; echo "$max" > "$rssfile"; fi
+          sleep 0.2
+      done ) & SAMPLER_PID=$!
+    line=$(loadgen "127.0.0.1:$GW_PORT" "$conc" "$burst_s") || line=""
+    line=${line//[\"\\]/ }
+    t_end=$(date +%s.%N)
+    kill "$SAMPLER_PID" 2>/dev/null || true; wait "$SAMPLER_PID" 2>/dev/null || true; SAMPLER_PID=""
+    rss_peak=$(cat "$rssfile" 2>/dev/null || echo 0); rm -f "$rssfile"
+
+    rps=$(field rps "$line"); fail=$(field fail "$line"); ok=$(field ok "$line")
+    p50=$(field p50us "$line"); p99=$(field p99us "$line")
+    rigref=$(field rigrefused "$line"); budget=$(field budgetexceeded "$line"); spawn=$(field spawnfailed "$line")
+    valid=true
+    [ "${fail:-1}" = "0" ] && [ "${rigref:-0}" = "0" ] && [ "${budget:-0}" = "0" ] \
+        && [ "${spawn:-0}" = "0" ] || valid=false
+    printf '{"kind":"decay_burst","entrant":"%s","conc":%s,"burst_s":%s,"valid":%s,"rps":%s,"fail":%s,"ok":%s,"p50_us":%s,"p99_us":%s,"gw_rss_peak_kb":%s,"otb_line":"%s"}\n' \
+        "$ENTRANT_NAME" "$conc" "$burst_s" "$valid" "${rps:-null}" "${fail:-null}" "${ok:-null}" \
+        "${p50:-null}" "${p99:-null}" "$rss_peak" "$line" >> "$RESULTS"
+    echo "  [burst] rps=$rps fail=$fail peak=${rss_peak}kB valid=$valid" >&2
+    if [ "$valid" != true ]; then
+        echo "WARNING: burst window invalid - no decay curve from this run" >&2
+        HARNESS_RC=1
+        return 0
+    fi
+
+    # Idle sampling. Timestamps are measured against the burst's end rather
+    # than accumulated from sleeps, so a slow smaps read cannot silently
+    # stretch the curve. Status (VmRSS/VmHWM) at ~2 Hz, smaps_rollup at ~1 Hz.
+    i=0
+    while :; do
+        t_now=$(date +%s.%N)
+        t_s=$(awk -v a="$t_end" -v b="$t_now" 'BEGIN{printf "%.1f", b-a}')
+        awk -v t="$t_s" -v d="$decay_s" 'BEGIN{exit !(t >= d)}' && break
+        if [ ! -d "/proc/$GW_PID" ]; then
+            echo "WARNING: gateway died ${t_s}s into the ${decay_s}s decay window - curve incomplete" >&2
+            HARNESS_RC=1
+            return 0
+        fi
+        read -r rss hwm <<<"$(status_mem_kb "$GW_PID")"
+        if [ $((i % 2)) -eq 0 ]; then
+            read -r pss lz <<<"$(smaps_mem_kb "$GW_PID")"
+        else
+            pss=null; lz=null
+        fi
+        printf '{"kind":"decay","entrant":"%s","t_s":%s,"rss_kb":%s,"hwm_kb":%s,"pss_kb":%s,"lazyfree_kb":%s}\n' \
+            "$ENTRANT_NAME" "$t_s" "$rss" "$hwm" "$pss" "$lz" >> "$RESULTS"
+        i=$((i + 1))
+        sleep 0.5
+    done
+
+    # One final full sample is the gate input: corrected residency and its
+    # distance from the idle anchor (RSS_IDLE is the sourcing runner's).
+    if [ ! -d "/proc/$GW_PID" ]; then
+        echo "WARNING: gateway died before the final decay sample" >&2
+        HARNESS_RC=1
+        return 0
+    fi
+    read -r rss hwm <<<"$(status_mem_kb "$GW_PID")"
+    read -r pss lz <<<"$(smaps_mem_kb "$GW_PID")"
+    corrected=null; delta=null
+    if [ "$rss" != null ] && [ "$lz" != null ]; then
+        corrected=$((rss - lz))
+        [ -n "${RSS_IDLE:-}" ] && delta=$((corrected - RSS_IDLE))
+    fi
+    printf '{"kind":"decay_summary","entrant":"%s","conc":%s,"burst_s":%s,"decay_s":%s,"rss_idle_kb":%s,"pre_rss_kb":%s,"burst_peak_kb":%s,"final_rss_kb":%s,"final_hwm_kb":%s,"final_pss_kb":%s,"final_lazyfree_kb":%s,"final_corrected_kb":%s,"residual_vs_idle_kb":%s}\n' \
+        "$ENTRANT_NAME" "$conc" "$burst_s" "$decay_s" "${RSS_IDLE:-null}" "$rss0" "$rss_peak" \
+        "$rss" "$hwm" "$pss" "$lz" "$corrected" "$delta" >> "$RESULTS"
+    echo "  [decay] idle=${RSS_IDLE:-?}kB pre=${rss0}kB peak=${rss_peak}kB final=${rss}kB lazyfree=${lz}kB corrected=${corrected}kB residual_vs_idle=${delta}kB" >&2
+}
+
 # ---- grid helpers ------------------------------------------------------------
 
 grid_ttfts() { # distinct delay tiers, in grid order

--- a/bench/onthebench/lib.sh
+++ b/bench/onthebench/lib.sh
@@ -379,12 +379,16 @@ decay_leg() { # decay_leg <conc> <burst_s> <decay_s>  (0-delay mock + gateway up
     local conc="$1" burst_s="$2" decay_s="$3"
     local rssfile="$OUT/.rss-decay.$$" line rss0 hwm0 pss0 lz0 rss_peak
     local rps fail ok p50 p99 rigref budget spawn valid t_end t_now t_s
-    local rss hwm pss lz i corrected delta
+    local rss hwm pss lz i corrected delta gw_birth
 
     echo "== decay leg (c=$conc, burst=${burst_s}s, decay=${decay_s}s, body=${#BODY}B) ==" >&2
 
     read -r rss0 hwm0 <<<"$(status_mem_kb "$GW_PID")"
     read -r pss0 lz0 <<<"$(smaps_mem_kb "$GW_PID")"
+    # starttime (field 22 of /proc/<pid>/stat) pins the pid to this incarnation:
+    # over a 120s idle window a dead gateway's pid can be reused, and /proc
+    # existence alone would then sample a stranger.
+    gw_birth=$(awk '{print $22}' "/proc/$GW_PID/stat" 2>/dev/null || echo "")
     printf '{"kind":"decay_anchor","entrant":"%s","conc":%s,"burst_s":%s,"decay_s":%s,"body_bytes":%s,"rss_kb":%s,"hwm_kb":%s,"pss_kb":%s,"lazyfree_kb":%s}\n' \
         "$ENTRANT_NAME" "$conc" "$burst_s" "$decay_s" "${#BODY}" "$rss0" "$hwm0" "$pss0" "$lz0" >> "$RESULTS"
 
@@ -446,9 +450,11 @@ decay_leg() { # decay_leg <conc> <burst_s> <decay_s>  (0-delay mock + gateway up
     done
 
     # One final full sample is the gate input: corrected residency and its
-    # distance from the idle anchor (RSS_IDLE is the sourcing runner's).
-    if [ ! -d "/proc/$GW_PID" ]; then
-        echo "WARNING: gateway died before the final decay sample" >&2
+    # distance from the corrected pre-burst anchor (same LazyFree correction
+    # on both sides, so an anchor that itself holds lazily-freed pages cannot
+    # understate the residual).
+    if [ "$(awk '{print $22}' "/proc/$GW_PID/stat" 2>/dev/null || echo x)" != "$gw_birth" ]; then
+        echo "WARNING: gateway died or its pid was reused during the decay window - no summary" >&2
         HARNESS_RC=1
         return 0
     fi
@@ -457,7 +463,9 @@ decay_leg() { # decay_leg <conc> <burst_s> <decay_s>  (0-delay mock + gateway up
     corrected=null; delta=null
     if [ "$rss" != null ] && [ "$lz" != null ]; then
         corrected=$((rss - lz))
-        [ -n "${RSS_IDLE:-}" ] && delta=$((corrected - RSS_IDLE))
+        if [ "$rss0" != null ] && [ "$lz0" != null ]; then
+            delta=$((corrected - (rss0 - lz0)))
+        fi
     fi
     printf '{"kind":"decay_summary","entrant":"%s","conc":%s,"burst_s":%s,"decay_s":%s,"rss_idle_kb":%s,"pre_rss_kb":%s,"burst_peak_kb":%s,"final_rss_kb":%s,"final_hwm_kb":%s,"final_pss_kb":%s,"final_lazyfree_kb":%s,"final_corrected_kb":%s,"residual_vs_idle_kb":%s}\n' \
         "$ENTRANT_NAME" "$conc" "$burst_s" "$decay_s" "${RSS_IDLE:-null}" "$rss0" "$rss_peak" \

--- a/bench/onthebench/run-decay.sh
+++ b/bench/onthebench/run-decay.sh
@@ -21,19 +21,22 @@ OUT="${2:?usage: run-decay.sh <aisix-src-dir> <out-dir>}"
 DECAY_CONC="${BENCH_DECAY_CONC:-64}"
 DECAY_BURST_S="${BENCH_DECAY_BURST_S:-60}"
 DECAY_S="${BENCH_DECAY_S:-120}"
-BODY_KB="${BENCH_DECAY_BODY_KB:-120}"
+DECAY_BODY_KB="${BENCH_DECAY_BODY_KB:-120}"
 
 # Same refuse-don't-collect policy as the lib.sh knobs: nonsense must fail
-# here, not after a gateway is up. The body cap is a transport limit, not a
-# taste choice: the body travels to otb as one argv string and Linux
-# MAX_ARG_STRLEN is 128 KiB, so MB-scale bodies need an @file mode in otb
-# first (out of scope for #968; 126 leaves room for the JSON envelope).
-for _k in DECAY_CONC:"$DECAY_CONC" DECAY_BURST_S:"$DECAY_BURST_S" DECAY_S:"$DECAY_S" DECAY_BODY_KB:"$BODY_KB"; do
-    [[ "${_k#*:}" =~ ^[1-9][0-9]*$ ]] ||
-        { echo "FATAL: BENCH_${_k%%:*} must be a positive integer, got '${_k#*:}'"; exit 1; }
+# here, not after a gateway is up. Indirect expansion, not word-splitting a
+# name:value list — a value with embedded whitespace ("64 128") must be
+# refused, not leak into the JSONL as non-numeric fields. The body cap is a
+# transport limit, not a taste choice: the body travels to otb as one argv
+# string and Linux MAX_ARG_STRLEN is 128 KiB, so MB-scale bodies need an
+# @file mode in otb first (out of scope for #968; 126 leaves room for the
+# JSON envelope).
+for _k in DECAY_CONC DECAY_BURST_S DECAY_S DECAY_BODY_KB; do
+    [[ "${!_k}" =~ ^[1-9][0-9]*$ ]] ||
+        { echo "FATAL: BENCH_$_k must be a positive integer, got '${!_k}'"; exit 1; }
 done
-[ "$BODY_KB" -le 126 ] ||
-    { echo "FATAL: BENCH_DECAY_BODY_KB must be <= 126 (argv transport limit), got '$BODY_KB'"; exit 1; }
+[ "$DECAY_BODY_KB" -le 126 ] ||
+    { echo "FATAL: BENCH_DECAY_BODY_KB must be <= 126 (argv transport limit), got '$DECAY_BODY_KB'"; exit 1; }
 
 # A legal chat-completions request padded to ~BODY_KB, standing in for an
 # inline-base64 multimodal payload — the traffic shape the issue names as the
@@ -43,7 +46,7 @@ BODY=$(python3 -c 'import json, sys
 pad = "x" * (int(sys.argv[1]) * 1024)
 print(json.dumps({"model": "gpt-4o-mini",
                   "messages": [{"role": "user", "content": pad}],
-                  "max_tokens": 16}))' "$BODY_KB")
+                  "max_tokens": 16}))' "$DECAY_BODY_KB")
 
 ENTRANT_NAME=aisix
 # shellcheck source=lib.sh

--- a/bench/onthebench/run-decay.sh
+++ b/bench/onthebench/run-decay.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Post-load RSS decay runner (api7/aisix#968): after a burst of large-payload
+# traffic stops, does the gateway hand freed pages back to the OS, or does
+# RSS ratchet at the burst peak? One saturating burst of BENCH_DECAY_BODY_KB
+# bodies, then BENCH_DECAY_S seconds of idle sampling (VmRSS/VmHWM at ~2 Hz,
+# smaps_rollup Pss/LazyFree at ~1 Hz), all appended to results.jsonl by
+# decay_leg in lib.sh.
+#
+# Deliberately a separate runner rather than a run-baseline.sh tier: the large
+# bodies drive VmHWM far above anything the baseline grid produces, and a
+# shared process lifetime would poison meta.json's rss_hwm_kb against every
+# historical baseline. This runner gets a fresh gateway, its own idle anchor,
+# and its own meta.json.
+#
+# Usage: run-decay.sh <aisix-src-dir> <out-dir>
+set -euo pipefail
+
+SRC="${1:?usage: run-decay.sh <aisix-src-dir> <out-dir>}"
+OUT="${2:?usage: run-decay.sh <aisix-src-dir> <out-dir>}"
+
+DECAY_CONC="${BENCH_DECAY_CONC:-64}"
+DECAY_BURST_S="${BENCH_DECAY_BURST_S:-60}"
+DECAY_S="${BENCH_DECAY_S:-120}"
+BODY_KB="${BENCH_DECAY_BODY_KB:-120}"
+
+# Same refuse-don't-collect policy as the lib.sh knobs: nonsense must fail
+# here, not after a gateway is up. The body cap is a transport limit, not a
+# taste choice: the body travels to otb as one argv string and Linux
+# MAX_ARG_STRLEN is 128 KiB, so MB-scale bodies need an @file mode in otb
+# first (out of scope for #968; 126 leaves room for the JSON envelope).
+for _k in DECAY_CONC:"$DECAY_CONC" DECAY_BURST_S:"$DECAY_BURST_S" DECAY_S:"$DECAY_S" DECAY_BODY_KB:"$BODY_KB"; do
+    [[ "${_k#*:}" =~ ^[1-9][0-9]*$ ]] ||
+        { echo "FATAL: BENCH_${_k%%:*} must be a positive integer, got '${_k#*:}'"; exit 1; }
+done
+[ "$BODY_KB" -le 126 ] ||
+    { echo "FATAL: BENCH_DECAY_BODY_KB must be <= 126 (argv transport limit), got '$BODY_KB'"; exit 1; }
+
+# A legal chat-completions request padded to ~BODY_KB, standing in for an
+# inline-base64 multimodal payload — the traffic shape the issue names as the
+# ratchet driver. Set before sourcing lib.sh so readiness probes, the burst,
+# and meta all see the same body.
+BODY=$(python3 -c 'import json, sys
+pad = "x" * (int(sys.argv[1]) * 1024)
+print(json.dumps({"model": "gpt-4o-mini",
+                  "messages": [{"role": "user", "content": pad}],
+                  "max_tokens": 16}))' "$BODY_KB")
+
+ENTRANT_NAME=aisix
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BIN="$SRC/target/release/aisix"
+
+# ---- sanity -----------------------------------------------------------------
+
+[ -x "$BIN" ] || { echo "FATAL: $BIN missing - build first"; exit 1; }
+rig_sanity
+
+bench_init
+
+# ---- config: same default-shipped-config claim set as run-baseline.sh -------
+
+cat > "$OUT/config.yaml" <<EOF
+resources_file: "$OUT/resources.yaml"
+proxy:
+  addr: "0.0.0.0:$GW_PORT"
+admin:
+  admin_keys:
+    - "aisix-admin-dummy"
+EOF
+cat > "$OUT/resources.yaml" <<EOF
+_format_version: "1"
+provider_keys:
+  - display_name: mock-openai
+    provider: openai
+    adapter: openai
+    api_base: "http://127.0.0.1:$MOCK_PORT/v1"
+    api_key: "sk-mock"
+models:
+  - display_name: gpt-4o-mini
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: mock-openai
+api_keys:
+  - display_name: bench
+    key_env: BENCH_AISIX_KEY
+    allowed_models: ["*"]
+EOF
+
+start_gateway() {
+    echo "== gateway ==" >&2
+    # aisix reads AISIX_* environment variables as config overrides; nothing
+    # from the harness environment may leak into the measured process.
+    while read -r v; do unset "$v"; done < <(compgen -v | grep '^AISIX_' || true)
+    BENCH_AISIX_KEY=bench-token taskset -c "$GW_CORES" "$BIN" --config "$OUT/config.yaml" \
+        > "$OUT/gateway.log" 2>&1 &
+    GW_PID=$!
+    # Readiness posts $BODY, so a gateway that cannot carry the large payload
+    # end to end fails here, before anything is measured.
+    wait_http_200 "http://127.0.0.1:$GW_PORT$REQ_PATH" "gateway"
+    assert_listener "$GW_PORT" "$GW_PID" "gateway"
+    sleep 3
+    RSS_IDLE=$(rss_kb "$GW_PID")
+    TPC_WORKERS=$(ps -T -p "$GW_PID" | grep -c 'tpc-' || true)
+    echo "  pid=$GW_PID idle_rss=${RSS_IDLE}kB tpc_workers=$TPC_WORKERS" >&2
+    local gw_nproc
+    gw_nproc=$(taskset -c "$GW_CORES" nproc)
+    [ "$TPC_WORKERS" -eq "$gw_nproc" ] ||
+        { echo "FATAL: expected $gw_nproc tpc- workers under the $GW_CORES affinity, got $TPC_WORKERS"; exit 1; }
+}
+
+write_meta() {
+    cat > "$OUT/meta.json" <<EOF
+{
+  "kind": "decay",
+  "commit": "${BENCH_SRC_COMMIT:-unknown}",
+  "dirty_files": ${BENCH_SRC_DIRTY:-0},
+  "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "rig": $(meta_rig_json),
+  "cores": $(meta_cores_json),
+  "instruments": $(meta_instruments_json),
+  "method": {
+    "burst_conc": $DECAY_CONC, "burst_s": $DECAY_BURST_S, "decay_s": $DECAY_S,
+    "body_bytes": ${#BODY}, "path": "$REQ_PATH",
+    "status_hz": 2, "smaps_hz": 1
+  },
+  "gateway": {
+    "binary_sha256": "$(sha256sum "$BIN" | cut -d' ' -f1)",
+    "rss_idle_kb": $RSS_IDLE,
+    "tpc_workers": $TPC_WORKERS
+  }
+}
+EOF
+}
+
+# ---- burst + decay ----------------------------------------------------------
+# Mock first: gateway readiness posts through to the upstream, so without a
+# mock the gateway answers 502 and never reads as ready.
+
+start_mock 0
+start_gateway
+write_meta
+
+decay_leg "$DECAY_CONC" "$DECAY_BURST_S" "$DECAY_S"
+
+[ "$HARNESS_RC" = 0 ] ||
+    echo "FATAL: decay run incomplete - do not read a curve out of it" >&2
+echo "== done: $OUT ==" >&2
+exit "$HARNESS_RC"

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -60,8 +60,13 @@ hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
 # bench (Linux glibc — the Docker image and both supported production
 # arches). Other targets (macOS dev builds, musl) keep the system
 # allocator rather than carry an allocator we never run in production.
+# The ctl crate exists for one runtime mallctl at startup (enable the
+# background purge thread, #968); it drags in the unmaintained `paste`
+# proc-macro (RUSTSEC-2024-0436, build-time only) — accepted until
+# jemalloc-ctl drops it upstream.
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 tikv-jemallocator = "0.6"
+tikv-jemalloc-ctl = "0.6"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -39,10 +39,13 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 // fatal — foreground decay still bounds RSS under load; only idle-time
 // reclamation is lost, which the warning makes visible.
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
-fn enable_jemalloc_background_thread() {
+fn enable_jemalloc_background_thread() -> Result<bool, tikv_jemalloc_ctl::Error> {
     use tikv_jemalloc_ctl::background_thread;
     // Write-then-read-back: the write is a request, the read is the fact.
-    match background_thread::write(true).and_then(|()| background_thread::read()) {
+    // The outcome is returned so the unit test exercises this function
+    // itself — a broken body must fail the test, not stay silently green.
+    let outcome = background_thread::write(true).and_then(|()| background_thread::read());
+    match &outcome {
         Ok(true) => tracing::info!("jemalloc background purge thread enabled"),
         Ok(false) => tracing::warn!(
             "jemalloc background purge thread did not enable on this target; \
@@ -54,6 +57,7 @@ fn enable_jemalloc_background_thread() {
              will not return to the OS while the process is idle"
         ),
     }
+    outcome
 }
 
 mod cert_bundle;
@@ -216,9 +220,10 @@ async fn async_main(cfg: Config) -> anyhow::Result<()> {
     let _otlp = install_otlp_tracer(&cfg.observability)
         .map_err(|e| anyhow::anyhow!("otlp init failed: {e}"))?;
 
-    // After tracing so the enable outcome is observable in the logs.
+    // After tracing so the enable outcome is observable in the logs; the
+    // returned outcome is already logged inside.
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
-    enable_jemalloc_background_thread();
+    let _ = enable_jemalloc_background_thread();
 
     // Before any bridge builds its `reqwest::Client` — the connection
     // pools are constructed once and can't be reconfigured afterwards.
@@ -1920,17 +1925,16 @@ mod tests {
     use super::*;
     use clap::Parser;
 
-    // The shipped-target contract for enable_jemalloc_background_thread():
-    // the runtime mallctl enable must actually take effect here — an
-    // Ok(false) read-back would mean the #968 fix silently does nothing.
-    // The test binary links the same #[global_allocator] as the shipped one.
+    // The shipped-target contract: the runtime mallctl enable must actually
+    // take effect here — an Ok(false) read-back would mean the #968 fix
+    // silently does nothing. Drives the delivered function, not an inline
+    // re-implementation of the mallctl pair; the test binary links the same
+    // #[global_allocator] as the shipped one.
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     #[test]
     fn jemalloc_background_thread_enables_at_runtime() {
-        use tikv_jemalloc_ctl::background_thread;
-        background_thread::write(true).expect("mallctl write background_thread");
         assert!(
-            background_thread::read().expect("mallctl read background_thread"),
+            matches!(enable_jemalloc_background_thread(), Ok(true)),
             "background_thread did not enable on a linux-gnu target"
         );
     }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -28,6 +28,34 @@ use std::sync::Arc;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+// jemalloc parks freed pages as "dirty" and only advances their decay clock
+// on later allocator activity in the same arena, so after a burst of
+// large-payload traffic an idle gateway keeps its peak RSS indefinitely
+// (#968: a 60s burst of ~120KiB bodies left +38MB resident, flat, on an
+// otherwise idle process). The background purge thread decouples purging
+// from traffic. Enabled via runtime mallctl on purpose: the equivalent
+// `opt.background_thread` startup path carries an upstream warning that it
+// "may cause crash or deadlock during initialization". Failure is never
+// fatal — foreground decay still bounds RSS under load; only idle-time
+// reclamation is lost, which the warning makes visible.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn enable_jemalloc_background_thread() {
+    use tikv_jemalloc_ctl::background_thread;
+    // Write-then-read-back: the write is a request, the read is the fact.
+    match background_thread::write(true).and_then(|()| background_thread::read()) {
+        Ok(true) => tracing::info!("jemalloc background purge thread enabled"),
+        Ok(false) => tracing::warn!(
+            "jemalloc background purge thread did not enable on this target; \
+             freed memory will not return to the OS while the process is idle"
+        ),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "failed to enable jemalloc background purge thread; freed memory \
+             will not return to the OS while the process is idle"
+        ),
+    }
+}
+
 mod cert_bundle;
 mod export;
 mod heartbeat;
@@ -187,6 +215,10 @@ async fn async_main(cfg: Config) -> anyhow::Result<()> {
     init_tracing(&cfg.observability).map_err(|e| anyhow::anyhow!("tracing init failed: {e}"))?;
     let _otlp = install_otlp_tracer(&cfg.observability)
         .map_err(|e| anyhow::anyhow!("otlp init failed: {e}"))?;
+
+    // After tracing so the enable outcome is observable in the logs.
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    enable_jemalloc_background_thread();
 
     // Before any bridge builds its `reqwest::Client` — the connection
     // pools are constructed once and can't be reconfigured afterwards.
@@ -1887,6 +1919,21 @@ async fn wait_for_signal(
 mod tests {
     use super::*;
     use clap::Parser;
+
+    // The shipped-target contract for enable_jemalloc_background_thread():
+    // the runtime mallctl enable must actually take effect here — an
+    // Ok(false) read-back would mean the #968 fix silently does nothing.
+    // The test binary links the same #[global_allocator] as the shipped one.
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    #[test]
+    fn jemalloc_background_thread_enables_at_runtime() {
+        use tikv_jemalloc_ctl::background_thread;
+        background_thread::write(true).expect("mallctl write background_thread");
+        assert!(
+            background_thread::read().expect("mallctl read background_thread"),
+            "background_thread did not enable on a linux-gnu target"
+        );
+    }
 
     #[tokio::test(start_paused = true)]
     async fn metrics_upkeep_runs_periodically_and_stops_on_cancel() {


### PR DESCRIPTION
Closes #968.

## Problem

We link jemalloc as the global allocator but never tune it. jemalloc only
advances a dirty page's decay clock on later allocator activity in the same
arena (the decay tick is sampled roughly once per thousand alloc/dalloc
events per thread), so once traffic stops, freed pages stop decaying: an idle
gateway keeps its burst-peak RSS indefinitely. For an AI gateway the driver
is payload size - multimodal inline-base64 bodies and replayed conversation
histories - so one tenant's burst can pin the process near peak forever. In a
container with a memory limit that is an OOM-kill risk our metrics cannot
explain.

Upstream references: https://jemalloc.net/jemalloc.3.html
(`background_thread`, `opt.dirty_decay_ms` default 10s, `opt.muzzy_decay_ms`
default 0, and the `opt.background_thread` initialization warning), plus
jemalloc's TUNING.md: "unintended purging delay caused by application
inactivity is avoided with background threads".

## Measurement (new harness leg)

`bench/onthebench/run-decay.sh`: one saturating burst of large bodies, then
120s of idle sampling - VmRSS/VmHWM at ~2 Hz plus `smaps_rollup` Pss/LazyFree
at ~1 Hz (MADV_FREE'd pages stay in VmRSS until the kernel reclaims them; the
corrected series `rss - lazyfree` is what an OOM limit actually enforces). A
separate runner on purpose, so the large bodies cannot poison `rss_hwm_kb` in
historical baseline metadata.

Local x86 probe, c=64 x 60s of ~120 KiB chat-completions bodies, 566,870
requests, fail=0, LazyFree=0 throughout (genuinely parked pages, not
lazily-freed ones):

| t after burst | before (jemalloc defaults) | after (this PR) |
|---|---|---|
| idle anchor | 99.1 MB | 98.7 MB |
| burst peak | 164.0 MB | 165.3 MB |
| +10s | 159.5 MB | 109.0 MB |
| +31s | 137.7 MB | 106.6 MB |
| +120s | **137.3 MB (flat since t=31s)** | 103.7 MB |

Before: +38.2 MB (59% of the burst's RSS growth) stays resident indefinitely;
the curve is perfectly flat from t=31s on. After: RSS re-enters the idle+10%
band at t=17.5s and the residual at t=120s is 5.0 MB (7.6%).

## Fix

Enable jemalloc's background purge thread at startup via a runtime mallctl
write plus read-back (the write is a request, the read-back is the fact),
placed after tracing init so the outcome is observable:
`INFO aisix: jemalloc background purge thread enabled`. Runtime rather than
`malloc_conf`/build features on purpose: the equivalent
`opt.background_thread` startup path carries an upstream "may cause crash or
deadlock during initialization" warning. Failure is warn-only - foreground
decay still bounds RSS under load; only idle-time reclamation is lost.

No fallback purge thread: the allocator (and now the ctl dependency) is
target-gated to linux-gnu, and background threads are supported on every
target where we link jemalloc. No decay tuning: the defaults (10s dirty
decay) plus the background thread meet the acceptance bar above. A unit test
asserts the runtime enable takes effect on linux-gnu.

## Throughput

Same probe, bracketing baselines (0:128 saturation point, 3 runs x 3 windows
per leg, all windows fail=0):

| leg | mean rps | sd |
|---|---|---|
| baseline (open) | 28,367 | 154 |
| **this PR** | **28,385** | 174 |
| baseline (close) | 28,178 | 304 |

Candidate vs open +0.06%, vs pooled bracket +0.40%, bracket drift -0.67% -
all inside the probe's +-1.04% (2 sigma) noise band; the +-2% regression gate
passes with margin. The purge thread's CPU cost lands in idle time by design.

## Prior art (three-plus mainstream implementations, per repo convention)

- A mainstream Rust gateway enables the background purge thread at startup
  via the same runtime mallctl write with read-back verification, and adds a
  fallback idle-purge thread only because its shipped release target is
  static-musl, where jemalloc background threads are compiled out. We ship
  jemalloc only on linux-gnu, so that fallback has no target to serve here -
  the one deliberate divergence.
- A mainstream C++ proxy is the only surveyed implementation with a
  product-level memory-return policy: overload-triggered heap shrink,
  opportunistic main-thread shrink, and an opt-in background release-rate
  thread, all config-driven.
- Three widely deployed Rust proxies ship jemalloc with stock settings (no
  background thread, no decay tuning) - the idle-retention axis is simply
  unaddressed there. Where the Rust ecosystem does flip `background_thread`
  at runtime (a distributed KV store, a foundations library), it uses the
  same mallctl mechanism, gated behind heap-profiling activation.

## Dependency note

`tikv-jemalloc-ctl 0.6` (paired with the existing jemallocator 0.6) pulls in
the unmaintained `paste` proc-macro transitively: RUSTSEC-2024-0436,
informational, build-time proc-macro only, no runtime code, no fixed release
upstream. Accepted until jemalloc-ctl drops it.

## Evidence reproducibility

The curves and throughput numbers above were produced on an off-repo local
x86 screening field: a fork of this harness that patches exactly two things -
the rig identity assertions (`rig_sanity`) and the core-split/port env. Its
measurement core (the appended `decay_leg`/sampling/validity code and the
runner flow) is the same as the committed one; the gateway-side listener
check is written in the fork's inline style. The committed, reproducible path
for these curves is `bench/onthebench/run-decay.sh` on the m7g rig; the
screening field exists so harness development and A/B screening do not occupy
the shared rig. Relative A/B conclusions (residual collapse, throughput
delta vs bracketing baselines) are the claim; absolute numbers are not
rig-comparable by design and are labeled as such by the harness itself.

## Independent audit

A cold independent audit (correctness / reliability / security / leakage /
breaking changes / E2E coverage) returned no HIGH findings. Both MEDIUMs are
resolved: the unit test now drives the delivered enable function instead of
re-implementing the mallctl pair, and evidence reproducibility is documented
above. All three LOWs are fixed in follow-up commits: the decay summary
compares corrected-vs-corrected (final minus pre-burst anchor, both LazyFree
adjusted), knob validation refuses whitespace-embedded values via indirect
expansion, and the final decay sample re-checks `/proc/<pid>/stat` starttime
so a pid reused during the idle window cannot be sampled as the gateway.

## Coordination

This adds a background thread to the gateway process; the #967 x86 throughput
baseline should be re-anchored after this merges (recorded on the
coordination board).
