### PR TITLE
fix(guardrails): reject non-UTF-8 prompt multipart fields on every surface

### DIFF
--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -845,6 +845,11 @@ async fn multipart_dispatch(
     // Client-IP allowlist gate (#557): reject before quota / upstream.
     crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;
 
+    // #1016: a `prompt` part that is not valid UTF-8 would be skipped by
+    // the guardrail scan below yet forwarded verbatim — reject it before
+    // the guardrail pass instead of leaving that asymmetry.
+    crate::dispatch::require_utf8_prompt_fields(&fields)?;
+
     // #696: transcriptions/translations run the guardrail chain too. The
     // audio bytes aren't scannable text, but the optional `prompt` form
     // field IS caller text forwarded verbatim to the provider — scan it
@@ -2460,6 +2465,92 @@ mod tests {
             .unwrap();
         let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// #1016: a `prompt` part that is not valid UTF-8 is rejected 400
+    /// BEFORE the guardrail pass — pre-fix the scan silently skipped it
+    /// while the rebuilt form forwarded the bytes verbatim, so an
+    /// invalid-byte prefix smuggled blocked text past a keyword
+    /// guardrail. The upstream must never be contacted.
+    #[tokio::test]
+    async fn non_utf8_prompt_rejected_400_before_guardrail_and_upstream() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"text":"x"})))
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(whisper_model("my-whisper"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let mut body: Vec<u8> = Vec::new();
+        body.extend_from_slice(
+            b"--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nmy-whisper\r\n",
+        );
+        body.extend_from_slice(b"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\n");
+        // 0xFF makes the field invalid UTF-8; the blocked keyword rides
+        // behind it, unseen by the scan pre-fix.
+        body.extend_from_slice(&[0xFF]);
+        body.extend_from_slice(b"BLOCKME\r\n");
+        body.extend_from_slice(
+            b"--b\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.mp3\"\r\n\
+             Content-Type: audio/mpeg\r\n\r\nID3fakeaudio\r\n--b--\r\n",
+        );
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "multipart/form-data; boundary=b")
+            .body(axum::body::Body::from(body))
+            .unwrap();
+
+        let app = build_app(snap);
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = to_bytes(resp.into_body(), 4096).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        assert!(v["error"]["message"].as_str().unwrap().contains("UTF-8"));
+    }
+
+    /// #1016 companion on the second wired route: translations shares
+    /// the dispatch, and the reject is UNCONDITIONAL — no guardrail
+    /// configured here, the invalid prompt still 400s (validity must
+    /// not flip when a guardrail is attached later).
+    #[tokio::test]
+    async fn translations_non_utf8_prompt_rejected_without_guardrail() {
+        let snap = new_snap("http://unused");
+        snap.models.insert(whisper_model("my-whisper"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let mut body: Vec<u8> = Vec::new();
+        body.extend_from_slice(
+            b"--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nmy-whisper\r\n",
+        );
+        body.extend_from_slice(b"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\n");
+        body.extend_from_slice(&[0xC3, 0x28]);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(
+            b"--b\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.mp3\"\r\n\
+             Content-Type: audio/mpeg\r\n\r\nID3fakeaudio\r\n--b--\r\n",
+        );
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/translations")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "multipart/form-data; boundary=b")
+            .body(axum::body::Body::from(body))
+            .unwrap();
+
+        let app = build_app(snap);
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     fn build_app_with_sink(

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -2553,6 +2553,38 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
+    /// #1016 audit LOW-2: the gate sits AFTER model resolution on the
+    /// audio dispatch too — an unknown model with an invalid prompt
+    /// still answers 404, pinning the placement like the edits test.
+    #[tokio::test]
+    async fn non_utf8_prompt_unknown_model_still_404() {
+        let snap = new_snap("http://unused");
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let mut body: Vec<u8> = Vec::new();
+        body.extend_from_slice(
+            b"--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nnope\r\n",
+        );
+        body.extend_from_slice(b"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\n");
+        body.extend_from_slice(&[0xFF]);
+        body.extend_from_slice(
+            b"x\r\n--b\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.mp3\"\r\n\
+             Content-Type: audio/mpeg\r\n\r\nID3fakeaudio\r\n--b--\r\n",
+        );
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "multipart/form-data; boundary=b")
+            .body(axum::body::Body::from(body))
+            .unwrap();
+
+        let app = build_app(snap);
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
     fn build_app_with_sink(
         snap: AisixSnapshot,
         tx: tokio::sync::mpsc::Sender<aisix_obs::UsageEvent>,

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -324,6 +324,37 @@ pub(crate) fn build_openai_url(base: &str, path: &str) -> String {
     }
 }
 
+/// Reject a multipart `prompt` field that is not valid UTF-8 (#1016).
+///
+/// The guardrail scan and mask passes read `prompt` through
+/// `std::str::from_utf8` and SKIP a field that fails to decode, while
+/// the rebuilt form forwards the original bytes verbatim — so a caller
+/// could smuggle text past a keyword/DLP input guardrail by prefixing
+/// one invalid byte or using a non-UTF-8 encoding. Fail closed instead:
+/// the upstream contracts type `prompt` as text, so a compliant caller
+/// loses nothing, and the JSON endpoints already behave this way (serde
+/// rejects invalid UTF-8 bodies with 400). Deliberately UNCONDITIONAL —
+/// not gated on a guardrail chain being configured — so a request's
+/// validity does not flip when a guardrail is attached later, matching
+/// the boundary-validation posture content-inspection systems use
+/// (validate encoding first, match second).
+///
+/// Called by every multipart surface that scans `prompt` (audio
+/// transcriptions/translations, image edits) after model resolution —
+/// unknown models keep answering 404 — and before the guardrail pass.
+pub(crate) fn require_utf8_prompt_fields(
+    fields: &[(String, Option<String>, Option<String>, bytes::Bytes)],
+) -> Result<(), ProxyError> {
+    for (name, _, _, data) in fields {
+        if name == "prompt" && std::str::from_utf8(data).is_err() {
+            return Err(ProxyError::InvalidRequest(
+                "`prompt` field is not valid UTF-8".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// The cache-fingerprint elements for a URL derived from
 /// [`resolve_base_url`]: every raw input the resolved URL depends on —
 /// `api_base` AND the vendor (the #1017 default-base fallback made the
@@ -646,6 +677,36 @@ mod tests {
             resolve_base_url(&pk).unwrap(),
             aisix_provider_openai::OPENAI_DEFAULT_BASE
         );
+    }
+
+    /// #1016: the multipart prompt UTF-8 gate — invalid bytes in a
+    /// `prompt` part reject; binary bytes in other parts (the image
+    /// itself) pass through untouched.
+    #[test]
+    fn require_utf8_prompt_fields_rejects_only_invalid_prompt() {
+        use bytes::Bytes;
+        let valid = vec![
+            ("model".to_string(), None, None, Bytes::from_static(b"m")),
+            ("prompt".to_string(), None, None, Bytes::from_static(b"ok")),
+            (
+                "image".to_string(),
+                Some("a.png".to_string()),
+                Some("image/png".to_string()),
+                Bytes::from_static(&[0xFF, 0xD8, 0xFF]),
+            ),
+        ];
+        assert!(require_utf8_prompt_fields(&valid).is_ok());
+
+        let invalid = vec![(
+            "prompt".to_string(),
+            None,
+            None,
+            Bytes::from_static(&[0xFF, b'h', b'i']),
+        )];
+        assert!(matches!(
+            require_utf8_prompt_fields(&invalid).unwrap_err(),
+            ProxyError::InvalidRequest(_)
+        ));
     }
 
     /// #1017 HIGH-1 regression: the cached-URL fingerprint at every

--- a/crates/aisix-proxy/src/images_edits.rs
+++ b/crates/aisix-proxy/src/images_edits.rs
@@ -293,6 +293,11 @@ async fn dispatch(
         ));
     }
 
+    // #1016: a `prompt` part that is not valid UTF-8 would be skipped by
+    // the guardrail scan below yet forwarded verbatim — reject it before
+    // the guardrail pass instead of leaving that asymmetry.
+    crate::dispatch::require_utf8_prompt_fields(&fields)?;
+
     // #545 parity with generations: the `prompt` form field is caller text
     // forwarded verbatim to the provider — scan it (input hook, before the
     // reservation per #542) and mask it (#932). The response is an image,
@@ -936,6 +941,84 @@ mod tests {
             .as_str()
             .unwrap_or_default()
             .contains("BLOCKME"));
+    }
+
+    /// #1016: a `prompt` part that is not valid UTF-8 is rejected 400
+    /// before the guardrail pass — pre-fix the scan silently skipped it
+    /// while the rebuilt form forwarded the bytes verbatim, and on this
+    /// route the input scan is the ONLY control (the response is an
+    /// image, no output hook). Upstream must never be contacted.
+    #[tokio::test]
+    async fn non_utf8_prompt_rejected_400_before_guardrail_and_upstream() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/images/edits"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(upstream_response()))
+            .expect(0)
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry("img-edit-prod"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+
+        let mut body: Vec<u8> = Vec::new();
+        body.extend_from_slice(
+            b"--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nimg-edit-prod\r\n",
+        );
+        body.extend_from_slice(b"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\n");
+        body.extend_from_slice(&[0xFF]);
+        body.extend_from_slice(b"BLOCKME\r\n");
+        body.extend_from_slice(
+            b"--b\r\nContent-Disposition: form-data; name=\"image\"; filename=\"a.png\"\r\n\
+             Content-Type: image/png\r\n\r\nPNGFAKEBYTES\r\n--b--\r\n",
+        );
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/images/edits")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "multipart/form-data; boundary=b")
+            .body(axum::body::Body::from(body))
+            .unwrap();
+
+        let app = build_app(snap);
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = to_bytes(resp.into_body(), 4096).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        assert!(v["error"]["message"].as_str().unwrap().contains("UTF-8"));
+    }
+
+    /// #1016: the reject sits AFTER model resolution — an unknown model
+    /// with an invalid prompt still answers 404, keeping the JSON
+    /// endpoints' status precedence.
+    #[tokio::test]
+    async fn non_utf8_prompt_unknown_model_still_404() {
+        let snap = new_snap("http://unused");
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let mut body: Vec<u8> = Vec::new();
+        body.extend_from_slice(
+            b"--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nnope\r\n",
+        );
+        body.extend_from_slice(b"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\n");
+        body.extend_from_slice(&[0xFF]);
+        body.extend_from_slice(b"x\r\n--b--\r\n");
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/images/edits")
+            .header("authorization", "Bearer sk-caller")
+            .header("content-type", "multipart/form-data; boundary=b")
+            .body(axum::body::Body::from(body))
+            .unwrap();
+
+        let app = build_app(snap);
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     /// #168 parallel: a non-OpenAI Model is rejected 400 at the gateway

--- a/tests/e2e/src/cases/non-utf8-prompt-reject-e2e.test.ts
+++ b/tests/e2e/src/cases/non-utf8-prompt-reject-e2e.test.ts
@@ -1,0 +1,140 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: non-UTF-8 `prompt` multipart fields are rejected 400 on every
+// multipart surface (api7/aisix#1016).
+//
+// The input-guardrail scan and mask passes read `prompt` as UTF-8 and
+// used to SKIP a field that failed to decode, while the rebuilt form
+// forwarded the original bytes verbatim — one invalid prefix byte
+// smuggled text past a keyword/DLP guardrail. The gateway now fails
+// closed: an invalid `prompt` answers 400 before the guardrail pass
+// and before any upstream contact, unconditionally (no guardrail needs
+// to be configured), matching the JSON endpoints' own posture (serde
+// rejects invalid UTF-8 bodies).
+//
+// One journey per wired route: /v1/audio/transcriptions,
+// /v1/audio/translations, /v1/images/edits.
+
+const CALLER_PLAINTEXT = "sk-non-utf8-prompt-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+/** Raw multipart body with an invalid-UTF-8 `prompt` part (0xFF prefix
+ * ahead of otherwise-normal text) plus the file part each route needs. */
+function invalidPromptBody(model: string, fileField: string): Blob {
+  const enc = new TextEncoder();
+  const head = enc.encode(
+    `--b\r\nContent-Disposition: form-data; name="model"\r\n\r\n${model}\r\n` +
+      `--b\r\nContent-Disposition: form-data; name="prompt"\r\n\r\n`,
+  );
+  const invalid = new Uint8Array([0xff]);
+  const tail = enc.encode(
+    `SMUGGLED\r\n--b\r\nContent-Disposition: form-data; name="${fileField}"; filename="a.bin"\r\n` +
+      `Content-Type: application/octet-stream\r\n\r\nFAKEBYTES\r\n--b--\r\n`,
+  );
+  const body = new Uint8Array(head.length + invalid.length + tail.length);
+  body.set(head, 0);
+  body.set(invalid, head.length);
+  body.set(tail, head.length + invalid.length);
+  // Blob, not the bare Uint8Array: fetch's BodyInit typing wants it,
+  // and the byte payload passes through unchanged.
+  return new Blob([body]);
+}
+
+describe("non-UTF-8 prompt rejected on every multipart surface (#1016)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: { text: "should never be reached" },
+    });
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "non-utf8-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "non-utf8-audio",
+      provider: "openai",
+      model_name: "gpt-4o-transcribe",
+      provider_key_id: pk.id,
+    });
+    await seed.createModel({
+      display_name: "non-utf8-edit",
+      provider: "openai",
+      model_name: "gpt-image-2",
+      provider_key_id: pk.id,
+    });
+    // Caller key last, so the readiness gate on it implies the whole
+    // seed set (harness AGENTS.md).
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["non-utf8-audio", "non-utf8-edit"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  const cases: Array<[route: string, model: string, fileField: string]> = [
+    ["/v1/audio/transcriptions", "non-utf8-audio", "file"],
+    ["/v1/audio/translations", "non-utf8-audio", "file"],
+    ["/v1/images/edits", "non-utf8-edit", "image"],
+  ];
+
+  for (const [route, model, fileField] of cases) {
+    test(`${route}: invalid prompt bytes answer 400, upstream untouched`, async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+      await waitConfigPropagation(
+        async () => (await probe.listModels()).status === 200,
+      );
+
+      const baseline = upstream.receivedRequests.length;
+      const res = await fetch(`${app.proxyUrl}${route}`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          "content-type": "multipart/form-data; boundary=b",
+        },
+        body: invalidPromptBody(model, fileField),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(body.error?.type).toBe("invalid_request_error");
+      expect(body.error?.message).toContain("UTF-8");
+      // Hard contract: the smuggled bytes never reach the provider.
+      expect(upstream.receivedRequests.length).toBe(baseline);
+    });
+  }
+});


