### PR TITLE
docs(readme): MCP gateway protocol-generation support in the feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,15 +177,12 @@ Covered by 183 end-to-end scenario files (496 cases) that run against real gatew
   memory and Redis backends; cost-saved telemetry on every hit. Separately, **automatic
   prompt caching** can be enabled per direct Anthropic model to inject cache breakpoints, so
   callers get provider-side prompt discounts without changing their requests.
-- **MCP gateway** — register upstream MCP servers as first-class resources and front them
-  all behind one endpoint (`/mcp`), with the gateway holding each server's upstream
-  credential, namespacing tools per server, and enforcing per-caller tool access. Serves
-  every current MCP protocol revision — `2025-03-26` through the stateless `2026-07-28` —
-  negotiated per client with no sessions to pin, and connects upstream per server via the
-  `initialize` handshake or, with `protocol_version: "2026-07-28"`, handshake-free
-  `server/discover` for servers that no longer answer `initialize`. The tool surface is
-  validated against the official MCP conformance suite in CI. Also exposes a REST API as
-  MCP tools from its OpenAPI description.
+- **MCP gateway** — front registered upstream MCP servers at `/mcp` with gateway-held
+  credentials, per-server tool namespaces, and per-caller access. It serves every
+  Streamable HTTP revision from `2025-03-26` through stateless `2026-07-28` without
+  downstream sessions. Upstreams use `initialize` by default or `server/discover` with
+  `protocol_version: "2026-07-28"`. CI runs the official MCP suite's applicable tools-only
+  protocol scenarios. Also exposes a REST API as MCP tools from its OpenAPI description.
 - **A2A agent gateway** — front A2A (Agent-to-Agent) agents at `/a2a/:agent`, serving each
   agent's card with URLs rewritten to the gateway, over JSON-RPC 2.0.
 - **Inbound authentication** — caller API keys (SHA-256 hashed, model allowlists, expiry,

--- a/README.md
+++ b/README.md
@@ -179,8 +179,13 @@ Covered by 183 end-to-end scenario files (496 cases) that run against real gatew
   callers get provider-side prompt discounts without changing their requests.
 - **MCP gateway** — register upstream MCP servers as first-class resources and front them
   all behind one endpoint (`/mcp`), with the gateway holding each server's upstream
-  credential, namespacing tools per server, and enforcing per-caller tool access. Also
-  exposes a REST API as MCP tools from its OpenAPI description.
+  credential, namespacing tools per server, and enforcing per-caller tool access. Serves
+  every current MCP protocol revision — `2025-03-26` through the stateless `2026-07-28` —
+  negotiated per client with no sessions to pin, and connects upstream per server via the
+  `initialize` handshake or, with `protocol_version: "2026-07-28"`, handshake-free
+  `server/discover` for servers that no longer answer `initialize`. The tool surface is
+  validated against the official MCP conformance suite in CI. Also exposes a REST API as
+  MCP tools from its OpenAPI description.
 - **A2A agent gateway** — front A2A (Agent-to-Agent) agents at `/a2a/:agent`, serving each
   agent's card with URLs rewritten to the gateway, over JSON-RPC 2.0.
 - **Inbound authentication** — caller API keys (SHA-256 hashed, model allowlists, expiry,


### PR DESCRIPTION
## What

Updates the README's **MCP gateway** feature bullet to reflect what shipped in the rmcp 3.x upgrade series (#980, #981):

- serves every current MCP protocol revision — `2025-03-26` through the stateless `2026-07-28` — negotiated per client, sessionless on every generation;
- per-server upstream protocol selection: the default `initialize` handshake, or `protocol_version: "2026-07-28"` for handshake-free `server/discover` against modern-only servers;
- the tool surface is validated against the official MCP conformance suite in CI (merge-blocking job).

Docs pages land separately in the docs repository (protocol version matrix on the MCP overview + endpoint facts in the proxy API reference; the setup guide's pin section already shipped there).

README-only change; every claim traces to `crates/aisix-mcp/src/gateway.rs` (`SUPPORTED_PROTOCOL_VERSION_NAMES`), `crates/aisix-mcp/src/bridge.rs` (`McpProtocol`), and `.github/workflows/ci.yml` (`mcp-conformance` job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated MCP gateway documentation to cover Streamable HTTP revisions `2025-03-26` through `2026-07-28`.
  - Documented gateway-managed credentials, per-server namespaces, and caller-specific access.
  - Clarified upstream initialization and server discovery flows.
  - Added details about tools-only conformance scenarios and REST-to-MCP tool exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->