### PR TITLE
chore: add glama.json for MCP directory maintainer verification

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["moonming"]
+}


### PR DESCRIPTION
Glama (glama.ai) has listed AISIX in its MCP server directory ([glama.ai/mcp/servers/api7/aisix](https://glama.ai/mcp/servers/api7/aisix), already marked *Official*, Maintenance score A). To manage the listing — configure the Docker build spec and publish a Glama release so the quality score gets computed — the org-owned repo must declare its maintainers in a `glama.json` at the repository root ([their org-claim flow](https://glama.ai/mcp/servers/api7/aisix/score)):

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["moonming"]
}
```

Validated against their schema (`maintainers` is the only defined field, required). Metadata-only file; no runtime surface.

Once merged and re-scanned, the claim completes and the Dockerfile/deploy step follows (needed for the quality badge that awesome-mcp-servers now requires on new entries).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Glama MCP server configuration describing the server schema.
  - Identified the project maintainer in the published metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->