### PR TITLE
chore(glama): add the Glama directory build/check profile

### DIFF
--- a/glama/README.md
+++ b/glama/README.md
@@ -1,0 +1,17 @@
+# Glama deployment check
+
+Files used by [Glama](https://glama.ai/mcp/servers/api7/aisix) to build and
+health-check the AISIX MCP gateway in its sandbox (which wraps a **stdio**
+MCP server and cannot run Docker):
+
+- `setup.sh` — Glama build step: extracts the latest release `aisix` binary
+  from the published GHCR image layers (`extract-aisix.sh`) and installs
+  `mcp-remote`.
+- `start.sh` — Glama start command: launches a tiny embedded MCP upstream
+  (`echo-mcp.py`), starts the gateway with `config.yaml` + `resources.yaml`
+  (anonymous access to the `echo` server only), and bridges Glama's stdio
+  transport to the gateway's Streamable HTTP `/mcp` endpoint via `mcp-remote`.
+
+This is a sandbox profile for the directory's automated checks — not a
+deployment example. For real deployments, see the
+[docs](https://docs.api7.ai/ai-gateway/).

--- a/glama/config.yaml
+++ b/glama/config.yaml
@@ -1,0 +1,8 @@
+resources_file: /app/glama/resources.yaml
+
+proxy:
+  addr: "127.0.0.1:3000"
+
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["glama-image-local-admin"]

--- a/glama/echo-mcp.py
+++ b/glama/echo-mcp.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Minimal streamable-HTTP MCP upstream: one `echo` tool. For the Glama check image only."""
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+TOOLS = [{
+    "name": "echo",
+    "description": "Echo the input text back.",
+    "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+}]
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def _json(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(n) or b"{}")
+        rid, method = req.get("id"), req.get("method", "")
+        if method == "initialize":
+            self._json(200, {"jsonrpc": "2.0", "id": rid, "result": {
+                "protocolVersion": req.get("params", {}).get("protocolVersion", "2025-06-18"),
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "echo-upstream", "version": "1.0.0"}}})
+        elif method == "notifications/initialized":
+            self.send_response(202); self.send_header("Content-Length", "0"); self.end_headers()
+        elif method == "tools/list":
+            self._json(200, {"jsonrpc": "2.0", "id": rid, "result": {"tools": TOOLS}})
+        elif method == "tools/call":
+            text = req.get("params", {}).get("arguments", {}).get("text", "")
+            self._json(200, {"jsonrpc": "2.0", "id": rid, "result": {"content": [{"type": "text", "text": text}]}})
+        else:
+            self._json(200, {"jsonrpc": "2.0", "id": rid, "error": {"code": -32601, "message": "method not found"}})
+
+HTTPServer(("127.0.0.1", 13100), H).serve_forever()

--- a/glama/extract-aisix.sh
+++ b/glama/extract-aisix.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Fetch the aisix binary for the latest release out of the published GHCR
+# image layers. Runs inside Glama's build sandbox, which has no Docker.
+set -euo pipefail
+VERSION=$(git -C /app describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+VERSION=${VERSION:-0.10.0}
+echo "extracting aisix ${VERSION} from ghcr.io/api7/aisix"
+TOKEN=$(curl -fsSL "https://ghcr.io/token?scope=repository:api7/aisix:pull&service=ghcr.io" | python -c 'import sys,json;print(json.load(sys.stdin)["token"])')
+MANIFEST=$(curl -fsSL -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" "https://ghcr.io/v2/api7/aisix/manifests/${VERSION}")
+DIGESTS=$(printf '%s' "$MANIFEST" | python -c 'import sys,json;[print(l["digest"]) for l in reversed(json.load(sys.stdin)["layers"])]')
+for D in $DIGESTS; do
+  curl -fsSL -H "Authorization: Bearer $TOKEN" "https://ghcr.io/v2/api7/aisix/blobs/$D" -o /tmp/layer.tgz
+  ENTRY=$(tar -tzf /tmp/layer.tgz 2>/dev/null | grep -E '(^|/)usr/local/bin/aisix$' | head -1 || true)
+  if [ -n "$ENTRY" ]; then
+    mkdir -p /tmp/x && tar -xzf /tmp/layer.tgz -C /tmp/x "$ENTRY"
+    mv "/tmp/x/$ENTRY" /app/glama/aisix && chmod +x /app/glama/aisix
+    rm -rf /tmp/layer.tgz /tmp/x
+    /app/glama/aisix --version
+    exit 0
+  fi
+  rm -f /tmp/layer.tgz
+done
+echo "aisix binary not found in any layer of ${VERSION}" >&2
+exit 1

--- a/glama/resources.yaml
+++ b/glama/resources.yaml
@@ -1,0 +1,20 @@
+_format_version: "1"
+
+mcp_servers:
+  - display_name: echo
+    url: http://127.0.0.1:13100/mcp
+    enabled: true
+
+api_keys:
+  - display_name: anon-principal
+    key_env: ANON_PRINCIPAL_KEY
+    allowed_models: []
+    mcp_access:
+      allow: ["*"]
+
+mcp_auth_settings:
+  - anonymous:
+      api_key_id: 9aeb246c-ed38-5bef-a854-c8565ca95fb4  # uuid5(FILE_RESOURCE_NAMESPACE, "api_keys/anon-principal")
+      source_cidrs: ["0.0.0.0/0", "::/0"]
+      servers: ["echo"]
+      aggregate_entry: true

--- a/glama/setup.sh
+++ b/glama/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Glama build step: fetch the release binary and the stdio<->HTTP bridge.
+set -euo pipefail
+bash /app/glama/extract-aisix.sh
+npm install -g mcp-remote

--- a/glama/start.sh
+++ b/glama/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+python /app/glama/echo-mcp.py &
+export ANON_PRINCIPAL_KEY="${ANON_PRINCIPAL_KEY:-glama-anon-principal-not-a-secret}"
+/app/glama/aisix --config /app/glama/config.yaml &
+for i in $(seq 1 50); do
+  curl -fsS -o /dev/null http://127.0.0.1:3000/livez 2>/dev/null && break
+  sleep 0.2
+done
+exec mcp-remote http://127.0.0.1:3000/mcp --transport http-only


### PR DESCRIPTION
Second and final repo-side piece for the Glama listing (follows #1012, which completed maintainer verification — the server is now claimed and the admin panel is unlocked).

Glama's build sandbox wraps a **stdio** MCP server and cannot run Docker: it clones this repo, runs configured *build steps*, and starts a command that must speak MCP over stdio. This adds the profile those steps point at:

- `glama/setup.sh` (build step) — extracts the **latest release** `aisix` binary from the published GHCR image layers (no Docker needed; version follows `git describe`), installs `mcp-remote`
- `glama/start.sh` (start command) — boots a 40-line embedded `echo` MCP upstream, starts the gateway in declarative mode (`resources.yaml` grants **anonymous access to the echo server only**, per the v0.10.0 `mcp_auth_settings` feature), and bridges stdio → Streamable HTTP `/mcp` via `mcp-remote`
- `glama/README.md` — states this is the directory's sandbox check profile, not a deployment example

## Verified locally

Reproduced Glama's exact build skeleton (debian:trixie-slim + node + `mcp-proxy`) and ran the full chain end-to-end: binary extraction from GHCR (`aisix 0.10.0`), gateway boot with zero config errors, and an `initialize` request through mcp-proxy → mcp-remote → anonymous `/mcp` returning a valid InitializeResult (rmcp 3.1.2). Two gotchas found and fixed during verification: `AISIX_CONFIG_PATH` must not be set when invoking the binary directly (it is an entrypoint-only variable and fails config parsing), and the layer-tar entry match needs to tolerate a leading `./`.

After merge I'll point the Glama build spec at `glama/setup.sh` / `glama/start.sh` and deploy; a passing build unlocks **Make Release** → quality score → the badge that awesome-mcp-servers now requires on new entries (punkpeye/awesome-mcp-servers#12567).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Glama sandbox deployment profile for AISIX MCP gateway checks.
  * Added a sample MCP echo service accessible through Streamable HTTP.
  * Added deployment configuration for proxying, administration, authentication, and resource access.
  * Added automated setup and startup scripts, including service readiness checks.
* **Documentation**
  * Added deployment guidance and references for running the Glama sandbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->