### PR TITLE
refactor(mcp): resolve tool access as three intersecting layers

### DIFF
--- a/crates/aisix-admin/src/apikeys_handlers.rs
+++ b/crates/aisix-admin/src/apikeys_handlers.rs
@@ -23,7 +23,7 @@ pub struct PublicApiKey {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<aisix_core::models::RateLimit>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_tools: Option<Vec<String>>,
+    pub mcp_access: Option<aisix_core::models::McpAccess>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_agents: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -38,7 +38,7 @@ impl From<ApiKey> for PublicApiKey {
             key_hash: value.key_hash,
             allowed_models: value.allowed_models,
             rate_limit: value.rate_limit,
-            allowed_tools: value.allowed_tools,
+            mcp_access: value.mcp_access,
             allowed_agents: value.allowed_agents,
             expires_at: value.expires_at,
             disabled: value.disabled,

--- a/crates/aisix-admin/src/lib.rs
+++ b/crates/aisix-admin/src/lib.rs
@@ -1191,7 +1191,7 @@ mod tests {
         // Non-default optional fields, so the PublicApiKey projection is
         // pinned field-by-field — a projection that dropped one of these
         // would still pass an id-only check.
-        payload["allowed_tools"] = json!(["github__create_issue"]);
+        payload["mcp_access"] = json!({"allow": ["github__create_issue"]});
         payload["allowed_agents"] = json!(["invoice-agent"]);
         payload["rate_limit"] = json!({"rpm": 60});
         payload["disabled"] = json!(true);
@@ -1214,8 +1214,8 @@ mod tests {
             assert_eq!(v["value"]["key_hash"], expected_hash.as_str(), "{base}");
             assert_eq!(v["value"]["allowed_models"], json!(["my-model"]), "{base}");
             assert_eq!(
-                v["value"]["allowed_tools"],
-                json!(["github__create_issue"]),
+                v["value"]["mcp_access"],
+                json!({"allow": ["github__create_issue"]}),
                 "{base}"
             );
             assert_eq!(

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1547,15 +1547,31 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "$ref": "#/components/schemas/RateLimit",
             "description": "Request, token, and concurrency limits for this key."
           },
-          "allowed_tools": {
+          "mcp_access": {
             "type": [
-              "array",
+              "object",
               "null"
             ],
-            "items": {
-              "type": "string"
+            "properties": {
+              "allow": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Namespaced `<server>__<tool>` glob patterns this key allows, intersected with the environment and team layers."
+              },
+              "deny": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Namespaced `<server>__<tool>` glob patterns subtracted from this key's effective grant. Deny always wins."
+              }
             },
-            "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted, set to `null`, or set to an empty list, the key has no MCP tool access \u2014 access is granted explicitly."
+            "required": [
+              "allow"
+            ],
+            "description": "This key's own layer of the MCP tool ACL, as namespaced `<server>__<tool>` glob patterns. Intersected with the environment and team MCP access policies: every present layer must allow a tool and no layer may deny it. When omitted the key adds no constraint of its own; with no layer present anywhere the grant is empty."
           },
           "allowed_agents": {
             "type": [
@@ -2170,10 +2186,6 @@ fn add_variant_titles(doc: &mut Value) {
         (
             "/components/schemas/KeywordPattern/oneOf",
             &["Literal", "Regex"],
-        ),
-        (
-            "/components/schemas/McpAccessMode/oneOf",
-            &["Inherit", "Restrict", "Deny"],
         ),
         (
             "/components/schemas/McpProtocolVersion/oneOf",

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -195,7 +195,7 @@ async fn apikeys_round_trip_through_real_etcd() {
         json!({
             "key_hash": key_hash,
             "allowed_models": ["it-gpt4"],
-            "allowed_tools": ["github__create_issue", "*"]
+            "mcp_access": {"allow": ["github__create_issue", "*"]}
         }),
     )
     .await;

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -77,23 +77,12 @@ pub struct ApiKey {
     #[schemars(length(min = 1))]
     pub jwt_provider: Option<String>,
 
-    /// MCP tools this key may call, as namespaced `<server>__<tool>` names
-    /// (the form the gateway exposes). Entries are matched as single-`*`
-    /// globs, mirroring `allowed_models`: `"*"` grants every tool and
-    /// `"<server>__*"` grants every tool on one server (e.g. `"github__*"`);
-    /// an entry without a `*` matches one tool exactly. When omitted, set to
-    /// `null`, or set to an empty list, the key has no MCP tool access —
-    /// access is granted explicitly.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub allowed_tools: Option<Vec<String>>,
-
-    /// Policy-driven MCP access for this key. When present, it supersedes
-    /// `allowed_tools`: the key's grant is computed from the environment's
-    /// and its team's MCP access policies according to `mode` (`inherit`,
-    /// `restrict`, or `deny`), and `allowed_tools` is not consulted. When
-    /// omitted, the key keeps the explicit `allowed_tools` behavior — with
-    /// policy `deny` patterns still subtracted, since deny applies to every
-    /// key the policy covers.
+    /// This key's own layer of the MCP tool ACL, as namespaced
+    /// `<server>__<tool>` glob patterns. It is intersected with the
+    /// environment and team MCP access policies: every present layer must
+    /// allow a tool and no layer may deny it. When omitted the key adds no
+    /// constraint of its own — but with no layer present anywhere the grant
+    /// is empty, so MCP access is always granted explicitly.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_access: Option<McpAccess>,
 
@@ -108,7 +97,7 @@ pub struct ApiKey {
     pub mcp_rate_limits: Option<BTreeMap<String, McpRateLimit>>,
 
     /// A2A agents this key may reach, named by their registered names. Entries
-    /// are matched as single-`*` globs, mirroring `allowed_tools`: `"*"` grants
+    /// are matched as single-`*` globs, mirroring `allowed_models`: `"*"` grants
     /// every agent and an entry without a `*` matches one agent exactly. When
     /// omitted, set to `null`, or set to an empty list, the key has no A2A
     /// agent access — access is granted explicitly.
@@ -116,7 +105,7 @@ pub struct ApiKey {
     pub allowed_agents: Option<Vec<String>>,
 
     /// Passthrough routes this key may use, named by their registered names.
-    /// Entries are matched as single-`*` globs, mirroring `allowed_tools`:
+    /// Entries are matched as single-`*` globs, mirroring `allowed_models`:
     /// `"*"` grants every route and an entry without a `*` matches one route
     /// exactly. When omitted, set to `null`, or set to an empty list, the key
     /// may use no passthrough route — access is granted explicitly.
@@ -174,30 +163,6 @@ impl ApiKey {
             .any(|n| crate::wildcard::wildcard_matches(n, model_name))
     }
 
-    /// True if this key may call the given MCP tool, named in the gateway's
-    /// namespaced `<server>__<tool>` form.
-    ///
-    /// Entries are matched as single-`*` globs, so `"*"` grants every tool and
-    /// `"<server>__*"` grants every tool on that server (e.g. `"github__*"`
-    /// permits `github__create_issue`); entries without a `*` match exactly.
-    /// A key with no `allowed_tools` (or an empty list) may call no MCP tools —
-    /// access is granted explicitly, matching [`ApiKey::can_access`].
-    ///
-    /// This mirrors only the legacy allow side (a key without an `mcp_access`
-    /// block and ignoring policy `deny` overlays). Currently exercised only by
-    /// tests: the live MCP enforcement path builds an `aisix_mcp::ToolAcl`
-    /// resolved against the key **and** the environment/team MCP policies,
-    /// using the identical matcher; this method is kept in lockstep as the
-    /// documented mirror of its legacy component.
-    pub fn can_access_tool(&self, tool: &str) -> bool {
-        match &self.allowed_tools {
-            None => false,
-            Some(allowed) => allowed
-                .iter()
-                .any(|t| crate::wildcard::wildcard_matches(t, tool)),
-        }
-    }
-
     /// The limits this key carries for one MCP server, named as it is
     /// registered (the `<server>` namespace of a `<server>__<tool>` call).
     /// `None` when the key sets no limit for that server.
@@ -208,7 +173,7 @@ impl ApiKey {
     /// True if this key may reach the given A2A agent, named by its registered
     /// name.
     ///
-    /// Semantics mirror [`ApiKey::can_access_tool`]: entries are single-`*`
+    /// Semantics mirror [`ApiKey::can_access`]: entries are single-`*`
     /// globs, so `"*"` grants every agent; entries without a `*` match exactly.
     /// A key with no `allowed_agents` (or an empty list) may reach no A2A agent
     /// — access is granted explicitly.
@@ -321,7 +286,6 @@ mod tests {
             user_name: None,
             jwt_subject: None,
             jwt_provider: None,
-            allowed_tools: None,
             mcp_access: None,
             allowed_routes: None,
             mcp_rate_limits: None,
@@ -335,87 +299,27 @@ mod tests {
     }
 
     #[test]
-    fn can_access_tool_enforces_namespaced_allowlist() {
-        // No `allowed_tools` configured → no MCP tool access.
-        let none: ApiKey =
-            serde_json::from_str(r#"{"key_hash":"h","allowed_models":["*"]}"#).unwrap();
-        assert!(!none.can_access_tool("github__create_issue"));
-
-        // Explicit null has the same no-access behavior as omission.
-        let null: ApiKey =
-            serde_json::from_str(r#"{"key_hash":"h","allowed_models":["*"],"allowed_tools":null}"#)
-                .unwrap();
-        assert!(!null.can_access_tool("github__create_issue"));
-
-        // Empty list also denies everything.
-        let empty: ApiKey =
-            serde_json::from_str(r#"{"key_hash":"h","allowed_models":[],"allowed_tools":[]}"#)
-                .unwrap();
-        assert!(!empty.can_access_tool("github__create_issue"));
-
-        // Exact namespaced names.
-        let specific: ApiKey = serde_json::from_str(
-            r#"{"key_hash":"h","allowed_models":[],"allowed_tools":["github__create_issue"]}"#,
-        )
-        .unwrap();
-        assert!(specific.can_access_tool("github__create_issue"));
-        assert!(!specific.can_access_tool("github__delete_repo"));
-
-        // Wildcard grants every tool.
-        let wildcard: ApiKey =
-            serde_json::from_str(r#"{"key_hash":"h","allowed_models":[],"allowed_tools":["*"]}"#)
-                .unwrap();
-        assert!(wildcard.can_access_tool("anything__at_all"));
-
-        // Per-server wildcard grants every tool on that server only.
-        let per_server: ApiKey = serde_json::from_str(
-            r#"{"key_hash":"h","allowed_models":[],"allowed_tools":["github__*"]}"#,
-        )
-        .unwrap();
-        assert!(per_server.can_access_tool("github__create_issue"));
-        assert!(per_server.can_access_tool("github__delete_repo"));
-        // It must not leak across the server boundary: a different server,
-        // and a server whose name merely shares the prefix, are both denied.
-        assert!(!per_server.can_access_tool("slack__post_message"));
-        assert!(!per_server.can_access_tool("githubenterprise__create_issue"));
-
-        // The glob is a single `*` anywhere, not only trailing (same as
-        // `allowed_models`): `"*__readonly"` is a genuine any-server grant of
-        // a same-named tool. Pinned so the breadth stays intentional.
-        let any_server: ApiKey = serde_json::from_str(
-            r#"{"key_hash":"h","allowed_models":[],"allowed_tools":["*__readonly"]}"#,
-        )
-        .unwrap();
-        assert!(any_server.can_access_tool("github__readonly"));
-        assert!(any_server.can_access_tool("slack__readonly"));
-        // The suffix still anchors — a longer tool name doesn't match.
-        assert!(!any_server.can_access_tool("github__readonly_admin"));
-    }
-
-    #[test]
     fn mcp_access_block_roundtrips_and_defaults_absent() {
-        // Every pre-existing key payload lacks `mcp_access`; it must load
-        // as None so the legacy allowed_tools behavior keeps applying.
-        let legacy = sample();
-        assert!(legacy.mcp_access.is_none());
-        let v = serde_json::to_value(&legacy).unwrap();
+        // A key with no block of its own adds no layer to the ACL.
+        let unconstrained = sample();
+        assert!(unconstrained.mcp_access.is_none());
+        let v = serde_json::to_value(&unconstrained).unwrap();
         assert!(v.get("mcp_access").is_none());
 
         let k: ApiKey = serde_json::from_str(
             r#"{
               "key_hash": "h",
               "allowed_models": [],
-              "mcp_access": {"mode": "restrict", "allow": ["github__*"], "deny": ["github__delete_repo"]}
+              "mcp_access": {"allow": ["github__*"], "deny": ["github__delete_repo"]}
             }"#,
         )
         .unwrap();
         let access = k.mcp_access.as_ref().unwrap();
-        assert_eq!(access.mode, crate::models::McpAccessMode::Restrict);
         assert_eq!(access.allow, vec!["github__*"]);
         assert_eq!(access.deny, vec!["github__delete_repo"]);
         // Round-trip preserves the block.
         let v = serde_json::to_value(&k).unwrap();
-        assert_eq!(v["mcp_access"]["mode"], "restrict");
+        assert_eq!(v["mcp_access"]["allow"], serde_json::json!(["github__*"]));
     }
 
     #[test]
@@ -424,13 +328,10 @@ mod tests {
         // out; serde must accept them (the write path still rejects them
         // via `validate_apikey` in models/schema.rs).
         let k: ApiKey = serde_json::from_str(
-            r#"{"key_hash":"h","allowed_models":[],"mcp_access":{"mode":"inherit","widen":["*"]}}"#,
+            r#"{"key_hash":"h","allowed_models":[],"mcp_access":{"allow":["*"],"widen":["*"]}}"#,
         )
         .unwrap();
-        assert_eq!(
-            k.mcp_access.unwrap().mode,
-            crate::models::McpAccessMode::Inherit
-        );
+        assert_eq!(k.mcp_access.unwrap().allow, vec!["*"]);
     }
 
     #[test]

--- a/crates/aisix-core/src/models/mcp_policy.rs
+++ b/crates/aisix-core/src/models/mcp_policy.rs
@@ -1,19 +1,19 @@
-//! `McpPolicy` entity — environment-default and team-level MCP tool access
+//! `McpPolicy` entity — environment-level and team-level MCP tool access
 //! policies stored in etcd under `mcp_policies/<uuid>`.
 //!
-//! Policies lift MCP tool access from per-key `allowed_tools` configuration
-//! to a layered grant: an `env`-scoped policy sets the environment-wide
-//! default, a `team`-scoped policy replaces that default for the keys that
-//! belong to the team, and each key narrows (never widens) the inherited
-//! grant through its `mcp_access` block. `deny` patterns from every
-//! applicable level are always subtracted, so a tool denied at the
-//! environment level stays unavailable regardless of team or key
-//! configuration.
+//! MCP tool access is resolved from up to three layers of the same shape,
+//! each an `allow`/`deny` pattern pair: the `env`-scoped policy, the
+//! `team`-scoped policy of the key's team, and the key's own `mcp_access`
+//! block. A tool is permitted when **every present layer** allows it and
+//! **no** layer denies it — allow intersects, deny unions. A layer that is
+//! absent (no policy row, a disabled one, or no `mcp_access` block) imposes
+//! no constraint; with no layer present at all the grant is empty, so MCP
+//! access is always granted explicitly.
 //!
-//! Keys without an `mcp_access` block keep the pre-policy behavior: their
-//! `allowed_tools` list is the entire allow side (no inheritance), with
-//! policy `deny` patterns still subtracted. The effective-ACL computation
-//! lives with the MCP gateway endpoint, which resolves it per request.
+//! Because `allow` is required on every layer, a layer that only wants to
+//! subtract tools spells its allow side `["*"]`. The effective-ACL
+//! computation lives with the MCP gateway endpoint, which resolves it per
+//! request.
 
 use serde::{Deserialize, Serialize};
 
@@ -23,26 +23,11 @@ use crate::resource::Resource;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum McpPolicyScope {
-    /// The environment-wide default, applied to keys whose team has no
-    /// enabled policy of its own.
+    /// Applied to every key in the environment.
     Env,
-    /// A team-level policy, applied to the keys that belong to the team
-    /// named by `scope_ref`. It replaces the environment default for those
-    /// keys.
+    /// Applied to the keys belonging to the team named by `scope_ref`, on
+    /// top of the environment policy rather than in place of it.
     Team,
-}
-
-/// What an MCP access policy grants before `deny` patterns are subtracted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum McpPolicyMode {
-    /// Grants no MCP tools.
-    None,
-    /// Grants exactly the tools matched by the `allow` patterns.
-    Selected,
-    /// Grants every tool on every registered MCP server, including servers
-    /// and tools added after the policy is created.
-    All,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -52,33 +37,29 @@ pub struct McpPolicy {
     pub scope: McpPolicyScope,
 
     /// Team identifier the policy targets. Required when `scope` is `team`;
-    /// omitted for an environment-default policy.
+    /// omitted for an environment policy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(length(min = 1))]
     pub scope_ref: Option<String>,
 
-    /// What the policy grants: `none`, `selected` (the `allow` patterns), or
-    /// `all` current and future tools.
-    pub mode: McpPolicyMode,
-
-    /// Namespaced `<server>__<tool>` patterns granted when `mode` is
-    /// `selected`. Entries are matched as single-`*` globs, the same form as
-    /// an API key's `allowed_tools`: `"<server>__*"` grants every tool on one
-    /// server and an entry without a `*` matches one tool exactly. Ignored
-    /// for the other modes.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// Namespaced `<server>__<tool>` patterns this layer allows. Entries are
+    /// matched as single-`*` globs: `"*"` allows every tool, `"<server>__*"`
+    /// every tool on one server, and an entry without a `*` matches one tool
+    /// exactly. An empty list allows nothing, which is how a policy blocks
+    /// all MCP access; a policy that only means to subtract tools writes
+    /// `["*"]` here and lists them under `deny`.
     pub allow: Vec<String>,
 
     /// Namespaced `<server>__<tool>` patterns subtracted from the effective
     /// grant of every key the policy applies to, using the same single-`*`
     /// glob matching as `allow`. Deny always wins: a tool matched here stays
-    /// unavailable even when a team policy or a key's own configuration
-    /// would otherwise grant it.
+    /// unavailable however the other layers allow it.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deny: Vec<String>,
 
     /// Whether the policy is applied. A disabled policy is kept but
-    /// ignored. Treated as `true` when omitted.
+    /// contributes neither its allow nor its deny side. Treated as `true`
+    /// when omitted.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 
@@ -92,39 +73,19 @@ fn default_enabled() -> bool {
     true
 }
 
-/// How an API key combines with the applicable MCP access policies:
-/// `inherit`, `restrict`, or `deny`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum McpAccessMode {
-    /// The key uses the inherited grant unchanged: its team's enabled policy
-    /// when one exists, otherwise the environment-default policy.
-    Inherit,
-    /// The key uses the intersection of the inherited grant and its own
-    /// `allow` patterns — a restriction can only narrow what the policies
-    /// grant, never widen it.
-    Restrict,
-    /// The key has no MCP tool access at all.
-    Deny,
-}
-
-/// Policy-driven MCP access configuration on an API key. When present, this
-/// block supersedes the key's `allowed_tools` list: the allow side of the
-/// key's effective grant is computed from the applicable MCP access policies
-/// and `mode`, and `allowed_tools` is not consulted.
+/// The API key's own layer of the MCP tool ACL, the same `allow`/`deny`
+/// shape an MCP access policy carries. Present means the key constrains its
+/// grant; omitted means the key adds no constraint of its own and takes
+/// whatever the environment and team layers leave.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct McpAccess {
-    /// How the key combines with the applicable policies: `inherit`,
-    /// `restrict`, or `deny`.
-    pub mode: McpAccessMode,
-
-    /// Namespaced `<server>__<tool>` patterns intersected with the inherited
-    /// grant when `mode` is `restrict`, using the same single-`*` glob
-    /// matching as `allowed_tools`. Ignored for the other modes.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// Namespaced `<server>__<tool>` patterns this key allows, intersected
+    /// with the environment and team layers. Same single-`*` glob matching a
+    /// policy's `allow` uses; an empty list leaves the key no MCP access,
+    /// and `["*"]` narrows nothing (useful with `deny` alone).
     pub allow: Vec<String>,
 
-    /// Namespaced `<server>__<tool>` patterns subtracted from the key's
+    /// Namespaced `<server>__<tool>` patterns subtracted from this key's
     /// effective grant, using the same single-`*` glob matching as `allow`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deny: Vec<String>,
@@ -136,9 +97,9 @@ impl Resource for McpPolicy {
     }
 
     /// The by-name index key: the targeted team id, or `"env"` for the
-    /// environment-default policy. Lookups during effective-ACL resolution
-    /// iterate and filter on `(scope, scope_ref)` rather than relying on
-    /// this index, so a malformed row can never shadow the default.
+    /// environment policy. Lookups during effective-ACL resolution iterate
+    /// and filter on `(scope, scope_ref)` rather than relying on this index,
+    /// so a malformed row can never shadow the environment layer.
     #[allow(clippy::misnamed_getters)]
     fn name(&self) -> &str {
         self.scope_ref.as_deref().unwrap_or("env")
@@ -154,11 +115,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn deserialises_env_default_policy() {
+    fn deserialises_env_policy() {
         let p: McpPolicy = serde_json::from_str(
             r#"{
               "scope": "env",
-              "mode": "selected",
               "allow": ["github__*", "postgres__query"],
               "deny": ["github__delete_repository"]
             }"#,
@@ -166,7 +126,6 @@ mod tests {
         .unwrap();
         assert_eq!(p.scope, McpPolicyScope::Env);
         assert!(p.scope_ref.is_none());
-        assert_eq!(p.mode, McpPolicyMode::Selected);
         assert_eq!(p.allow, vec!["github__*", "postgres__query"]);
         assert_eq!(p.deny, vec!["github__delete_repository"]);
         assert!(p.enabled);
@@ -175,18 +134,19 @@ mod tests {
     #[test]
     fn deserialises_team_policy() {
         let p: McpPolicy = serde_json::from_str(
-            r#"{
-              "scope": "team",
-              "scope_ref": "team-uuid-1",
-              "mode": "all"
-            }"#,
+            r#"{"scope": "team", "scope_ref": "team-uuid-1", "allow": ["*"]}"#,
         )
         .unwrap();
         assert_eq!(p.scope, McpPolicyScope::Team);
         assert_eq!(p.scope_ref.as_deref(), Some("team-uuid-1"));
-        assert_eq!(p.mode, McpPolicyMode::All);
-        assert!(p.allow.is_empty());
+        assert_eq!(p.allow, vec!["*"]);
         assert!(p.deny.is_empty());
+    }
+
+    #[test]
+    fn allow_is_required_on_both_layers() {
+        assert!(serde_json::from_str::<McpPolicy>(r#"{"scope":"env"}"#).is_err());
+        assert!(serde_json::from_str::<McpAccess>(r#"{"deny":["github__*"]}"#).is_err());
     }
 
     #[test]
@@ -195,23 +155,23 @@ mod tests {
         // accept them. The write path still rejects them via the strict
         // schema validators (validate_mcp_policy in models/schema.rs).
         let p: McpPolicy =
-            serde_json::from_str(r#"{"scope":"env","mode":"all","extra":1}"#).unwrap();
-        assert_eq!(p.mode, McpPolicyMode::All);
+            serde_json::from_str(r#"{"scope":"env","allow":["*"],"extra":1}"#).unwrap();
+        assert_eq!(p.allow, vec!["*"]);
     }
 
     #[test]
-    fn rejects_unknown_mode_and_scope() {
-        assert!(serde_json::from_str::<McpPolicy>(r#"{"scope":"org","mode":"all"}"#).is_err());
-        assert!(serde_json::from_str::<McpPolicy>(r#"{"scope":"env","mode":"open"}"#).is_err());
+    fn rejects_unknown_scope() {
+        assert!(serde_json::from_str::<McpPolicy>(r#"{"scope":"org","allow":["*"]}"#).is_err());
     }
 
     #[test]
     fn enabled_defaults_true_and_roundtrips_false() {
-        let active: McpPolicy = serde_json::from_str(r#"{"scope":"env","mode":"all"}"#).unwrap();
+        let active: McpPolicy =
+            serde_json::from_str(r#"{"scope":"env","allow":["*"]}"#).unwrap();
         assert!(active.enabled);
 
         let disabled: McpPolicy =
-            serde_json::from_str(r#"{"scope":"env","mode":"all","enabled":false}"#).unwrap();
+            serde_json::from_str(r#"{"scope":"env","allow":["*"],"enabled":false}"#).unwrap();
         assert!(!disabled.enabled);
     }
 
@@ -219,59 +179,45 @@ mod tests {
     fn resource_trait_points_at_scope_ref_and_kind() {
         assert_eq!(McpPolicy::kind(), "mcp_policies");
 
-        let mut env: McpPolicy = serde_json::from_str(r#"{"scope":"env","mode":"all"}"#).unwrap();
+        let mut env: McpPolicy =
+            serde_json::from_str(r#"{"scope":"env","allow":["*"]}"#).unwrap();
         env.runtime_id = "p-env".into();
         assert_eq!(env.id(), "p-env");
         assert_eq!(env.name(), "env");
 
-        let mut team: McpPolicy =
-            serde_json::from_str(r#"{"scope":"team","scope_ref":"team-uuid-1","mode":"none"}"#)
-                .unwrap();
+        let mut team: McpPolicy = serde_json::from_str(
+            r#"{"scope":"team","scope_ref":"team-uuid-1","allow":[]}"#,
+        )
+        .unwrap();
         team.runtime_id = "p-team".into();
         assert_eq!(team.name(), "team-uuid-1");
     }
 
     #[test]
-    fn mcp_access_deserialises_all_modes() {
-        let inherit: McpAccess = serde_json::from_str(r#"{"mode":"inherit"}"#).unwrap();
-        assert_eq!(inherit.mode, McpAccessMode::Inherit);
-        assert!(inherit.allow.is_empty());
-        assert!(inherit.deny.is_empty());
-
-        let restrict: McpAccess = serde_json::from_str(
-            r#"{"mode":"restrict","allow":["github__*"],"deny":["github__delete_repository"]}"#,
+    fn mcp_access_deserialises_allow_and_deny() {
+        let narrow: McpAccess = serde_json::from_str(
+            r#"{"allow":["github__*"],"deny":["github__delete_repository"]}"#,
         )
         .unwrap();
-        assert_eq!(restrict.mode, McpAccessMode::Restrict);
-        assert_eq!(restrict.allow, vec!["github__*"]);
-        assert_eq!(restrict.deny, vec!["github__delete_repository"]);
+        assert_eq!(narrow.allow, vec!["github__*"]);
+        assert_eq!(narrow.deny, vec!["github__delete_repository"]);
 
-        let deny: McpAccess = serde_json::from_str(r#"{"mode":"deny"}"#).unwrap();
-        assert_eq!(deny.mode, McpAccessMode::Deny);
+        // The old `mode: deny` is now an empty allow list.
+        let blocked: McpAccess = serde_json::from_str(r#"{"allow":[]}"#).unwrap();
+        assert!(blocked.allow.is_empty());
+        assert!(blocked.deny.is_empty());
     }
 
     #[test]
-    fn mcp_access_tolerates_unknown_fields_for_forward_compat_but_rejects_unknown_modes() {
-        // cp-api may ship new fields ahead of the DP rolling out; serde must
-        // accept them (the write path still rejects them via the strict
-        // schema validators in models/schema.rs). Unknown enum values stay
-        // hard errors.
-        let a: McpAccess = serde_json::from_str(r#"{"mode":"inherit","extra":1}"#).unwrap();
-        assert_eq!(a.mode, McpAccessMode::Inherit);
-        assert!(serde_json::from_str::<McpAccess>(r#"{"mode":"legacy"}"#).is_err());
-    }
-
-    #[test]
-    fn empty_lists_stay_off_the_wire() {
-        let p: McpPolicy = serde_json::from_str(r#"{"scope":"env","mode":"all"}"#).unwrap();
+    fn empty_deny_stays_off_the_wire() {
+        let p: McpPolicy = serde_json::from_str(r#"{"scope":"env","allow":["*"]}"#).unwrap();
         let v = serde_json::to_value(&p).unwrap();
-        assert!(v.get("allow").is_none());
         assert!(v.get("deny").is_none());
         assert!(v.get("scope_ref").is_none());
+        assert_eq!(v["allow"], serde_json::json!(["*"]));
 
-        let a: McpAccess = serde_json::from_str(r#"{"mode":"inherit"}"#).unwrap();
+        let a: McpAccess = serde_json::from_str(r#"{"allow":["*"]}"#).unwrap();
         let v = serde_json::to_value(&a).unwrap();
-        assert!(v.get("allow").is_none());
         assert!(v.get("deny").is_none());
     }
 }

--- a/crates/aisix-core/src/models/mcp_policy.rs
+++ b/crates/aisix-core/src/models/mcp_policy.rs
@@ -166,8 +166,7 @@ mod tests {
 
     #[test]
     fn enabled_defaults_true_and_roundtrips_false() {
-        let active: McpPolicy =
-            serde_json::from_str(r#"{"scope":"env","allow":["*"]}"#).unwrap();
+        let active: McpPolicy = serde_json::from_str(r#"{"scope":"env","allow":["*"]}"#).unwrap();
         assert!(active.enabled);
 
         let disabled: McpPolicy =
@@ -179,26 +178,23 @@ mod tests {
     fn resource_trait_points_at_scope_ref_and_kind() {
         assert_eq!(McpPolicy::kind(), "mcp_policies");
 
-        let mut env: McpPolicy =
-            serde_json::from_str(r#"{"scope":"env","allow":["*"]}"#).unwrap();
+        let mut env: McpPolicy = serde_json::from_str(r#"{"scope":"env","allow":["*"]}"#).unwrap();
         env.runtime_id = "p-env".into();
         assert_eq!(env.id(), "p-env");
         assert_eq!(env.name(), "env");
 
-        let mut team: McpPolicy = serde_json::from_str(
-            r#"{"scope":"team","scope_ref":"team-uuid-1","allow":[]}"#,
-        )
-        .unwrap();
+        let mut team: McpPolicy =
+            serde_json::from_str(r#"{"scope":"team","scope_ref":"team-uuid-1","allow":[]}"#)
+                .unwrap();
         team.runtime_id = "p-team".into();
         assert_eq!(team.name(), "team-uuid-1");
     }
 
     #[test]
     fn mcp_access_deserialises_allow_and_deny() {
-        let narrow: McpAccess = serde_json::from_str(
-            r#"{"allow":["github__*"],"deny":["github__delete_repository"]}"#,
-        )
-        .unwrap();
+        let narrow: McpAccess =
+            serde_json::from_str(r#"{"allow":["github__*"],"deny":["github__delete_repository"]}"#)
+                .unwrap();
         assert_eq!(narrow.allow, vec!["github__*"]);
         assert_eq!(narrow.deny, vec!["github__delete_repository"]);
 

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -54,7 +54,7 @@ pub use guardrail::{
     PiiConfig, PiiCustomPattern, PiiDetectorConfig, PresidioConfig, PresidioEntityConfig,
 };
 pub use mcp_auth_settings::McpAuthSettings;
-pub use mcp_policy::{McpAccess, McpAccessMode, McpPolicy, McpPolicyMode, McpPolicyScope};
+pub use mcp_policy::{McpAccess, McpPolicy, McpPolicyScope};
 pub use mcp_server::{McpAuthType, McpProtocolVersion, McpServer, McpServerType, McpTransport};
 pub use model::{
     Adapter, BackgroundModelCheck, CooldownConfig, Model, DEFAULT_COOLDOWN_TRIGGER_STATUSES,

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -786,12 +786,11 @@ pub fn mcp_auth_settings_root_schema() -> Value {
 /// Canonical JSON Schema for the `mcp_policy` resource, derived from the
 /// [`McpPolicy`](crate::models::McpPolicy) struct. Uses the nullable `Option`
 /// representation (`true`) so `scope_ref` accepts an explicit `null` as
-/// well as being absent. The `scope`/`mode` closed sets come from
-/// the [`McpPolicyScope`](crate::models::McpPolicyScope) /
-/// [`McpPolicyMode`](crate::models::McpPolicyMode) enums, plus the one
+/// well as being absent. The closed `scope` set comes from the
+/// [`McpPolicyScope`](crate::models::McpPolicyScope) enum, plus the one
 /// cross-field invariant `schemars` cannot express: a `team`-scoped policy
 /// must name its team in `scope_ref` (otherwise the row could shadow the
-/// environment default).
+/// environment layer).
 pub fn mcp_policy_root_schema() -> Value {
     let mut schema = struct_root_schema::<crate::models::McpPolicy>(true);
     schema
@@ -1908,23 +1907,45 @@ mod tests {
         let v = json!({
             "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
             "allowed_models":["gpt-4o"],
-            "mcp_access": {"mode": "inherit"}
+            "mcp_access": {"allow": ["*"]}
         });
         validate_apikey(&v).unwrap();
         let v = json!({
             "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
             "allowed_models":["gpt-4o"],
-            "mcp_access": {"mode": "restrict", "allow": ["github__*"], "deny": ["github__delete_repo"]}
+            "mcp_access": {"allow": ["github__*"], "deny": ["github__delete_repo"]}
         });
         validate_apikey(&v).unwrap();
     }
 
     #[test]
-    fn apikey_mcp_access_rejects_unknown_mode() {
+    fn apikey_mcp_access_requires_an_explicit_allow_side() {
+        // A block carrying only `deny` would silently grant nothing; the
+        // schema forces the author to say what the key allows.
         let v = json!({
             "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
             "allowed_models":[],
-            "mcp_access": {"mode": "legacy"}
+            "mcp_access": {"deny": ["github__*"]}
+        });
+        assert!(validate_apikey(&v).is_err());
+    }
+
+    #[test]
+    fn apikey_mcp_access_rejects_the_removed_mode_field() {
+        let v = json!({
+            "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
+            "allowed_models":[],
+            "mcp_access": {"mode": "inherit", "allow": ["*"]}
+        });
+        assert!(validate_apikey(&v).is_err());
+    }
+
+    #[test]
+    fn apikey_rejects_the_removed_allowed_tools_field() {
+        let v = json!({
+            "key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20",
+            "allowed_models":[],
+            "allowed_tools": ["github__*"]
         });
         assert!(validate_apikey(&v).is_err());
     }
@@ -1933,7 +1954,6 @@ mod tests {
     fn mcp_policy_env_and_team_forms_pass() {
         validate_mcp_policy(&json!({
             "scope": "env",
-            "mode": "selected",
             "allow": ["github__*"],
             "deny": ["github__delete_repo"]
         }))
@@ -1941,7 +1961,7 @@ mod tests {
         validate_mcp_policy(&json!({
             "scope": "team",
             "scope_ref": "team-uuid-1",
-            "mode": "all",
+            "allow": ["*"],
             "enabled": true
         }))
         .unwrap();
@@ -1950,21 +1970,29 @@ mod tests {
     #[test]
     fn mcp_policy_team_scope_requires_scope_ref() {
         // A team row without its team id could shadow the environment
-        // default; the cross-field guard rejects it at the schema gate.
-        assert!(validate_mcp_policy(&json!({"scope": "team", "mode": "all"})).is_err());
+        // layer; the cross-field guard rejects it at the schema gate.
+        assert!(validate_mcp_policy(&json!({"scope": "team", "allow": ["*"]})).is_err());
         assert!(
-            validate_mcp_policy(&json!({"scope": "team", "scope_ref": null, "mode": "all"}))
+            validate_mcp_policy(&json!({"scope": "team", "scope_ref": null, "allow": ["*"]}))
                 .is_err()
         );
-        // The environment default carries no scope_ref.
-        validate_mcp_policy(&json!({"scope": "env", "mode": "none"})).unwrap();
+        // The environment layer carries no scope_ref.
+        validate_mcp_policy(&json!({"scope": "env", "allow": []})).unwrap();
+    }
+
+    #[test]
+    fn mcp_policy_requires_an_explicit_allow_side() {
+        assert!(validate_mcp_policy(&json!({"scope": "env"})).is_err());
+        assert!(validate_mcp_policy(&json!({"scope": "env", "deny": ["github__*"]})).is_err());
     }
 
     #[test]
     fn mcp_policy_rejects_unknown_fields_and_values() {
-        assert!(validate_mcp_policy(&json!({"scope": "org", "mode": "all"})).is_err());
-        assert!(validate_mcp_policy(&json!({"scope": "env", "mode": "open"})).is_err());
-        assert!(validate_mcp_policy(&json!({"scope": "env", "mode": "all", "rogue": 1})).is_err());
+        assert!(validate_mcp_policy(&json!({"scope": "org", "allow": ["*"]})).is_err());
+        assert!(validate_mcp_policy(&json!({"scope": "env", "allow": ["*"], "rogue": 1})).is_err());
+        // `mode` is gone; a payload still carrying it is a write from a
+        // control plane that has not caught up.
+        assert!(validate_mcp_policy(&json!({"scope": "env", "mode": "all", "allow": ["*"]})).is_err());
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -1992,7 +1992,9 @@ mod tests {
         assert!(validate_mcp_policy(&json!({"scope": "env", "allow": ["*"], "rogue": 1})).is_err());
         // `mode` is gone; a payload still carrying it is a write from a
         // control plane that has not caught up.
-        assert!(validate_mcp_policy(&json!({"scope": "env", "mode": "all", "allow": ["*"]})).is_err());
+        assert!(
+            validate_mcp_policy(&json!({"scope": "env", "mode": "all", "allow": ["*"]})).is_err()
+        );
     }
 
     #[test]

--- a/crates/aisix-gateway/src/upstream_headers.rs
+++ b/crates/aisix-gateway/src/upstream_headers.rs
@@ -154,7 +154,7 @@ fn is_forwardable_name(name: &str) -> bool {
 
 /// Whether an allowlist pattern admits a header name. Patterns are matched
 /// case-insensitively against the lowercase name, and a single `*` glob is
-/// supported (`"x-trace-*"`), matching how `allowed_models` / `allowed_tools`
+/// supported (`"x-trace-*"`), matching how `allowed_models` / `allowed_agents`
 /// patterns behave elsewhere in the snapshot.
 fn allowlist_admits(patterns: &[String], name: &str) -> bool {
     patterns

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -40,9 +40,7 @@ use rmcp::transport::streamable_http_server::session::local::LocalSessionManager
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use rmcp::{RoleServer, ServerHandler};
 
-use aisix_core::models::{
-    ApiKey, McpPolicy, McpPolicyScope, McpServerType,
-};
+use aisix_core::models::{ApiKey, McpPolicy, McpPolicyScope, McpServerType};
 use aisix_core::{AisixSnapshot, ResourceEntry};
 
 use crate::bridge::{upstream_from_mcp_server, EphemeralBridge, McpBridge};
@@ -233,7 +231,10 @@ impl ToolAcl {
         }
 
         let mut allow: Vec<AllowLayer> = Vec::new();
-        for policy in [env_policy.as_ref(), team_policy.as_ref()].into_iter().flatten() {
+        for policy in [env_policy.as_ref(), team_policy.as_ref()]
+            .into_iter()
+            .flatten()
+        {
             allow.push(AllowLayer::from_patterns(&policy.value.allow));
         }
         if let Some(access) = &key.mcp_access {

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -41,7 +41,7 @@ use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, Stream
 use rmcp::{RoleServer, ServerHandler};
 
 use aisix_core::models::{
-    ApiKey, McpAccessMode, McpPolicy, McpPolicyMode, McpPolicyScope, McpServerType,
+    ApiKey, McpPolicy, McpPolicyScope, McpServerType,
 };
 use aisix_core::{AisixSnapshot, ResourceEntry};
 
@@ -93,13 +93,13 @@ pub fn strip_server_prefix<'a>(server: &str, name: &'a str) -> Option<&'a str> {
 /// the environment's / the key's team's MCP access policies, so MCP tool
 /// access is governed by the same key object as LLM access.
 ///
-/// A tool is permitted only when **every** allow layer admits it and **no**
-/// deny pattern matches it. A legacy key (no `mcp_access` block) carries a
-/// single allow layer built from its `allowed_tools`; a policy-driven key
-/// carries the inherited policy grant and, in `restrict` mode, its own
-/// `allow` patterns as a second conjunctive layer — a key can narrow the
-/// inherited grant but never widen it. Deny patterns are unioned across the
-/// environment policy, the team policy, and the key, and always win.
+/// Three layers of identical shape contribute: the environment policy, the
+/// key's team policy, and the key's own `mcp_access` block. A tool is
+/// permitted only when **every present** allow layer admits it and **no**
+/// deny pattern matches it — allow intersects, deny unions, and no layer can
+/// widen what another one already narrowed. A layer that is absent or
+/// disabled contributes nothing; with no allow layer at all the ACL grants
+/// nothing, so MCP access is always granted explicitly.
 #[derive(Clone)]
 pub struct ToolAcl {
     /// Conjunctive allow layers: a tool must match every layer.
@@ -176,12 +176,11 @@ impl ToolAcl {
         self
     }
 
-    /// Build a legacy ACL from an API key's `allowed_tools` list alone:
-    /// `None` or an empty list grants no tools; a list containing `"*"`
-    /// grants all; otherwise the listed patterns. Entries are matched as
-    /// single-`*` globs (see [`ToolAcl::permits`]), mirroring
-    /// `ApiKey::can_access_tool`. Policy deny overlays are NOT applied here —
-    /// any caller serving external traffic uses [`ToolAcl::resolve`].
+    /// Build a single-layer ACL from one allow list: an empty list grants no
+    /// tools, a list containing `"*"` grants all, otherwise the listed
+    /// patterns are matched as single-`*` globs (see [`ToolAcl::permits`]).
+    /// No deny side — any caller serving external traffic resolves the full
+    /// layered ACL with [`ToolAcl::resolve`] instead.
     pub fn from_allowed(allowed: Option<&[String]>) -> Self {
         Self {
             allow: vec![AllowLayer::from_patterns(allowed.unwrap_or(&[]))],
@@ -192,20 +191,15 @@ impl ToolAcl {
     /// Resolve the effective ACL for `key` from the `mcp_policies` in
     /// `snapshot`.
     ///
-    /// - A key without an `mcp_access` block keeps its legacy allow side
-    ///   (`allowed_tools`, no inheritance) — with enabled policies' `deny`
-    ///   patterns still subtracted, since deny applies to every key a policy
-    ///   covers.
-    /// - `deny` mode grants nothing.
-    /// - `inherit` / `restrict` take the base grant from the key's team
-    ///   policy when one is enabled, else the environment-default policy,
-    ///   else nothing; `restrict` intersects the key's own `allow` patterns
-    ///   on top.
-    /// - Deny patterns are unioned across the environment policy, the team
-    ///   policy, and the key — an environment-level deny holds even when a
-    ///   team policy replaces the environment's grant.
+    /// Up to three layers apply, each an `allow`/`deny` pair: the
+    /// environment policy, the key's team policy, and the key's own
+    /// `mcp_access` block. Allow sides intersect (a layer can only narrow
+    /// what the others left), deny sides union and always win. A layer that
+    /// is absent — no row, a disabled row, or no `mcp_access` block —
+    /// contributes neither side.
     ///
-    /// Disabled policies neither grant nor deny.
+    /// With no allow layer at all the ACL grants nothing: MCP access is
+    /// granted explicitly, never by the absence of configuration.
     pub fn resolve(snapshot: &AisixSnapshot, key: &ApiKey) -> Self {
         // Grant side: pick the governing row per scope deterministically
         // (lowest id wins) so a duplicated row — the writer enforces
@@ -238,35 +232,21 @@ impl ToolAcl {
             }
         }
 
-        let Some(access) = &key.mcp_access else {
-            return Self {
-                allow: vec![AllowLayer::from_patterns(
-                    key.allowed_tools.as_deref().unwrap_or(&[]),
-                )],
-                deny,
-            };
-        };
-
-        match access.mode {
-            McpAccessMode::Deny => Self {
-                allow: vec![AllowLayer::Patterns(Vec::new())],
-                deny: Vec::new(),
-            },
-            mode @ (McpAccessMode::Inherit | McpAccessMode::Restrict) => {
-                let governing = team_policy.as_ref().or(env_policy.as_ref());
-                let base = match governing.map(|p| (p.value.mode, &p.value.allow)) {
-                    None | Some((McpPolicyMode::None, _)) => AllowLayer::Patterns(Vec::new()),
-                    Some((McpPolicyMode::All, _)) => AllowLayer::All,
-                    Some((McpPolicyMode::Selected, allow)) => AllowLayer::from_patterns(allow),
-                };
-                let mut allow = vec![base];
-                if mode == McpAccessMode::Restrict {
-                    allow.push(AllowLayer::from_patterns(&access.allow));
-                }
-                deny.extend(access.deny.iter().cloned());
-                Self { allow, deny }
-            }
+        let mut allow: Vec<AllowLayer> = Vec::new();
+        for policy in [env_policy.as_ref(), team_policy.as_ref()].into_iter().flatten() {
+            allow.push(AllowLayer::from_patterns(&policy.value.allow));
         }
+        if let Some(access) = &key.mcp_access {
+            allow.push(AllowLayer::from_patterns(&access.allow));
+            deny.extend(access.deny.iter().cloned());
+        }
+        // Deny-by-default: an unconfigured key in an unconfigured
+        // environment has no MCP access, rather than the empty conjunction's
+        // "everything".
+        if allow.is_empty() {
+            allow.push(AllowLayer::Patterns(Vec::new()));
+        }
+        Self { allow, deny }
     }
 
     /// Whether `namespaced_tool` is permitted: every allow layer must admit

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -602,8 +602,7 @@ fn resolve_env_layer_alone_governs_a_key_with_no_block() {
 fn resolve_empty_allow_list_on_any_layer_grants_nothing() {
     // The explicit "block everything" spelling, replacing the removed
     // `mode: none` / `mode: deny`.
-    let wide_env =
-        policy_snapshot(&[("p-env", serde_json::json!({"scope":"env","allow":["*"]}))]);
+    let wide_env = policy_snapshot(&[("p-env", serde_json::json!({"scope":"env","allow":["*"]}))]);
     let blocked_key = acl_key(serde_json::json!({
         "key_hash":"h","allowed_models":[],"mcp_access":{"allow":[]}
     }));

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -522,7 +522,7 @@ async fn from_snapshot_degrades_misconfigured_oauth2_upstream_gracefully() {
 
 #[test]
 fn tool_acl_from_allowed_semantics() {
-    // No allowed_tools / empty → deny all.
+    // No list / empty → deny all.
     assert!(!ToolAcl::from_allowed(None).permits("github__create_issue"));
     assert!(!ToolAcl::from_allowed(Some(&[])).permits("github__create_issue"));
     // Wildcard → allow all.
@@ -540,7 +540,7 @@ fn tool_acl_from_allowed_semantics() {
     assert!(!scoped.permits("slack__post_message"));
 }
 
-// ---- policy-driven effective-ACL resolution (`ToolAcl::resolve`) ----
+// ---- layered effective-ACL resolution (`ToolAcl::resolve`) ----
 
 /// Build a caller key from raw JSON (the etcd document shape).
 fn acl_key(json: serde_json::Value) -> aisix_core::models::ApiKey {
@@ -564,70 +564,34 @@ fn resolve_now(snapshot: &AisixSnapshot, key: &aisix_core::models::ApiKey) -> To
 }
 
 #[test]
-fn resolve_legacy_key_without_policies_matches_from_allowed() {
+fn resolve_grants_nothing_when_no_layer_is_configured() {
+    // Deny-by-default: an empty conjunction must not mean "everything".
     let snapshot = AisixSnapshot::new();
-    let no_tools = acl_key(serde_json::json!({"key_hash":"h","allowed_models":[]}));
-    assert!(!resolve_now(&snapshot, &no_tools).permits("github__create_issue"));
+    let key = acl_key(serde_json::json!({"key_hash":"h","allowed_models":[]}));
+    assert!(!resolve_now(&snapshot, &key).permits("github__create_issue"));
+}
 
-    let listed = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"allowed_tools":["github__*"]
+#[test]
+fn resolve_key_layer_alone_governs_when_no_policy_exists() {
+    let snapshot = AisixSnapshot::new();
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"mcp_access":{"allow":["github__*"]}
     }));
-    let acl = resolve_now(&snapshot, &listed);
+    let acl = resolve_now(&snapshot, &key);
     assert!(acl.permits("github__create_issue"));
     assert!(!acl.permits("slack__post_message"));
 }
 
 #[test]
-fn resolve_legacy_key_gets_deny_overlay_but_no_policy_grant() {
-    // An env policy grants everything and denies one tool. A legacy key
-    // (no mcp_access block) must NOT be widened by the grant — its
-    // allowed_tools stays the whole allow side — but the deny overlay
-    // applies: deny covers every key the policy covers.
-    let snapshot = policy_snapshot(&[(
-        "p-env",
-        serde_json::json!({"scope":"env","mode":"all","deny":["github__delete_repo"]}),
-    )]);
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"allowed_tools":["github__*"]
-    }));
-    let acl = resolve_now(&snapshot, &key);
-    assert!(acl.permits("github__create_issue"));
-    assert!(
-        !acl.permits("github__delete_repo"),
-        "policy deny must subtract from a legacy key's grant"
-    );
-    assert!(
-        !acl.permits("slack__post_message"),
-        "an env grant must not widen a legacy key"
-    );
-}
-
-#[test]
-fn resolve_deny_mode_grants_nothing() {
-    let snapshot = policy_snapshot(&[("p-env", serde_json::json!({"scope":"env","mode":"all"}))]);
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],
-        "allowed_tools":["*"],
-        "mcp_access":{"mode":"deny"}
-    }));
-    let acl = resolve_now(&snapshot, &key);
-    assert!(!acl.permits("github__create_issue"));
-    assert!(!acl.permits("anything__at_all"));
-}
-
-#[test]
-fn resolve_inherit_takes_env_default() {
+fn resolve_env_layer_alone_governs_a_key_with_no_block() {
+    // A key that adds no constraint of its own takes the env layer as-is.
     let snapshot = policy_snapshot(&[(
         "p-env",
         serde_json::json!({
-            "scope":"env","mode":"selected",
-            "allow":["github__*"],
-            "deny":["github__delete_repo"]
+            "scope":"env","allow":["github__*"],"deny":["github__delete_repo"]
         }),
     )]);
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"mcp_access":{"mode":"inherit"}
-    }));
+    let key = acl_key(serde_json::json!({"key_hash":"h","allowed_models":[]}));
     let acl = resolve_now(&snapshot, &key);
     assert!(acl.permits("github__create_issue"));
     assert!(!acl.permits("github__delete_repo"), "deny beats allow");
@@ -635,177 +599,199 @@ fn resolve_inherit_takes_env_default() {
 }
 
 #[test]
-fn resolve_inherit_env_all_and_none_modes() {
-    let all = policy_snapshot(&[("p", serde_json::json!({"scope":"env","mode":"all"}))]);
-    let none = policy_snapshot(&[("p", serde_json::json!({"scope":"env","mode":"none"}))]);
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"mcp_access":{"mode":"inherit"}
+fn resolve_empty_allow_list_on_any_layer_grants_nothing() {
+    // The explicit "block everything" spelling, replacing the removed
+    // `mode: none` / `mode: deny`.
+    let wide_env =
+        policy_snapshot(&[("p-env", serde_json::json!({"scope":"env","allow":["*"]}))]);
+    let blocked_key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"mcp_access":{"allow":[]}
     }));
-    assert!(resolve_now(&all, &key).permits("anything__at_all"));
-    assert!(!resolve_now(&none, &key).permits("anything__at_all"));
+    assert!(!resolve_now(&wide_env, &blocked_key).permits("github__create_issue"));
+
+    let blocked_env = policy_snapshot(&[("p-env", serde_json::json!({"scope":"env","allow":[]}))]);
+    let wide_key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"mcp_access":{"allow":["*"]}
+    }));
+    assert!(!resolve_now(&blocked_env, &wide_key).permits("github__create_issue"));
 }
 
 #[test]
-fn resolve_inherit_without_any_policy_grants_nothing() {
-    let snapshot = AisixSnapshot::new();
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"mcp_access":{"mode":"inherit"}
-    }));
-    assert!(!resolve_now(&snapshot, &key).permits("github__create_issue"));
-}
-
-#[test]
-fn resolve_team_policy_replaces_env_grant_for_member_keys() {
-    let snapshot = policy_snapshot(&[
-        (
-            "p-env",
-            serde_json::json!({"scope":"env","mode":"selected","allow":["slack__*"]}),
-        ),
-        (
-            "p-team",
-            serde_json::json!({
-                "scope":"team","scope_ref":"team-1","mode":"selected","allow":["github__*"]
-            }),
-        ),
-    ]);
-
-    // A key in team-1 gets the team grant, not the env default.
-    let member = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"team_id":"team-1",
-        "mcp_access":{"mode":"inherit"}
-    }));
-    let acl = resolve_now(&snapshot, &member);
-    assert!(acl.permits("github__create_issue"));
-    assert!(
-        !acl.permits("slack__post_message"),
-        "the team policy replaces the env grant, it does not union with it"
-    );
-
-    // A key outside any team falls back to the env default.
-    let unbound = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"mcp_access":{"mode":"inherit"}
-    }));
-    let acl = resolve_now(&snapshot, &unbound);
-    assert!(acl.permits("slack__post_message"));
-    assert!(!acl.permits("github__create_issue"));
-
-    // A key in a team WITHOUT its own policy also falls back to the env
-    // default.
-    let other_team = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"team_id":"team-2",
-        "mcp_access":{"mode":"inherit"}
-    }));
-    assert!(resolve_now(&snapshot, &other_team).permits("slack__post_message"));
-}
-
-#[test]
-fn resolve_env_deny_survives_team_takeover() {
-    // The approved deny semantics: deny patterns are a global union — an
-    // environment-level deny holds even when a team policy replaces the
-    // environment's grant with a broader one.
-    let snapshot = policy_snapshot(&[
-        (
-            "p-env",
-            serde_json::json!({
-                "scope":"env","mode":"selected","allow":["slack__*"],
-                "deny":["github__delete_repo"]
-            }),
-        ),
-        (
-            "p-team",
-            serde_json::json!({"scope":"team","scope_ref":"team-1","mode":"all"}),
-        ),
-    ]);
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"team_id":"team-1",
-        "mcp_access":{"mode":"inherit"}
-    }));
-    let acl = resolve_now(&snapshot, &key);
-    assert!(acl.permits("github__create_issue"));
-    assert!(
-        !acl.permits("github__delete_repo"),
-        "an env-level deny must survive a team policy taking over the grant"
-    );
-}
-
-#[test]
-fn resolve_restrict_narrows_but_never_widens() {
-    let snapshot = policy_snapshot(&[("p-env", serde_json::json!({"scope":"env","mode":"all"}))]);
+fn resolve_key_layer_narrows_but_never_widens_the_policy_layers() {
+    let snapshot = policy_snapshot(&[("p-env", serde_json::json!({"scope":"env","allow":["*"]}))]);
     let key = acl_key(serde_json::json!({
         "key_hash":"h","allowed_models":[],
-        "mcp_access":{"mode":"restrict","allow":["github__*"],"deny":["github__delete_repo"]}
+        "mcp_access":{"allow":["github__*"],"deny":["github__delete_repo"]}
     }));
     let acl = resolve_now(&snapshot, &key);
     assert!(acl.permits("github__create_issue"));
-    assert!(
-        !acl.permits("slack__post_message"),
-        "restrict narrows `all`"
-    );
+    assert!(!acl.permits("slack__post_message"), "the key narrows `*`");
     assert!(!acl.permits("github__delete_repo"), "key deny subtracts");
 
-    // Restriction patterns outside the base grant add nothing: base is
-    // selected [slack__*], the key asks for github — the intersection is
-    // empty in the github direction and slack is cut by the key layer.
-    let narrow_base = policy_snapshot(&[(
+    // The key cannot reach outside a narrower env layer either: the
+    // intersection of [slack__*] and [github__*] is empty.
+    let narrow_env = policy_snapshot(&[(
         "p-env",
-        serde_json::json!({"scope":"env","mode":"selected","allow":["slack__*"]}),
+        serde_json::json!({"scope":"env","allow":["slack__*"]}),
     )]);
-    let acl = resolve_now(&narrow_base, &key);
+    let acl = resolve_now(&narrow_env, &key);
     assert!(!acl.permits("github__create_issue"));
     assert!(!acl.permits("slack__post_message"));
 }
 
 #[test]
-fn resolve_inherit_ignores_key_allow_patterns() {
-    // `allow` participates only in restrict mode; an inherit key carrying
-    // stray allow patterns must not have them narrow (or widen) the grant.
-    let snapshot = policy_snapshot(&[("p-env", serde_json::json!({"scope":"env","mode":"all"}))]);
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],
-        "mcp_access":{"mode":"inherit","allow":["github__*"]}
-    }));
-    assert!(resolve_now(&snapshot, &key).permits("slack__post_message"));
-}
-
-#[test]
-fn resolve_ignores_disabled_policies() {
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"team_id":"team-1",
-        "mcp_access":{"mode":"inherit"}
-    }));
-
-    // Disabled team policy → fall back to the env default.
+fn resolve_team_layer_intersects_with_env_rather_than_replacing_it() {
     let snapshot = policy_snapshot(&[
         (
             "p-env",
-            serde_json::json!({"scope":"env","mode":"selected","allow":["slack__*"]}),
+            serde_json::json!({"scope":"env","allow":["github__*","slack__*"]}),
         ),
         (
             "p-team",
             serde_json::json!({
-                "scope":"team","scope_ref":"team-1","mode":"all","enabled":false
+                "scope":"team","scope_ref":"team-1","allow":["github__*","jira__*"]
             }),
         ),
     ]);
+
+    // A key in team-1 gets exactly the overlap of the two layers: the team
+    // layer narrows the environment and cannot add `jira__*` on its own.
+    let member = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"team_id":"team-1"
+    }));
+    let acl = resolve_now(&snapshot, &member);
+    assert!(acl.permits("github__create_issue"));
+    assert!(
+        !acl.permits("slack__post_message"),
+        "the team layer narrows the env layer"
+    );
+    assert!(
+        !acl.permits("jira__create_ticket"),
+        "a team layer must never widen beyond the env layer"
+    );
+
+    // A key outside any team sees the env layer alone.
+    let unbound = acl_key(serde_json::json!({"key_hash":"h","allowed_models":[]}));
+    let acl = resolve_now(&snapshot, &unbound);
+    assert!(acl.permits("slack__post_message"));
+    assert!(acl.permits("github__create_issue"));
+
+    // A key in a team WITHOUT its own policy also sees the env layer alone.
+    let other_team = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"team_id":"team-2"
+    }));
+    assert!(resolve_now(&snapshot, &other_team).permits("slack__post_message"));
+}
+
+#[test]
+fn resolve_all_three_layers_intersect() {
+    let snapshot = policy_snapshot(&[
+        (
+            "p-env",
+            serde_json::json!({"scope":"env","allow":["*"],"deny":["github__delete_repo"]}),
+        ),
+        (
+            "p-team",
+            serde_json::json!({"scope":"team","scope_ref":"team-1","allow":["github__*"]}),
+        ),
+    ]);
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"team_id":"team-1",
+        "mcp_access":{"allow":["github__create_issue","github__delete_repo"]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("github__create_issue"));
+    assert!(
+        !acl.permits("github__list_issues"),
+        "the key layer narrows the team layer"
+    );
+    assert!(
+        !acl.permits("github__delete_repo"),
+        "an env deny survives allows on every other layer"
+    );
+}
+
+#[test]
+fn resolve_env_deny_survives_a_broader_team_layer() {
+    // Deny patterns are a global union: an environment-level deny holds
+    // however wide the team and key layers are.
+    let snapshot = policy_snapshot(&[
+        (
+            "p-env",
+            serde_json::json!({
+                "scope":"env","allow":["*"],"deny":["github__delete_repo"]
+            }),
+        ),
+        (
+            "p-team",
+            serde_json::json!({"scope":"team","scope_ref":"team-1","allow":["*"]}),
+        ),
+    ]);
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"team_id":"team-1"
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("github__create_issue"));
+    assert!(
+        !acl.permits("github__delete_repo"),
+        "an env-level deny must survive a wide-open team layer"
+    );
+}
+
+#[test]
+fn resolve_deny_only_layer_is_spelled_with_a_wildcard_allow() {
+    // A layer that only means to subtract writes `allow: ["*"]`; forgetting
+    // it is a schema error rather than a silent lockout (see
+    // `mcp_policy_requires_an_explicit_allow_side` in aisix-core).
+    let snapshot = policy_snapshot(&[(
+        "p-env",
+        serde_json::json!({"scope":"env","allow":["*"],"deny":["github__delete_repo"]}),
+    )]);
+    let key = acl_key(serde_json::json!({"key_hash":"h","allowed_models":[]}));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("slack__post_message"));
+    assert!(!acl.permits("github__delete_repo"));
+}
+
+#[test]
+fn resolve_ignores_disabled_policies() {
+    // Disabled team policy → the env layer is the only policy layer left.
+    let snapshot = policy_snapshot(&[
+        (
+            "p-env",
+            serde_json::json!({"scope":"env","allow":["slack__*"]}),
+        ),
+        (
+            "p-team",
+            serde_json::json!({
+                "scope":"team","scope_ref":"team-1","allow":["github__*"],"enabled":false
+            }),
+        ),
+    ]);
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"team_id":"team-1"
+    }));
     let acl = resolve_now(&snapshot, &key);
     assert!(acl.permits("slack__post_message"));
     assert!(!acl.permits("github__create_issue"));
 
-    // Disabled env policy → no grant at all, and its deny stops
-    // applying (a disabled policy neither grants nor denies).
+    // Disabled env policy → neither its grant nor its deny applies, leaving
+    // the key layer as the only layer.
     let snapshot = policy_snapshot(&[(
         "p-env",
         serde_json::json!({
-            "scope":"env","mode":"all","deny":["slack__*"],
-            "enabled":false
+            "scope":"env","allow":["*"],"deny":["slack__*"],"enabled":false
         }),
     )]);
-    let legacy = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"allowed_tools":["slack__*"]
+    let scoped = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"mcp_access":{"allow":["slack__*"]}
     }));
-    assert!(!resolve_now(&snapshot, &key).permits("anything__at_all"));
     assert!(
-        resolve_now(&snapshot, &legacy).permits("slack__post_message"),
+        !resolve_now(&snapshot, &key).permits("anything__at_all"),
+        "with every policy disabled and no key block, nothing is granted"
+    );
+    assert!(
+        resolve_now(&snapshot, &scoped).permits("slack__post_message"),
         "a disabled policy's deny must stop applying"
     );
 }
@@ -817,16 +803,14 @@ fn resolve_duplicate_scope_rows_pick_lowest_id() {
     let snapshot = policy_snapshot(&[
         (
             "p-b",
-            serde_json::json!({"scope":"env","mode":"selected","allow":["beta__*"]}),
+            serde_json::json!({"scope":"env","allow":["beta__*"]}),
         ),
         (
             "p-a",
-            serde_json::json!({"scope":"env","mode":"selected","allow":["alpha__*"]}),
+            serde_json::json!({"scope":"env","allow":["alpha__*"]}),
         ),
     ]);
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"mcp_access":{"mode":"inherit"}
-    }));
+    let key = acl_key(serde_json::json!({"key_hash":"h","allowed_models":[]}));
     let acl = resolve_now(&snapshot, &key);
     assert!(acl.permits("alpha__echo"));
     assert!(!acl.permits("beta__echo"));
@@ -935,13 +919,11 @@ fn resolve_duplicate_scope_rows_deny_union_survives_tie_break() {
     let snapshot = policy_snapshot(&[
         (
             "p-b",
-            serde_json::json!({"scope":"env","mode":"all","deny":["beta__echo"]}),
+            serde_json::json!({"scope":"env","allow":["*"],"deny":["beta__echo"]}),
         ),
-        ("p-a", serde_json::json!({"scope":"env","mode":"all"})),
+        ("p-a", serde_json::json!({"scope":"env","allow":["*"]})),
     ]);
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"mcp_access":{"mode":"inherit"}
-    }));
+    let key = acl_key(serde_json::json!({"key_hash":"h","allowed_models":[]}));
     let acl = resolve_now(&snapshot, &key);
     assert!(acl.permits("alpha__echo"));
     assert!(
@@ -951,23 +933,13 @@ fn resolve_duplicate_scope_rows_deny_union_survives_tie_break() {
 }
 
 #[test]
-fn resolve_restrict_with_empty_allow_grants_nothing() {
-    // restrict + empty allow = the empty intersection, whatever the base.
-    let snapshot = policy_snapshot(&[("p-env", serde_json::json!({"scope":"env","mode":"all"}))]);
+fn resolve_key_block_without_an_allow_side_grants_nothing() {
+    // A key block is the key's whole allow side; an empty one is the empty
+    // intersection, whatever the policy layers grant. (The write path
+    // requires the field, so this only guards the runtime loader.)
+    let snapshot = policy_snapshot(&[("p-env", serde_json::json!({"scope":"env","allow":["*"]}))]);
     let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"mcp_access":{"mode":"restrict"}
-    }));
-    assert!(!resolve_now(&snapshot, &key).permits("alpha__echo"));
-}
-
-#[test]
-fn resolve_selected_with_empty_allow_grants_nothing() {
-    let snapshot = policy_snapshot(&[(
-        "p-env",
-        serde_json::json!({"scope":"env","mode":"selected"}),
-    )]);
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"mcp_access":{"mode":"inherit"}
+        "key_hash":"h","allowed_models":[],"mcp_access":{"allow":[]}
     }));
     assert!(!resolve_now(&snapshot, &key).permits("alpha__echo"));
 }
@@ -981,13 +953,12 @@ fn resolve_team_row_without_scope_ref_matches_no_key() {
     let snapshot = policy_snapshot(&[
         (
             "p-env",
-            serde_json::json!({"scope":"env","mode":"selected","allow":["alpha__*"]}),
+            serde_json::json!({"scope":"env","allow":["alpha__*"]}),
         ),
-        ("p-bad", serde_json::json!({"scope":"team","mode":"all"})),
+        ("p-bad", serde_json::json!({"scope":"team","allow":["*"]})),
     ]);
     let teamed = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"team_id":"team-1",
-        "mcp_access":{"mode":"inherit"}
+        "key_hash":"h","allowed_models":[],"team_id":"team-1"
     }));
     let acl = resolve_now(&snapshot, &teamed);
     assert!(
@@ -996,22 +967,20 @@ fn resolve_team_row_without_scope_ref_matches_no_key() {
     );
     assert!(
         !acl.permits("beta__echo"),
-        "a scope_ref-less team row must not grant anything"
+        "a scope_ref-less team row must not apply to any key"
     );
 }
 
 #[tokio::test]
 async fn policy_resolved_acl_filters_list_and_rejects_calls() {
-    // Full wiring: an env policy granting alpha only, denied one level up
-    // by nothing; the key inherits. beta stays hidden from tools/list and
-    // rejected on tools/call, exactly like a legacy allowlist would.
+    // Full wiring: an env policy granting alpha only and a key that adds no
+    // constraint of its own. beta stays hidden from tools/list and rejected
+    // on tools/call.
     let snapshot = policy_snapshot(&[(
         "p-env",
-        serde_json::json!({"scope":"env","mode":"selected","allow":["alpha__*"]}),
+        serde_json::json!({"scope":"env","allow":["alpha__*"]}),
     )]);
-    let key = acl_key(serde_json::json!({
-        "key_hash":"h","allowed_models":[],"mcp_access":{"mode":"inherit"}
-    }));
+    let key = acl_key(serde_json::json!({"key_hash":"h","allowed_models":[]}));
     let acl = resolve_now(&snapshot, &key);
 
     let gateway = McpGateway::new([

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -10,7 +10,7 @@
 //! live `mcp_servers` set.
 //!
 //! A `tools/call` is governed by the SAME pipeline as an LLM request, keyed on
-//! the caller's API key: per-tool access control (the key's `allowed_tools`),
+//! the caller's API key: per-tool access control (the layered MCP ACL),
 //! rate-limit + budget (`quota::enforce_mcp`, which adds the key's per-MCP-server
 //! limit to the shared layers), guardrails on both the tool arguments (input)
 //! and the tool result (output), and a usage event into the shared sink.
@@ -842,7 +842,7 @@ mod tests {
         let apikey: ApiKey = serde_json::from_value(serde_json::json!({
             "key_hash": key_hash,
             "allowed_models": ["*"],
-            "allowed_tools": ["*"],
+            "mcp_access": { "allow": ["*"] },
             "rate_limit": { "rpm": rpm },
         }))
         .expect("valid apikey");
@@ -913,7 +913,7 @@ mod tests {
             let apikey: ApiKey = serde_json::from_value(serde_json::json!({
                 "key_hash": ApiKey::hash_bearer(token),
                 "allowed_models": ["*"],
-                "allowed_tools": ["*"],
+                "mcp_access": { "allow": ["*"] },
                 "mcp_rate_limits": limits,
             }))
             .expect("valid apikey");
@@ -1071,19 +1071,54 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mcp_access_deny_mode_rejects_tool_calls_at_the_acl() {
-        // The key's legacy allowlist grants everything, but its mcp_access
-        // block says deny — the policy layer must win. The rejection is the
-        // ACL's neutral "not available" (reached before upstream routing),
-        // not the router's "unknown MCP server", which proves the endpoint
-        // resolves the ACL from the key + policies rather than allowed_tools
-        // alone.
+    async fn empty_key_allow_list_rejects_tool_calls_at_the_acl() {
+        // An `mcp_access` block whose allow side is empty leaves the key no
+        // MCP access even though an env policy grants everything. The
+        // rejection is the ACL's neutral "not available" (reached before
+        // upstream routing), not the router's "unknown MCP server", which
+        // proves the endpoint resolves the layered ACL rather than falling
+        // through to routing.
         let key_hash = ApiKey::hash_bearer(TOKEN);
         let apikey: ApiKey = serde_json::from_value(serde_json::json!({
             "key_hash": key_hash,
             "allowed_models": ["*"],
-            "allowed_tools": ["*"],
-            "mcp_access": { "mode": "deny" },
+            "mcp_access": { "allow": [] },
+        }))
+        .expect("valid apikey");
+        let policy: aisix_core::models::McpPolicy = serde_json::from_value(serde_json::json!({
+            "scope": "env",
+            "allow": ["*"],
+        }))
+        .expect("valid policy");
+        let snapshot = AisixSnapshot::new();
+        snapshot
+            .apikeys
+            .insert(ResourceEntry::new("ak-1", apikey, 1));
+        snapshot
+            .mcp_policies
+            .insert(ResourceEntry::new("p-env", policy, 1));
+
+        let router = router_with(snapshot);
+        let resp = router
+            .oneshot(tools_call_request())
+            .await
+            .expect("router responds");
+        let body = body_json(resp).await;
+        let message = body["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            message.contains("not available"),
+            "a key allowing nothing must be rejected by the ACL, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unconfigured_key_has_no_mcp_access_at_the_endpoint() {
+        // No policy anywhere and no `mcp_access` block: the grant is empty
+        // rather than unrestricted, so the call never reaches routing.
+        let key_hash = ApiKey::hash_bearer(TOKEN);
+        let apikey: ApiKey = serde_json::from_value(serde_json::json!({
+            "key_hash": key_hash,
+            "allowed_models": ["*"],
         }))
         .expect("valid apikey");
         let snapshot = AisixSnapshot::new();
@@ -1100,26 +1135,25 @@ mod tests {
         let message = body["error"]["message"].as_str().unwrap_or_default();
         assert!(
             message.contains("not available"),
-            "deny-mode key must be rejected by the ACL, got: {body}"
+            "an unconfigured key must have no MCP access, got: {body}"
         );
     }
 
     #[tokio::test]
-    async fn env_policy_deny_overlays_legacy_key_at_the_endpoint() {
-        // A legacy key (no mcp_access block) with a wildcard allowlist, plus
-        // an env policy that denies exactly one tool: the denied tool is
-        // rejected by the ACL while any other name still reaches routing
-        // (and fails as "unknown MCP server" — no upstreams are registered).
+    async fn env_policy_deny_overlays_a_wildcard_key_at_the_endpoint() {
+        // An env policy allowing everything but denying exactly one tool:
+        // the denied tool is rejected by the ACL while any other name still
+        // reaches routing (and fails as "unknown MCP server" — no upstreams
+        // are registered).
         let key_hash = ApiKey::hash_bearer(TOKEN);
         let apikey: ApiKey = serde_json::from_value(serde_json::json!({
             "key_hash": key_hash,
             "allowed_models": ["*"],
-            "allowed_tools": ["*"],
         }))
         .expect("valid apikey");
         let policy: aisix_core::models::McpPolicy = serde_json::from_value(serde_json::json!({
             "scope": "env",
-            "mode": "none",
+            "allow": ["*"],
             "deny": ["ghost__tool"],
         }))
         .expect("valid policy");
@@ -1142,7 +1176,7 @@ mod tests {
         let message = body["error"]["message"].as_str().unwrap_or_default();
         assert!(
             message.contains("not available"),
-            "env-policy deny must subtract from a legacy key, got: {body}"
+            "env-policy deny must subtract from the inherited grant, got: {body}"
         );
 
         let other = router
@@ -1156,7 +1190,7 @@ mod tests {
         let message = body["error"]["message"].as_str().unwrap_or_default();
         assert!(
             message.contains("unknown MCP server"),
-            "a non-denied tool must still pass the ACL for a wildcard legacy key, got: {body}"
+            "a non-denied tool must still pass the ACL, got: {body}"
         );
     }
 
@@ -2157,7 +2191,7 @@ mod tests {
         let apikey: ApiKey = serde_json::from_value(serde_json::json!({
             "key_hash": ApiKey::hash_bearer(TOKEN),
             "allowed_models": ["*"],
-            "allowed_tools": ["*"],
+            "mcp_access": { "allow": ["*"] },
         }))
         .expect("valid apikey");
         let snapshot = AisixSnapshot::new();

--- a/crates/aisix-proxy/src/passthrough_route.rs
+++ b/crates/aisix-proxy/src/passthrough_route.rs
@@ -476,7 +476,7 @@ async fn dispatch(
     .await
     .map_err(RouteError::pre_auth)?;
 
-    // Route ACL: explicit grant, mirroring allowed_tools / allowed_agents.
+    // Route ACL: explicit grant, mirroring allowed_agents.
     if !auth.key().can_access_route(&route.name) {
         return Err(RouteError::of(
             ProxyError::RouteForbidden(route.name.clone()),

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -4,61 +4,27 @@
   "definitions": {
     "McpAccess": {
       "additionalProperties": false,
-      "description": "Policy-driven MCP access configuration on an API key. When present, this block supersedes the key's `allowed_tools` list: the allow side of the key's effective grant is computed from the applicable MCP access policies and `mode`, and `allowed_tools` is not consulted.",
+      "description": "The API key's own layer of the MCP tool ACL, the same `allow`/`deny` shape an MCP access policy carries. Present means the key constrains its grant; omitted means the key adds no constraint of its own and takes whatever the environment and team layers leave.",
       "properties": {
         "allow": {
-          "description": "Namespaced `<server>__<tool>` patterns intersected with the inherited grant when `mode` is `restrict`, using the same single-`*` glob matching as `allowed_tools`. Ignored for the other modes.",
+          "description": "Namespaced `<server>__<tool>` patterns this key allows, intersected with the environment and team layers. Same single-`*` glob matching a policy's `allow` uses; an empty list leaves the key no MCP access, and `[\"*\"]` narrows nothing (useful with `deny` alone).",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "deny": {
-          "description": "Namespaced `<server>__<tool>` patterns subtracted from the key's effective grant, using the same single-`*` glob matching as `allow`.",
+          "description": "Namespaced `<server>__<tool>` patterns subtracted from this key's effective grant, using the same single-`*` glob matching as `allow`.",
           "items": {
             "type": "string"
           },
           "type": "array"
-        },
-        "mode": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/McpAccessMode"
-            }
-          ],
-          "description": "How the key combines with the applicable policies: `inherit`, `restrict`, or `deny`."
         }
       },
       "required": [
-        "mode"
+        "allow"
       ],
       "type": "object"
-    },
-    "McpAccessMode": {
-      "description": "How an API key combines with the applicable MCP access policies: `inherit`, `restrict`, or `deny`.",
-      "oneOf": [
-        {
-          "description": "The key uses the inherited grant unchanged: its team's enabled policy when one exists, otherwise the environment-default policy.",
-          "enum": [
-            "inherit"
-          ],
-          "type": "string"
-        },
-        {
-          "description": "The key uses the intersection of the inherited grant and its own `allow` patterns — a restriction can only narrow what the policies grant, never widen it.",
-          "enum": [
-            "restrict"
-          ],
-          "type": "string"
-        },
-        {
-          "description": "The key has no MCP tool access at all.",
-          "enum": [
-            "deny"
-          ],
-          "type": "string"
-        }
-      ]
     },
     "McpRateLimit": {
       "additionalProperties": false,
@@ -184,7 +150,7 @@
   },
   "properties": {
     "allowed_agents": {
-      "description": "A2A agents this key may reach, named by their registered names. Entries are matched as single-`*` globs, mirroring `allowed_tools`: `\"*\"` grants every agent and an entry without a `*` matches one agent exactly. When omitted, set to `null`, or set to an empty list, the key has no A2A agent access — access is granted explicitly.",
+      "description": "A2A agents this key may reach, named by their registered names. Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every agent and an entry without a `*` matches one agent exactly. When omitted, set to `null`, or set to an empty list, the key has no A2A agent access — access is granted explicitly.",
       "items": {
         "type": "string"
       },
@@ -201,17 +167,7 @@
       "type": "array"
     },
     "allowed_routes": {
-      "description": "Passthrough routes this key may use, named by their registered names. Entries are matched as single-`*` globs, mirroring `allowed_tools`: `\"*\"` grants every route and an entry without a `*` matches one route exactly. When omitted, set to `null`, or set to an empty list, the key may use no passthrough route — access is granted explicitly.",
-      "items": {
-        "type": "string"
-      },
-      "type": [
-        "array",
-        "null"
-      ]
-    },
-    "allowed_tools": {
-      "description": "MCP tools this key may call, as namespaced `<server>__<tool>` names (the form the gateway exposes). Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every tool and `\"<server>__*\"` grants every tool on one server (e.g. `\"github__*\"`); an entry without a `*` matches one tool exactly. When omitted, set to `null`, or set to an empty list, the key has no MCP tool access — access is granted explicitly.",
+      "description": "Passthrough routes this key may use, named by their registered names. Entries are matched as single-`*` globs, mirroring `allowed_models`: `\"*\"` grants every route and an entry without a `*` matches one route exactly. When omitted, set to `null`, or set to an empty list, the key may use no passthrough route — access is granted explicitly.",
       "items": {
         "type": "string"
       },
@@ -269,7 +225,7 @@
           "type": "null"
         }
       ],
-      "description": "Policy-driven MCP access for this key. When present, it supersedes `allowed_tools`: the key's grant is computed from the environment's and its team's MCP access policies according to `mode` (`inherit`, `restrict`, or `deny`), and `allowed_tools` is not consulted. When omitted, the key keeps the explicit `allowed_tools` behavior — with policy `deny` patterns still subtracted, since deny applies to every key the policy covers."
+      "description": "This key's own layer of the MCP tool ACL, as namespaced `<server>__<tool>` glob patterns. It is intersected with the environment and team MCP access policies: every present layer must allow a tool and no layer may deny it. When omitted the key adds no constraint of its own — but with no layer present anywhere the grant is empty, so MCP access is always granted explicitly."
     },
     "mcp_rate_limits": {
       "additionalProperties": {

--- a/schemas/resources/mcp_policy.schema.json
+++ b/schemas/resources/mcp_policy.schema.json
@@ -24,44 +24,18 @@
     }
   ],
   "definitions": {
-    "McpPolicyMode": {
-      "description": "What an MCP access policy grants before `deny` patterns are subtracted.",
-      "oneOf": [
-        {
-          "description": "Grants no MCP tools.",
-          "enum": [
-            "none"
-          ],
-          "type": "string"
-        },
-        {
-          "description": "Grants exactly the tools matched by the `allow` patterns.",
-          "enum": [
-            "selected"
-          ],
-          "type": "string"
-        },
-        {
-          "description": "Grants every tool on every registered MCP server, including servers and tools added after the policy is created.",
-          "enum": [
-            "all"
-          ],
-          "type": "string"
-        }
-      ]
-    },
     "McpPolicyScope": {
       "description": "Which API keys an MCP access policy applies to.",
       "oneOf": [
         {
-          "description": "The environment-wide default, applied to keys whose team has no enabled policy of its own.",
+          "description": "Applied to every key in the environment.",
           "enum": [
             "env"
           ],
           "type": "string"
         },
         {
-          "description": "A team-level policy, applied to the keys that belong to the team named by `scope_ref`. It replaces the environment default for those keys.",
+          "description": "Applied to the keys belonging to the team named by `scope_ref`, on top of the environment policy rather than in place of it.",
           "enum": [
             "team"
           ],
@@ -72,14 +46,14 @@
   },
   "properties": {
     "allow": {
-      "description": "Namespaced `<server>__<tool>` patterns granted when `mode` is `selected`. Entries are matched as single-`*` globs, the same form as an API key's `allowed_tools`: `\"<server>__*\"` grants every tool on one server and an entry without a `*` matches one tool exactly. Ignored for the other modes.",
+      "description": "Namespaced `<server>__<tool>` patterns this layer allows. Entries are matched as single-`*` globs: `\"*\"` allows every tool, `\"<server>__*\"` every tool on one server, and an entry without a `*` matches one tool exactly. An empty list allows nothing, which is how a policy blocks all MCP access; a policy that only means to subtract tools writes `[\"*\"]` here and lists them under `deny`.",
       "items": {
         "type": "string"
       },
       "type": "array"
     },
     "deny": {
-      "description": "Namespaced `<server>__<tool>` patterns subtracted from the effective grant of every key the policy applies to, using the same single-`*` glob matching as `allow`. Deny always wins: a tool matched here stays unavailable even when a team policy or a key's own configuration would otherwise grant it.",
+      "description": "Namespaced `<server>__<tool>` patterns subtracted from the effective grant of every key the policy applies to, using the same single-`*` glob matching as `allow`. Deny always wins: a tool matched here stays unavailable however the other layers allow it.",
       "items": {
         "type": "string"
       },
@@ -87,16 +61,8 @@
     },
     "enabled": {
       "default": true,
-      "description": "Whether the policy is applied. A disabled policy is kept but ignored. Treated as `true` when omitted.",
+      "description": "Whether the policy is applied. A disabled policy is kept but contributes neither its allow nor its deny side. Treated as `true` when omitted.",
       "type": "boolean"
-    },
-    "mode": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/McpPolicyMode"
-        }
-      ],
-      "description": "What the policy grants: `none`, `selected` (the `allow` patterns), or `all` current and future tools."
     },
     "scope": {
       "allOf": [
@@ -107,7 +73,7 @@
       "description": "Which API keys the policy applies to: the whole environment or one team."
     },
     "scope_ref": {
-      "description": "Team identifier the policy targets. Required when `scope` is `team`; omitted for an environment-default policy.",
+      "description": "Team identifier the policy targets. Required when `scope` is `team`; omitted for an environment policy.",
       "minLength": 1,
       "type": [
         "string",
@@ -116,7 +82,7 @@
     }
   },
   "required": [
-    "mode",
+    "allow",
     "scope"
   ],
   "title": "McpPolicy",

--- a/tests/e2e/src/cases/mcp-access-policy-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-access-policy-e2e.test.ts
@@ -10,20 +10,22 @@ import {
   type SpawnedApp,
 } from "../harness/index.js";
 
-// E2E: layered MCP access policies against a real gateway + etcd + two real
-// MCP upstreams (official TypeScript SDK servers).
+// E2E: layered MCP access against a real gateway + etcd + two real MCP
+// upstreams (official TypeScript SDK servers). Three layers of the same
+// allow/deny shape intersect on the allow side and union on the deny side.
 //
-//   env default policy    → selected [alpha__*], deny [beta__reverse]
-//   team T1 policy        → selected [beta__*]      (replaces the env grant)
-//   team T2 policy        → all                     (replaces the env grant)
-//   per-key mcp_access    → inherit / restrict / deny; absent = legacy
+//   env policy      → allow [alpha__*, beta__*], deny [beta__reverse]
+//   team T1 policy  → allow [beta__*]
+//   team T2 policy  → allow [*]
+//   key mcp_access  → the key's own layer; absent = no constraint
 //
-// Pinned contract, per key:
-//   - legacy keys keep their allowed_tools allow side (no policy widening),
-//     but policy deny patterns still subtract;
-//   - inherit keys take the team policy when one exists, else the env
-//     default; an env-level deny survives a team policy takeover;
-//   - restrict intersects (narrow-only); deny grants nothing;
+// Pinned contract:
+//   - a key with no block of its own takes the policy layers unchanged;
+//   - a team layer narrows the env layer and can never widen it, and
+//     neither can a key layer;
+//   - an empty allow list on any layer leaves the key nothing;
+//   - a deny on any layer wins over every allow;
+//   - with no layer present at all the grant is empty;
 //   - tools/list hides what tools/call rejects (one ACL, two checkpoints);
 //   - policy edits and deletes propagate through the etcd watch path.
 
@@ -34,13 +36,13 @@ const ENV_POLICY_ID = "11111111-1111-1111-1111-11111111aaaa";
 const T1_POLICY_ID = "11111111-1111-1111-1111-11111111bbbb";
 const T2_POLICY_ID = "11111111-1111-1111-1111-11111111cccc";
 
-const KEY_LEGACY_SCOPED = "sk-mcp-legacy-scoped";
-const KEY_LEGACY_WILD = "sk-mcp-legacy-wild";
-const KEY_INHERIT = "sk-mcp-inherit";
-const KEY_T1 = "sk-mcp-t1-inherit";
-const KEY_T2 = "sk-mcp-t2-inherit";
-const KEY_RESTRICT = "sk-mcp-t2-restrict";
-const KEY_DENY = "sk-mcp-deny";
+const KEY_NO_BLOCK = "sk-mcp-no-block";
+const KEY_SCOPED = "sk-mcp-scoped";
+const KEY_T1 = "sk-mcp-t1";
+const KEY_T1_WIDE = "sk-mcp-t1-wide";
+const KEY_T2 = "sk-mcp-t2";
+const KEY_NARROW = "sk-mcp-t2-narrow";
+const KEY_BLOCKED = "sk-mcp-blocked";
 
 const sha256 = (s: string) => createHash("sha256").update(s).digest("hex");
 
@@ -56,7 +58,7 @@ interface RpcReply {
   };
 }
 
-describe("mcp access policy e2e: env default + team entitlement + key narrowing", () => {
+describe("mcp access policy e2e: env, team and key layers intersect", () => {
   let app: SpawnedApp | undefined;
   let alpha: McpUpstream | undefined;
   let beta: McpUpstream | undefined;
@@ -154,14 +156,16 @@ describe("mcp access policy e2e: env default + team entitlement + key narrowing"
     );
   };
 
+  const ENV_GRANT = ["alpha__echo", "alpha__reverse", "beta__echo"];
+
   const EXPECTED: Array<[string, string[]]> = [
-    [KEY_LEGACY_SCOPED, ["alpha__echo", "alpha__reverse"]],
-    [KEY_LEGACY_WILD, ["alpha__echo", "alpha__reverse", "beta__echo"]],
-    [KEY_INHERIT, ["alpha__echo", "alpha__reverse"]],
+    [KEY_NO_BLOCK, ENV_GRANT],
+    [KEY_SCOPED, ["alpha__echo", "alpha__reverse"]],
     [KEY_T1, ["beta__echo"]],
-    [KEY_T2, ["alpha__echo", "alpha__reverse", "beta__echo"]],
-    [KEY_RESTRICT, ["alpha__echo"]],
-    [KEY_DENY, []],
+    [KEY_T1_WIDE, ["beta__echo"]],
+    [KEY_T2, ENV_GRANT],
+    [KEY_NARROW, ["alpha__echo"]],
+    [KEY_BLOCKED, []],
   ];
 
   beforeAll(async () => {
@@ -187,20 +191,18 @@ describe("mcp access policy e2e: env default + team entitlement + key narrowing"
 
     await seed.update("mcp_policies", ENV_POLICY_ID, {
       scope: "env",
-      mode: "selected",
-      allow: ["alpha__*"],
+      allow: ["alpha__*", "beta__*"],
       deny: ["beta__reverse"],
     });
     await seed.update("mcp_policies", T1_POLICY_ID, {
       scope: "team",
       scope_ref: TEAM1,
-      mode: "selected",
       allow: ["beta__*"],
     });
     await seed.update("mcp_policies", T2_POLICY_ID, {
       scope: "team",
       scope_ref: TEAM2,
-      mode: "all",
+      allow: ["*"],
     });
 
     const keyDoc = (
@@ -211,32 +213,24 @@ describe("mcp access policy e2e: env default + team entitlement + key narrowing"
       allowed_models: [],
       ...extra,
     });
+    await seed.createApiKey(keyDoc(KEY_NO_BLOCK, {}));
     await seed.createApiKey(
-      keyDoc(KEY_LEGACY_SCOPED, { allowed_tools: ["alpha__*"] }),
-    );
-    await seed.createApiKey(keyDoc(KEY_LEGACY_WILD, { allowed_tools: ["*"] }));
-    await seed.createApiKey(
-      keyDoc(KEY_INHERIT, { mcp_access: { mode: "inherit" } }),
-    );
-    await seed.createApiKey(
-      keyDoc(KEY_T1, { team_id: TEAM1, mcp_access: { mode: "inherit" } }),
-    );
-    await seed.createApiKey(
-      keyDoc(KEY_T2, { team_id: TEAM2, mcp_access: { mode: "inherit" } }),
-    );
-    await seed.createApiKey(
-      keyDoc(KEY_RESTRICT, {
-        team_id: TEAM2,
-        mcp_access: {
-          mode: "restrict",
-          allow: ["alpha__*"],
-          deny: ["alpha__reverse"],
-        },
+      keyDoc(KEY_SCOPED, {
+        mcp_access: { allow: ["alpha__*", "beta__reverse"] },
       }),
     );
+    await seed.createApiKey(keyDoc(KEY_T1, { team_id: TEAM1 }));
     await seed.createApiKey(
-      keyDoc(KEY_DENY, { allowed_tools: ["*"], mcp_access: { mode: "deny" } }),
+      keyDoc(KEY_T1_WIDE, { team_id: TEAM1, mcp_access: { allow: ["*"] } }),
     );
+    await seed.createApiKey(keyDoc(KEY_T2, { team_id: TEAM2 }));
+    await seed.createApiKey(
+      keyDoc(KEY_NARROW, {
+        team_id: TEAM2,
+        mcp_access: { allow: ["alpha__*"], deny: ["alpha__reverse"] },
+      }),
+    );
+    await seed.createApiKey(keyDoc(KEY_BLOCKED, { mcp_access: { allow: [] } }));
 
     // Probe EVERY key to its expected steady state: keys are written at
     // higher revisions than servers/policies, but each key's list also
@@ -256,88 +250,90 @@ describe("mcp access policy e2e: env default + team entitlement + key narrowing"
     await beta?.close();
   });
 
-  test("legacy key keeps its allowed_tools scope", async (ctx) => {
+  test("a key with no block of its own takes the env layer unchanged", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
 
-    await expectList(KEY_LEGACY_SCOPED, ["alpha__echo", "alpha__reverse"]);
-    const ok = await callTool(KEY_LEGACY_SCOPED, "alpha__echo", "hi");
+    await expectList(KEY_NO_BLOCK, ENV_GRANT);
+    const ok = await callTool(KEY_NO_BLOCK, "alpha__echo", "hi");
     expect(ok).toEqual({ ok: true, text: "alpha:hi" });
-    const rejected = await callTool(KEY_LEGACY_SCOPED, "beta__echo", "hi");
-    expect(rejected.ok).toBe(false);
-    expect(rejected.error).toContain("not available");
-  });
-
-  test("policy deny subtracts from a legacy wildcard key without widening it", async (ctx) => {
-    if (!etcdReachable || !app) return ctx.skip();
-
-    // beta__reverse is hidden by the env deny even though allowed_tools=["*"].
-    await expectList(KEY_LEGACY_WILD, [
-      "alpha__echo",
-      "alpha__reverse",
-      "beta__echo",
-    ]);
-    const denied = await callTool(KEY_LEGACY_WILD, "beta__reverse", "hi");
+    // beta__reverse is allowed by `beta__*` but denied one layer up.
+    const denied = await callTool(KEY_NO_BLOCK, "beta__reverse", "hi");
     expect(denied.ok).toBe(false);
     expect(denied.error).toContain("not available");
-    const ok = await callTool(KEY_LEGACY_WILD, "beta__echo", "hi");
-    expect(ok).toEqual({ ok: true, text: "beta:hi" });
   });
 
-  test("inherit takes the env default when the key has no team", async (ctx) => {
+  test("the key layer narrows the env layer", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
 
-    await expectList(KEY_INHERIT, ["alpha__echo", "alpha__reverse"]);
-    const ok = await callTool(KEY_INHERIT, "alpha__reverse", "hi");
+    // The key asks for alpha__* plus beta__reverse; the env deny keeps
+    // beta__reverse out, so only the alpha tools survive.
+    await expectList(KEY_SCOPED, ["alpha__echo", "alpha__reverse"]);
+    const ok = await callTool(KEY_SCOPED, "alpha__reverse", "hi");
     expect(ok).toEqual({ ok: true, text: "ih" });
-    const rejected = await callTool(KEY_INHERIT, "beta__echo", "hi");
-    expect(rejected.ok).toBe(false);
-    expect(rejected.error).toContain("not available");
+    for (const tool of ["beta__echo", "beta__reverse"]) {
+      const rejected = await callTool(KEY_SCOPED, tool, "hi");
+      expect(rejected.ok).toBe(false);
+      expect(rejected.error).toContain("not available");
+    }
   });
 
-  test("a team policy replaces the env grant; the env deny survives", async (ctx) => {
+  test("a team layer narrows the env layer; the env deny survives", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
 
-    // T1 grants beta__*; the env deny on beta__reverse still subtracts.
+    // T1 allows beta__*; intersected with the env layer and minus the env
+    // deny on beta__reverse, one tool is left.
     await expectList(KEY_T1, ["beta__echo"]);
     const ok = await callTool(KEY_T1, "beta__echo", "hi");
     expect(ok).toEqual({ ok: true, text: "beta:hi" });
     const envDenied = await callTool(KEY_T1, "beta__reverse", "hi");
     expect(envDenied.ok).toBe(false);
     expect(envDenied.error).toContain("not available");
-    // The env grant (alpha__*) is replaced, not unioned.
-    const replaced = await callTool(KEY_T1, "alpha__echo", "hi");
-    expect(replaced.ok).toBe(false);
-    expect(replaced.error).toContain("not available");
+    // alpha__* is granted by the env layer but not by T1 — the layers
+    // intersect, so it is not reachable.
+    const narrowed = await callTool(KEY_T1, "alpha__echo", "hi");
+    expect(narrowed.ok).toBe(false);
+    expect(narrowed.error).toContain("not available");
   });
 
-  test("a team `all` grant covers both servers, still minus the env deny", async (ctx) => {
+  test("a wide-open key layer cannot widen the layers above it", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
 
-    await expectList(KEY_T2, ["alpha__echo", "alpha__reverse", "beta__echo"]);
+    // Same team as KEY_T1 but asking for `*`: the result is identical.
+    await expectList(KEY_T1_WIDE, ["beta__echo"]);
+    const rejected = await callTool(KEY_T1_WIDE, "alpha__echo", "hi");
+    expect(rejected.ok).toBe(false);
+    expect(rejected.error).toContain("not available");
+  });
+
+  test("a team layer of `*` leaves the env layer as the only constraint", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    await expectList(KEY_T2, ENV_GRANT);
     const denied = await callTool(KEY_T2, "beta__reverse", "hi");
     expect(denied.ok).toBe(false);
     expect(denied.error).toContain("not available");
   });
 
-  test("restrict narrows the inherited grant and never widens it", async (ctx) => {
+  test("all three layers intersect", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
 
-    // Base is team T2 `all`; the key narrows to alpha__* minus alpha__reverse.
-    await expectList(KEY_RESTRICT, ["alpha__echo"]);
-    const ok = await callTool(KEY_RESTRICT, "alpha__echo", "hi");
+    // env [alpha__*, beta__*] ∩ team T2 [*] ∩ key [alpha__*], minus the
+    // key's own deny on alpha__reverse.
+    await expectList(KEY_NARROW, ["alpha__echo"]);
+    const ok = await callTool(KEY_NARROW, "alpha__echo", "hi");
     expect(ok).toEqual({ ok: true, text: "alpha:hi" });
     for (const tool of ["alpha__reverse", "beta__echo"]) {
-      const rejected = await callTool(KEY_RESTRICT, tool, "hi");
+      const rejected = await callTool(KEY_NARROW, tool, "hi");
       expect(rejected.ok).toBe(false);
       expect(rejected.error).toContain("not available");
     }
   });
 
-  test("deny mode grants nothing, whatever allowed_tools says", async (ctx) => {
+  test("an empty allow list on the key leaves it nothing", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
 
-    await expectList(KEY_DENY, []);
-    const rejected = await callTool(KEY_DENY, "alpha__echo", "hi");
+    await expectList(KEY_BLOCKED, []);
+    const rejected = await callTool(KEY_BLOCKED, "alpha__echo", "hi");
     expect(rejected.ok).toBe(false);
     expect(rejected.error).toContain("not available");
   });
@@ -345,31 +341,26 @@ describe("mcp access policy e2e: env default + team entitlement + key narrowing"
   test("policy edits and deletes propagate through the watch path", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
 
-    // Flip T1 to `none`: its member key loses everything.
+    // Flip T1 to an empty allow list: its member keys lose everything.
     await seed.update("mcp_policies", T1_POLICY_ID, {
       scope: "team",
       scope_ref: TEAM1,
-      mode: "none",
+      allow: [],
     });
     await waitConfigPropagation(() => listMatches(KEY_T1, []));
     const rejected = await callTool(KEY_T1, "beta__echo", "hi");
     expect(rejected.ok).toBe(false);
     expect(rejected.error).toContain("not available");
 
-    // Delete the env policy: its deny stops applying to the legacy
-    // wildcard key (all four tools return), and an inherit key with no
-    // policy left anywhere falls back to no access.
+    // Delete the env policy: its deny stops applying, so the key layer of
+    // KEY_SCOPED finally admits beta__reverse — and a key with no layer
+    // left anywhere drops to no access rather than to everything.
     await seed.delete("mcp_policies", ENV_POLICY_ID);
     await waitConfigPropagation(() =>
-      listMatches(KEY_LEGACY_WILD, [
-        "alpha__echo",
-        "alpha__reverse",
-        "beta__echo",
-        "beta__reverse",
-      ]),
+      listMatches(KEY_SCOPED, ["alpha__echo", "alpha__reverse", "beta__reverse"]),
     );
-    const restored = await callTool(KEY_LEGACY_WILD, "beta__reverse", "hi");
+    const restored = await callTool(KEY_SCOPED, "beta__reverse", "hi");
     expect(restored).toEqual({ ok: true, text: "ih" });
-    await expectList(KEY_INHERIT, []);
+    await expectList(KEY_NO_BLOCK, []);
   });
 });

--- a/tests/e2e/src/cases/mcp-anonymous-access-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-anonymous-access-e2e.test.ts
@@ -171,12 +171,12 @@ describe("mcp anonymous access e2e", () => {
     const principal = await seed.createApiKey({
       key_hash: sha256(ANON_PRINCIPAL_SECRET),
       allowed_models: [],
-      allowed_tools: ["*"],
+      mcp_access: { allow: ["*"] },
     });
     await seed.createApiKey({
       key_hash: sha256(KEY_WILD),
       allowed_models: [],
-      allowed_tools: ["*"],
+      mcp_access: { allow: ["*"] },
     });
 
     await seed.update("mcp_auth_settings", settingsId, {

--- a/tests/e2e/src/cases/mcp-cleartext-credential-warn-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-cleartext-credential-warn-e2e.test.ts
@@ -72,7 +72,7 @@ describe("mcp cleartext credential warning e2e", () => {
     await seed.createApiKey({
       key_hash: sha256(KEY),
       allowed_models: [],
-      allowed_tools: ["*"],
+      mcp_access: { allow: ["*"] },
     });
 
     await waitConfigPropagation(async () => (await initialize()) === 200);

--- a/tests/e2e/src/cases/mcp-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-guardrail-e2e.test.ts
@@ -151,7 +151,7 @@ describe("mcp guardrails e2e: /mcp", () => {
     await seed.createApiKey({
       key_hash: sha256(KEY),
       allowed_models: [],
-      allowed_tools: ["*"],
+      mcp_access: { allow: ["*"] },
     });
     const proxy = new ProxyClient(app.proxyUrl, KEY);
     await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);

--- a/tests/e2e/src/cases/mcp-openapi-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-openapi-e2e.test.ts
@@ -195,12 +195,12 @@ describe("mcp openapi e2e: REST API exposed as MCP tools", () => {
     await seed.createApiKey({
       key_hash: sha256(KEY_FULL),
       allowed_models: [],
-      allowed_tools: ["*"],
+      mcp_access: { allow: ["*"] },
     });
     await seed.createApiKey({
       key_hash: sha256(KEY_SCOPED),
       allowed_models: [],
-      allowed_tools: ["erp__getitem"],
+      mcp_access: { allow: ["erp__getitem"] },
     });
 
     // Tolerant probe (no assertions): both the key and the server must have

--- a/tests/e2e/src/cases/mcp-scoped-endpoint-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-scoped-endpoint-e2e.test.ts
@@ -184,7 +184,7 @@ describe("mcp scoped endpoint e2e: /mcp/{server}", () => {
     ): Record<string, unknown> => ({
       key_hash: sha256(plaintext),
       allowed_models: [],
-      allowed_tools: allowedTools,
+      mcp_access: { allow: allowedTools },
     });
     await seed.createApiKey(keyDoc(KEY_WILD, ["*"]));
     await seed.createApiKey(keyDoc(KEY_ALPHA_ECHO, ["alpha__echo"]));

--- a/tests/e2e/src/cases/mcp-server-ratelimit-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-server-ratelimit-e2e.test.ts
@@ -159,7 +159,7 @@ describe("mcp server rate limit e2e: per api key × mcp server", () => {
     ): Record<string, unknown> => ({
       key_hash: sha256(plaintext),
       allowed_models: [],
-      allowed_tools: ["*"],
+      mcp_access: { allow: ["*"] },
       ...extra,
     });
     // Both capped keys carry the SAME alpha cap, so a shared counter would

--- a/tests/e2e/src/cases/passthrough-model-acl-e2e.test.ts
+++ b/tests/e2e/src/cases/passthrough-model-acl-e2e.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../harness/index.js";
 
 // E2E: passthrough routes are an explicit grant on the API key
-// (`allowed_routes`, mirroring `allowed_tools`/`allowed_agents`). The
+// (`allowed_routes`, mirroring `allowed_agents`). The
 // removed implicit tunnel derived authorization from the key's model ACL
 // (#449); routes carry their own dimension: a key with no grant for the
 // route's name must not reach the route's upstream credential, whatever

--- a/tests/e2e/src/cases/url-rewrite-e2e.test.ts
+++ b/tests/e2e/src/cases/url-rewrite-e2e.test.ts
@@ -154,7 +154,7 @@ describe("url rewrite e2e: proxy.url_rewrites", () => {
     await seed.createApiKey({
       key_hash: sha256(KEY),
       allowed_models: [],
-      allowed_tools: ["*"],
+      mcp_access: { allow: ["*"] },
     });
 
     await waitConfigPropagation(async () => {


### PR DESCRIPTION
MCP tool access was resolved through two different mechanisms glued together by a `mode` field: an `mcp_access.mode` of `inherit`/`restrict`/`deny` on the key, plus a `legacy` state (no block at all) where the key's `allowed_tools` was its whole grant and the policies could not reach it. A team policy *replaced* the environment grant rather than narrowing it, and `allowed_tools` and `mcp_access.allow` were two fields expressing the same thing, with `mode` deciding which one counted. The result was four key states, three policy modes, and a per-environment "migrate legacy keys" batch operation in the control plane to move keys between them.

This collapses all of it into one rule. Three layers of identical shape contribute to the ACL — the environment policy, the key's team policy, and the key's own `mcp_access` block — each carrying `allow` and `deny` pattern lists. Allow sides intersect, deny sides union, and a layer that is absent (no row, disabled, or no block on the key) imposes no constraint. With no layer present at all the grant is empty, so MCP access is still granted explicitly and never by the absence of configuration.

What that removes:

- `McpPolicy.mode` (`none`/`selected`/`all`) — `all` is `allow: ["*"]`, `none` is `allow: []`
- `McpAccess.mode` (`inherit`/`restrict`/`deny`) — inheriting is what a key does when it has no block, narrowing is what its `allow` list does, and denying everything is `allow: []`
- `ApiKey.allowed_tools` — the key's layer is `mcp_access.allow`

`allow` is now required on every layer, so a layer that only means to subtract tools has to spell its allow side `["*"]` instead of silently granting nothing. A policy or key block carrying only `deny` is a schema error, not a lockout.

Behaviour changes beyond the field shapes: a team policy now narrows the environment layer instead of replacing it, so it can no longer grant a tool the environment does not; and a key with no `mcp_access` block now follows the policy layers instead of standing outside them.

The control-plane half (schema, projection, dashboard, and the removal of the legacy-key migration flow) follows in a paired PR.
