### PR TITLE
docs: catch README and ROADMAP up to shipped semantic caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,13 @@ Covered by 183 end-to-end scenario files (496 cases) that run against real gatew
   Moderation, AWS Bedrock Guardrails, Azure AI Content Safety (Prompt Shield + text
   moderation), and two Alibaba Cloud services. A block returns `422 content_filter`;
   monitor mode records what would have happened without blocking.
-- **Caching** — exact-match response cache with per-policy TTL and model/key scope matchers;
-  memory and Redis backends; cost-saved telemetry on every hit. Separately, **automatic
-  prompt caching** can be enabled per direct Anthropic model to inject cache breakpoints, so
-  callers get provider-side prompt discounts without changing their requests.
+- **Caching** — exact-match and **semantic** response caching with per-policy TTL and
+  model/key scope matchers; memory and Redis backends; cost-saved telemetry on every hit.
+  A cache policy carrying a `semantic` block serves a cached answer to a differently-worded
+  question at or above its cosine similarity threshold — in-process, or shared across
+  gateway replicas on Redis vector search. Separately, **automatic prompt caching** can be
+  enabled per direct Anthropic model to inject cache breakpoints, so callers get
+  provider-side prompt discounts without changing their requests.
 - **MCP gateway** — front registered upstream MCP servers at `/mcp` with gateway-held
   credentials, per-server tool namespaces, and per-caller access. It serves every
   Streamable HTTP revision from `2025-03-26` through stateless `2026-07-28` without
@@ -305,14 +308,14 @@ crates/
 Highlights on the [roadmap](ROADMAP.md); tracked live in
 [issues](https://github.com/api7/aisix/issues):
 
-- Semantic (embedding-similarity) response caching
 - More observability sinks — Langsmith, Helicone, Slack alerts
 - Prompt templates managed as gateway resources
 - Llama-Guard as a guardrail provider
 
-Shipped since this list was last written: the MCP gateway, the A2A agent gateway,
-OIDC/JWT inbound auth, Redis-backed distributed rate limiting, and the Lakera, Presidio,
-PII, and OpenAI Moderation guardrails — see **Features** above.
+Shipped since this list was last written: semantic (embedding-similarity) response caching,
+the MCP gateway, the A2A agent gateway, OIDC/JWT inbound auth, Redis-backed distributed
+rate limiting, and the Lakera, Presidio, PII, and OpenAI Moderation guardrails — see
+**Features** above.
 
 ## 🛠️ Development
 

--- a/README.md
+++ b/README.md
@@ -175,12 +175,14 @@ Covered by 183 end-to-end scenario files (496 cases) that run against real gatew
   moderation), and two Alibaba Cloud services. A block returns `422 content_filter`;
   monitor mode records what would have happened without blocking.
 - **Caching** — exact-match and **semantic** response caching with per-policy TTL and
-  model/key scope matchers; memory and Redis backends; cost-saved telemetry on every hit.
+  model/key match rules; memory and Redis backends; cost-saved telemetry on every hit.
   A cache policy carrying a `semantic` block serves a cached answer to a differently-worded
   question at or above its cosine similarity threshold — in-process, or shared across
-  gateway replicas on Redis vector search. Separately, **automatic prompt caching** can be
-  enabled per direct Anthropic model to inject cache breakpoints, so callers get
-  provider-side prompt discounts without changing their requests.
+  gateway replicas on Redis vector search. Only fully textual requests match semantically,
+  and entries stay private to the caller's API key unless the policy sets `scope: env`.
+  Separately, **automatic prompt caching** can be enabled per direct Anthropic model to
+  inject cache breakpoints, so callers get provider-side prompt discounts without changing
+  their requests.
 - **MCP gateway** — front registered upstream MCP servers at `/mcp` with gateway-held
   credentials, per-server tool namespaces, and per-caller access. It serves every
   Streamable HTTP revision from `2025-03-26` through stateless `2026-07-28` without
@@ -196,9 +198,10 @@ Covered by 183 end-to-end scenario files (496 cases) that run against real gatew
   events, OTLP/GenAI span export (Langfuse, Honeycomb, Grafana Cloud, or any OTLP receiver),
   plus dedicated Datadog and Aliyun SLS log exporters and object-storage (S3/GCS/Azure Blob)
   telemetry.
