### PR TITLE
fix(audio): relay a streamed transcription live, and quiet the metadata-probe WARNs

### DIFF
--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -55,8 +55,11 @@ pub enum ObsError {
     AlreadyInitialised,
 }
 
-/// Third-party log targets pinned below WARN, applied last so they hold
-/// whatever the operator asked for otherwise.
+/// Third-party log targets pinned below WARN. Applied after the
+/// configured level and after `RUST_LOG`, so they hold for these targets
+/// either way — a `log`-crate record's level is fixed at its callsite and
+/// a subscriber can only filter it, never re-level it, so keeping these
+/// out of the log is the available form of "not a warning".
 ///
 /// `lofty` is the audio-metadata reader behind the transcription duration
 /// probe (`aisix-proxy::audio`). Every real mp3 upload logs one or more

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -55,14 +55,41 @@ pub enum ObsError {
     AlreadyInitialised,
 }
 
-/// Install a process-wide tracing subscriber.
-pub fn init_tracing(cfg: &ObservabilityConfig) -> Result<(), ObsError> {
-    let filter = EnvFilter::try_from_default_env()
+/// Third-party log targets pinned below WARN, applied last so they hold
+/// whatever the operator asked for otherwise.
+///
+/// `lofty` is the audio-metadata reader behind the transcription duration
+/// probe (`aisix-proxy::audio`). Every real mp3 upload logs one or more
+/// parse observations at WARN — `Chunk exceeds reader size, stopping`,
+/// `MPEG: Using bitrate to estimate duration` — that describe the
+/// uploaded container, not a gateway fault, and that no operator can act
+/// on: the probe already treats an unreadable file as a zero cost basis
+/// rather than an error. Left at WARN they turn every transcription into
+/// a warning line and fail the e2e log scan (#998).
+const QUIET_TARGETS: &[&str] = &["lofty=error"];
+
+/// The subscriber's level filter: `RUST_LOG` when set, else the
+/// configured level, with [`QUIET_TARGETS`] applied on top.
+fn build_filter(cfg: &ObservabilityConfig) -> Result<EnvFilter, ObsError> {
+    let mut filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new(&cfg.log_level))
         .map_err(|source| ObsError::Filter {
             directive: cfg.log_level.clone(),
             source,
         })?;
+    for directive in QUIET_TARGETS {
+        filter = filter.add_directive(
+            directive
+                .parse()
+                .expect("QUIET_TARGETS holds valid filter directives"),
+        );
+    }
+    Ok(filter)
+}
+
+/// Install a process-wide tracing subscriber.
+pub fn init_tracing(cfg: &ObservabilityConfig) -> Result<(), ObsError> {
+    let filter = build_filter(cfg)?;
 
     // Colorize only for a human at a terminal. When stderr is a pipe or a
     // file — every real deployment, where logs go to a container runtime and
@@ -93,6 +120,60 @@ pub fn init_tracing(cfg: &ObservabilityConfig) -> Result<(), ObsError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    /// Collect emitted log bytes into an in-memory buffer.
+    #[derive(Clone, Default)]
+    struct VecWriter {
+        buf: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    }
+    impl std::io::Write for VecWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.buf.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl<'a> MakeWriter<'a> for VecWriter {
+        type Writer = VecWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// #998: the audio-metadata reader's parse chatter must not reach the
+    /// log as a WARN, while the gateway's own WARNs still do.
+    #[test]
+    fn quiet_targets_drop_lofty_warnings_only() {
+        let writer = VecWriter::default();
+        let cfg = ObservabilityConfig {
+            log_level: "info".into(),
+            ..Default::default()
+        };
+        let subscriber = tracing_subscriber::registry()
+            .with(build_filter(&cfg).expect("filter builds"))
+            .with(fmt::layer().with_ansi(false).with_writer(writer.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!(target: "lofty::mpeg::properties", "MPEG: Using bitrate to estimate duration");
+            tracing::error!(target: "lofty::iff::chunk", "unreadable");
+            tracing::warn!(target: "aisix_proxy::audio", "transcription failed");
+        });
+        let logged = String::from_utf8_lossy(&writer.buf.lock().unwrap()).into_owned();
+        assert!(
+            !logged.contains("Using bitrate"),
+            "lofty WARN chatter must be filtered out, got: {logged}"
+        );
+        assert!(
+            logged.contains("unreadable"),
+            "a lofty ERROR must still surface, got: {logged}"
+        );
+        assert!(
+            logged.contains("transcription failed"),
+            "the gateway's own WARNs must be unaffected, got: {logged}"
+        );
+    }
 
     #[test]
     fn already_initialised_variant_is_displayable() {

--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -28,6 +28,46 @@ interval) so a model that is slow to its first token doesn't look like an
 abandoned connection to a proxy in front. Only for SSE: the same wrapper on an
 opaque binary passthrough (audio, images) corrupts it.
 
+## Turning a buffered relay into a streamed one moves four things, not one
+
+Swapping `resp.bytes()` for `resp.bytes_stream()` is the visible part of the
+change and the least of it. The handler now returns while the response is still
+being delivered, and three request-scoped things that used to be finished by then
+are not — none of which errors when missed:
+
+- **The reqwest request-level timeout has to go.** `RequestBuilder::timeout`
+  bounds the body read too, so it cuts a long stream off mid-response. Bound the
+  connect phase with `stream_timeout::send_with_deadline` and each chunk with
+  `stream_timeout::with_read_timeout_bytes`, both from the model's `stream`
+  budget (`routing::effective_timeouts`).
+- **The rate-limit reservation has to become a `into_stream_hold()`.** Dropping it
+  at handler return releases the concurrency slot while the stream is still
+  running, which is how a key capped at N serves more than N at once (#450). The
+  terminal token cost then rides `Limiter::add_tokens_post_stream` instead of
+  `commit_tokens`.
+- **The UsageEvent moves into the stream's Drop guard.** Counts that arrive on a
+  terminal SSE event are unknown at handler return, so the guard owns the emit —
+  fired at end-of-stream AND on client disconnect, since SDKs routinely close on
+  the terminal frame. Whatever flag says "the guard owns it" must gate the
+  handler's own emit, or the request is counted twice.
+- **A block- or mask-capable output guardrail keeps the buffered path.** It has to
+  see the whole response before any of it reaches the caller, or the streaming
+  request is a way around the check the same request gets without it. That is
+  `runs_on_output(chain) && chain.stream_output_policy().holds_back()`. A
+  monitor-only chain resolves to `EndOfStreamCheck` and must NOT hold the stream
+  back (AISIX-Cloud#1010) — it takes the live path and scans once at
+  end-of-stream via `guardrail_stream::EosOutputScan`.
+
+Retry semantics change too, and that is intended: the retryable unit ends at the
+status check, because once the first frame is on the wire there is no failing
+over left to do.
+
+An e2e that asserts the response CONTENT cannot see any of this — a buffered relay
+and a streamed one return identical bytes. Assert the delivery shape instead: a
+mock upstream that trickles its response over ~1s, and a client read loop that
+counts chunks and measures first-byte against last-byte
+(`audio-stream-relay-e2e.test.ts`).
+
 ## Every terminal path emits the access log — including the ones that give up early
 
 The access log and `request_metrics::record` are emitted **by the handler**, at

--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -32,8 +32,9 @@ opaque binary passthrough (audio, images) corrupts it.
 
 Swapping `resp.bytes()` for `resp.bytes_stream()` is the visible part of the
 change and the least of it. The handler now returns while the response is still
-being delivered, and three request-scoped things that used to be finished by then
-are not — none of which errors when missed:
+being delivered, so three request-scoped things that used to be finished by then
+are not — and a fourth rule decides whether the path may stream at all. None of
+the four errors when missed:
 
 - **The reqwest request-level timeout has to go.** `RequestBuilder::timeout`
   bounds the body read too, so it cuts a long stream off mid-response. Bound the

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -650,18 +650,46 @@ where
     // its `request_id` correlation (AISIX-Cloud#1060).
     crate::request_id::in_request_span(async_stream::stream! {
         let mut guard = TranscriptGuard { slot: Some((on_complete, StreamedTranscript::default())) };
-        let mut decoder = aisix_gateway::SseDecoder::new();
+        // `None` once the side-channel parse has been abandoned; the
+        // relay itself carries on either way.
+        let mut decoder = Some(aisix_gateway::SseDecoder::new());
+        // Bytes fed since the decoder last unlocked a frame. The decoder
+        // holds an unterminated frame indefinitely, so an upstream that
+        // streams without a `\n\n` terminator would grow it without
+        // bound; drop the parse at the cap (losing telemetry for that
+        // pathological case) rather than OOM. Same bound and same trade
+        // as the `/v1/responses` passthrough.
+        let mut unterminated: usize = 0;
         futures::pin_mut!(upstream);
         while let Some(item) = upstream.next().await {
-            if let Ok(bytes) = &item {
+            if let (Ok(bytes), Some(d)) = (&item, decoder.as_mut()) {
                 // Side-channel parse over a copy of the frames; `item` is
                 // yielded below untouched.
-                let events = decoder.feed(bytes.as_ref());
+                let events = d.feed(bytes.as_ref());
+                unterminated = if events.is_empty() {
+                    unterminated + bytes.len()
+                } else {
+                    0
+                };
                 observe_transcript_events(guard.observed(), &events, text_cap);
+                if unterminated > crate::messages::MAX_SSE_FRAME_BUF_BYTES {
+                    tracing::warn!(
+                        buffered = unterminated,
+                        "transcription stream: no SSE frame terminator within the buffer cap; \
+                         dropping the parse (usage and capture skipped)"
+                    );
+                    decoder = None;
+                }
             }
             yield item;
         }
-        observe_transcript_events(guard.observed(), &decoder.finish().into_iter().collect::<Vec<_>>(), text_cap);
+        if let Some(mut d) = decoder.take() {
+            observe_transcript_events(
+                guard.observed(),
+                &d.finish().into_iter().collect::<Vec<_>>(),
+                text_cap,
+            );
+        }
         // Upstream EOF — the response was delivered in full. Recorded
         // before the scan below, which awaits a remote provider and is a
         // routine drop point for clients that close on the terminal frame.
@@ -1021,8 +1049,11 @@ async fn multipart_dispatch(
     let tracker = &state.runtime_status;
     let model_id: &str = &model_entry.id;
     let cooldown_cfg = model.cooldown.as_ref();
-    // Send, check the status, and read the body as one retryable unit. See
-    // the same shape in rerank.rs for why `note_failure` stays per attempt.
+    // Send, check the status, and — unless the answer is a stream being
+    // relayed — read the body as one retryable unit. See the same shape in
+    // rerank.rs for why `note_failure` stays per attempt. A relayed stream
+    // leaves the retryable unit at the status check: once its first frame
+    // is on the wire there is no failing over left to do.
     let timeouts = crate::routing::effective_timeouts(model, None, state.default_timeouts);
     let request_budget = timeouts.request;
     let stream_budget = timeouts.stream;

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -54,6 +54,12 @@ struct AudioDispatchSuccess {
     /// whisper-1 (no usage block) — those still emit a zero-token event
     /// so the request is visible + attributed.
     usage: Option<(u32, u32)>,
+    /// Set on the streamed-transcription relay (#998): the SSE frames are
+    /// consumed by the caller after this handler returns, so the terminal
+    /// event's counts are only known inside the stream — its Drop guard
+    /// owns the UsageEvent and `usage` stays `None` here. Guards the
+    /// handler against a second, zero-token emit.
+    usage_handled_by_stream: bool,
     /// Audio length in seconds — the cost basis for the duration-billed
     /// models (whisper-1), which report no tokens at all (#457).
     duration_seconds: f64,
@@ -160,18 +166,24 @@ pub async fn transcriptions(
                 status,
                 elapsed,
             );
-            emit_audio_usage(
-                &state,
-                &snapshot,
-                &pk,
-                &request_id,
-                "/v1/audio/transcriptions",
-                &success,
-                &api_key_id,
-                status,
-                elapsed,
-                &client,
-            );
+            // #998: the streamed relay's Drop guard emits the event once
+            // the terminal `transcript.text.done` has been parsed off the
+            // wire; emitting here too would double-count the request with
+            // zero tokens.
+            if !success.usage_handled_by_stream {
+                emit_audio_usage(
+                    &state,
+                    &snapshot,
+                    &pk,
+                    &request_id,
+                    "/v1/audio/transcriptions",
+                    &success,
+                    &api_key_id,
+                    status,
+                    elapsed,
+                    &client,
+                );
+            }
             success.response
         }
         Err(err) => {
@@ -306,18 +318,24 @@ pub async fn translations(
                 status,
                 elapsed,
             );
-            emit_audio_usage(
-                &state,
-                &snapshot,
-                &pk,
-                &request_id,
-                "/v1/audio/translations",
-                &success,
-                &api_key_id,
-                status,
-                elapsed,
-                &client,
-            );
+            // #998: the streamed relay's Drop guard emits the event once
+            // the terminal `transcript.text.done` has been parsed off the
+            // wire; emitting here too would double-count the request with
+            // zero tokens.
+            if !success.usage_handled_by_stream {
+                emit_audio_usage(
+                    &state,
+                    &snapshot,
+                    &pk,
+                    &request_id,
+                    "/v1/audio/translations",
+                    &success,
+                    &api_key_id,
+                    status,
+                    elapsed,
+                    &client,
+                );
+            }
             success.response
         }
         Err(err) => {
@@ -530,6 +548,172 @@ pub async fn speech(
 // Shared dispatch functions
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// What one upstream audio call handed back.
+///
+/// A transcription is normally read whole — the usage block, the duration,
+/// the output-guardrail scan and the PII mask all need the body in hand.
+/// A `stream=true` request answered with `text/event-stream` is the
+/// exception (#998): its frames are relayed to the caller as they arrive,
+/// so the response is carried live instead of as bytes.
+enum AudioUpstreamBody {
+    Buffered(Bytes),
+    Live(reqwest::Response),
+}
+
+/// Whether an upstream response is an SSE stream.
+fn is_event_stream(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.starts_with("text/event-stream"))
+}
+
+/// What the relayed transcription stream observed by the time it ended.
+#[derive(Default)]
+struct StreamedTranscript {
+    /// `(prompt, completion)` off the terminal event's `usage` block —
+    /// `None` when the stream ended before one arrived (a client that
+    /// disconnected, an upstream that reports no tokens).
+    usage: Option<(u32, u32)>,
+    /// The transcript assembled from the `transcript.text.delta` events,
+    /// capped at the exporter's content-capture limit. Empty when no
+    /// exporter asked for content and no output chain needs a scan.
+    text: String,
+    /// False when the caller disconnected before the upstream ended.
+    reached_end: bool,
+    /// End-of-stream monitor observations (AISIX-Cloud#1010).
+    output_hits: Vec<aisix_core::GuardrailMonitorHit>,
+}
+
+/// Fires `on_complete` exactly once with what the relay saw — at
+/// end-of-stream AND on client-disconnect, where the generator is simply
+/// dropped at its suspension point. Same shape as the `/v1/responses`
+/// and chat.rs stream guards: without it a caller that closes the
+/// connection on the terminal frame takes the whole UsageEvent with it.
+struct TranscriptGuard<F: FnOnce(StreamedTranscript)> {
+    slot: Option<(F, StreamedTranscript)>,
+}
+
+impl<F: FnOnce(StreamedTranscript)> TranscriptGuard<F> {
+    fn observed(&mut self) -> &mut StreamedTranscript {
+        &mut self
+            .slot
+            .as_mut()
+            .expect("TranscriptGuard accessed after take")
+            .1
+    }
+}
+
+impl<F: FnOnce(StreamedTranscript)> Drop for TranscriptGuard<F> {
+    fn drop(&mut self) {
+        if let Some((f, observed)) = self.slot.take() {
+            f(observed);
+        }
+    }
+}
+
+/// Relay a streamed transcription verbatim while reading its telemetry off
+/// the same bytes (#998).
+///
+/// The caller gets the upstream's exact SSE wire shape — every frame
+/// forwarded unchanged, as it arrives — and a side-channel decoder pulls
+/// the `transcript.text.delta` text and the terminal
+/// `transcript.text.done` usage block out of the copy. `on_complete` fires
+/// once the upstream ends or the caller disconnects, whichever comes
+/// first; it owns the UsageEvent for this request.
+///
+/// `capture_cap` bounds the assembled transcript; an output chain that
+/// needs a scan raises the floor to its own scan bound, so neither
+/// consumer sees past its own limit.
+fn transcription_relay<S, F>(
+    upstream: S,
+    content_cap: Option<u32>,
+    eos_scan: Option<crate::guardrail_stream::EosOutputScan>,
+    on_complete: F,
+) -> impl futures::Stream<Item = reqwest::Result<Bytes>> + Send
+where
+    S: futures::Stream<Item = reqwest::Result<Bytes>> + Send + 'static,
+    F: FnOnce(StreamedTranscript) + Send + 'static,
+{
+    use futures::StreamExt as _;
+
+    let text_cap = content_cap
+        .map(|cap| cap as usize)
+        .unwrap_or(0)
+        .max(if eos_scan.is_some() {
+            aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES
+        } else {
+            0
+        });
+    // Re-attach the request span: the body is polled after the request-id
+    // middleware returns, so anything logged from here would otherwise lose
+    // its `request_id` correlation (AISIX-Cloud#1060).
+    crate::request_id::in_request_span(async_stream::stream! {
+        let mut guard = TranscriptGuard { slot: Some((on_complete, StreamedTranscript::default())) };
+        let mut decoder = aisix_gateway::SseDecoder::new();
+        futures::pin_mut!(upstream);
+        while let Some(item) = upstream.next().await {
+            if let Ok(bytes) = &item {
+                // Side-channel parse over a copy of the frames; `item` is
+                // yielded below untouched.
+                let events = decoder.feed(bytes.as_ref());
+                observe_transcript_events(guard.observed(), &events, text_cap);
+            }
+            yield item;
+        }
+        observe_transcript_events(guard.observed(), &decoder.finish().into_iter().collect::<Vec<_>>(), text_cap);
+        // Upstream EOF — the response was delivered in full. Recorded
+        // before the scan below, which awaits a remote provider and is a
+        // routine drop point for clients that close on the terminal frame.
+        guard.observed().reached_end = true;
+        if let Some(scan) = eos_scan {
+            // The guard stays armed across the await: an SDK that closes
+            // on the terminal frame drops this generator here, and the
+            // Drop emit must still carry the usage it already parsed.
+            let text = guard.observed().text.clone();
+            let hits = scan.observe(&text).await;
+            guard.observed().output_hits = hits;
+        }
+        if let Some((f, observed)) = guard.slot.take() {
+            f(observed);
+        }
+    })
+}
+
+/// Fold one batch of decoded SSE events into the running observation:
+/// `transcript.text.delta` appends to the transcript (bounded by `cap`),
+/// and any event carrying a `usage` block updates the counts — the last
+/// one wins, so a provider that reports usage on a later event than
+/// `transcript.text.done` is read the same way.
+fn observe_transcript_events(
+    observed: &mut StreamedTranscript,
+    events: &[aisix_gateway::SseEvent],
+    cap: usize,
+) {
+    for event in events {
+        let aisix_gateway::SseEvent::Data(payload) = event else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(payload) else {
+            continue;
+        };
+        if let Some(usage) = extract_token_usage(&value) {
+            observed.usage = Some(usage);
+        }
+        if observed.text.len() >= cap {
+            continue;
+        }
+        if let Some(delta) = value.get("delta").and_then(Value::as_str) {
+            let room = cap - observed.text.len();
+            let mut end = delta.len().min(room);
+            while end > 0 && !delta.is_char_boundary(end) {
+                end -= 1;
+            }
+            observed.text.push_str(&delta[..end]);
+        }
+    }
+}
+
 /// Collect all multipart fields, resolve the model, swap in the upstream
 /// model id, then rebuild and forward the multipart form.
 async fn multipart_dispatch(
@@ -547,6 +731,12 @@ async fn multipart_dispatch(
     request_id: &str,
     client_ctx: &ClientContext,
 ) -> Result<AudioDispatchSuccess, ProxyError> {
+    // The request clock for the streamed relay's end-of-stream emit
+    // (#998): the handler has long returned by the time it fires, so it
+    // can't read `started` there. Taken before the upload is drained, so
+    // it measures the same span the handler's own clock does.
+    let dispatch_started = Instant::now();
+
     // Collect all fields first so we can find `model` before building the
     // outgoing reqwest multipart.
     let mut fields: Vec<(String, Option<String>, Option<String>, Bytes)> = Vec::new();
@@ -579,6 +769,15 @@ async fn multipart_dispatch(
         .map(|s| s.trim().to_string())
         .ok_or_else(|| ProxyError::InvalidRequest("`model` field missing from form".into()))?;
 
+    // `stream=true` asks for the transcript incrementally: the transcribe
+    // models answer with `text/event-stream` instead of a JSON object.
+    // Known before the request is built because it decides the timeout
+    // shape — reqwest's request-level timeout bounds the body read too, so
+    // it would cut a relayed stream off mid-transcript (#998).
+    let stream_requested = fields.iter().any(|(name, _, _, data)| {
+        name == "stream" && std::str::from_utf8(data).map(str::trim) == Ok("true")
+    });
+
     let snapshot = &**snapshot_out.insert(state.snapshot.load());
     let model_entry = crate::model_resolve::resolve_model(snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
@@ -604,6 +803,19 @@ async fn multipart_dispatch(
     };
     let resolved_chain = state.guardrail_index.resolve(&guardrail_ctx);
     let applied_guardrails = resolved_chain.applied().to_vec();
+
+    // #998: relay the upstream SSE live, or hold it back to scan it?
+    // An output guardrail that can block or mask has to see the whole
+    // transcript before any of it reaches the caller — otherwise
+    // `stream=true` is a bypass for the check the non-streaming request
+    // gets — so a hold-back chain keeps the buffered relay, the same
+    // secure default the chat / responses surfaces use (#719). A
+    // monitor-only chain resolves to `EndOfStreamCheck`: it can never
+    // block, so it must NOT change delivery (AISIX-Cloud#1010) and takes
+    // the live path, scanning once at end-of-stream.
+    let live_relay = stream_requested
+        && !(aisix_guardrails::Guardrail::runs_on_output(&resolved_chain)
+            && aisix_guardrails::Guardrail::stream_output_policy(&resolved_chain).holds_back());
     let mut redactions = crate::redact::RedactionCounts::new();
     let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     if !resolved_chain.is_empty() {
@@ -811,22 +1023,31 @@ async fn multipart_dispatch(
     let cooldown_cfg = model.cooldown.as_ref();
     // Send, check the status, and read the body as one retryable unit. See
     // the same shape in rerank.rs for why `note_failure` stays per attempt.
-    let (upstream_headers, body_bytes) =
+    let timeouts = crate::routing::effective_timeouts(model, None, state.default_timeouts);
+    let request_budget = timeouts.request;
+    let stream_budget = timeouts.stream;
+    let (upstream_headers, upstream_body) =
         match crate::routing::retrying_dispatch(state, model, retry_endpoint_label, || {
             let mut req = url
                 .clone()
                 .post_on(&client)
                 .headers(headers.clone())
                 .multipart(build_form());
-            // #554/#911: audio transcription/translation is non-streaming; apply
-            // the per-model E2E request timeout like the other direct-upstream
-            // paths (count_tokens/rerank/responses) so a slow/blackholed audio
-            // provider fails over and the model's timeout cooldown can engage.
-            if let Some(d) =
-                crate::routing::effective_timeouts(model, None, state.default_timeouts).request
-            {
-                req = req.timeout(d);
+            // #554/#911: a buffered audio call takes the per-model E2E
+            // request timeout like the other direct-upstream paths
+            // (count_tokens/rerank/responses), so a slow/blackholed audio
+            // provider fails over and the model's timeout cooldown can
+            // engage. A relayed stream must NOT carry it: reqwest's
+            // request-level timeout bounds the body read too, so it would
+            // cut the transcript off mid-stream (#998). That path bounds the
+            // connect phase and each chunk by the stream budget instead —
+            // the same split `/v1/responses` uses.
+            if !live_relay {
+                if let Some(d) = request_budget {
+                    req = req.timeout(d);
+                }
             }
+            let connect_deadline = if live_relay { stream_budget } else { None };
             async move {
                 // `reqwest_error_to_bridge`, not a bare `Transport`: an
                 // elapsed `timeout` has to surface as `BridgeError::Timeout`
@@ -836,14 +1057,12 @@ async fn multipart_dispatch(
                 // timeout as transport made the model's own timeout get
                 // retried, turning a 400ms budget into ~2s.
                 let send_started = Instant::now();
-                let resp = req.send().await.map_err(|e| {
-                    crate::cooldown::note_failure(
-                        tracker,
-                        model_id,
-                        cooldown_cfg,
-                        crate::dispatch::reqwest_error_to_bridge(&e, send_started),
-                    )
-                })?;
+                let resp =
+                    crate::stream_timeout::send_with_deadline(req, connect_deadline, send_started)
+                        .await
+                        .map_err(|be| {
+                            crate::cooldown::note_failure(tracker, model_id, cooldown_cfg, be)
+                        })?;
 
                 let status = resp.status();
                 if !status.is_success() {
@@ -864,15 +1083,36 @@ async fn multipart_dispatch(
 
                 // Relay response headers that matter for the client.
                 let upstream_headers = resp.headers().clone();
-                let body_bytes = resp.bytes().await.map_err(|e| {
-                    crate::cooldown::note_failure(
-                        tracker,
-                        model_id,
-                        cooldown_cfg,
-                        aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
-                    )
+                // The caller asked to stream and the upstream answered one:
+                // hand the live response on so its frames reach the caller
+                // as they arrive (#998). Everything else — including a
+                // provider that ignored `stream=true` and replied with a
+                // JSON transcript — is read whole, so the usage, duration
+                // and output-guardrail passes below still see a body.
+                if live_relay && is_event_stream(&upstream_headers) {
+                    return Ok((upstream_headers, AudioUpstreamBody::Live(resp)));
+                }
+                let read = async {
+                    match stream_budget.filter(|_| live_relay) {
+                        // No request-level timeout was set on the live path,
+                        // so bound this read rather than leaving it open.
+                        Some(d) => tokio::time::timeout(d, resp.bytes())
+                            .await
+                            .map_err(|_| aisix_gateway::BridgeError::Timeout {
+                                elapsed_ms: d.as_millis() as u64,
+                                cause: String::new(),
+                            })?
+                            .map_err(|e| aisix_gateway::BridgeError::UpstreamDecode(e.to_string())),
+                        None => resp
+                            .bytes()
+                            .await
+                            .map_err(|e| aisix_gateway::BridgeError::UpstreamDecode(e.to_string())),
+                    }
+                };
+                let body_bytes = read.await.map_err(|be| {
+                    crate::cooldown::note_failure(tracker, model_id, cooldown_cfg, be)
                 })?;
-                Ok((upstream_headers, body_bytes))
+                Ok((upstream_headers, AudioUpstreamBody::Buffered(body_bytes)))
             }
         })
         .await
@@ -883,6 +1123,143 @@ async fn multipart_dispatch(
 
     state.health.record_success(&model_entry.value.display_name);
     state.runtime_status.mark_healthy(&model_entry.id);
+
+    let body_bytes = match upstream_body {
+        AudioUpstreamBody::Buffered(bytes) => bytes,
+        // #998: forward the upstream's SSE frames as they arrive. The
+        // caller sees the same wire bytes it would get straight from the
+        // provider, at the same pace; a side-channel decoder reads the
+        // terminal `transcript.text.done` off the same stream so the
+        // request is still billed and attributed.
+        AudioUpstreamBody::Live(resp) => {
+            // Duration cost basis (#457): a streamed transcription reports
+            // no duration anywhere — the terminal event carries tokens
+            // only — so the uploaded file is the only basis. Probed here,
+            // while `fields` is still in scope.
+            let duration_seconds = fields
+                .iter()
+                .find(|(name, ..)| name == "file")
+                .and_then(|(.., data)| probe_audio_duration_seconds(data))
+                .unwrap_or(0.0);
+
+            // #450/#688: the reservation outlives the handler. The
+            // concurrency slot stays held until the stream ends, and the
+            // terminal token cost is applied to TPM/TPD from the guard —
+            // the sync analog of the buffered path's `commit_tokens`.
+            let post_stream_keys = reservation.keys();
+            let stream_hold = reservation.into_stream_hold();
+            let limiter = std::sync::Arc::clone(&state.limiter);
+
+            // Monitor-only output chains still get their end-of-stream
+            // observation (AISIX-Cloud#1010); a block-capable chain never
+            // reaches here — `live_relay` sent it down the buffered path.
+            let eos_scan =
+                aisix_guardrails::Guardrail::runs_on_output(&resolved_chain).then(|| {
+                    crate::guardrail_stream::EosOutputScan::new(
+                        std::sync::Arc::new(resolved_chain),
+                        upstream_model.clone(),
+                    )
+                });
+
+            let state_c = state.clone();
+            let request_id_c = request_id.to_string();
+            let model_id_c = model_entry.id.to_string();
+            let model_name_c = model_name.clone();
+            let provider_c = provider_label.clone();
+            let upstream_model_c = upstream_model.clone();
+            let pk_id_c = pk_entry.id.to_string();
+            let api_key_id_c = auth.entry.id.clone();
+            let applied_c = applied_guardrails.clone();
+            let redactions_c = redactions.clone();
+            let input_monitor_hits = monitor_hits.clone();
+            let client_c = client_ctx.clone();
+            let captured_prompt_c = captured_prompt.clone();
+
+            let relayed = transcription_relay(
+                crate::stream_timeout::with_read_timeout_bytes(resp.bytes_stream(), stream_budget),
+                content_cap,
+                eos_scan,
+                move |outcome| {
+                    let (prompt_tokens, completion_tokens) = outcome.usage.unwrap_or((0, 0));
+                    let total = u64::from(prompt_tokens) + u64::from(completion_tokens);
+                    for key in &post_stream_keys {
+                        limiter.add_tokens_post_stream(key, total);
+                    }
+                    drop(stream_hold);
+                    // A stream can outlive several config generations, so
+                    // the end-of-stream emit reads a FRESH snapshot rather
+                    // than the one the request started on (#941).
+                    let snap = state_c.snapshot.load();
+                    let pk = crate::usage_attr::ResolvedPk::resolve(&snap, &pk_id_c);
+                    let mut monitor_hits = input_monitor_hits;
+                    monitor_hits.extend(outcome.output_hits);
+                    let captured_content = match (&captured_prompt_c, content_cap) {
+                        (Some(prompt), Some(cap)) => {
+                            Some(CapturedContent::new(prompt, &outcome.text, cap as usize))
+                        }
+                        _ => None,
+                    };
+                    emit_usage_event(
+                        &state_c,
+                        &snap,
+                        &pk,
+                        &request_id_c,
+                        &model_id_c,
+                        &model_name_c,
+                        &api_key_id_c,
+                        retry_endpoint_label,
+                        &provider_c,
+                        &upstream_model_c,
+                        &applied_c,
+                        // A caller that walked away mid-transcript is
+                        // reported as 499, matching the other streaming
+                        // surfaces — the upstream work still happened, so
+                        // the event is emitted either way.
+                        if outcome.reached_end {
+                            200
+                        } else {
+                            crate::CLIENT_CLOSED_REQUEST
+                        },
+                        dispatch_started.elapsed(),
+                        prompt_tokens,
+                        completion_tokens,
+                        duration_seconds,
+                        &client_c,
+                        redactions_c,
+                        monitor_hits,
+                        /* guardrail_blocked */ false,
+                        captured_content.as_ref(),
+                    );
+                },
+            );
+            let mut out = axum::response::Response::new(axum::body::Body::from_stream(
+                crate::sse_keepalive::with_heartbeat(
+                    Box::pin(relayed),
+                    crate::sse_keepalive::interval(),
+                ),
+            ));
+            copy_response_header(&upstream_headers, &mut out, header::CONTENT_TYPE);
+            return Ok(AudioDispatchSuccess {
+                usage_handled_by_stream: true,
+                response: out,
+                model_name,
+                provider: provider_label,
+                model_id: model_entry.id.to_string(),
+                provider_key_id: pk_entry.id.to_string(),
+                upstream_model,
+                // The Drop guard owns the emit; the handler must not
+                // double-emit with the counts it cannot see yet.
+                usage: None,
+                duration_seconds,
+                applied_guardrails,
+                redactions,
+                monitor_hits,
+                guardrail_blocked: false,
+                // The guard's emit carries the captured content too.
+                captured_content: None,
+            });
+        }
+    };
 
     // Parse the response body best-effort for a `usage` token block
     // (gpt-4o-transcribe returns one; whisper-1 returns none, and the
@@ -952,6 +1329,7 @@ async fn multipart_dispatch(
                     "guardrail blocked audio transcript response",
                 );
                 return Ok(AudioDispatchSuccess {
+                    usage_handled_by_stream: false,
                     response: ProxyError::ContentFiltered(crate::error::guardrail_block_message(
                         "response",
                         guardrail_name.as_deref(),
@@ -1002,6 +1380,7 @@ async fn multipart_dispatch(
     let mut out = axum::response::Response::new(axum::body::Body::from(body_bytes));
     copy_response_header(&upstream_headers, &mut out, header::CONTENT_TYPE);
     Ok(AudioDispatchSuccess {
+        usage_handled_by_stream: false,
         response: out,
         model_name,
         provider: provider_label,
@@ -1238,22 +1617,29 @@ async fn speech_dispatch(
     let tracker = &state.runtime_status;
     let model_id: &str = &model_entry.id;
     let cooldown_cfg = model.cooldown.as_ref();
-    // Send, check the status, and read the body as one retryable unit. See
-    // the same shape in rerank.rs for why `note_failure` stays per attempt.
-    let (upstream_headers, body_bytes) =
+    // Send and check the status as one retryable unit; the audio bytes are
+    // relayed, not read here. See the same shape in rerank.rs for why
+    // `note_failure` stays per attempt.
+    //
+    // #998: the synthesized audio is forwarded chunk by chunk (LiteLLM's
+    // `/v1/audio/speech` does the same, explicitly for latency) — a player
+    // can start on the first bytes instead of waiting for the whole file.
+    // That moves the read out of the retryable unit: once the 200 is on the
+    // wire a failed read truncates the download rather than failing over,
+    // the same trade `/v1/videos`' content proxy makes.
+    let stream_budget =
+        crate::routing::effective_timeouts(model, None, state.default_timeouts).stream;
+    let upstream_resp =
         match crate::routing::retrying_dispatch(state, model, "/v1/audio/speech", || {
-            let mut req = speech_url
+            let req = speech_url
                 .clone()
                 .post_on(&client)
                 .headers(headers.clone())
                 .json(&body);
-            // #554/#911: speech synthesis is non-streaming; apply the per-model
-            // E2E request timeout (same as count_tokens/rerank/responses).
-            if let Some(d) =
-                crate::routing::effective_timeouts(model, None, state.default_timeouts).request
-            {
-                req = req.timeout(d);
-            }
+            // #554/#911: reqwest's request-level timeout would bound the
+            // body read too and cut a long synthesis off mid-file, so the
+            // stream budget bounds the connect phase and each chunk
+            // instead — the split every relayed path uses.
             async move {
                 // `reqwest_error_to_bridge`, not a bare `Transport`: an
                 // elapsed `timeout` has to surface as `BridgeError::Timeout`
@@ -1263,14 +1649,12 @@ async fn speech_dispatch(
                 // timeout as transport made the model's own timeout get
                 // retried, turning a 400ms budget into ~2s.
                 let send_started = Instant::now();
-                let resp = req.send().await.map_err(|e| {
-                    crate::cooldown::note_failure(
-                        tracker,
-                        model_id,
-                        cooldown_cfg,
-                        crate::dispatch::reqwest_error_to_bridge(&e, send_started),
-                    )
-                })?;
+                let resp =
+                    crate::stream_timeout::send_with_deadline(req, stream_budget, send_started)
+                        .await
+                        .map_err(|be| {
+                            crate::cooldown::note_failure(tracker, model_id, cooldown_cfg, be)
+                        })?;
 
                 let status = resp.status();
                 if !status.is_success() {
@@ -1288,17 +1672,7 @@ async fn speech_dispatch(
                         ),
                     ));
                 }
-
-                let upstream_headers = resp.headers().clone();
-                let body_bytes = resp.bytes().await.map_err(|e| {
-                    crate::cooldown::note_failure(
-                        tracker,
-                        model_id,
-                        cooldown_cfg,
-                        aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
-                    )
-                })?;
-                Ok((upstream_headers, body_bytes))
+                Ok(resp)
             }
         })
         .await
@@ -1311,13 +1685,33 @@ async fn speech_dispatch(
     state.runtime_status.mark_healthy(&model_entry.id);
 
     // #911 [21]: speech synthesis (TTS) reports no token usage — it is billed
-    // per input character — so there are no tokens to add to TPM/TPD. Commit 0
-    // to release the reservation the same way the other handlers do, keeping
-    // the "every reserve is committed" invariant explicit.
-    reservation.commit_tokens(0).await;
+    // per input character — so there are no tokens to add to TPM/TPD. The
+    // reservation instead becomes a hold that spans the relayed body: the
+    // handler returns once the headers are out, so releasing the concurrency
+    // slot at handler return would let a key run more simultaneous
+    // syntheses than its cap allows (#450).
+    let stream_hold = reservation.into_stream_hold();
 
-    let mut out = axum::response::Response::new(axum::body::Body::from(body_bytes));
+    let upstream_headers = upstream_resp.headers().clone();
+    let relayed = crate::request_id::in_request_span(async_stream::stream! {
+        let _hold = stream_hold;
+        let inner = crate::stream_timeout::with_read_timeout_bytes(
+            upstream_resp.bytes_stream(),
+            stream_budget,
+        );
+        futures::pin_mut!(inner);
+        while let Some(item) = futures::StreamExt::next(&mut inner).await {
+            yield item;
+        }
+    });
+    let mut out = axum::response::Response::new(axum::body::Body::from_stream(relayed));
     copy_response_header(&upstream_headers, &mut out, header::CONTENT_TYPE);
+    // Relayed verbatim when the upstream sent one, like `/v1/videos`'
+    // content proxy: reqwest strips it only when it decompresses, which it
+    // never does for audio. A mid-stream read timeout then shows up as a
+    // short read — the intended signal that the download failed rather than
+    // a silently truncated file.
+    copy_response_header(&upstream_headers, &mut out, header::CONTENT_LENGTH);
     Ok(SpeechDispatchSuccess {
         response: out,
         provider: provider_label,
@@ -1350,11 +1744,7 @@ async fn speech_dispatch(
 /// Gated on the upstream content type so a `text`/`srt`/`vtt` transcript
 /// that happens to contain a `data:` line is never mistaken for a stream.
 fn extract_sse_token_usage(headers: &HeaderMap, body: &[u8]) -> Option<(u32, u32)> {
-    let is_sse = headers
-        .get(header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .is_some_and(|ct| ct.starts_with("text/event-stream"));
-    if !is_sse {
+    if !is_event_stream(headers) {
         return None;
     }
     let mut decoder = aisix_gateway::SseDecoder::new();
@@ -1450,6 +1840,10 @@ fn record_audio_metrics(
             model: &success.model_name,
             upstream_model: &success.upstream_model,
             pk: pk.labels(),
+            // True exactly on the live SSE relay (#998) — the flag that
+            // moves the usage emit into the stream is the same condition
+            // that makes this a streamed response.
+            stream: success.usage_handled_by_stream,
             ..Default::default()
         },
         status,
@@ -2019,6 +2413,21 @@ mod tests {
     /// A minimal multipart body carrying `model` + a tiny fake audio
     /// `file` field — enough for the gateway to extract the model and
     /// forward the form.
+    /// `transcription_multipart` plus the `stream=true` field, i.e. what a
+    /// caller that wants the transcript incrementally sends.
+    fn streaming_transcription_multipart(model: &str) -> (String, axum::body::Body) {
+        let body = format!(
+            "--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n{model}\r\n\
+             --b\r\nContent-Disposition: form-data; name=\"stream\"\r\n\r\ntrue\r\n\
+             --b\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.mp3\"\r\n\
+             Content-Type: audio/mpeg\r\n\r\nID3fakeaudio\r\n--b--\r\n"
+        );
+        (
+            "multipart/form-data; boundary=b".to_string(),
+            axum::body::Body::from(body),
+        )
+    }
+
     fn transcription_multipart(model: &str) -> (String, axum::body::Body) {
         let body = format!(
             "--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n{model}\r\n\
@@ -2344,6 +2753,118 @@ mod tests {
             (26, 12),
             "the terminal transcript.text.done usage must be billed"
         );
+    }
+
+    /// #998: with `stream=true` and an SSE answer the relay is live —
+    /// the frames reach the caller as they arrive rather than being
+    /// buffered — and the UsageEvent comes from the stream's own guard.
+    /// The wire bytes must still be the upstream's, event for event, and
+    /// the request must be billed exactly once.
+    #[tokio::test]
+    async fn streamed_transcription_relays_verbatim_and_bills_once() {
+        let upstream = MockServer::start().await;
+        let sse = concat!(
+            "data: {\"type\":\"transcript.text.delta\",\"delta\":\"hello\"}\n\n",
+            "data: {\"type\":\"transcript.text.delta\",\"delta\":\" world\"}\n\n",
+            "data: {\"type\":\"transcript.text.done\",\"text\":\"hello world\",",
+            "\"usage\":{\"type\":\"tokens\",\"total_tokens\":38,\"input_tokens\":26,",
+            "\"input_token_details\":{\"text_tokens\":0,\"audio_tokens\":26},",
+            "\"output_tokens\":12}}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse, "text/event-stream"))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-transcribe"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let (ct, body) = streaming_transcription_multipart("my-transcribe");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream"),
+            "the caller must keep the upstream's streaming content type"
+        );
+        let relayed = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("the relayed stream must read cleanly");
+        assert_eq!(
+            String::from_utf8_lossy(&relayed),
+            sse,
+            "the relay must forward the upstream SSE verbatim"
+        );
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("the stream guard must emit a UsageEvent")
+            .expect("usage_sink sender dropped");
+        assert_eq!(
+            (event.prompt_tokens, event.completion_tokens),
+            (26, 12),
+            "the terminal transcript.text.done usage must be billed"
+        );
+        assert_eq!(event.status_code, 200);
+        assert!(
+            rx.try_recv().is_err(),
+            "the handler must not emit a second, zero-token event for the same request"
+        );
+    }
+
+    /// A provider that ignores `stream=true` and answers with a JSON
+    /// transcript falls back to the buffered path, so its `usage` block
+    /// is still read — a streamed request must not become an unbilled
+    /// channel just because the upstream declined to stream (#998).
+    #[tokio::test]
+    async fn stream_requested_but_json_answered_is_still_billed() {
+        let upstream = MockServer::start().await;
+        let body = serde_json::json!({
+            "text": "hello world",
+            "usage": {"type": "tokens", "input_tokens": 14, "output_tokens": 4},
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-transcribe"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let (ct, form) = streaming_transcription_multipart("my-transcribe");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(form)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted")
+            .expect("usage_sink sender dropped");
+        assert_eq!((event.prompt_tokens, event.completion_tokens), (14, 4));
     }
 
     /// The SSE read is content-type gated: a `srt`/`vtt` transcript is

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -575,14 +575,36 @@ struct StreamedTranscript {
     /// `None` when the stream ended before one arrived (a client that
     /// disconnected, an upstream that reports no tokens).
     usage: Option<(u32, u32)>,
-    /// The transcript assembled from the `transcript.text.delta` events,
-    /// capped at the exporter's content-capture limit. Empty when no
-    /// exporter asked for content and no output chain needs a scan.
-    text: String,
+    /// The transcript assembled from the `transcript.text.delta` events.
+    deltas: String,
+    /// The whole transcript as the terminal `transcript.text.done` event
+    /// reports it. Preferred over the assembled deltas — same precedence
+    /// the `/v1/responses` capture uses — so a provider that answers with
+    /// the terminal event alone still yields a scannable transcript.
+    terminal: Option<String>,
     /// False when the caller disconnected before the upstream ended.
     reached_end: bool,
     /// End-of-stream monitor observations (AISIX-Cloud#1010).
     output_hits: Vec<aisix_core::GuardrailMonitorHit>,
+}
+
+impl StreamedTranscript {
+    /// The transcript the caller received, for the end-of-stream scan and
+    /// the content capture. Both are capped at their own limits on top of
+    /// this one.
+    fn text(&self) -> &str {
+        self.terminal.as_deref().unwrap_or(&self.deltas)
+    }
+}
+
+/// The longest prefix of `text` that fits in `cap` bytes without splitting
+/// a codepoint.
+fn truncate_on_char_boundary(text: &str, cap: usize) -> &str {
+    let mut end = text.len().min(cap);
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
 }
 
 /// Fires `on_complete` exactly once with what the relay saw — at
@@ -698,7 +720,7 @@ where
             // The guard stays armed across the await: an SDK that closes
             // on the terminal frame drops this generator here, and the
             // Drop emit must still carry the usage it already parsed.
-            let text = guard.observed().text.clone();
+            let text = guard.observed().text().to_string();
             let hits = scan.observe(&text).await;
             guard.observed().output_hits = hits;
         }
@@ -708,11 +730,15 @@ where
     })
 }
 
-/// Fold one batch of decoded SSE events into the running observation:
-/// `transcript.text.delta` appends to the transcript (bounded by `cap`),
-/// and any event carrying a `usage` block updates the counts — the last
-/// one wins, so a provider that reports usage on a later event than
-/// `transcript.text.done` is read the same way.
+/// Fold one batch of decoded SSE events into the running observation, all
+/// of it bounded by `cap`.
+///
+/// Read by field rather than by event type, so a provider that names its
+/// events differently is still observed: a `usage` block updates the
+/// counts (last one wins, so usage reported after
+/// `transcript.text.done` is read the same way), a whole-transcript
+/// `text` becomes the terminal text, and a `delta` appends to the
+/// assembled one.
 fn observe_transcript_events(
     observed: &mut StreamedTranscript,
     events: &[aisix_gateway::SseEvent],
@@ -728,16 +754,18 @@ fn observe_transcript_events(
         if let Some(usage) = extract_token_usage(&value) {
             observed.usage = Some(usage);
         }
-        if observed.text.len() >= cap {
+        if let Some(full) = value.get("text").and_then(Value::as_str) {
+            observed.terminal = Some(truncate_on_char_boundary(full, cap).to_string());
+            continue;
+        }
+        if observed.deltas.len() >= cap {
             continue;
         }
         if let Some(delta) = value.get("delta").and_then(Value::as_str) {
-            let room = cap - observed.text.len();
-            let mut end = delta.len().min(room);
-            while end > 0 && !delta.is_char_boundary(end) {
-                end -= 1;
-            }
-            observed.text.push_str(&delta[..end]);
+            let room = cap - observed.deltas.len();
+            observed
+                .deltas
+                .push_str(truncate_on_char_boundary(delta, room));
         }
     }
 }
@@ -1222,14 +1250,14 @@ async fn multipart_dispatch(
                     // than the one the request started on (#941).
                     let snap = state_c.snapshot.load();
                     let pk = crate::usage_attr::ResolvedPk::resolve(&snap, &pk_id_c);
-                    let mut monitor_hits = input_monitor_hits;
-                    monitor_hits.extend(outcome.output_hits);
                     let captured_content = match (&captured_prompt_c, content_cap) {
                         (Some(prompt), Some(cap)) => {
-                            Some(CapturedContent::new(prompt, &outcome.text, cap as usize))
+                            Some(CapturedContent::new(prompt, outcome.text(), cap as usize))
                         }
                         _ => None,
                     };
+                    let mut monitor_hits = input_monitor_hits;
+                    monitor_hits.extend(outcome.output_hits);
                     emit_usage_event(
                         &state_c,
                         &snap,
@@ -2896,6 +2924,62 @@ mod tests {
             .expect("UsageEvent must be emitted")
             .expect("usage_sink sender dropped");
         assert_eq!((event.prompt_tokens, event.completion_tokens), (14, 4));
+    }
+
+    /// The relay's side-channel observation reads by FIELD, not by event
+    /// name: a provider that answers with the terminal event alone —
+    /// whole transcript in `text`, no incremental deltas — must still
+    /// leave a scannable, capturable transcript behind, or the
+    /// end-of-stream guardrail scan and the content capture both see
+    /// nothing (#998).
+    #[test]
+    fn terminal_text_stands_in_for_missing_deltas() {
+        let decode = |payloads: &[&str]| {
+            let mut observed = super::StreamedTranscript::default();
+            let events: Vec<aisix_gateway::SseEvent> = payloads
+                .iter()
+                .map(|p| aisix_gateway::SseEvent::Data((*p).to_string()))
+                .collect();
+            super::observe_transcript_events(&mut observed, &events, 1024);
+            observed
+        };
+
+        let terminal_only = decode(&[r#"{"type":"transcript.text.done","text":"hello world",
+                "usage":{"type":"tokens","input_tokens":26,"output_tokens":12}}"#]);
+        assert_eq!(terminal_only.text(), "hello world");
+        assert_eq!(terminal_only.usage, Some((26, 12)));
+
+        let deltas_only = decode(&[
+            r#"{"type":"transcript.text.delta","delta":"hello"}"#,
+            r#"{"type":"transcript.text.delta","delta":" world"}"#,
+        ]);
+        assert_eq!(
+            deltas_only.text(),
+            "hello world",
+            "without a terminal event the assembled deltas are the transcript"
+        );
+
+        // The terminal event wins over the deltas — the two say the same
+        // thing, and counting both would double the captured transcript.
+        let both = decode(&[
+            r#"{"type":"transcript.text.delta","delta":"hello"}"#,
+            r#"{"type":"transcript.text.delta","delta":" world"}"#,
+            r#"{"type":"transcript.text.done","text":"hello world"}"#,
+        ]);
+        assert_eq!(both.text(), "hello world");
+    }
+
+    /// The observation is bounded, and the bound never splits a codepoint
+    /// — the captured text is handed to `CapturedContent` as a `&str`.
+    #[test]
+    fn observation_is_capped_on_a_char_boundary() {
+        let mut observed = super::StreamedTranscript::default();
+        let events: Vec<aisix_gateway::SseEvent> = (0..4)
+            .map(|_| aisix_gateway::SseEvent::Data(r#"{"delta":"日本語"}"#.to_string()))
+            .collect();
+        // 3 bytes per char: a 7-byte cap must stop after two chars.
+        super::observe_transcript_events(&mut observed, &events, 7);
+        assert_eq!(observed.text(), "日本");
     }
 
     /// The SSE read is content-type gated: a `srt`/`vtt` transcript is

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -3386,4 +3386,61 @@ mod tests {
         assert_eq!(event.prompt_tokens, 21, "billed tokens must be kept");
         assert_eq!(event.completion_tokens, 7);
     }
+
+    /// #998: `stream=true` must not become a way around the output
+    /// guardrail the same transcript gets when it is not streamed. A
+    /// block-capable chain keeps the buffered relay — the whole
+    /// transcript is scanned before any of it reaches the caller — so the
+    /// streamed request is blocked exactly like the non-streamed one.
+    #[tokio::test]
+    async fn streamed_transcription_is_not_an_output_guardrail_bypass() {
+        let upstream = MockServer::start().await;
+        let sse = concat!(
+            "data: {\"type\":\"transcript.text.delta\",\"delta\":\"the secret word is \"}\n\n",
+            "data: {\"type\":\"transcript.text.delta\",\"delta\":\"BLOCKME\"}\n\n",
+            "data: {\"type\":\"transcript.text.done\",\"text\":\"the secret word is BLOCKME\",",
+            "\"usage\":{\"type\":\"tokens\",\"input_tokens\":21,\"output_tokens\":7}}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse, "text/event-stream"))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-whisper"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = build_app_with_sink(snap, tx);
+        let (ct, body) = streaming_transcription_multipart("my-whisper");
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", ct)
+            .body(body)
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "a blocked transcript must not be released just because it streamed"
+        );
+        let bytes = to_bytes(resp.into_body(), 65536).await.unwrap();
+        assert!(
+            !String::from_utf8_lossy(&bytes).contains("BLOCKME"),
+            "the blocked transcript must not reach the caller"
+        );
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("UsageEvent must be emitted for the billed-then-blocked transcript")
+            .expect("usage_sink sender dropped");
+        assert_eq!(event.status_code, 422);
+        assert!(event.guardrail_blocked, "event must be marked blocked");
+        assert_eq!((event.prompt_tokens, event.completion_tokens), (21, 7));
+    }
 }

--- a/crates/aisix-proxy/src/guardrail_stream.rs
+++ b/crates/aisix-proxy/src/guardrail_stream.rs
@@ -1,0 +1,105 @@
+//! End-of-stream output-guardrail observation for the live-forward
+//! streaming paths (AISIX-Cloud#1010).
+//!
+//! A live-forwarded stream has already put its bytes on the wire, so an
+//! output-hook chain can no longer block it — which is exactly why only
+//! the chains that *can't* block reach here: a block-capable chain
+//! resolves to a hold-back [`aisix_guardrails::StreamOutputPolicy`] and
+//! takes its endpoint's buffered branch instead. What remains is the
+//! monitor-only chain, whose whole purpose is to observe without changing
+//! delivery — so it must still get its scan, and must never hold the
+//! stream back to get it.
+//!
+//! Shared by `/v1/responses` (#808) and the streamed audio transcription
+//! relay (#998); both assemble the response text as it streams and hand
+//! it here once the upstream ends.
+
+use std::sync::Arc;
+
+use aisix_gateway::{ChatMessage, ChatResponse, FinishReason, UsageStats};
+
+/// Build the minimal internal `ChatResponse` an output guardrail needs to
+/// scan: the assistant text in `message.content`. Only the text is read by
+/// `check_output` (via `guardrail_output_text`); the other fields are
+/// placeholders and never reach the client.
+pub(crate) fn synth_chat_response(model: &str, text: String) -> ChatResponse {
+    ChatResponse {
+        id: String::new(),
+        model: model.to_string(),
+        message: ChatMessage::assistant(text),
+        finish_reason: FinishReason::Stop,
+        usage: UsageStats::default(),
+    }
+}
+
+/// End-of-stream output observation for a live-forward path. Reachable
+/// only when the output-hook chain's resolved streaming policy is
+/// `EndOfStreamCheck` — today that is exactly the monitor-only chains,
+/// which can never block. Runs the same two-phase scan as the buffered
+/// branch (blob check + segment pass) so would-block / would-mask hits
+/// reach telemetry; the bytes are already on the wire, so a `Block`
+/// verdict (unreachable for monitor members) is logged, not enforced.
+pub(crate) struct EosOutputScan {
+    chain: Arc<aisix_guardrails::GuardrailChain>,
+    upstream_model: String,
+}
+
+impl EosOutputScan {
+    pub(crate) fn new(
+        chain: Arc<aisix_guardrails::GuardrailChain>,
+        upstream_model: String,
+    ) -> Self {
+        Self {
+            chain,
+            upstream_model,
+        }
+    }
+
+    pub(crate) async fn observe(self, text: &str) -> Vec<aisix_core::GuardrailMonitorHit> {
+        // Bound the provider calls the same way the buffered branch's byte
+        // cap does — scan at most the cap's worth of text.
+        let mut end = text
+            .len()
+            .min(aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES);
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        let scan_text = &text[..end];
+        if scan_text.is_empty() {
+            return Vec::new();
+        }
+        let synth = synth_chat_response(&self.upstream_model, scan_text.to_string());
+        let (verdict, mut hits) = aisix_guardrails::Guardrail::check_output_non_segment_observed(
+            self.chain.as_ref(),
+            &synth,
+        )
+        .await;
+        // Segment pass (bedrock/lakera/presidio members): offer the flattened
+        // text as one segment so monitor-mode segment moderators record their
+        // observations too. Masks are suppressed in monitor mode, and nothing
+        // could be rewritten anyway — the counts are discarded.
+        let mut seg_counts = crate::redact::RedactionCounts::new();
+        let verdict = crate::redact::moderate_body(
+            self.chain.as_ref(),
+            crate::redact::Direction::Output,
+            verdict,
+            &mut seg_counts,
+            &mut hits,
+            |g| {
+                let _ = g.redact_output_text(scan_text);
+                crate::redact::RedactionCounts::new()
+            },
+        )
+        .await;
+        if let aisix_guardrails::GuardrailVerdict::Block { reason, .. } = verdict {
+            tracing::warn!(
+                guardrail_hook = "output",
+                model = %self.upstream_model,
+                reason = %reason,
+                "output guardrail returned a block after live forward; \
+                 response already sent (EndOfStreamCheck policy)",
+            );
+        }
+        hits
+    }
+}

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -42,6 +42,7 @@ mod embeddings;
 mod ensemble;
 mod error;
 mod error_translate;
+mod guardrail_stream;
 pub mod health;
 mod http_client;
 mod images;

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -12,7 +12,7 @@
 //! Only OpenAI models support this endpoint. Non-OpenAI models receive a
 //! 400 with an explanatory message.
 
-use aisix_gateway::{ChatFormat, ChatMessage, ChatResponse, FinishReason, UsageStats};
+use aisix_gateway::{ChatFormat, ChatMessage};
 use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, LatencyLabels, UsageEvent};
 use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
@@ -32,6 +32,7 @@ use crate::auth::AuthenticatedKey;
 use crate::chat::sanitize_tag;
 use crate::client_ip::ClientContext;
 use crate::error::ProxyError;
+use crate::guardrail_stream::{synth_chat_response, EosOutputScan};
 use crate::state::ProxyState;
 use crate::usage_attr::{total_tokens_with_cache, ResolvedPk};
 
@@ -1490,10 +1491,8 @@ async fn responses_to_target(
         // the only way an output-hook chain reaches this live-forward branch)
         // still gets its end-of-stream scan, so would-block / would-mask
         // observations reach telemetry. `None` without an output hook.
-        let eos_scan = aisix_guardrails::Guardrail::runs_on_output(chain).then(|| EosOutputScan {
-            chain: Arc::clone(&chain_arc),
-            upstream_model: upstream_model.clone(),
-        });
+        let eos_scan = aisix_guardrails::Guardrail::runs_on_output(chain)
+            .then(|| EosOutputScan::new(Arc::clone(&chain_arc), upstream_model.clone()));
         // Token-estimation fallback context (AISIX-Cloud#1074): the request
         // body is cloned because the closure runs at end-of-stream Drop.
         // Tokenized only if the upstream never reports usage.
@@ -2602,68 +2601,6 @@ impl<F: FnOnce(ResponseUsage, String, Vec<aisix_core::GuardrailMonitorHit>)> Dro
     }
 }
 
-/// End-of-stream output observation for the live-forward verbatim path
-/// (AISIX-Cloud#1010). Reachable only when the output-hook chain's resolved
-/// streaming policy is `EndOfStreamCheck` — today that is exactly the
-/// monitor-only chains, which can never block. Runs the same two-phase scan
-/// as the buffered branch (blob check + segment pass) so would-block /
-/// would-mask hits reach telemetry; the bytes are already on the wire, so a
-/// `Block` verdict (unreachable for monitor members) is logged, not enforced.
-struct EosOutputScan {
-    chain: Arc<aisix_guardrails::GuardrailChain>,
-    upstream_model: String,
-}
-
-impl EosOutputScan {
-    async fn observe(self, text: &str) -> Vec<aisix_core::GuardrailMonitorHit> {
-        // Bound the provider calls the same way the buffered branch's byte
-        // cap does — scan at most the cap's worth of text.
-        let mut end = text
-            .len()
-            .min(aisix_guardrails::DEFAULT_STREAM_OUTPUT_BUFFER_BYTES);
-        while end > 0 && !text.is_char_boundary(end) {
-            end -= 1;
-        }
-        let scan_text = &text[..end];
-        if scan_text.is_empty() {
-            return Vec::new();
-        }
-        let synth = synth_chat_response(&self.upstream_model, scan_text.to_string());
-        let (verdict, mut hits) = aisix_guardrails::Guardrail::check_output_non_segment_observed(
-            self.chain.as_ref(),
-            &synth,
-        )
-        .await;
-        // Segment pass (bedrock/lakera/presidio members): offer the flattened
-        // text as one segment so monitor-mode segment moderators record their
-        // observations too. Masks are suppressed in monitor mode, and nothing
-        // could be rewritten anyway — the counts are discarded.
-        let mut seg_counts = crate::redact::RedactionCounts::new();
-        let verdict = crate::redact::moderate_body(
-            self.chain.as_ref(),
-            crate::redact::Direction::Output,
-            verdict,
-            &mut seg_counts,
-            &mut hits,
-            |g| {
-                let _ = g.redact_output_text(scan_text);
-                crate::redact::RedactionCounts::new()
-            },
-        )
-        .await;
-        if let aisix_guardrails::GuardrailVerdict::Block { reason, .. } = verdict {
-            tracing::warn!(
-                guardrail_hook = "output",
-                model = %self.upstream_model,
-                reason = %reason,
-                "output guardrail returned a block after live forward; \
-                 response already sent (EndOfStreamCheck policy)",
-            );
-        }
-        hits
-    }
-}
-
 /// Wrap a Responses-API upstream byte stream so the terminal event's usage is
 /// parsed in-flight and `on_complete` fires once at end-of-stream (or
 /// client-disconnect) with the accumulated counts (#808) plus the captured
@@ -2899,20 +2836,6 @@ fn responses_sse_output_text(bytes: &[u8]) -> String {
         }
     }
     deltas
-}
-
-/// Build the minimal internal `ChatResponse` an output guardrail needs to
-/// scan: the assistant text in `message.content`. Only the text is read by
-/// `check_output` (via `guardrail_output_text`); the other fields are
-/// placeholders and never reach the client.
-fn synth_chat_response(model: &str, text: String) -> ChatResponse {
-    ChatResponse {
-        id: String::new(),
-        model: model.to_string(),
-        message: ChatMessage::assistant(text),
-        finish_reason: FinishReason::Stop,
-        usage: UsageStats::default(),
-    }
 }
 
 /// Copy the upstream `content-type` onto the client response and stamp the

--- a/tests/e2e/src/cases/audio-stream-relay-e2e.test.ts
+++ b/tests/e2e/src/cases/audio-stream-relay-e2e.test.ts
@@ -76,10 +76,14 @@ async function measure(res: Response): Promise<Delivery> {
   return out;
 }
 
+/** A whole-file speech answer, served with a Content-Length. */
+const WHOLE_SPEECH_BODY = "ID3whole-file-audio-body";
+
 describe("the audio endpoints relay their response as it arrives (#998)", () => {
   let app: SpawnedApp | undefined;
   let transcribeUpstream: OpenAiUpstream | undefined;
   let speechUpstream: OpenAiUpstream | undefined;
+  let wholeSpeechUpstream: OpenAiUpstream | undefined;
   let etcdReachable = false;
 
   beforeAll(async () => {
@@ -98,6 +102,11 @@ describe("the audio endpoints relay their response as it arrives (#998)", () => 
       rawBodyChunks: SPEECH_CHUNKS,
       rawContentType: "audio/mpeg",
       eventDelayMs: CHUNK_DELAY_MS,
+    });
+
+    wholeSpeechUpstream = await startOpenAiUpstream({
+      rawBody: WHOLE_SPEECH_BODY,
+      rawContentType: "audio/mpeg",
     });
 
     app = await spawnApp();
@@ -124,9 +133,20 @@ describe("the audio endpoints relay their response as it arrives (#998)", () => 
       model_name: "tts-1",
       provider_key_id: speechPk.id,
     });
+    const wholeSpeechPk = await seed.createProviderKey({
+      display_name: "issue998-whole-speech-pk",
+      secret: "sk-openai-mock",
+      api_base: `${wholeSpeechUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "whole-tts",
+      provider: "openai",
+      model_name: "tts-1",
+      provider_key_id: wholeSpeechPk.id,
+    });
     await seed.createApiKey({
       key_hash: CALLER_KEY_HASH,
-      allowed_models: ["relay-transcribe", "relay-tts"],
+      allowed_models: ["relay-transcribe", "relay-tts", "whole-tts"],
     });
   });
 
@@ -134,6 +154,7 @@ describe("the audio endpoints relay their response as it arrives (#998)", () => 
     await app?.exit();
     await transcribeUpstream?.close();
     await speechUpstream?.close();
+    await wholeSpeechUpstream?.close();
   });
 
   test("a streamed transcription arrives frame by frame", async (ctx) => {
@@ -233,5 +254,47 @@ describe("the audio endpoints relay their response as it arrives (#998)", () => 
       delivery.lastByteMs - delivery.firstByteMs,
       "a player must be able to start before the whole file exists",
     ).toBeGreaterThan(CHUNK_DELAY_MS);
+  });
+
+  // Relaying the body must not cost the caller the size of the download:
+  // an upstream that declares a Content-Length still has it declared
+  // downstream, which is what a client needs to show progress.
+  test("an upstream Content-Length survives the relay", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const call = () =>
+      fetch(`${app!.proxyUrl}/v1/audio/speech`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "whole-tts",
+          input: "Hello from AISIX.",
+          voice: "alloy",
+        }),
+      });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await call();
+        const ok = probe.ok;
+        await probe.text();
+        return ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-length")).toBe(
+      String(WHOLE_SPEECH_BODY.length),
+    );
+    expect(res.headers.get("transfer-encoding")).toBeNull();
+    expect(await res.text()).toBe(WHOLE_SPEECH_BODY);
   });
 });

--- a/tests/e2e/src/cases/audio-stream-relay-e2e.test.ts
+++ b/tests/e2e/src/cases/audio-stream-relay-e2e.test.ts
@@ -1,0 +1,237 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E regression for #998: the audio endpoints must relay a response as
+// it arrives, not collect it and hand the caller one write at the end.
+//
+// The functional assertions on these routes all passed before the fix —
+// the caller got the right transcript and the right audio — because a
+// buffered relay differs from a streaming one only in DELIVERY SHAPE.
+// Both legs below therefore measure time and chunk count, not content:
+// the mock upstream trickles its response over ~1s and the spec asserts
+// the caller sees that same spread. Pre-fix each leg read exactly one
+// chunk with a zero spread.
+
+const CALLER_PLAINTEXT = "sk-issue-998-audio-stream-relay";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+/** ~1s of upstream deltas: 8 frames, 120ms apart. */
+const CHUNK_DELAY_MS = 120;
+const TRANSCRIPT_FRAMES = [
+  ...["Streaming", " recognition", " emits", " partial", " results"].map(
+    (delta) =>
+      `data: ${JSON.stringify({ type: "transcript.text.delta", delta })}\n\n`,
+  ),
+  `data: ${JSON.stringify({
+    type: "transcript.text.done",
+    text: "Streaming recognition emits partial results",
+    usage: {
+      type: "tokens",
+      input_tokens: 26,
+      output_tokens: 12,
+      total_tokens: 38,
+    },
+  })}\n\n`,
+  "data: [DONE]\n\n",
+];
+const SPEECH_CHUNKS = ["ID3", "audio-part-1", "audio-part-2", "audio-part-3"];
+
+/** One measured read loop over a response body. */
+interface Delivery {
+  chunks: number;
+  firstByteMs: number;
+  lastByteMs: number;
+  body: string;
+}
+
+async function measure(res: Response): Promise<Delivery> {
+  const started = Date.now();
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  const out: Delivery = {
+    chunks: 0,
+    firstByteMs: 0,
+    lastByteMs: 0,
+    body: "",
+  };
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (out.chunks === 0) out.firstByteMs = Date.now() - started;
+    out.chunks += 1;
+    out.lastByteMs = Date.now() - started;
+    out.body += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+describe("the audio endpoints relay their response as it arrives (#998)", () => {
+  let app: SpawnedApp | undefined;
+  let transcribeUpstream: OpenAiUpstream | undefined;
+  let speechUpstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    // The upload is multipart, so the mock can't be driven off a
+    // `stream: true` JSON field — it serves the SSE frames as the raw
+    // streaming 200 body instead.
+    transcribeUpstream = await startOpenAiUpstream({
+      rawStreamFrames: TRANSCRIPT_FRAMES,
+      eventDelayMs: CHUNK_DELAY_MS,
+    });
+    speechUpstream = await startOpenAiUpstream({
+      rawBodyChunks: SPEECH_CHUNKS,
+      rawContentType: "audio/mpeg",
+      eventDelayMs: CHUNK_DELAY_MS,
+    });
+
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    const transcribePk = await seed.createProviderKey({
+      display_name: "issue998-transcribe-pk",
+      secret: "sk-openai-mock",
+      api_base: `${transcribeUpstream.baseUrl}/v1`,
+    });
+    const speechPk = await seed.createProviderKey({
+      display_name: "issue998-speech-pk",
+      secret: "sk-openai-mock",
+      api_base: `${speechUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "relay-transcribe",
+      provider: "openai",
+      model_name: "gpt-4o-transcribe",
+      provider_key_id: transcribePk.id,
+    });
+    await seed.createModel({
+      display_name: "relay-tts",
+      provider: "openai",
+      model_name: "tts-1",
+      provider_key_id: speechPk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["relay-transcribe", "relay-tts"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await transcribeUpstream?.close();
+    await speechUpstream?.close();
+  });
+
+  test("a streamed transcription arrives frame by frame", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const call = () => {
+      const form = new FormData();
+      form.set("model", "relay-transcribe");
+      form.set("stream", "true");
+      form.set(
+        "file",
+        new Blob([new Uint8Array([0x49, 0x44, 0x33])], { type: "audio/mpeg" }),
+        "a.mp3",
+      );
+      return fetch(`${app!.proxyUrl}/v1/audio/transcriptions`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+        body: form,
+      });
+    };
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await call();
+        const ok = probe.ok;
+        await probe.text();
+        return ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const delivery = await measure(res);
+
+    // Content first: relaying must not rewrite the stream.
+    expect(delivery.body).toBe(TRANSCRIPT_FRAMES.join(""));
+
+    // Delivery shape: the upstream spread its frames over ~840ms, so a
+    // relay that forwards them keeps that spread. A buffered one reads
+    // the whole body first and answers in a single write.
+    expect(
+      delivery.chunks,
+      "a relayed stream reaches the caller in several reads",
+    ).toBeGreaterThan(1);
+    expect(
+      delivery.lastByteMs - delivery.firstByteMs,
+      "the caller must see the upstream's own delivery spread",
+    ).toBeGreaterThan(2 * CHUNK_DELAY_MS);
+  });
+
+  test("synthesized speech arrives chunk by chunk", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const call = () =>
+      fetch(`${app!.proxyUrl}/v1/audio/speech`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "relay-tts",
+          input: "Streaming recognition emits partial results.",
+          voice: "alloy",
+        }),
+      });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const probe = await call();
+        const ok = probe.ok;
+        await probe.text();
+        return ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("audio/mpeg");
+    const delivery = await measure(res);
+
+    expect(delivery.body).toBe(SPEECH_CHUNKS.join(""));
+    expect(
+      delivery.chunks,
+      "the audio must reach the caller while the upstream is still writing it",
+    ).toBeGreaterThan(1);
+    expect(
+      delivery.lastByteMs - delivery.firstByteMs,
+      "a player must be able to start before the whole file exists",
+    ).toBeGreaterThan(CHUNK_DELAY_MS);
+  });
+});

--- a/tests/e2e/src/harness/upstream-openai.ts
+++ b/tests/e2e/src/harness/upstream-openai.ts
@@ -48,6 +48,14 @@ export interface OpenAiUpstreamOptions {
    * the content GET.
    */
   rawBody?: string;
+  /**
+   * `rawBody` split into chunks written one at a time, `eventDelayMs`
+   * apart, so a spec can tell a relayed body from a buffered one: an
+   * upstream that trickles its bytes is only visibly trickling
+   * downstream if the gateway forwards them as they arrive. Takes
+   * precedence over `rawBody`; no Content-Length is sent.
+   */
+  rawBodyChunks?: string[];
   /** Content-Type for `rawBody` (default `application/octet-stream`). */
   rawContentType?: string;
   /** Per-request response script; used in order before static opts. */
@@ -85,6 +93,8 @@ export interface OpenAiUpstreamStep {
   responseHeaders?: Record<string, string>;
   /** Raw (non-JSON) 200 body — see `OpenAiUpstreamOptions.rawBody`. */
   rawBody?: string;
+  /** See `OpenAiUpstreamOptions.rawBodyChunks`. */
+  rawBodyChunks?: string[];
   /** Content-Type for `rawBody` (default `application/octet-stream`). */
   rawContentType?: string;
 }
@@ -163,6 +173,22 @@ export async function startOpenAiUpstream(
             step.errorBody ?? { error: { message: "mock error" } },
           ),
         );
+        return;
+      }
+
+      if (step.rawBodyChunks !== undefined) {
+        res.statusCode = 200;
+        res.setHeader(
+          "content-type",
+          step.rawContentType ?? "application/octet-stream",
+        );
+        res.flushHeaders();
+        for (const chunk of step.rawBodyChunks) {
+          if (res.writableEnded || res.destroyed) return;
+          res.write(Buffer.from(chunk));
+          if (step.eventDelayMs) await sleep(step.eventDelayMs);
+        }
+        if (!res.writableEnded && !res.destroyed) res.end();
         return;
       }
 


### PR DESCRIPTION
Fixes #998

Two problems on the audio surface, plus a third the investigation turned up.

**The relay buffered a streamed transcription.** `stream=true` was answered from a fully-read body — `resp.bytes()` on the upstream, then one write to the caller. The transcript was correct, but the incremental delivery `stream=true` exists for was gone: the probe in #998 recorded 1.476s of upstream deltas over 172 reads collapsing into a single write. The relay now forwards frames as they arrive, while a side-channel SSE decoder reads the terminal `transcript.text.done` off the same bytes, so the request is still billed and attributed — from the stream's own guard, which fires at end-of-stream or at client disconnect, whichever comes first. The concurrency slot and the TPM/TPD commit move onto that guard too, so a stream can't release its reservation while it is still running.

A block- or mask-capable output guardrail keeps the buffered path: it has to see the whole transcript before any of it reaches the caller, or `stream=true` would be a way around the check the same request gets without it. That is the chat/responses convention (#719). A monitor-only chain can never block, so it must not change delivery — it takes the live path and scans once at end-of-stream, the same shape `/v1/responses` uses. `EosOutputScan` moved out of `responses.rs` into a shared `guardrail_stream` module so both live-forward paths run one implementation.

Timeouts split the way every relayed path splits them: reqwest's request-level timeout bounds the body read too, so it would cut a long transcript off mid-stream — the streamed path bounds the connect phase and each chunk by the stream budget instead, and the buffered path keeps the request timeout unchanged.

**`/v1/audio/speech` had the same collapse** — the synthesized audio was read whole before any of it was forwarded — and is now relayed chunk by chunk, so a player can start on the first bytes. LiteLLM's own speech proxy streams for exactly this reason; ours was the outlier. The reservation becomes a stream hold so the concurrency slot lives as long as the download, and the upstream `Content-Length` is relayed when present, matching the `/v1/videos` content proxy.

One telemetry shape changes with the speech relay: the handler returns once the headers are out, so a speech request's reported latency is now time-to-first-byte rather than time-to-last-byte. That is the convention every streaming surface here already follows.

**`lofty` WARNs.** The audio-metadata reader behind the duration probe logs parse observations at WARN on ordinary mp3 uploads (`Chunk exceeds reader size, stopping`, `MPEG: Using bitrate to estimate duration`). They describe the uploaded container, not a gateway fault, and there is nothing an operator can do with them — the probe already treats an unreadable file as a zero cost basis. The subscriber pins that target to ERROR rather than allowlisting the lines in the e2e log scan. The issue suggested dropping them to DEBUG, which is not reachable from here: `lofty` logs through the `log` crate, and a record's level is fixed at its callsite — a subscriber can filter it but never re-level it — so keeping it out of the log is the available form of "not a warning".

**The SSE event-count mismatch in the issue is not a relay defect.** `gpt-4o-transcribe` emits one delta per output token — a stream reporting `output_tokens: 185` carries 185 `data: ` lines — and the probe compares two *independent* transcription requests. The 184-vs-185 difference is a one-token difference in what the model heard on each leg, along with 57 bytes of different transcript text; the DP forwards the frames unchanged and cannot add one. The probe's assertion is replaced in AISIX-Cloud#1340 with one the DP's own stream can be held to: its deltas must reassemble into exactly the text its terminal event reports.

## Testing

New e2e (`audio-stream-relay-e2e.test.ts`) measures delivery shape rather than content, because a buffered relay and a streaming one differ only in when the bytes arrive: the mock upstream trickles its response over ~1s and the spec asserts the caller sees that same spread, on both the transcription and the speech leg. Both legs read exactly one chunk with a zero spread against a pre-fix binary, and pass after.

Unit tests cover what timing can't: the relayed bytes are the upstream's frame for frame, the guard emits exactly one UsageEvent (no second zero-token emit from the handler), a provider that ignores `stream=true` and answers JSON is still billed, and a block-capable output guardrail still blocks a streamed transcript. `rawBodyChunks` gives the OpenAI mock a raw body written in pieces, which is what the speech leg needs.

Verified locally: `cargo test --workspace`, `cargo clippy --workspace --all-targets -D warnings`, and the audio + responses/guardrail e2e cases against a local binary and etcd.

`crates/aisix-proxy/AGENTS.md` gains a section on what moves when a buffered relay becomes a streamed one — the timeout shape, the reservation, the usage emit and the guardrail branch all have to move together, and none of them errors when missed.

## Paired changes

- api7/docs#2142 and api7/docs.apiseven.com#468 — the audio page documented the buffering as current behavior.
- AISIX-Cloud#1340 — the live probe's assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Audio transcription and translation responses can now be delivered incrementally as live streams.
  - Speech synthesis audio is relayed progressively, preserving response headers and content.
  - Streaming responses include improved usage tracking, duration metering, and provider attribution.

- **Bug Fixes**
  - Added safeguards for stream timeouts, retries, concurrency limits, and upstream failures.
  - Guardrail monitoring now also observes completed live streams.
  - Reduced noisy non-error logs while preserving important warnings and errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->