### PR DESCRIPTION
Closes #1016.

## Problem

On the three multipart surfaces — `/v1/audio/transcriptions`, `/v1/audio/translations`, `/v1/images/edits` — the input-guardrail scan and mask-action passes read the `prompt` field through `std::str::from_utf8(...).ok()` and **skip** a field that fails to decode, while the rebuilt form forwards the original bytes verbatim. One invalid prefix byte (or a non-UTF-8 encoding) smuggles text past a keyword/DLP guardrail. On the edits route the input scan is the only control — the response is an image, no output hook.

## Fix

One chokepoint, `dispatch::require_utf8_prompt_fields`: any `prompt` part that is not valid UTF-8 answers `400 invalid_request_error`, called by both multipart dispatches **after model resolution** (unknown models keep answering 404) and **before the guardrail pass and quota reservation**.

Two deliberate choices:

- **Unconditional** — not gated on a guardrail chain being configured. A request's validity must not flip when a guardrail is attached later, and the JSON endpoints already behave exactly this way (serde rejects invalid-UTF-8 bodies with 400), so this converges the multipart surfaces to the rest of the proxy.
- **Reject, not lossy-decode.** Scanning a lossy-decoded copy while forwarding the original bytes leaves the same gap (a keyword in a foreign encoding never appears in the lossy text); forwarding the lossy copy mutates caller content. Validate-then-match is the standard boundary posture in content-inspection systems (the classic WAF anti-smuggling rule); of the comparators we checked, the Python-framework camp gets scan==forward parity incidentally from framework decoding but never rejects, and the plugin camp simply has no text guardrails on these route types at all — fail-closed is strictly stronger than both.

The upstream contracts type `prompt` as text, so a compliant caller loses nothing.

## Tests

- **Unit (5)**: the smuggle shape itself (0xFF + blocked keyword with a guardrail configured, upstream `expect(0)`) on transcriptions and edits; the unconditional reject with no guardrail on translations; 404 precedence for an unknown model; the pure helper (binary `image`/`mask` parts pass untouched). 1002 lib tests green.
- **e2e (3, real binary + etcd)**: one journey per wired route — raw-byte multipart with an invalid `prompt`, asserting 400 + `invalid_request_error` + the UTF-8 message + zero upstream hits.

No CP work: no config surface changes; behavior is a fail-closed validation tightening on malformed input only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multipart audio and image-edit requests now return `400 Bad Request` when the `prompt` contains invalid UTF-8 data.
  * Invalid prompts are rejected before safety checks and upstream processing, preventing malformed requests from being forwarded.
  * Other binary multipart fields continue to be accepted normally.
  * Added coverage across transcription, translation, and image-edit requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->