### PR TITLE
fix(dispatch): openai keys with no api_base fall back to the default base on every route

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -990,6 +990,11 @@ async fn multipart_dispatch(
         url_cache_key,
         &[
             pk_entry.value.api_base.as_deref().unwrap_or(""),
+            // The resolver's output depends on the vendor since #1017
+            // (openai default-base fallback) — a fingerprint without it
+            // would keep serving a stale api.openai.com URL after the
+            // row is repurposed to another vendor.
+            pk_entry.value.provider.as_str(),
             upstream_path,
         ],
         || {
@@ -1664,7 +1669,11 @@ async fn speech_dispatch(
     let speech_url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/audio/speech",
-        &[pk_entry.value.api_base.as_deref().unwrap_or("")],
+        &[
+            pk_entry.value.api_base.as_deref().unwrap_or(""),
+            // Vendor in the fingerprint — see multipart_dispatch (#1017).
+            pk_entry.value.provider.as_str(),
+        ],
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -988,15 +988,13 @@ async fn multipart_dispatch(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         url_cache_key,
-        &[
-            pk_entry.value.api_base.as_deref().unwrap_or(""),
-            // The resolver's output depends on the vendor since #1017
-            // (openai default-base fallback) — a fingerprint without it
-            // would keep serving a stale api.openai.com URL after the
-            // row is repurposed to another vendor.
-            pk_entry.value.provider.as_str(),
-            upstream_path,
-        ],
+        // Every resolve_base_url input, via the shared constructor
+        // (#1017: the resolved URL depends on the vendor too), plus the
+        // per-call path.
+        &{
+            let [base, vendor] = crate::dispatch::pk_url_fingerprint(&pk_entry.value);
+            [base, vendor, upstream_path]
+        },
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(
@@ -1669,11 +1667,8 @@ async fn speech_dispatch(
     let speech_url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/audio/speech",
-        &[
-            pk_entry.value.api_base.as_deref().unwrap_or(""),
-            // Vendor in the fingerprint — see multipart_dispatch (#1017).
-            pk_entry.value.provider.as_str(),
-        ],
+        // Every resolve_base_url input (#1017) via the shared constructor.
+        &crate::dispatch::pk_url_fingerprint(&pk_entry.value),
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -409,13 +409,8 @@ async fn count_tokens_to_target(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/messages/count_tokens",
-        &[
-            pk_entry.value.api_base.as_deref().unwrap_or(""),
-            // The resolver's output depends on the vendor since #1017
-            // (openai default-base fallback); without it in the
-            // fingerprint a repurposed row would keep its stale URL.
-            pk_entry.value.provider.as_str(),
-        ],
+        // Every resolve_base_url input (#1017) via the shared constructor.
+        &crate::dispatch::pk_url_fingerprint(&pk_entry.value),
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_anthropic_url(

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -409,7 +409,13 @@ async fn count_tokens_to_target(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/messages/count_tokens",
-        &[pk_entry.value.api_base.as_deref().unwrap_or("")],
+        &[
+            pk_entry.value.api_base.as_deref().unwrap_or(""),
+            // The resolver's output depends on the vendor since #1017
+            // (openai default-base fallback); without it in the
+            // fingerprint a repurposed row would keep its stale URL.
+            pk_entry.value.provider.as_str(),
+        ],
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_anthropic_url(

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -231,22 +231,48 @@ fn strip_endpoint_suffix(base: &str) -> &str {
 /// image edits, jobs, realtime). The fallback here converges all of
 /// them. Strictly the exact vendor string: an empty or
 /// OpenAI-compatible vendor still errors, because this resolver also
-/// serves non-OpenAI-family paths and must never send another vendor's
-/// credential to api.openai.com (the same refusal the family bridge
-/// makes). Every other catalog vendor keeps requiring `api_base` —
-/// the DP does not enumerate per-vendor default URLs.
+/// serves non-OpenAI-family paths (messages / count_tokens) and must
+/// never send another vendor's credential to api.openai.com. Note the
+/// family bridge is LOOSER: it refuses only a non-empty non-openai
+/// vendor and still falls back for the legacy empty-provider shape —
+/// so a legacy `{provider: "", adapter: "openai"}` row with no
+/// `api_base` remains route-dependent (chat falls back, direct routes
+/// 400); that residue is tracked in #1019 rather than widened here. A
+/// key misdeclared as `provider: "openai"` on an anthropic-adapter
+/// path now dispatches to api.openai.com and gets the upstream's 401
+/// instead of a gateway 400 — by declaration that secret is an OpenAI
+/// credential, so nothing crosses vendors. Every other catalog vendor
+/// keeps requiring `api_base` — the DP does not enumerate per-vendor
+/// default URLs.
+///
+/// Callers that cache the built URL MUST include the vendor in the
+/// cache fingerprint alongside `api_base` — since this fallback, the
+/// resolved URL depends on both.
 pub(crate) fn resolve_base_url(provider_key: &ProviderKey) -> Result<String, ProxyError> {
     match provider_key.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => Ok(strip_endpoint_suffix(b.trim()).to_string()),
         _ if provider_key.provider.trim().eq_ignore_ascii_case("openai") => {
             Ok(aisix_provider_openai::OPENAI_DEFAULT_BASE.to_string())
         }
-        _ => Err(ProxyError::InvalidRequest(format!(
-            "provider_key {:?} has no api_base — cp-api must populate api_base \
-             for every catalog vendor (the DP does not enumerate per-vendor \
-             default URLs; the openai vendor is the one built-in default)",
-            provider_key.display_name
-        ))),
+        _ => {
+            // Remediation detail (control-plane field names, provider
+            // topology) goes to logs only — the customer-visible body
+            // stays free of internal taxonomy, matching the family
+            // bridge's posture.
+            tracing::error!(
+                pk_display_name = %provider_key.display_name,
+                pk_vendor = %provider_key.provider,
+                "provider_key has no api_base. Operator action: populate \
+                 `api_base` on the ProviderKey resource (managed \
+                 deployments: via the control plane's provider settings; \
+                 standalone: directly on the resource). Only the openai \
+                 vendor has a built-in default base."
+            );
+            Err(ProxyError::InvalidRequest(format!(
+                "provider_key {:?} has no api_base configured",
+                provider_key.display_name
+            )))
+        }
     }
 }
 
@@ -606,6 +632,62 @@ mod tests {
         assert_eq!(
             resolve_base_url(&pk).unwrap(),
             aisix_provider_openai::OPENAI_DEFAULT_BASE
+        );
+    }
+
+    /// #1017 HIGH-1 regression: the cached-URL fingerprint at every
+    /// resolver-fed call site must include the vendor. Simulated here at
+    /// the cache level with the exact fingerprint shape those sites use:
+    /// a row cached under `provider: "openai"` (no api_base → default
+    /// base) must NOT keep serving that URL after the row is repurposed
+    /// to another vendor — the rebuild must run and surface the 400,
+    /// or the repurposed vendor's credential would flow to
+    /// api.openai.com until restart.
+    #[test]
+    fn cached_url_rebuilds_when_provider_changes_without_api_base() {
+        let openai_pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"repurpose","secret":"k","provider":"openai"}"#,
+        )
+        .unwrap();
+        let deepseek_pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"repurpose","secret":"k2","provider":"deepseek","adapter":"openai"}"#,
+        )
+        .unwrap();
+        let resource_id = "test-1017-fingerprint-repurpose";
+
+        let first = aisix_gateway::url_cache::cached_endpoint_url(
+            resource_id,
+            "test/1017-fingerprint",
+            &[
+                openai_pk.api_base.as_deref().unwrap_or(""),
+                openai_pk.provider.as_str(),
+            ],
+            || {
+                let base = resolve_base_url(&openai_pk)?;
+                Ok::<_, ProxyError>(build_openai_url(&base, "/responses"))
+            },
+        )
+        .unwrap();
+        assert!(format!("{first:?}").contains("api.openai.com"));
+
+        // Same resource id + endpoint, vendor edited: the fingerprint
+        // mismatch must force a rebuild, which errors — the stale
+        // api.openai.com URL must not be served.
+        let second = aisix_gateway::url_cache::cached_endpoint_url(
+            resource_id,
+            "test/1017-fingerprint",
+            &[
+                deepseek_pk.api_base.as_deref().unwrap_or(""),
+                deepseek_pk.provider.as_str(),
+            ],
+            || {
+                let base = resolve_base_url(&deepseek_pk)?;
+                Ok::<_, ProxyError>(build_openai_url(&base, "/responses"))
+            },
+        );
+        assert!(
+            second.is_err(),
+            "repurposed vendor must rebuild and surface the 400, not the cached URL"
         );
     }
 

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -245,9 +245,9 @@ fn strip_endpoint_suffix(base: &str) -> &str {
 /// keeps requiring `api_base` — the DP does not enumerate per-vendor
 /// default URLs.
 ///
-/// Callers that cache the built URL MUST include the vendor in the
-/// cache fingerprint alongside `api_base` — since this fallback, the
-/// resolved URL depends on both.
+/// Callers that cache the built URL take their fingerprint from
+/// [`pk_url_fingerprint`], which carries every input this resolver
+/// reads — never hand-build a partial fingerprint.
 pub(crate) fn resolve_base_url(provider_key: &ProviderKey) -> Result<String, ProxyError> {
     match provider_key.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => Ok(strip_endpoint_suffix(b.trim()).to_string()),
@@ -322,6 +322,19 @@ pub(crate) fn build_openai_url(base: &str, path: &str) -> String {
     } else {
         format!("{trimmed}/v1{path}")
     }
+}
+
+/// The cache-fingerprint elements for a URL derived from
+/// [`resolve_base_url`]: every raw input the resolved URL depends on —
+/// `api_base` AND the vendor (the #1017 default-base fallback made the
+/// output vendor-dependent). One constructor for all call sites, so a
+/// future input added here reaches every cached URL at once instead of
+/// relying on each site's comment discipline.
+pub(crate) fn pk_url_fingerprint(provider_key: &ProviderKey) -> [&str; 2] {
+    [
+        provider_key.api_base.as_deref().unwrap_or(""),
+        provider_key.provider.as_str(),
+    ]
 }
 
 /// Join an Anthropic upstream base with a version-independent endpoint
@@ -658,10 +671,7 @@ mod tests {
         let first = aisix_gateway::url_cache::cached_endpoint_url(
             resource_id,
             "test/1017-fingerprint",
-            &[
-                openai_pk.api_base.as_deref().unwrap_or(""),
-                openai_pk.provider.as_str(),
-            ],
+            &pk_url_fingerprint(&openai_pk),
             || {
                 let base = resolve_base_url(&openai_pk)?;
                 Ok::<_, ProxyError>(build_openai_url(&base, "/responses"))
@@ -676,10 +686,7 @@ mod tests {
         let second = aisix_gateway::url_cache::cached_endpoint_url(
             resource_id,
             "test/1017-fingerprint",
-            &[
-                deepseek_pk.api_base.as_deref().unwrap_or(""),
-                deepseek_pk.provider.as_str(),
-            ],
+            &pk_url_fingerprint(&deepseek_pk),
             || {
                 let base = resolve_base_url(&deepseek_pk)?;
                 Ok::<_, ProxyError>(build_openai_url(&base, "/responses"))

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -219,16 +219,32 @@ fn strip_endpoint_suffix(base: &str) -> &str {
 }
 
 /// The upstream base URL: `provider_key.api_base` override if set,
-/// otherwise the `Provider`'s built-in default. Tolerates an operator
+/// otherwise the one built-in vendor default. Tolerates an operator
 /// pasting the full upstream URL into `api_base` by stripping any
 /// trailing endpoint suffix — see [`API_BASE_ENDPOINT_SUFFIXES`].
+///
+/// The `openai` vendor is the single default-base exception (#1017):
+/// before it, an OpenAI key with no `api_base` worked on the
+/// bridge-dispatched routes (chat, generations) and `/v1/videos` —
+/// both fall back to [`aisix_provider_openai::OPENAI_DEFAULT_BASE`] —
+/// but 400'd on every direct-HTTP route through this resolver (audio,
+/// image edits, jobs, realtime). The fallback here converges all of
+/// them. Strictly the exact vendor string: an empty or
+/// OpenAI-compatible vendor still errors, because this resolver also
+/// serves non-OpenAI-family paths and must never send another vendor's
+/// credential to api.openai.com (the same refusal the family bridge
+/// makes). Every other catalog vendor keeps requiring `api_base` —
+/// the DP does not enumerate per-vendor default URLs.
 pub(crate) fn resolve_base_url(provider_key: &ProviderKey) -> Result<String, ProxyError> {
     match provider_key.api_base.as_deref() {
         Some(b) if !b.trim().is_empty() => Ok(strip_endpoint_suffix(b.trim()).to_string()),
+        _ if provider_key.provider.trim().eq_ignore_ascii_case("openai") => {
+            Ok(aisix_provider_openai::OPENAI_DEFAULT_BASE.to_string())
+        }
         _ => Err(ProxyError::InvalidRequest(format!(
             "provider_key {:?} has no api_base — cp-api must populate api_base \
              for every catalog vendor (the DP does not enumerate per-vendor \
-             default URLs)",
+             default URLs; the openai vendor is the one built-in default)",
             provider_key.display_name
         ))),
     }
@@ -547,6 +563,9 @@ mod tests {
     /// admission gap into a loud 400 instead of a silent mis-route.
     #[test]
     fn resolve_base_url_errors_when_api_base_missing() {
+        // No provider (legacy row) — must NOT get the openai default:
+        // sending an unknown vendor's credential to api.openai.com is
+        // worse than the 400.
         let pk: ProviderKey = serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
         let err = resolve_base_url(&pk).unwrap_err();
         match err {
@@ -558,6 +577,51 @@ mod tests {
             }
             other => panic!("expected InvalidRequest, got {other:?}"),
         }
+    }
+
+    /// #1017: the `openai` vendor is the one built-in default base — a
+    /// key with no `api_base` resolves to the same base the specialized
+    /// bridge and the videos route fall back to, so an OpenAI key
+    /// behaves identically on every route family.
+    #[test]
+    fn resolve_base_url_openai_vendor_falls_back_to_default_base() {
+        let pk: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"x","secret":"k","provider":"openai"}"#)
+                .unwrap();
+        assert_eq!(
+            resolve_base_url(&pk).unwrap(),
+            aisix_provider_openai::OPENAI_DEFAULT_BASE
+        );
+    }
+
+    /// The vendor match is trim + case-insensitive (operator-typed
+    /// declarative rows), and a whitespace-only `api_base` counts as
+    /// unset — same emptiness rule as the error arm.
+    #[test]
+    fn resolve_base_url_openai_fallback_tolerates_case_and_blank_base() {
+        let pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"x","secret":"k","provider":" OpenAI ","api_base":"   "}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_base_url(&pk).unwrap(),
+            aisix_provider_openai::OPENAI_DEFAULT_BASE
+        );
+    }
+
+    /// An OpenAI-COMPATIBLE vendor is not OpenAI: it still requires
+    /// `api_base`, mirroring the family bridge's refusal to fall back —
+    /// a DeepSeek credential must never be sent to api.openai.com.
+    #[test]
+    fn resolve_base_url_openai_compatible_vendor_still_errors() {
+        let pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"x","secret":"k","provider":"deepseek","adapter":"openai"}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            resolve_base_url(&pk).unwrap_err(),
+            ProxyError::InvalidRequest(_)
+        ));
     }
 
     fn pk_with_base(api_base: &str) -> ProviderKey {

--- a/crates/aisix-proxy/src/images_edits.rs
+++ b/crates/aisix-proxy/src/images_edits.rs
@@ -436,14 +436,12 @@ async fn dispatch(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/images/edits",
-        &[
-            pk_entry.value.api_base.as_deref().unwrap_or(""),
-            // The resolver's output depends on the vendor since #1017
-            // (openai default-base fallback); without it in the
-            // fingerprint a repurposed row would keep its stale URL.
-            pk_entry.value.provider.as_str(),
-            "/images/edits",
-        ],
+        // Every resolve_base_url input, via the shared constructor
+        // (#1017), plus the endpoint path.
+        &{
+            let [base, vendor] = crate::dispatch::pk_url_fingerprint(&pk_entry.value);
+            [base, vendor, "/images/edits"]
+        },
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(

--- a/crates/aisix-proxy/src/images_edits.rs
+++ b/crates/aisix-proxy/src/images_edits.rs
@@ -438,6 +438,10 @@ async fn dispatch(
         "proxy/images/edits",
         &[
             pk_entry.value.api_base.as_deref().unwrap_or(""),
+            // The resolver's output depends on the vendor since #1017
+            // (openai default-base fallback); without it in the
+            // fingerprint a repurposed row would keep its stale URL.
+            pk_entry.value.provider.as_str(),
             "/images/edits",
         ],
         || {

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1107,7 +1107,13 @@ async fn anthropic_passthrough_dispatch(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         pk_id,
         "proxy/messages",
-        &[pk_value.api_base.as_deref().unwrap_or("")],
+        &[
+            pk_value.api_base.as_deref().unwrap_or(""),
+            // The resolver's output depends on the vendor since #1017
+            // (openai default-base fallback); without it in the
+            // fingerprint a repurposed row would keep its stale URL.
+            pk_value.provider.as_str(),
+        ],
         || {
             let base = crate::dispatch::resolve_base_url(pk_value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_anthropic_url(

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1107,13 +1107,8 @@ async fn anthropic_passthrough_dispatch(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         pk_id,
         "proxy/messages",
-        &[
-            pk_value.api_base.as_deref().unwrap_or(""),
-            // The resolver's output depends on the vendor since #1017
-            // (openai default-base fallback); without it in the
-            // fingerprint a repurposed row would keep its stale URL.
-            pk_value.provider.as_str(),
-        ],
+        // Every resolve_base_url input (#1017) via the shared constructor.
+        &crate::dispatch::pk_url_fingerprint(pk_value),
         || {
             let base = crate::dispatch::resolve_base_url(pk_value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_anthropic_url(

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1093,7 +1093,13 @@ async fn responses_to_target(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/responses",
-        &[pk_entry.value.api_base.as_deref().unwrap_or("")],
+        &[
+            pk_entry.value.api_base.as_deref().unwrap_or(""),
+            // The resolver's output depends on the vendor since #1017
+            // (openai default-base fallback); without it in the
+            // fingerprint a repurposed row would keep its stale URL.
+            pk_entry.value.provider.as_str(),
+        ],
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1093,13 +1093,8 @@ async fn responses_to_target(
     let url = aisix_gateway::url_cache::cached_endpoint_url(
         &pk_entry.id,
         "proxy/responses",
-        &[
-            pk_entry.value.api_base.as_deref().unwrap_or(""),
-            // The resolver's output depends on the vendor since #1017
-            // (openai default-base fallback); without it in the
-            // fingerprint a repurposed row would keep its stale URL.
-            pk_entry.value.provider.as_str(),
-        ],
+        // Every resolve_base_url input (#1017) via the shared constructor.
+        &crate::dispatch::pk_url_fingerprint(&pk_entry.value),
         || {
             let base = crate::dispatch::resolve_base_url(&pk_entry.value)?;
             Ok::<_, crate::error::ProxyError>(crate::dispatch::build_openai_url(


### PR DESCRIPTION
Closes #1017.

## Problem

An OpenAI provider key configured without `api_base` behaved inconsistently by route:

| Route family | Unset `api_base` on an `openai` key |
| --- | --- |
| Bridge-dispatched (chat, generations, …) | Falls back to the bridge's built-in `https://api.openai.com/v1` |
| `/v1/videos` | Falls back explicitly (`videos.rs`) |
| Direct-HTTP via `resolve_base_url` — audio ×3, `/v1/images/edits`, jobs, realtime | `400 invalid_request_error` |

Same declarative config: chat works, audio breaks. The OpenAI provider docs also promise an alias works with `api_base` unset "exactly like the chat alias".

## Fix

One chokepoint: `resolve_base_url` falls back to `OPENAI_DEFAULT_BASE` when `api_base` is unset/blank **and** the key's vendor is exactly `openai` (trim + case-insensitive). Every `resolve_base_url` caller converges at once.

Deliberately strict on the vendor string, mirroring the openai family bridge's refusal: an empty or OpenAI-compatible vendor (`deepseek`, `openrouter`, …) still 400s — this resolver also serves non-OpenAI-family paths (messages/count_tokens), and falling back would send another vendor's credential to api.openai.com. `videos.rs` keeps its equivalent local fallback untouched (keyed on the model's provider; behavior identical).

## Tests

- Unit: openai fallback; trim/case tolerance + whitespace-only `api_base`; OpenAI-compatible vendor still errors; legacy no-provider row still errors. 996 lib tests green.
- e2e: the 400-contract spec for family-adapter vendors (`invalid-upstream-config-400-e2e`) passes unchanged, plus the audio/images/edits specs. The fallback itself cannot be pinned e2e without dialing the real api.openai.com — the resolver unit tests are the contract (same coverage stance as the videos-route fallback).

## Docs note

The in-review docs PRs (api7/docs#2162 / docs.apiseven.com#487) currently document the 400; once this merges they will be updated to the fallback wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Requests now consistently use the correct provider-specific API endpoint, even after provider settings change.
  - Prevented stale endpoint reuse across audio, speech, token counting, image editing, messaging, and response requests.
  - OpenAI requests use OpenAI’s default API endpoint when no custom base URL is provided.
  - Blank or whitespace-only base URLs are handled correctly.
  - Vendor matching for OpenAI is case-insensitive.
  - Other vendors continue to require an explicitly configured API endpoint.
  - Missing endpoint errors now include clearer remediation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->