### PR TITLE
build: add thin-LTO release-dev profile for iteration builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,10 +207,11 @@ strip = "debuginfo"
 
 # Iteration-speed sibling of `release`: thin LTO parallelizes the LTO
 # stage across cores instead of fat LTO's single-threaded whole-graph
-# pass, cutting link-heavy rebuilds from minutes to tens of seconds.
-# Functionally identical output, slightly less optimized — so any number
-# that gets reported, compared against a baseline, or fed into the
-# saturation grid MUST come from `--release`, never from this profile.
+# pass — measured cold builds of the aisix binary on a 12-core host:
+# 6m37s (release) vs 2m27s (release-dev). Functionally identical output,
+# slightly less optimized — so any number that gets reported, compared
+# against a baseline, or fed into the saturation grid MUST come from
+# `--release`, never from this profile.
 [profile.release-dev]
 inherits = "release"
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,17 @@ lto = "fat"
 codegen-units = 1
 strip = "debuginfo"
 
+# Iteration-speed sibling of `release`: thin LTO parallelizes the LTO
+# stage across cores instead of fat LTO's single-threaded whole-graph
+# pass, cutting link-heavy rebuilds from minutes to tens of seconds.
+# Functionally identical output, slightly less optimized — so any number
+# that gets reported, compared against a baseline, or fed into the
+# saturation grid MUST come from `--release`, never from this profile.
+[profile.release-dev]
+inherits = "release"
+lto = "thin"
+codegen-units = 16
+
 [profile.coverage]
 inherits = "dev"
 opt-level = 0

--- a/bench/onthebench/run-baseline.sh
+++ b/bench/onthebench/run-baseline.sh
@@ -27,7 +27,12 @@ BIN="$SRC/target/release/aisix"
 
 # ---- sanity -----------------------------------------------------------------
 
-[ -x "$BIN" ] || { echo "FATAL: $BIN missing - build first"; exit 1; }
+# Rebuild instead of trusting mtime: with iteration builds living in
+# target/release-dev, a stale target/release binary is silent poison —
+# meta.json would attribute the numbers to the wrong commit. A no-op
+# when the binary is already current.
+( cd "$SRC" && cargo build --locked --release --bin aisix )
+[ -x "$BIN" ] || { echo "FATAL: $BIN missing after build"; exit 1; }
 rig_sanity
 if [ "$FLAMEGRAPH" = 1 ]; then require_symbols "$BIN"; fi
 

--- a/bench/onthebench/run-decay.sh
+++ b/bench/onthebench/run-decay.sh
@@ -56,7 +56,10 @@ BIN="$SRC/target/release/aisix"
 
 # ---- sanity -----------------------------------------------------------------
 
-[ -x "$BIN" ] || { echo "FATAL: $BIN missing - build first"; exit 1; }
+# Rebuild instead of trusting mtime — same stale-binary gate as
+# run-baseline.sh; a no-op when the binary is already current.
+( cd "$SRC" && cargo build --locked --release --bin aisix )
+[ -x "$BIN" ] || { echo "FATAL: $BIN missing after build"; exit 1; }
 rig_sanity
 
 bench_init


### PR DESCRIPTION
## What

Adds a `release-dev` cargo profile: inherits `release`, flips `lto = "fat"` → `"thin"` and `codegen-units = 1` → `16`. One file, 11 lines, purely additive — the shipped `release` profile is untouched. A follow-up commit hardens the bench run scripts' sanity gate (see below).

**Status: on hold pending a profile-matrix decision** — the LTO×PGO 2×2 was measured on the x86 probe rig (2026-08-14); results below.

## Why

Fat LTO + CU=1 serializes the whole LTO stage onto a single core. That is the right trade for shipped artifacts (measured per-request win, #939), but every link-heavy local rebuild pays minutes of single-threaded work, and the PGO pipeline (#975) pays it **twice per training cycle**: the changed `RUSTFLAGS` invalidates every fingerprint, so the instrumented and optimized builds are both full rebuilds.

## Build-time measurements (same 12-core host, cold builds, `--bin aisix`)

| profile | wall | binary size |
|---|---|---|
| `release` (fat, CU=1) | 6m37s | 52.9 MB |
| `release-dev` (thin, CU=16) | **2m27s** | 74.5 MB |

## Runtime: the LTO×PGO 2×2 (x86 probe rig, 0:128 grid, in-batch anchors, drift +0.24% / −0.07%)

| | no PGO | PGO (matched-config profile) |
|---|---|---|
| thin CU=16 | 25,866 rps (−9.9%) | 34,579 rps (+20.5%) |
| fat CU=1 | 28,700 rps (anchor) | 36,502 rps (**+29.0%**) |

Each cell normalized to its own batch anchor. Two findings:

1. **Fat LTO keeps a real edge under PGO: PGO+thin trails PGO+fat by ~5–7%** (anchor-normalized −6.6%, raw −5.3%) — outside the rig's ±2% decision band. The hypothesis that PGO would close thin's gap is refuted for this codebase.
2. **PGO profiles do not transfer across LTO configs.** A profile collected on a thin-LTO instrumented build and applied to a fat-LTO optimized build changed codegen (binary 52.9→57.4 MB) but delivered **+0.6%** instead of +29%. An earlier revision of this PR suggested building the instrumented leg with `release-dev` to halve pipeline time — that suggestion is withdrawn: **instrumented and optimized legs must use the same profile**, exactly as the Dockerfile already does.

## Discipline pinned in the profile comment

`release-dev` output is functionally identical but less optimized (−9.9% without PGO). Any number that is reported, compared against a baseline, or fed into the saturation grid must come from `--release`, never from this profile.

## Open decision

Whether `release-dev` ships at all is under discussion (single-profile preference vs the measured 5–7% cost of flipping `release` to thin). The bench sanity-gate commit stands on its own either way.