### PR TITLE
feat(mcp): per-server protocol_version for modern-only (2026-07-28) upstreams + conformance CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,8 +380,14 @@ jobs:
     name: mcp conformance (official suite)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # This job executes third-party code (npm ci + cargo build scripts):
+    # keep the token read-only and out of the checkout's git config.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
     # other open PRs still report the old name and would all break the
     # moment the required contexts were renamed to the two leg names.
     name: e2e (vitest) + coverage
-    needs: [e2e]
+    needs: [e2e, mcp-conformance]
     # A skipped required check counts as satisfied, so this must still run
     # when the matrix fails — otherwise the gate would vanish exactly when
     # it matters.
@@ -361,14 +361,25 @@ jobs:
             echo "::error::e2e matrix result: ${{ needs.e2e.result }}"
             exit 1
           fi
+      - name: assert MCP conformance passed
+        # Folded into this required aggregate so the official-suite gate is
+        # merge-blocking without renaming the branch-protection contexts.
+        run: |
+          if [ "${{ needs.mcp-conformance.result }}" != "success" ]; then
+            echo "::error::mcp conformance result: ${{ needs.mcp-conformance.result }}"
+            exit 1
+          fi
 
   mcp-conformance:
     # The OFFICIAL MCP conformance suite against the shipped /mcp chain
     # (scoped gateway + bridge + in-process upstream). Scenario list and
     # deliberate exclusions live in scripts/mcp-conformance.sh; the suite
-    # needs Node >= 22 (fs.globSync).
+    # and its transitive graph are pinned by tools/mcp-conformance/
+    # package-lock.json; needs Node >= 22 (fs.globSync). Merge-blocking
+    # through the e2e-gate aggregate below.
     name: mcp conformance (official suite)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,26 @@ jobs:
             exit 1
           fi
 