-- **Declarative configuration** — one `resources.yaml` carries all ten resource collections
-  (provider keys, models, caller keys, guardrails, MCP servers, A2A agents, cache policies,
-  observability exporters, rate-limit policies, OIDC providers), validated against the same
+- **Declarative configuration** — one `resources.yaml` carries all thirteen resource
+  collections (provider keys, models, caller keys, guardrails, MCP servers, MCP auth
+  settings, A2A agents, cache policies, observability exporters, rate-limit policies,
+  OIDC providers, JWT claim mappings, passthrough routes), validated against the same
   JSON Schemas the gateway uses at runtime. `aisix validate` checks a file offline; `SIGHUP`
   reloads it atomically.
 - **Operational endpoints** — `/livez` and `/readyz` on the proxy listener; `/status/config`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,14 +20,13 @@ The **Surface** column shows where a capability lands: **Gateway** is the AISIX 
 | Enterprise SSO | Single sign-on through SAML and generic OIDC, beyond today's social logins. | Cloud |
 | Directory sync (SCIM) | Provision and deprovision users and groups from your identity provider. | Cloud |
 | Service accounts | Login-less, first-class principals for automated callers. | Cloud |
-| Semantic caching | Serve responses for prompts close in meaning, on top of today's exact-match cache. | Gateway |
 
 ## Next
 
 | Capability | What's planned | Surface |
 | --- | --- | --- |
 | Fine-grained authorization | Custom roles with per-resource and per-action permissions, beyond today's fixed roles and read/write scopes. | Cloud |
-| Conditional and wildcard routing | Route on request metadata, headers, and tags, and match upstreams by wildcard names such as `provider/*`. | Gateway |
+| Conditional routing | Route on request metadata and arbitrary headers, beyond today's tag-conditional targets and wildcard model names such as `provider/*`. | Gateway |
 | Prompt management | Store, version, and reuse prompt templates with variables, resolved at the gateway. | Gateway · Cloud |
 | Caller key rotation experience | Self-service key rotation in the dashboard, plus scheduled auto-rotation with a grace overlap. | Cloud |
 | Production-path playground | Run the Cloud playground through a connected AISIX gateway so it reflects real routing, caching, guardrails, and rate limiting. | Cloud |


### PR DESCRIPTION
## What

An external audit cross-checking the README against the [v0.9.0 release notes](https://github.com/api7/aisix/releases/tag/v0.9.0) found the README behind the release: semantic caching shipped in v0.9.0 (#918, #921) but the README still listed it as a Roadmap item and described the response cache as exact-match only.

- **README › Features › Caching** — now covers semantic caching, wording aligned with the release notes: a cache policy carrying a `semantic` block serves a cached answer to a differently-worded question at or above its cosine similarity threshold, in-process or shared across gateway replicas on Redis vector search.
- **README › Roadmap** — the semantic-caching bullet is removed and folded into the "shipped since this list was last written" trailer.
- **ROADMAP.md › Now** — the Semantic caching row is removed.
- **ROADMAP.md › Next** — while sweeping for other delivered-but-still-listed items: "Conditional and wildcard routing" was partially delivered — wildcard model rows (`provider/*`, `crates/aisix-proxy/src/model_resolve.rs`) and tag-conditional targets fed by the `x-aisix-routing-tags` header are on main. The row is narrowed to the undelivered remainder (conditional routing on request metadata and arbitrary headers). Happy to reword if maintainers see the remainder differently.

Other Roadmap entries were checked against main and stand: no Langsmith/Helicone/Slack sinks, no prompt-template resource, no Llama-Guard provider in the tree.

## Note on the performance-figure claim

The same audit flagged a "~28,300 req/s baseline predating v0.9's thread-per-core numbers" in the README. The README carries no throughput figure — none in the current text and none anywhere in its git history — so there is nothing to update; the figure the audit saw must live outside this repo. No performance numbers are touched by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented semantic response caching with similarity thresholds, model and key scoping, and memory or Redis backends.
  * Updated the shipped features list to include semantic caching.
  * Refined the roadmap to highlight conditional routing based on request metadata and headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Independent audit

A cold audit agent verified every claim above against main and the v0.9.0 release notes (wildcard/tag routing code, exporter kinds, schemas, and all 26 historical README revisions for the perf figure). No HIGH findings. Its one MEDIUM and two LOW findings are fixed in the follow-up commit: the declarative-configuration bullet said "ten resource collections" while `filesource` on main registers thirteen (`claim_mappings` shipped in v0.9.0, plus `passthrough_routes` and `mcp_auth_settings`); "scope matchers" collided with the v0.9.0 cache `scope` field (now "match rules"); and the semantic-caching sentence now carries the release notes' two caveats (textual-only matching, per-key isolation unless `scope: env`).
