### PR TITLE
test(mcp): pin GET/DELETE on /mcp as 405, behind authentication

### DIFF
--- a/crates/aisix-mcp/tests/protocol_generations.rs
+++ b/crates/aisix-mcp/tests/protocol_generations.rs
@@ -172,6 +172,32 @@ async fn non_loopback_host_is_served() {
     );
 }
 
+/// The sessionless serving posture means only `POST` carries MCP
+/// protocol messages: `GET` (the SSE stream a stateful server would
+/// offer) and `DELETE` (session teardown) are not served. The gateway
+/// gets this from its `legacy_session_mode = false` + no-event-store
+/// configuration rather than from its own code, so pin it here — an SDK
+/// upgrade that starts serving either verb by default would otherwise
+/// change the endpoint's wire surface with nothing failing.
+#[tokio::test]
+async fn get_and_delete_are_not_served() {
+    let addr = spawn_gateway().await;
+    let client = reqwest::Client::new();
+    for method in [reqwest::Method::GET, reqwest::Method::DELETE] {
+        let response = client
+            .request(method.clone(), format!("http://{addr}/mcp"))
+            .header("accept", "application/json, text/event-stream")
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(
+            response.status(),
+            405,
+            "{method} /mcp must not be served on a sessionless endpoint"
+        );
+    }
+}
+
 /// `server/discover` advertises exactly the supported list — the same list
 /// `initialize` negotiates against and the proxy header gate enforces.
 #[tokio::test]

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -2417,6 +2417,51 @@ mod tests {
         }
     }
 
+    /// Method handling sits BEHIND authentication: an unauthenticated
+    /// `GET`/`DELETE` on `/mcp` is rejected as unauthorized, and only an
+    /// authenticated one reaches the sessionless endpoint's `405`. The
+    /// order matters — answering `405` first would tell an anonymous
+    /// caller which paths exist.
+    #[tokio::test]
+    async fn get_and_delete_are_authenticated_before_method_handling() {
+        for method in ["GET", "DELETE"] {
+            let anonymous = HttpRequest::builder()
+                .method(method)
+                .uri("/mcp")
+                .header("host", "mcp.aisix.example.com")
+                .header("accept", "application/json, text/event-stream")
+                .body(Body::empty())
+                .unwrap();
+            let response = router_with(snapshot_with_key())
+                .oneshot(anonymous)
+                .await
+                .expect("router responds");
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "{method} /mcp must authenticate before it decides on the method"
+            );
+
+            let authenticated = HttpRequest::builder()
+                .method(method)
+                .uri("/mcp")
+                .header("host", "mcp.aisix.example.com")
+                .header("accept", "application/json, text/event-stream")
+                .header("authorization", format!("Bearer {TOKEN}"))
+                .body(Body::empty())
+                .unwrap();
+            let response = router_with(snapshot_with_key())
+                .oneshot(authenticated)
+                .await
+                .expect("router responds");
+            assert_eq!(
+                response.status(),
+                StatusCode::METHOD_NOT_ALLOWED,
+                "an authenticated {method} /mcp is not served on a sessionless endpoint"
+            );
+        }
+    }
+
     /// Hostile header values cannot abuse the rejection envelope: an
     /// overlong value is truncated to 64 echoed characters, a non-ASCII
     /// (obs-text) value gets the static message (never echoed), and an


### PR DESCRIPTION
Closes #991.

## What

`/mcp` serves POST only — `GET` (the SSE stream a stateful server would offer) and `DELETE` (session teardown) return `405`. The docs state it, but no test in this repo pinned it: the behavior came from the vendored SDK's dispatch arm under `legacy_session_mode = false` + no event store, so an SDK upgrade that started serving either verb by default would have changed the endpoint's wire surface with nothing going red.

Two layers, matching where each guarantee actually lives:

- `crates/aisix-mcp/tests/protocol_generations.rs` — the gateway service answers `405` for both verbs. Revert-checked: flipping `legacy_session_mode` to `true` fails it.
- `crates/aisix-proxy/src/mcp.rs` — the ordering. An anonymous `GET`/`DELETE` is `401`; only an authenticated one reaches `405`, so the endpoint doesn't disclose which paths exist to an unauthenticated caller.

## Verification

`cargo test -p aisix-mcp -p aisix-proxy` green; both new tests confirmed to fail when the behavior they pin is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsupported GET and DELETE requests to the MCP endpoint.
  * Unauthenticated requests now correctly return an authorization error before method validation.

* **Tests**
  * Added regression coverage for sessionless and authenticated MCP request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->