+  mcp-conformance:
+    # The OFFICIAL MCP conformance suite against the shipped /mcp chain
+    # (scoped gateway + bridge + in-process upstream). Scenario list and
+    # deliberate exclusions live in scripts/mcp-conformance.sh; the suite
+    # needs Node >= 22 (fs.globSync).
+    name: mcp conformance (official suite)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-protoc
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: build the conformance target
+        run: cargo build -p aisix-mcp --example conformance_server
+      - name: run the applicable server scenarios
+        run: bash scripts/mcp-conformance.sh
+
   coverage-gate:
     name: coverage >= 90%
     needs: [rust-unit, e2e]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -2036,6 +2036,10 @@ fn add_variant_titles(doc: &mut Value) {
             &["Inherit", "Restrict", "Deny"],
         ),
         (
+            "/components/schemas/McpProtocolVersion/oneOf",
+            &["MCP 2026-07-28"],
+        ),
+        (
             // Model's top-level direct/routing/ensemble/semantic
             // mutual-exclusion `oneOf` (injected by
             // `aisix_core::models::schema::model_root_schema`). Order must

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -47,11 +47,12 @@ pub use models::{
     validate_rate_limit_policy, A2aAgent, A2aAuthType, A2aProtocolVersion, Adapter, AisixSnapshot,
     ApiKey, AppliedGuardrail, CachePolicy, CooldownConfig, ExporterKind, Guardrail,
     GuardrailExecution, GuardrailHookPoint, GuardrailKind, GuardrailMetricsSink,
-    GuardrailMonitorHit, KeywordConfig, KeywordPattern, McpAuthType, McpRateLimit, McpServer,
-    McpServerType, McpTransport, Model, ObservabilityExporter, ParamConstraints, PolicyScope,
-    PolicyWindow, ProviderKey, RateLimit, RateLimitPolicy, RequestOverrides, ResponseOverrides,
-    Routing, RoutingStrategy, RoutingTarget, SchemaError, StreamDoneMarker, TelemetryKind,
-    TelemetryTags, WhenAllUnavailablePolicy, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
+    GuardrailMonitorHit, KeywordConfig, KeywordPattern, McpAuthType, McpProtocolVersion,
+    McpRateLimit, McpServer, McpServerType, McpTransport, Model, ObservabilityExporter,
+    ParamConstraints, PolicyScope, PolicyWindow, ProviderKey, RateLimit, RateLimitPolicy,
+    RequestOverrides, ResponseOverrides, Routing, RoutingStrategy, RoutingTarget, SchemaError,
+    StreamDoneMarker, TelemetryKind, TelemetryTags, WhenAllUnavailablePolicy,
+    DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
 pub use resource::{Resource, ResourceEntry};
 pub use snapshot::{ResourceTable, SnapshotHandle};

--- a/crates/aisix-core/src/models/mcp_server.rs
+++ b/crates/aisix-core/src/models/mcp_server.rs
@@ -105,6 +105,19 @@ pub struct McpServer {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scopes: Option<Vec<String>>,
 
+    /// MCP protocol revision the gateway uses when connecting to this
+    /// upstream server. When omitted, the gateway opens the session with the
+    /// `initialize` handshake, which negotiates among the pre-2026 protocol
+    /// revisions — the right choice for most servers, including `2026-07-28`
+    /// servers that keep backward compatibility. Set `2026-07-28` for a
+    /// server that requires the stateless MCP `2026-07-28` revision
+    /// (handshake-free `server/discover` startup); the connection fails
+    /// rather than silently downgrading when the server does not support the
+    /// configured revision. Only used when `type` is `mcp`; ignored for
+    /// `type: openapi`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<McpProtocolVersion>,
+
     /// Maximum time, in milliseconds, to wait for a single upstream operation
     /// (establishing the session, listing tools, or calling a tool). Must be at
     /// least `1` when set. When omitted, the gateway applies a built-in default.
@@ -138,6 +151,18 @@ pub enum McpServerType {
     /// A REST API described by an OpenAPI document; the gateway generates the
     /// tools itself and issues plain HTTP requests against `url`.
     Openapi,
+}
+
+/// MCP protocol revision used for an upstream connection. Values are the
+/// specification's dated version identifiers; revisions before `2026-07-28`
+/// need no entry here because the `initialize` handshake negotiates among
+/// them automatically when `protocol_version` is omitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub enum McpProtocolVersion {
+    /// The stateless MCP `2026-07-28` revision: handshake-free startup via
+    /// `server/discover`, with self-contained per-request metadata.
+    #[serde(rename = "2026-07-28")]
+    V20260728,
 }
 
 /// Transport used to reach an upstream MCP server.
@@ -620,6 +645,7 @@ mod tests {
             client_id: None,
             token_url: None,
             scopes: None,
+            protocol_version: None,
             timeout_ms: None,
             enabled: true,
             runtime_id: String::new(),

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -52,7 +52,7 @@ pub use guardrail::{
     PiiConfig, PiiCustomPattern, PiiDetectorConfig, PresidioConfig, PresidioEntityConfig,
 };
 pub use mcp_policy::{McpAccess, McpAccessMode, McpPolicy, McpPolicyMode, McpPolicyScope};
-pub use mcp_server::{McpAuthType, McpServer, McpServerType, McpTransport};
+pub use mcp_server::{McpAuthType, McpProtocolVersion, McpServer, McpServerType, McpTransport};
 pub use model::{
     Adapter, BackgroundModelCheck, CooldownConfig, Model, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };

--- a/crates/aisix-mcp/src/bridge.rs
+++ b/crates/aisix-mcp/src/bridge.rs
@@ -357,7 +357,9 @@ fn transport_config(url: &str) -> StreamableHttpClientTransportConfig {
 impl RmcpBridge {
     /// Open a session to `upstream`: build the Streamable HTTP transport
     /// (injecting gateway-held auth — for `oauth2` this mints or reuses a
-    /// cached access token first) and run the `initialize` handshake. The
+    /// cached access token first) and run the startup lifecycle selected by
+    /// [`McpUpstream::protocol`] — the `initialize` handshake by default,
+    /// or handshake-free `server/discover` for `2026-07-28` upstreams. The
     /// whole sequence, token minting included, is bounded by the upstream's
     /// timeout.
     pub async fn connect(upstream: &McpUpstream) -> Result<Self, McpError> {

--- a/crates/aisix-mcp/src/bridge.rs
+++ b/crates/aisix-mcp/src/bridge.rs
@@ -17,14 +17,14 @@ use std::time::Duration;
 use aisix_core::{McpAuthType, McpServer};
 use async_trait::async_trait;
 use http::{HeaderName, HeaderValue};
-use rmcp::model::{CallToolRequestParams, CallToolResponse};
+use rmcp::model::{CallToolRequestParams, CallToolResponse, ClientInfo, ProtocolVersion};
 use rmcp::service::{ClientInitializeError, RoleClient, RunningService};
 use rmcp::transport::streamable_http_client::{
     StreamableHttpClientTransportConfig, StreamableHttpError,
 };
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::ClientCacheConfig;
-use rmcp::ServiceExt;
+use rmcp::{ClientLifecycleMode, ClientServiceExt};
 
 use crate::error::McpError;
 
@@ -187,6 +187,26 @@ impl std::fmt::Debug for McpAuth {
     }
 }
 
+/// The MCP protocol revision the bridge opens an upstream session with.
+///
+/// Explicit, never probed: a server that does not speak the configured
+/// revision produces a visible connect failure instead of a silent
+/// cross-generation downgrade. (Automatic fallback is how version and
+/// session context ends up crossing the protocol boundary — the bug class
+/// sibling gateways are currently working through.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum McpProtocol {
+    /// Open with the `initialize` handshake and negotiate among the
+    /// pre-2026 protocol revisions. Works with every legacy server and with
+    /// `2026-07-28` servers that keep backward compatibility.
+    #[default]
+    LegacyHandshake,
+    /// The stateless MCP `2026-07-28` revision: handshake-free
+    /// `server/discover` startup, self-contained per-request metadata.
+    /// Required for servers that no longer answer `initialize`.
+    V20260728,
+}
+
 /// Connection parameters for a single upstream MCP server.
 #[derive(Clone)]
 pub struct McpUpstream {
@@ -197,6 +217,9 @@ pub struct McpUpstream {
     pub auth: McpAuth,
     /// Per-operation deadline. Defaults to [`DEFAULT_UPSTREAM_TIMEOUT`].
     pub timeout: Duration,
+    /// Protocol revision the session is opened with. Defaults to the
+    /// legacy `initialize` handshake.
+    pub protocol: McpProtocol,
 }
 
 // Manual so a `Bearer` token cannot leak through `McpUpstream`'s `Debug`
@@ -207,6 +230,7 @@ impl std::fmt::Debug for McpUpstream {
             .field("url", &self.url)
             .field("auth", &self.auth)
             .field("timeout", &self.timeout)
+            .field("protocol", &self.protocol)
             .finish()
     }
 }
@@ -218,7 +242,14 @@ impl McpUpstream {
             url: url.into(),
             auth: McpAuth::None,
             timeout: DEFAULT_UPSTREAM_TIMEOUT,
+            protocol: McpProtocol::default(),
         }
+    }
+
+    /// Select the protocol revision the session is opened with.
+    pub fn with_protocol(mut self, protocol: McpProtocol) -> Self {
+        self.protocol = protocol;
+        self
     }
 
     /// Set Bearer auth (raw token, no `Bearer ` prefix).
@@ -296,7 +327,7 @@ pub trait McpBridge: Send + Sync {
 /// `rmcp`-backed [`McpBridge`]: holds one running client session to the
 /// upstream. Dropping it tears the session down.
 pub struct RmcpBridge {
-    running: RunningService<RoleClient, ()>,
+    running: RunningService<RoleClient, ClientInfo>,
     timeout: Duration,
 }
 
@@ -370,22 +401,40 @@ impl RmcpBridge {
                     )
                 }
             };
-            ().serve(transport).await.map_err(|e| {
-                // An upstream 401 against a minted token means the token was
-                // revoked or expired earlier than promised: drop the cache
-                // entry so the next attempt re-mints instead of replaying it.
-                if let McpAuth::OAuth2(cfg) = &upstream.auth {
-                    if init_error_is_unauthorized(&e) {
-                        crate::oauth::invalidate(cfg);
+            // Lifecycle follows the configured protocol revision. The
+            // handler is `ClientInfo::default()` on BOTH paths — identical
+            // handshake bytes to the previous unit handler (whose default
+            // `get_info()` returns exactly `ClientInfo::default()`), plus
+            // the per-request metadata the Discover lifecycle needs.
+            let lifecycle = match upstream.protocol {
+                McpProtocol::LegacyHandshake => ClientLifecycleMode::Initialize,
+                // Discover, NOT Auto: a server that answers `server/discover`
+                // with an error must fail the connect visibly. `Auto` would
+                // silently retry the legacy handshake, hiding real
+                // misconfiguration and version drift.
+                McpProtocol::V20260728 => ClientLifecycleMode::Discover {
+                    preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+                },
+            };
+            ClientInfo::default()
+                .serve_with_lifecycle(transport, lifecycle)
+                .await
+                .map_err(|e| {
+                    // An upstream 401 against a minted token means the token was
+                    // revoked or expired earlier than promised: drop the cache
+                    // entry so the next attempt re-mints instead of replaying it.
+                    if let McpAuth::OAuth2(cfg) = &upstream.auth {
+                        if init_error_is_unauthorized(&e) {
+                            crate::oauth::invalidate(cfg);
+                        }
                     }
-                }
-                // Bound + sanitize: a bare-401 shape embeds the upstream's
-                // response body in the error text, which lands in gateway
-                // logs. An upstream that reflects request headers into its
-                // error body (or emits control characters for log injection)
-                // must not get either past this point verbatim.
-                McpError::Connect(sanitize_error_message(&e.to_string()))
-            })
+                    // Bound + sanitize: a bare-401 shape embeds the upstream's
+                    // response body in the error text, which lands in gateway
+                    // logs. An upstream that reflects request headers into its
+                    // error body (or emits control characters for log injection)
+                    // must not get either past this point verbatim.
+                    McpError::Connect(sanitize_error_message(&e.to_string()))
+                })
         };
         let running = tokio::time::timeout(upstream.timeout, establish)
             .await
@@ -633,10 +682,18 @@ pub fn upstream_from_mcp_server(server: &McpServer) -> McpUpstream {
         .timeout_ms
         .map(Duration::from_millis)
         .unwrap_or(DEFAULT_UPSTREAM_TIMEOUT);
+    // Dated spec revisions map one-to-one onto session lifecycles; absent
+    // means the legacy handshake (which negotiates among the pre-2026
+    // revisions on its own).
+    let protocol = match server.protocol_version {
+        None => McpProtocol::LegacyHandshake,
+        Some(aisix_core::McpProtocolVersion::V20260728) => McpProtocol::V20260728,
+    };
     McpUpstream {
         url: server.url.clone(),
         auth,
         timeout,
+        protocol,
     }
 }
 

--- a/crates/aisix-mcp/src/lib.rs
+++ b/crates/aisix-mcp/src/lib.rs
@@ -20,8 +20,8 @@ mod oauth;
 pub mod openapi;
 
 pub use bridge::{
-    upstream_from_mcp_server, EphemeralBridge, McpAuth, McpBridge, McpTool, McpToolResult,
-    McpUpstream, OAuthClientConfig, RmcpBridge,
+    upstream_from_mcp_server, EphemeralBridge, McpAuth, McpBridge, McpProtocol, McpTool,
+    McpToolResult, McpUpstream, OAuthClientConfig, RmcpBridge,
 };
 pub use error::McpError;
 pub use gateway::{

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use aisix_core::{AisixSnapshot, McpServer, ResourceEntry};
 use aisix_mcp::{
     streamable_http_service, upstream_from_mcp_server, McpAuth, McpBridge, McpError, McpGateway,
-    McpTool, McpToolResult, McpUpstream, RmcpBridge, ToolAcl,
+    McpProtocol, McpTool, McpToolResult, McpUpstream, RmcpBridge, ToolAcl,
 };
 use rmcp::model::{
     CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
@@ -313,6 +313,42 @@ fn upstream_from_mcp_server_maps_auth_and_timeout() {
         upstream_from_mcp_server(&plain).auth,
         McpAuth::None
     ));
+}
+
+/// The configured `protocol_version` — the wire value a control plane
+/// writes — selects the bridge lifecycle, and its absence keeps the legacy
+/// handshake. Pins the deserialize → upstream mapping itself, so reverting
+/// the mapping (not just the lifecycle switch) fails a test.
+#[test]
+fn upstream_from_mcp_server_maps_protocol_version() {
+    let modern: McpServer = serde_json::from_value(serde_json::json!({
+        "display_name": "m",
+        "url": "https://api.example.com/mcp",
+        "protocol_version": "2026-07-28"
+    }))
+    .unwrap();
+    assert_eq!(
+        upstream_from_mcp_server(&modern).protocol,
+        McpProtocol::V20260728
+    );
+
+    let dflt: McpServer = serde_json::from_value(serde_json::json!({
+        "display_name": "d", "url": "https://api.example.com/mcp"
+    }))
+    .unwrap();
+    assert_eq!(
+        upstream_from_mcp_server(&dflt).protocol,
+        McpProtocol::LegacyHandshake
+    );
+
+    // An unknown revision is a hard deserialization error, not a silent
+    // fallback to some default lifecycle.
+    let unknown = serde_json::from_value::<McpServer>(serde_json::json!({
+        "display_name": "u",
+        "url": "https://api.example.com/mcp",
+        "protocol_version": "2099-01-01"
+    }));
+    assert!(unknown.is_err(), "unknown revisions must be rejected");
 }
 
 #[test]

--- a/crates/aisix-mcp/tests/modern_upstream.rs
+++ b/crates/aisix-mcp/tests/modern_upstream.rs
@@ -66,6 +66,21 @@ async fn stub_mcp(
     };
     let method = message["method"].as_str().unwrap_or_default().to_string();
     let id = message["id"].clone();
+    // A STATEFUL legacy server enforces its session: every post-initialize
+    // request must carry the exact minted id, or the sequence test would
+    // pass even if the bridge dropped the session header entirely.
+    if let StubGeneration::Legacy { stateful: true } = stub.generation {
+        if method != "initialize" {
+            let session = headers.get("mcp-session-id").and_then(|v| v.to_str().ok());
+            if session != Some("sess-legacy-1") {
+                return (
+                    axum::http::StatusCode::NOT_FOUND,
+                    format!("missing or wrong session id on {method}: {session:?}"),
+                )
+                    .into_response();
+            }
+        }
+    }
     stub.recorder
         .sequence
         .lock()
@@ -321,27 +336,27 @@ async fn downstream_context_never_crosses_to_the_upstream() {
     let (stub_addr, recorder) = spawn_stub(StubGeneration::Legacy { stateful: false }).await;
     let headers = upstream_headers_after_gateway_call(stub_addr, &recorder).await;
 
-    let get = |name: &str| {
+    // Collect EVERY value per name: a duplicated header (bridge's own plus
+    // a forwarded downstream copy) must fail, not hide behind first-match.
+    let values = |name: &str| -> Vec<&str> {
         headers
             .iter()
-            .find(|(n, _)| n == name)
+            .filter(|(n, _)| n == name)
             .map(|(_, v)| v.as_str())
+            .collect()
     };
-    assert_eq!(
-        get("authorization"),
-        None,
+    assert!(
+        values("authorization").is_empty(),
         "the caller's credential must never be forwarded (upstream auth is \
          gateway-held): {headers:?}"
     );
-    assert_eq!(
-        get("mcp-session-id"),
-        None,
+    assert!(
+        values("mcp-session-id").is_empty(),
         "a downstream session id must never leak into the upstream session: {headers:?}"
     );
-    let upstream_version = get("mcp-protocol-version");
-    assert_ne!(
-        upstream_version,
-        Some("2026-07-28"),
+    let versions = values("mcp-protocol-version");
+    assert!(
+        !versions.contains(&"2026-07-28"),
         "the downstream protocol version must not be mirrored upstream — the \
          bridge negotiated its own (legacy) session: {headers:?}"
     );

--- a/crates/aisix-mcp/tests/modern_upstream.rs
+++ b/crates/aisix-mcp/tests/modern_upstream.rs
@@ -347,6 +347,64 @@ async fn downstream_context_never_crosses_to_the_upstream() {
     );
 }
 
+/// The full user-facing chain for the new field: a registered row carrying
+/// `protocol_version: "2026-07-28"` — the exact wire value a control plane
+/// writes — is deserialized, loaded through `from_snapshot_scoped`, and
+/// reaches a modern-only upstream through the production bridge. Pins
+/// deserialization → snapshot → lifecycle selection in one, so no single
+/// link of the mapping can be reverted silently.
+#[tokio::test]
+async fn snapshot_row_with_protocol_version_reaches_modern_only_upstream() {
+    let (stub_addr, recorder) = spawn_stub(StubGeneration::ModernOnly).await;
+    let server: aisix_core::McpServer = serde_json::from_value(serde_json::json!({
+        "display_name": "modern",
+        "url": format!("http://{stub_addr}/mcp"),
+        "protocol_version": "2026-07-28",
+    }))
+    .expect("valid mcp_servers row");
+    let snapshot = aisix_core::AisixSnapshot::new();
+    snapshot
+        .mcp_servers
+        .insert(aisix_core::ResourceEntry::new("mcp-modern", server, 1));
+    let gateway = McpGateway::from_snapshot_scoped(&snapshot, "modern")
+        .expect("scoped gateway over the registered row");
+    let app = axum::Router::new().nest_service("/mcp", streamable_http_service(gateway, 0));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind gateway port");
+    let gw_addr = listener.local_addr().expect("gateway addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve gateway");
+    });
+
+    // Downstream generation is independent of the upstream lifecycle: a
+    // plain stateless legacy call is enough to force one bridge session.
+    let response = reqwest::Client::new()
+        .post(format!("http://{gw_addr}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": { "name": "echo", "arguments": {} }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(response.status(), 200, "{}", response.text().await.unwrap());
+
+    assert_eq!(
+        recorder.initialize.load(Ordering::SeqCst),
+        0,
+        "the configured revision must select the discover lifecycle end to end"
+    );
+    assert!(recorder.discover.load(Ordering::SeqCst) >= 1);
+}
+
 /// A stateful legacy upstream sees the COMPLETE handshake sequence for the
 /// bridge's session — never a bare `tools/call` riding on a session the
 /// upstream doesn't have.

--- a/crates/aisix-mcp/tests/modern_upstream.rs
+++ b/crates/aisix-mcp/tests/modern_upstream.rs
@@ -1,0 +1,368 @@
+//! The per-server `protocol_version` bridge contract (AISIX-Cloud#1151):
+//!
+//! - `protocol_version: "2026-07-28"` opens the upstream session with the
+//!   handshake-free `server/discover` lifecycle — the only way to reach a
+//!   server that no longer answers `initialize`.
+//! - The selection is EXPLICIT in both directions: a modern-only server
+//!   under the default (legacy handshake) config fails visibly, and a
+//!   legacy server under the `2026-07-28` config fails visibly. No probe,
+//!   no silent cross-generation fallback — automatic bridging is how
+//!   version/session context ends up crossing the protocol boundary (the
+//!   open bug class in auto-bridging gateways).
+//! - Downstream context never crosses to the upstream: the bridge opens
+//!   its own session, so the caller's `Authorization`, session id, and
+//!   protocol version header are absent from upstream requests by
+//!   construction — pinned here against a header-capturing upstream.
+//! - A stateful legacy upstream receives the COMPLETE handshake sequence
+//!   (`initialize` → `notifications/initialized` → operation) on every
+//!   bridge session.
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use aisix_mcp::{
+    streamable_http_service, EphemeralBridge, McpBridge, McpGateway, McpProtocol, McpUpstream,
+    RmcpBridge,
+};
+use axum::extract::State;
+use axum::response::IntoResponse;
+
+/// Which generation the stub upstream speaks.
+#[derive(Clone, Copy, PartialEq)]
+enum StubGeneration {
+    /// Answers `initialize` (optionally minting a session id); rejects
+    /// `server/discover` with JSON-RPC method-not-found.
+    Legacy { stateful: bool },
+    /// Answers `server/discover` and stateless operations; rejects
+    /// `initialize` with JSON-RPC method-not-found.
+    ModernOnly,
+}
+
+#[derive(Default)]
+struct StubRecorder {
+    initialize: AtomicUsize,
+    discover: AtomicUsize,
+    /// JSON-RPC method sequence, in arrival order.
+    sequence: Mutex<Vec<String>>,
+    /// Headers seen on the most recent `tools/call`.
+    call_headers: Mutex<Vec<(String, String)>>,
+}
+
+#[derive(Clone)]
+struct Stub {
+    generation: StubGeneration,
+    recorder: Arc<StubRecorder>,
+}
+
+async fn stub_mcp(
+    State(stub): State<Stub>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let message: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => return (axum::http::StatusCode::BAD_REQUEST, "not json").into_response(),
+    };
+    let method = message["method"].as_str().unwrap_or_default().to_string();
+    let id = message["id"].clone();
+    stub.recorder
+        .sequence
+        .lock()
+        .expect("sequence lock")
+        .push(method.clone());
+    let respond = |result: serde_json::Value| {
+        (
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            serde_json::json!({ "jsonrpc": "2.0", "id": id.clone(), "result": result }).to_string(),
+        )
+            .into_response()
+    };
+    let method_not_found = |what: &str| {
+        (
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id.clone(),
+                "error": { "code": -32601, "message": format!("method not found: {what}") }
+            })
+            .to_string(),
+        )
+            .into_response()
+    };
+    match method.as_str() {
+        "initialize" => {
+            stub.recorder.initialize.fetch_add(1, Ordering::SeqCst);
+            match stub.generation {
+                StubGeneration::ModernOnly => method_not_found("initialize"),
+                StubGeneration::Legacy { stateful } => {
+                    let result = serde_json::json!({
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": { "tools": {} },
+                        "serverInfo": { "name": "stub", "version": "0.0.0" },
+                    });
+                    if stateful {
+                        (
+                            [
+                                (axum::http::header::CONTENT_TYPE, "application/json"),
+                                (
+                                    axum::http::HeaderName::from_static("mcp-session-id"),
+                                    "sess-legacy-1",
+                                ),
+                            ],
+                            serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result })
+                                .to_string(),
+                        )
+                            .into_response()
+                    } else {
+                        respond(result)
+                    }
+                }
+            }
+        }
+        "server/discover" => {
+            stub.recorder.discover.fetch_add(1, Ordering::SeqCst);
+            match stub.generation {
+                StubGeneration::Legacy { .. } => method_not_found("server/discover"),
+                StubGeneration::ModernOnly => respond(serde_json::json!({
+                    "resultType": "complete",
+                    "supportedVersions": ["2026-07-28"],
+                    "capabilities": { "tools": {} },
+                    "ttlMs": 0,
+                    "cacheScope": "private",
+                })),
+            }
+        }
+        "notifications/initialized" => axum::http::StatusCode::ACCEPTED.into_response(),
+        "tools/list" => respond(serde_json::json!({
+            "tools": [{
+                "name": "echo",
+                "description": "echo",
+                "inputSchema": { "type": "object" },
+            }],
+        })),
+        "tools/call" => {
+            let mut seen = stub
+                .recorder
+                .call_headers
+                .lock()
+                .expect("call_headers lock");
+            *seen = headers
+                .iter()
+                .map(|(name, value)| {
+                    (
+                        name.as_str().to_ascii_lowercase(),
+                        String::from_utf8_lossy(value.as_bytes()).into_owned(),
+                    )
+                })
+                .collect();
+            respond(serde_json::json!({
+                "content": [{ "type": "text", "text": "ok" }],
+                "isError": false,
+            }))
+        }
+        other => (
+            axum::http::StatusCode::BAD_REQUEST,
+            format!("unexpected method {other}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn spawn_stub(generation: StubGeneration) -> (SocketAddr, Arc<StubRecorder>) {
+    let recorder = Arc::new(StubRecorder::default());
+    let stub = Stub {
+        generation,
+        recorder: Arc::clone(&recorder),
+    };
+    let app = axum::Router::new()
+        .route("/mcp", axum::routing::post(stub_mcp))
+        .with_state(stub);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve");
+    });
+    (addr, recorder)
+}
+
+/// `protocol_version: "2026-07-28"` reaches a modern-only upstream:
+/// handshake-free startup, list + call work, and `initialize` is never
+/// attempted.
+#[tokio::test]
+async fn modern_only_upstream_works_with_the_dated_protocol_version() {
+    let (addr, recorder) = spawn_stub(StubGeneration::ModernOnly).await;
+    let upstream =
+        McpUpstream::new(format!("http://{addr}/mcp")).with_protocol(McpProtocol::V20260728);
+    let bridge = RmcpBridge::connect(&upstream)
+        .await
+        .expect("discover-lifecycle connect");
+
+    let tools = bridge.list_tools().await.expect("list tools");
+    assert_eq!(tools[0].name, "echo");
+    let result = bridge
+        .call_tool("echo", serde_json::json!({}))
+        .await
+        .expect("call tool");
+    assert!(!result.is_error);
+
+    assert_eq!(
+        recorder.initialize.load(Ordering::SeqCst),
+        0,
+        "a 2026-07-28 session must never attempt the legacy handshake"
+    );
+    assert!(recorder.discover.load(Ordering::SeqCst) >= 1);
+}
+
+/// A modern-only upstream under the DEFAULT (legacy handshake) config
+/// fails visibly at connect — and the bridge does not secretly probe
+/// `server/discover` to save it.
+#[tokio::test]
+async fn modern_only_upstream_fails_visibly_under_default_config() {
+    let (addr, recorder) = spawn_stub(StubGeneration::ModernOnly).await;
+    let result = RmcpBridge::connect(&McpUpstream::new(format!("http://{addr}/mcp"))).await;
+    assert!(
+        result.is_err(),
+        "a modern-only server must fail the legacy handshake visibly"
+    );
+    assert_eq!(
+        recorder.discover.load(Ordering::SeqCst),
+        0,
+        "the legacy lifecycle must not silently probe server/discover"
+    );
+}
+
+/// A legacy upstream under the `2026-07-28` config fails visibly — no
+/// silent fallback to the `initialize` handshake.
+#[tokio::test]
+async fn legacy_upstream_fails_visibly_under_modern_config_without_fallback() {
+    let (addr, recorder) = spawn_stub(StubGeneration::Legacy { stateful: false }).await;
+    let upstream =
+        McpUpstream::new(format!("http://{addr}/mcp")).with_protocol(McpProtocol::V20260728);
+    let result = RmcpBridge::connect(&upstream).await;
+    assert!(
+        result.is_err(),
+        "a legacy server must fail the discover lifecycle visibly"
+    );
+    assert_eq!(
+        recorder.initialize.load(Ordering::SeqCst),
+        0,
+        "the discover lifecycle must not silently fall back to initialize"
+    );
+}
+
+/// Drive one modern downstream `tools/call` through the full gateway chain
+/// and return the headers the upstream saw.
+async fn upstream_headers_after_gateway_call(
+    stub_addr: SocketAddr,
+    recorder: &StubRecorder,
+) -> Vec<(String, String)> {
+    let bridge = EphemeralBridge::new(McpUpstream::new(format!("http://{stub_addr}/mcp")));
+    let gateway = McpGateway::new([("alpha".to_string(), Arc::new(bridge) as Arc<dyn McpBridge>)]);
+    let app = axum::Router::new().nest_service("/mcp", streamable_http_service(gateway, 0));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind gateway port");
+    let gw_addr = listener.local_addr().expect("gateway addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve gateway");
+    });
+
+    // A modern (2026-07-28) downstream caller carrying context that must
+    // NOT cross to the upstream: an API credential, a stale session id,
+    // and its own protocol version header.
+    let response = reqwest::Client::new()
+        .post(format!("http://{gw_addr}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .header("authorization", "Bearer sk-DOWNSTREAM-SECRET")
+        .header("mcp-session-id", "downstream-session-1")
+        .header("mcp-protocol-version", "2026-07-28")
+        .header("mcp-method", "tools/call")
+        .header("mcp-name", "alpha__echo")
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "alpha__echo",
+                    "arguments": {},
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                        "io.modelcontextprotocol/clientInfo": {
+                            "name": "ctx-test", "version": "0.0.0"
+                        },
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(response.status(), 200, "{}", response.text().await.unwrap());
+
+    recorder
+        .call_headers
+        .lock()
+        .expect("call_headers lock")
+        .clone()
+}
+
+/// Downstream `Authorization`, session id, and protocol version never
+/// cross the protocol boundary: the bridge opens its own upstream session
+/// with its own negotiated context.
+#[tokio::test]
+async fn downstream_context_never_crosses_to_the_upstream() {
+    let (stub_addr, recorder) = spawn_stub(StubGeneration::Legacy { stateful: false }).await;
+    let headers = upstream_headers_after_gateway_call(stub_addr, &recorder).await;
+
+    let get = |name: &str| {
+        headers
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, v)| v.as_str())
+    };
+    assert_eq!(
+        get("authorization"),
+        None,
+        "the caller's credential must never be forwarded (upstream auth is \
+         gateway-held): {headers:?}"
+    );
+    assert_eq!(
+        get("mcp-session-id"),
+        None,
+        "a downstream session id must never leak into the upstream session: {headers:?}"
+    );
+    let upstream_version = get("mcp-protocol-version");
+    assert_ne!(
+        upstream_version,
+        Some("2026-07-28"),
+        "the downstream protocol version must not be mirrored upstream — the \
+         bridge negotiated its own (legacy) session: {headers:?}"
+    );
+}
+
+/// A stateful legacy upstream sees the COMPLETE handshake sequence for the
+/// bridge's session — never a bare `tools/call` riding on a session the
+/// upstream doesn't have.
+#[tokio::test]
+async fn stateful_legacy_upstream_receives_the_full_handshake_sequence() {
+    let (stub_addr, recorder) = spawn_stub(StubGeneration::Legacy { stateful: true }).await;
+    let _ = upstream_headers_after_gateway_call(stub_addr, &recorder).await;
+
+    let sequence = recorder.sequence.lock().expect("sequence lock").clone();
+    assert_eq!(
+        sequence,
+        vec![
+            "initialize".to_string(),
+            "notifications/initialized".to_string(),
+            "tools/call".to_string(),
+        ],
+        "every bridge session must run the full legacy lifecycle"
+    );
+}

--- a/schemas/resources/mcp_server.schema.json
+++ b/schemas/resources/mcp_server.schema.json
@@ -223,6 +223,18 @@
         }
       ]
     },
+    "McpProtocolVersion": {
+      "description": "MCP protocol revision used for an upstream connection. Values are the specification's dated version identifiers; revisions before `2026-07-28` need no entry here because the `initialize` handshake negotiates among them automatically when `protocol_version` is omitted.",
+      "oneOf": [
+        {
+          "description": "The stateless MCP `2026-07-28` revision: handshake-free startup via `server/discover`, with self-contained per-request metadata.",
+          "enum": [
+            "2026-07-28"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "McpServerType": {
       "description": "What backs a registered MCP server entry.",
       "oneOf": [
@@ -299,6 +311,17 @@
       "minLength": 1,
       "pattern": "^(?:[^_]|_[^_])*$",
       "type": "string"
+    },
+    "protocol_version": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/McpProtocolVersion"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "MCP protocol revision the gateway uses when connecting to this upstream server. When omitted, the gateway opens the session with the `initialize` handshake, which negotiates among the pre-2026 protocol revisions — the right choice for most servers, including `2026-07-28` servers that keep backward compatibility. Set `2026-07-28` for a server that requires the stateless MCP `2026-07-28` revision (handshake-free `server/discover` startup); the connection fails rather than silently downgrading when the server does not support the configured revision. Only used when `type` is `mcp`; ignored for `type: openapi`."
     },
     "scopes": {
       "description": "OAuth scopes to request. Joined with spaces into the `scope` parameter of the token request. Only used when `auth_type` is `oauth2`.",

--- a/scripts/mcp-conformance.sh
+++ b/scripts/mcp-conformance.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Official MCP conformance suite against the shipped /mcp gateway chain:
+# conformance client → scoped gateway → EphemeralBridge → in-process
+# upstream (see crates/aisix-mcp/examples/conformance_server.rs).
+#
+# Runs every scenario applicable to the tools-only surface. The scenarios
+# NOT in the list are deliberate surface decisions, documented in the
+# example's module docs: prompts/resources content scenarios (capabilities
+# this gateway does not advertise), server-initiated relay scenarios
+# (sampling/elicitation/progress/logging), and the Host-allowlist half of
+# dns-rebinding-protection (the endpoint is API-key-gated at the proxy
+# layer). Growing this list is expected as the gateway's MCP surface grows.
+#
+# The package version is pinned: the suite is young and its scenario set
+# moves; bumps should be deliberate, with the scenario list re-reviewed.
+set -euo pipefail
+
+CONFORMANCE_PKG="@modelcontextprotocol/conformance@0.1.16"
+ADDR="${1:-127.0.0.1:3111}"
+BIN="${CONFORMANCE_TARGET:-./target/debug/examples/conformance_server}"
+
+SCENARIOS=(
+  server-initialize
+  ping
+  completion-complete
+  tools-list
+  tools-call-simple-text
+  tools-call-image
+  tools-call-audio
+  tools-call-embedded-resource
+  tools-call-mixed-content
+  tools-call-error
+  server-sse-multiple-streams
+  resources-list
+  prompts-list
+)
+
+"$BIN" "$ADDR" &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+
+# Wait until the endpoint answers (ping needs no handshake on any generation).
+ready=0
+for _ in $(seq 1 100); do
+  if curl -sf -o /dev/null -X POST "http://$ADDR/mcp" \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"ping"}'; then
+    ready=1
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" != 1 ]; then
+  echo "::error::conformance target never became ready on $ADDR"
+  exit 1
+fi
+
+failed=0
+for scenario in "${SCENARIOS[@]}"; do
+  echo "=== scenario: $scenario"
+  # The CLI's exit code is not a reliable pass signal across versions;
+  # the per-run "N failed" line is. `|| true` keeps set -e out of it.
+  out=$(npx -y "$CONFORMANCE_PKG" server --url "http://$ADDR/mcp" --scenario "$scenario" 2>&1) || true
+  echo "$out" | sed -n '/Test Results:/,+2p'
+  if ! echo "$out" | grep -q ", 0 failed"; then
+    echo "::error::conformance scenario '$scenario' failed"
+    echo "$out" | tail -30
+    failed=1
+  fi
+done
+
+exit "$failed"

--- a/scripts/mcp-conformance.sh
+++ b/scripts/mcp-conformance.sh
@@ -7,17 +7,21 @@
 # NOT in the list are deliberate surface decisions, documented in the
 # example's module docs: prompts/resources content scenarios (capabilities
 # this gateway does not advertise), server-initiated relay scenarios
-# (sampling/elicitation/progress/logging), and the Host-allowlist half of
+# (sampling/elicitation/progress/logging), the Host-allowlist half of
 # dns-rebinding-protection (the endpoint is API-key-gated at the proxy
-# layer). Growing this list is expected as the gateway's MCP surface grows.
+# layer), and session-dependent scenarios (this gateway is stateless by
+# design). Growing this list is expected as the gateway's MCP surface
+# grows.
 #
-# The package version is pinned: the suite is young and its scenario set
-# moves; bumps should be deliberate, with the scenario list re-reviewed.
+# The suite AND its full transitive dependency graph are pinned by
+# tools/mcp-conformance/package-lock.json (`npm ci`); a floating install
+# would let protocol behavior drift with the suite's own SDK dependency.
 set -euo pipefail
 
-CONFORMANCE_PKG="@modelcontextprotocol/conformance@0.1.16"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HARNESS_DIR="$REPO_ROOT/tools/mcp-conformance"
 ADDR="${1:-127.0.0.1:3111}"
-BIN="${CONFORMANCE_TARGET:-./target/debug/examples/conformance_server}"
+BIN="${CONFORMANCE_TARGET:-$REPO_ROOT/target/debug/examples/conformance_server}"
 
 SCENARIOS=(
   server-initialize
@@ -30,19 +34,37 @@ SCENARIOS=(
   tools-call-embedded-resource
   tools-call-mixed-content
   tools-call-error
-  server-sse-multiple-streams
+  # server-sse-multiple-streams is deliberately ABSENT: it requires a
+  # server-minted session id, and this gateway is stateless by design —
+  # the scenario runs zero checks (a 0/0 WARNING) and would gate nothing.
   resources-list
   prompts-list
 )
 
+npm ci --prefix "$HARNESS_DIR" --ignore-scripts --no-audit --no-fund >/dev/null
+CONFORMANCE_BIN="$HARNESS_DIR/node_modules/.bin/conformance"
+[ -x "$CONFORMANCE_BIN" ] || { echo "::error::conformance binary missing after npm ci"; exit 1; }
+
+# Per-scenario wall-clock bound. GNU coreutils `timeout` exists on the CI
+# runners; degrade to unbounded where it is absent (macOS dev machines).
+if command -v timeout >/dev/null; then
+  BOUND=(timeout 120)
+else
+  BOUND=()
+fi
+
 "$BIN" "$ADDR" &
 SERVER_PID=$!
-trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+cleanup() {
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
 
 # Wait until the endpoint answers (ping needs no handshake on any generation).
 ready=0
 for _ in $(seq 1 100); do
-  if curl -sf -o /dev/null -X POST "http://$ADDR/mcp" \
+  if curl -sf --max-time 2 -o /dev/null -X POST "http://$ADDR/mcp" \
     -H 'content-type: application/json' \
     -H 'accept: application/json, text/event-stream' \
     -d '{"jsonrpc":"2.0","id":1,"method":"ping"}'; then
@@ -59,12 +81,16 @@ fi
 failed=0
 for scenario in "${SCENARIOS[@]}"; do
   echo "=== scenario: $scenario"
-  # The CLI's exit code is not a reliable pass signal across versions;
-  # the per-run "N failed" line is. `|| true` keeps set -e out of it.
-  out=$(npx -y "$CONFORMANCE_PKG" server --url "http://$ADDR/mcp" --scenario "$scenario" 2>&1) || true
-  echo "$out" | sed -n '/Test Results:/,+2p'
-  if ! echo "$out" | grep -q ", 0 failed"; then
-    echo "::error::conformance scenario '$scenario' failed"
+  rc=0
+  # `${BOUND[@]+...}`: expands to nothing when the array is empty — plain
+  # `"${BOUND[@]}"` trips `set -u` on bash 3.2 (macOS dev machines).
+  out=$(${BOUND[@]+"${BOUND[@]}"} "$CONFORMANCE_BIN" server --url "http://$ADDR/mcp" --scenario "$scenario" 2>&1) || rc=$?
+  echo "$out" | grep -A2 'Test Results:' || true
+  # Pass = the CLI exited 0 AND at least one check ran AND none failed.
+  # Each leg matters: a nonzero exit with a clean-looking summary, or a
+  # 0/0 not-applicable run, must not count as coverage.
+  if [ "$rc" != 0 ] || ! echo "$out" | grep -qE 'Passed: [0-9]+/[1-9][0-9]*, 0 failed'; then
+    echo "::error::conformance scenario '$scenario' failed (exit $rc)"
     echo "$out" | tail -30
     failed=1
   fi

--- a/scripts/mcp-conformance.sh
+++ b/scripts/mcp-conformance.sh
@@ -45,12 +45,13 @@ npm ci --prefix "$HARNESS_DIR" --ignore-scripts --no-audit --no-fund >/dev/null
 CONFORMANCE_BIN="$HARNESS_DIR/node_modules/.bin/conformance"
 [ -x "$CONFORMANCE_BIN" ] || { echo "::error::conformance binary missing after npm ci"; exit 1; }
 
-# Per-scenario wall-clock bound. GNU coreutils `timeout` exists on the CI
-# runners; degrade to unbounded where it is absent (macOS dev machines).
+# Per-scenario wall-clock bound. GNU coreutils `timeout` on the CI
+# runners; perl's alarm as the portable fallback (macOS dev machines) so
+# a hung scenario is bounded on every platform.
 if command -v timeout >/dev/null; then
   BOUND=(timeout 120)
 else
-  BOUND=()
+  BOUND=(perl -e 'alarm shift; exec @ARGV' 120)
 fi
 
 "$BIN" "$ADDR" &
@@ -86,10 +87,12 @@ for scenario in "${SCENARIOS[@]}"; do
   # `"${BOUND[@]}"` trips `set -u` on bash 3.2 (macOS dev machines).
   out=$(${BOUND[@]+"${BOUND[@]}"} "$CONFORMANCE_BIN" server --url "http://$ADDR/mcp" --scenario "$scenario" 2>&1) || rc=$?
   echo "$out" | grep -A2 'Test Results:' || true
-  # Pass = the CLI exited 0 AND at least one check ran AND none failed.
-  # Each leg matters: a nonzero exit with a clean-looking summary, or a
-  # 0/0 not-applicable run, must not count as coverage.
-  if [ "$rc" != 0 ] || ! echo "$out" | grep -qE 'Passed: [0-9]+/[1-9][0-9]*, 0 failed'; then
+  # Pass = the CLI exited 0 AND at least one check ran AND none failed
+  # AND no warnings. Each leg matters: a nonzero exit with a clean-looking
+  # summary, a 0/0 not-applicable run, or a warning-only pass must not
+  # count as coverage (the pinned suite is deterministic, so a new warning
+  # is a real behavior change worth a red build).
+  if [ "$rc" != 0 ] || ! echo "$out" | grep -qE 'Passed: [0-9]+/[1-9][0-9]*, 0 failed, 0 warnings'; then
     echo "::error::conformance scenario '$scenario' failed (exit $rc)"
     echo "$out" | tail -30
     failed=1

--- a/tools/mcp-conformance/package-lock.json
+++ b/tools/mcp-conformance/package-lock.json
@@ -1,0 +1,1445 @@
+{
+  "name": "aisix-mcp-conformance-harness",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aisix-mcp-conformance-harness",
+      "dependencies": {
+        "@modelcontextprotocol/conformance": "0.1.16"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/conformance": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/conformance/-/conformance-0.1.16.tgz",
+      "integrity": "sha512-GI7qiN0r39/MH2srVUR3AXaEN0YLCro20lIBbnvc1frBhszenxvUifBuTzxeVQVagILfBzCIcnungUOma8OrgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@octokit/rest": "^22.0.0",
+        "commander": "^14.0.2",
+        "eventsource-parser": "^3.0.6",
+        "express": "^5.1.0",
+        "jose": "^6.1.2",
+        "undici": "^7.19.0",
+        "yaml": "^2.8.2",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "conformance": "dist/index.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
+      "integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.4",
+        "@octokit/request": "^10.0.13",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+      "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.4.tgz",
+      "integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.13",
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.13.tgz",
+      "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
+      "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.12.tgz",
+      "integrity": "sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "aisix-mcp-conformance-harness",
+  "private": true,
+  "description": "Pins the official MCP conformance suite (and its full transitive graph, via the committed lockfile) for scripts/mcp-conformance.sh. Bump deliberately; re-review the scenario list on every bump.",
+  "dependencies": {
+    "@modelcontextprotocol/conformance": "0.1.16"
+  }
+}


### PR DESCRIPTION
## What

The bridge half of MCP `2026-07-28` support (`AISIX-Cloud#1151`), on top of the SDK upgrade in #980:

1. **Per-server `protocol_version`** (optional, `mcp_servers`): takes the specification's dated revision identifier. `"2026-07-28"` opens the upstream session with the handshake-free `server/discover` lifecycle — the only way to reach a server that no longer answers `initialize`. Omitted (the default) keeps today's `initialize` handshake, which negotiates among the pre-2026 revisions on its own — which is why earlier revisions need no enum entry, and why every existing configuration keeps working unchanged.
2. **Explicit in both directions, no probing, no fallback**: a modern-only server under the default config fails visibly (`initialize` → method-not-found, and the bridge does NOT secretly try `server/discover` to save it); a legacy server under the `2026-07-28` config fails visibly (no silent retry of the handshake). Dated values were chosen over era-relative words (`modern`/`legacy`) deliberately: the ecosystem's own vocabulary is dated revisions, new versions become new enum values (existing pins never move), and a future `auto` value can be added once probe semantics are trustworthy.
3. **Bridge-boundary counter-example tests** — the three failure shapes currently open in auto-bridging gateways, pinned against header/sequence-capturing upstreams:
   - a stateful legacy upstream receives the COMPLETE `initialize` → `notifications/initialized` → operation sequence on every bridge session (never a bare call riding a session the upstream doesn't have);
   - downstream `Authorization`, `Mcp-Session-Id`, and `MCP-Protocol-Version` never cross to the upstream — the bridge opens its own session with gateway-held auth and its own negotiated version;
   - a mis-generation connect is a loud error, never a silent downgrade or a dropped target.
4. **Official conformance suite becomes a CI gate** (`mcp conformance (official suite)` job): a lockfile-pinned `@modelcontextprotocol/conformance` (full transitive graph, `npm ci`) drives the 12 tools-surface scenarios against the shipped scoped-gateway chain via `scripts/mcp-conformance.sh`. Deliberate exclusions (capabilities we don't advertise, server-initiated relay, the no-auth-localhost Host check) are documented in the script and the example's module docs.

## Design comparison (per repo rule 7)

Spec: <https://modelcontextprotocol.io/specification/2026-07-28> (SEP-2575 discovery / SEP-2567 stateless HTTP). Of the two gateway implementations that have shipped this revision, one uses an explicit per-upstream protocol strategy with era-relative enum values and no automatic fallback; the other auto-bridges and currently carries open regressions where downstream version/session context crossed the protocol boundary — those regressions are exactly the counter-example tests here. This PR lands on the explicit-selection posture with dated identifiers instead of era words; the trade-offs and the future `auto` path are recorded in the internal tracking issue.

## Cross-plane note

`protocol_version` is a user-facing config surface, so this DP PR implies the paired CP work (closed-enum in `cp-admin.yaml`, dashboard field + en/zh i18n, CP↔DP e2e) — tracked in `AISIX-Cloud#1151` and shipping as the follow-up CP PR. Until it lands the field is reachable through the declarative resources file. Deploy order: DP first — on pre-#871 data planes the strict write path whole-row-rejects rows carrying the unknown field; post-#871 read paths load leniently but would silently ignore it, so exposing the field in the control plane before the data-plane rollout completes would let users save configuration that does not yet apply.

## Tests

- `cargo test --workspace`: 3114 passed, 0 failed. New: `crates/aisix-mcp/tests/modern_upstream.rs` (5 scenarios: modern-only happy path with zero `initialize` attempts; both visible-failure directions with zero cross-generation probes; downstream-context isolation; full handshake sequence to a stateful upstream).
- Conformance: `bash scripts/mcp-conformance.sh` — 12/12 locally (exit-0 + ≥1-check + 0-failed per scenario); the same script is the new CI job, merge-blocking via the required `e2e (vitest) + coverage` aggregate.


## Audit triage (two independent auditors, per repo rule 8)

**Auditor A (cold)** — BLOCKED-ON 2 findings, both fixed: (1 HIGH) the config→lifecycle mapping could be reverted with all tests green → now pinned twice (pure `upstream_from_mcp_server` mapping incl. unknown-revision rejection, plus the full snapshot-row→scoped-gateway→modern-only-upstream chain); (2 MEDIUM) `server-sse-multiple-streams` was a 0-check WARNING scenario on a stateless server and the detector accepted 0/0 → scenario dropped with rationale, detector requires ≥1 executed check. Its LOWs: GNU-only `sed` (now portable `grep -A2`) and the deny_unknown_fields wording (corrected above).

**Auditor B (independent toolchain)** — BLOCKED on overlapping findings plus three of its own, all fixed: exit-status now required alongside the summary grep; the suite's transitive dependency graph is lockfile-pinned (`tools/mcp-conformance`, the top-level npx pin left the SDK floating on `^1.27.1`); the job is now merge-blocking by folding into the required `e2e (vitest) + coverage` aggregate (branch protection untouched); timeouts and wait-based cleanup added.

Accepted-with-justification (no code change): header-leak assertions run on `tools/call` only — the bridge builds every request from its own session state, so there is no per-method forwarding path to regress independently; the stateful-sequence test doesn't assert the session-id echo — rmcp's session handling is SDK-internal and the sequence itself is the gateway's contract; no meta-test pins the scenario COUNT — the list is the script, and the merge-blocking gate plus per-scenario detector cover the real risk (a silently weakened list still has to pass every remaining scenario for real).

**Bot round 2 (CodeRabbit 4 + Copilot 2)** — adopted: read-only job token + no persisted credentials on the npm-executing CI job; zero-warnings requirement in the pass detector; perl-alarm watchdog so the macOS path stays bounded; connect() doc drift; stateful-stub session enforcement; multi-value header assertion. Skipped with reason: Copilot's readiness-probe-timeout comment predates the hardening commit (the probe already runs `--max-time 2` per attempt, bounded loop); CodeRabbit's "add control-plane support before merge" is the cross-plane pairing this PR already declares — the paired CP PR follows in `AISIX-Cloud`, and the required rollout order is DP first, so gating this merge on the CP half would invert the deploy order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the MCP `2026-07-28` protocol revision.
  - MCP server configurations can specify an optional protocol version.
  - Added explicit handling for legacy and modern MCP servers.
  - Improved connection behavior with clear protocol mismatch errors and no unintended fallback.

- **Bug Fixes**
  - Preserved authorization, session, and protocol context across downstream MCP requests.

- **Tests**
  - Added comprehensive integration testing and official MCP conformance validation for legacy and modern connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->