### PR TITLE
feat(guardrails): hand redaction rules the field name of a structured value

### DIFF
--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -728,6 +728,21 @@ impl Guardrail for MonitorGuardrail {
         self.observe_redaction("output", self.inner.redact_output_text(text));
         None
     }
+
+    // A speculative pass records nothing — not the enforcement audit, and
+    // not the monitor observation either: the caller may throw the rewrite
+    // away, and a would_mask hit for it would be as false as an enforced one.
+    fn redact_input_text_unaudited(&self, _text: &str) -> Option<Redaction> {
+        None
+    }
+
+    fn redact_output_text_unaudited(&self, _text: &str) -> Option<Redaction> {
+        None
+    }
+
+    fn redacts_positionally(&self) -> bool {
+        self.inner.redacts_positionally()
+    }
 }
 
 /// `mandatory: true` decorator. A remote guardrail that can't reach its
@@ -813,6 +828,18 @@ impl Guardrail for MandatoryGuardrail {
 
     fn redact_output_text(&self, text: &str) -> Option<Redaction> {
         self.inner.redact_output_text(text)
+    }
+
+    fn redact_input_text_unaudited(&self, text: &str) -> Option<Redaction> {
+        self.inner.redact_input_text_unaudited(text)
+    }
+
+    fn redact_output_text_unaudited(&self, text: &str) -> Option<Redaction> {
+        self.inner.redact_output_text_unaudited(text)
+    }
+
+    fn redacts_positionally(&self) -> bool {
+        self.inner.redacts_positionally()
     }
 }
 
@@ -927,6 +954,18 @@ impl Guardrail for LiveGuardrailChain {
 
     fn redact_output_text(&self, text: &str) -> Option<Redaction> {
         self.current().redact_output_text(text)
+    }
+
+    fn redact_input_text_unaudited(&self, text: &str) -> Option<Redaction> {
+        self.current().redact_input_text_unaudited(text)
+    }
+
+    fn redact_output_text_unaudited(&self, text: &str) -> Option<Redaction> {
+        self.current().redact_output_text_unaudited(text)
+    }
+
+    fn redacts_positionally(&self) -> bool {
+        self.current().redacts_positionally()
     }
 }
 

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -698,6 +698,33 @@ impl Guardrail for GuardrailChain {
             self.audit.as_deref(),
         )
     }
+
+    // The speculative pair: same fold, no audit sink. A caller that may
+    // throw the rewrite away uses these, then replays the audited call on
+    // the rewrite it actually keeps.
+    fn redact_input_text_unaudited(&self, text: &str) -> Option<Redaction> {
+        fold_redactions(
+            text,
+            self.members.iter().filter(|m| m.guardrail.redacts_input()),
+            true,
+            None,
+        )
+    }
+
+    fn redact_output_text_unaudited(&self, text: &str) -> Option<Redaction> {
+        fold_redactions(
+            text,
+            self.members.iter().filter(|m| m.guardrail.redacts_output()),
+            false,
+            None,
+        )
+    }
+
+    fn redacts_positionally(&self) -> bool {
+        self.members
+            .iter()
+            .any(|m| m.guardrail.redacts_positionally())
+    }
 }
 
 /// Fold the texts through each segment-moderating member. Mirrors the

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -532,6 +532,18 @@ pub trait Guardrail: Send + Sync + 'static {
         None
     }
 
+    /// `true` when this redactor consumes the offered texts POSITIONALLY —
+    /// it pairs slot *i* of one walk over a body with slot *i* of the next,
+    /// rather than deciding each text on its own content. A wire walker must
+    /// then offer every text exactly once and exactly as it stands: no repeat
+    /// call, no context synthesized around a value, or the two walks stop
+    /// lining up and masks land on the wrong fields. Only the collect/apply
+    /// probes of the segment-moderation bridge set this; a real guardrail
+    /// redacts each text independently and leaves it `false`.
+    fn redacts_positionally(&self) -> bool {
+        false
+    }
+
     // --- remote segment moderation (#932 bedrock follow-up) ---------------
     //
     // A remote-API guardrail that can MASK (Bedrock PII anonymize) can't

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -532,6 +532,23 @@ pub trait Guardrail: Send + Sync + 'static {
         None
     }
 
+    /// The same rewrite as [`Self::redact_input_text`], but SPECULATIVE: the
+    /// caller may discard the result, so nothing may reach the per-request
+    /// enforcement audit. A discarded rewrite that had already been recorded
+    /// would put a `masked` hit on the usage event for a mask no client ever
+    /// saw — worse than no audit, because the operator reads that array as
+    /// evidence. Only a guardrail that records (a chain) needs to override
+    /// this; a plain redactor's audited and speculative rewrites are the same
+    /// pure function.
+    fn redact_input_text_unaudited(&self, text: &str) -> Option<Redaction> {
+        self.redact_input_text(text)
+    }
+
+    /// Response-side [`Self::redact_input_text_unaudited`].
+    fn redact_output_text_unaudited(&self, text: &str) -> Option<Redaction> {
+        self.redact_output_text(text)
+    }
+
     /// `true` when this redactor consumes the offered texts POSITIONALLY —
     /// it pairs slot *i* of one walk over a body with slot *i* of the next,
     /// rather than deciding each text on its own content. A wire walker must

--- a/crates/aisix-proxy/src/json_splice.rs
+++ b/crates/aisix-proxy/src/json_splice.rs
@@ -38,6 +38,15 @@ impl PathSeg {
     }
 }
 
+/// The object key the value at `path` is a member of; `None` for an array
+/// element or the document root, where there is no key to speak of.
+pub fn member_key(path: &[PathSeg]) -> Option<&str> {
+    match path.last() {
+        Some(PathSeg::Key(k)) => Some(k.as_str()),
+        _ => None,
+    }
+}
+
 /// Scanner failure. Carries no document content (the byte offset only),
 /// so an error can be logged without leaking the payload.
 #[derive(Debug, thiserror::Error)]
@@ -55,8 +64,10 @@ const MAX_DEPTH: usize = 256;
 /// leaving every other byte untouched.
 ///
 /// For each string VALUE (never a key) whose path satisfies the
-/// predicate, the decoded text is offered to `rewrite`; `Some(new)`
-/// replaces that value's bytes with the JSON encoding of `new`.
+/// predicate, the decoded text is offered to `rewrite` along with that
+/// path — so a caller can hand the leaf's object key to the rule that
+/// decides ([`member_key`]); `Some(new)` replaces that value's bytes with
+/// the JSON encoding of `new`.
 ///
 /// Returns `Ok(None)` when nothing changed (callers keep the original
 /// buffer — the no-hit case allocates nothing), `Ok(Some(bytes))` with
@@ -64,7 +75,7 @@ const MAX_DEPTH: usize = 256;
 pub fn rewrite_string_values(
     input: &[u8],
     mut should_rewrite: impl FnMut(&[PathSeg]) -> bool,
-    mut rewrite: impl FnMut(&str) -> Option<String>,
+    mut rewrite: impl FnMut(&[PathSeg], &str) -> Option<String>,
 ) -> Result<Option<Vec<u8>>, SpliceError> {
     enum Frame {
         Object,
@@ -153,7 +164,7 @@ pub fn rewrite_string_values(
                 let end = scan_string(pos)?;
                 if should_rewrite(&path) {
                     let decoded = decode_str(pos..end)?;
-                    if let Some(new) = rewrite(&decoded) {
+                    if let Some(new) = rewrite(&path, &decoded) {
                         // to_string of a String is infallible.
                         let encoded = serde_json::to_string(&new).map_err(|_| err(pos))?;
                         splices.push((pos..end, encoded));
@@ -246,8 +257,8 @@ pub fn rewrite_string_values(
 mod tests {
     use super::*;
 
-    fn rewrite_all(input: &str, f: impl FnMut(&str) -> Option<String>) -> Option<String> {
-        rewrite_string_values(input.as_bytes(), |_| true, f)
+    fn rewrite_all(input: &str, mut f: impl FnMut(&str) -> Option<String>) -> Option<String> {
+        rewrite_string_values(input.as_bytes(), |_| true, |_, s| f(s))
             .unwrap()
             .map(|b| String::from_utf8(b).unwrap())
     }
@@ -267,7 +278,7 @@ mod tests {
     #[test]
     fn no_change_returns_none() {
         let doc = r#"{"a": "x", "b": 2}"#;
-        assert!(rewrite_string_values(doc.as_bytes(), |_| true, |_| None)
+        assert!(rewrite_string_values(doc.as_bytes(), |_| true, |_, _| None)
             .unwrap()
             .is_none());
     }
@@ -283,7 +294,7 @@ mod tests {
                 paths.push(p.to_vec());
                 true
             },
-            |s| {
+            |_, s| {
                 offered.push(s.to_owned());
                 None
             },
@@ -301,6 +312,32 @@ mod tests {
     }
 
     #[test]
+    fn rewrite_sees_the_member_key_of_each_leaf() {
+        // The key a leaf hangs off is what a key-anchored redaction rule
+        // needs; array elements and the root have none.
+        let doc = r#"{"version":"12.1","tags":["a"],"run":{"版本":"2022.4"}}"#;
+        let mut seen = Vec::new();
+        rewrite_string_values(
+            doc.as_bytes(),
+            |_| true,
+            |path, text| {
+                seen.push((member_key(path).map(str::to_owned), text.to_owned()));
+                None
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            seen,
+            vec![
+                (Some("version".to_owned()), "12.1".to_owned()),
+                (None, "a".to_owned()),
+                (Some("版本".to_owned()), "2022.4".to_owned()),
+            ],
+        );
+        assert_eq!(member_key(&[]), None);
+    }
+
+    #[test]
     fn array_indices_and_nesting_track_correctly() {
         let doc = r#"{"params":{"arguments":{"xs":["a",{"y":"b"},[],"c"],"n":7}},"id":"z"}"#;
         let mut seen = Vec::new();
@@ -310,7 +347,7 @@ mod tests {
                 p.first().is_some_and(|s| s.is_key("params"))
                     && p.get(1).is_some_and(|s| s.is_key("arguments"))
             },
-            |s| {
+            |_, s| {
                 seen.push(s.to_owned());
                 None
             },
@@ -328,7 +365,7 @@ mod tests {
         let out = rewrite_string_values(
             doc.as_bytes(),
             |p| p.first().is_some_and(|s| s.is_key("params")),
-            |s| (s == "hit").then(|| "X".to_string()),
+            |_, s| (s == "hit").then(|| "X".to_string()),
         )
         .unwrap()
         .unwrap();
@@ -375,7 +412,7 @@ mod tests {
             "null",
             r#""s""#,
         ] {
-            let got = rewrite_string_values(doc.as_bytes(), |_| true, |_| None).unwrap();
+            let got = rewrite_string_values(doc.as_bytes(), |_| true, |_, _| None).unwrap();
             assert!(got.is_none(), "{doc}");
         }
         // A bare root string IS a value and can be rewritten.
@@ -392,7 +429,7 @@ mod tests {
             r#"{'a':1}"#,
         ] {
             assert!(
-                rewrite_string_values(doc.as_bytes(), |_| true, |_| Some("m".into())).is_err(),
+                rewrite_string_values(doc.as_bytes(), |_| true, |_, _| Some("m".into())).is_err(),
                 "{doc}",
             );
         }
@@ -407,6 +444,6 @@ mod tests {
         for _ in 0..300 {
             doc.push(']');
         }
-        assert!(rewrite_string_values(doc.as_bytes(), |_| true, |_| None).is_err());
+        assert!(rewrite_string_values(doc.as_bytes(), |_| true, |_, _| None).is_err());
     }
 }

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -672,9 +672,12 @@ fn rewrite_tool_arguments(
             let key = (path.len() > 2)
                 .then(|| crate::json_splice::member_key(path))
                 .flatten();
-            crate::redact::redact_with_key_context(key, text, |t| {
-                aisix_guardrails::Guardrail::redact_input_text(chain, t)
-            })
+            crate::redact::redact_with_key_context(
+                chain,
+                crate::redact::Direction::Input,
+                key,
+                text,
+            )
             .map(|r| {
                 crate::redact::merge_counts(&mut counts, r.counts);
                 r.text
@@ -855,16 +858,19 @@ async fn apply_output_guardrails(
             // Under `structuredContent` the field name is the tool's own
             // (`{"version": "12.1"}`), so it is handed to the rule; a content
             // block's `text`/`description`/`title`/`resource.text` are MCP
-            // envelope names, and synthesizing `"text": "…"` around a prose
+            // envelope names, and synthesizing `"text":"…"` around a prose
             // block would reintroduce exactly the envelope-name false
             // positives the scan path decodes the blocks to avoid.
             let key = (path.len() > 2
                 && path.get(1).is_some_and(|s| s.is_key("structuredContent")))
             .then(|| crate::json_splice::member_key(path))
             .flatten();
-            crate::redact::redact_with_key_context(key, text, |t| {
-                aisix_guardrails::Guardrail::redact_output_text(chain, t)
-            })
+            crate::redact::redact_with_key_context(
+                chain,
+                crate::redact::Direction::Output,
+                key,
+                text,
+            )
             .map(|r| {
                 crate::redact::merge_counts(&mut counts, r.counts);
                 r.text
@@ -2166,7 +2172,7 @@ mod tests {
     /// AISIX-Cloud#1330 case B: when the sensitive value IS a JSON field, a
     /// leaf-by-leaf rewrite hands the rule a bare `12.1` and the key-anchored
     /// rule can never fire — the value ships unmasked with no signal. Offering
-    /// each `structuredContent` member as `"key": "value"` makes it fire, and
+    /// each `structuredContent` member as `"key":"value"` makes it fire, and
     /// the discrimination is the point: same-shaped values under a field the
     /// rule does not name survive byte-for-byte.
     #[tokio::test]
@@ -2205,7 +2211,7 @@ mod tests {
     /// The MCP envelope's own field names are NOT synthesized as context. The
     /// scan path decodes the content blocks precisely so `content`/`type`/
     /// `text` can't trip a rule; wrapping a prose block back up as
-    /// `"text": "…"` would reintroduce exactly that false positive. Only the
+    /// `"text":"…"` would reintroduce exactly that false positive. Only the
     /// tool's own `structuredContent` keys are its data.
     #[tokio::test]
     async fn envelope_field_names_are_not_offered_as_key_context() {
@@ -2260,6 +2266,38 @@ mod tests {
             r#""arguments":{"elapsed":"12.345","port":"10.2.255.1"}}}"#,
         );
         assert!(rewrite_tool_arguments(&chain, clean.as_bytes())
+            .unwrap()
+            .is_none());
+    }
+
+    /// A discarded speculative pass must leave NO trace in the enforcement
+    /// audit. A key-anchored rule WITHOUT a capture group replaces the whole
+    /// match, which swallows the synthesized wrapper: the rewrite is dropped
+    /// and the value ships as it stood, so a `masked` hit on the usage event
+    /// would describe a mask no client ever saw — worse than no audit, since
+    /// operators read that array as evidence (#1023).
+    #[test]
+    fn a_discarded_wrapped_pass_files_no_enforced_hit() {
+        let chain = env_chain_with(
+            r#"{"name":"pii-key","kind":"pii","hook_point":"input","custom_patterns":[{"name":"whole_match","regex":"\"version\"\\s*:\\s*\"[^\"]*\"","action":"mask","replacement":"***"}]}"#,
+        );
+        let body = r#"{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"t","arguments":{"version":"12.1"}}}"#;
+        assert!(rewrite_tool_arguments(&chain, body.as_bytes())
+            .unwrap()
+            .is_none());
+        let hits = chain.enforced_hits();
+        assert!(hits.is_empty(), "nothing was masked: {hits:?}");
+    }
+
+    /// An empty argument has nothing to mask. Without the guard the wrapped
+    /// pass lets a `"key":"([^"]*)"` rule match the empty value and plant a
+    /// mask token in a field that carried none — which a downstream agent
+    /// reads as a real value.
+    #[test]
+    fn an_empty_argument_is_never_given_a_mask_token() {
+        let chain = env_chain_with(&pii_json_key_guard("input"));
+        let body = r#"{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"t","arguments":{"version":""}}}"#;
+        assert!(rewrite_tool_arguments(&chain, body.as_bytes())
             .unwrap()
             .is_none());
     }

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -650,6 +650,11 @@ async fn dispatch(
 /// Splice-rewrite the string leaves under `params.arguments` of a
 /// `tools/call` body through the chain's input redactor (AISIX-Cloud#1330).
 /// `Ok(None)` = nothing masked, keep the original bytes.
+///
+/// The keys under `arguments` are the TOOL's own input schema, so each
+/// member is offered to the redactor with its key as context — a rule
+/// anchored on the field name fires on `{"version": "12.1"}` exactly as it
+/// does on a document embedded in prose (`redact_with_key_context`).
 fn rewrite_tool_arguments(
     chain: &aisix_guardrails::GuardrailChain,
     body: &[u8],
@@ -661,8 +666,16 @@ fn rewrite_tool_arguments(
             path.first().is_some_and(|s| s.is_key("params"))
                 && path.get(1).is_some_and(|s| s.is_key("arguments"))
         },
-        |text| {
-            aisix_guardrails::Guardrail::redact_input_text(chain, text).map(|r| {
+        |path, text| {
+            // Only members INSIDE `arguments` carry a tool-defined key;
+            // `arguments` itself is the envelope's name.
+            let key = (path.len() > 2)
+                .then(|| crate::json_splice::member_key(path))
+                .flatten();
+            crate::redact::redact_with_key_context(key, text, |t| {
+                aisix_guardrails::Guardrail::redact_input_text(chain, t)
+            })
+            .map(|r| {
                 crate::redact::merge_counts(&mut counts, r.counts);
                 r.text
             })
@@ -837,8 +850,22 @@ async fn apply_output_guardrails(
                 _ => false,
             }
         },
-        |text| {
-            aisix_guardrails::Guardrail::redact_output_text(chain, text).map(|r| {
+        |path, text| {
+            // Key context only where the keys are the TOOL's output schema.
+            // Under `structuredContent` the field name is the tool's own
+            // (`{"version": "12.1"}`), so it is handed to the rule; a content
+            // block's `text`/`description`/`title`/`resource.text` are MCP
+            // envelope names, and synthesizing `"text": "…"` around a prose
+            // block would reintroduce exactly the envelope-name false
+            // positives the scan path decodes the blocks to avoid.
+            let key = (path.len() > 2
+                && path.get(1).is_some_and(|s| s.is_key("structuredContent")))
+            .then(|| crate::json_splice::member_key(path))
+            .flatten();
+            crate::redact::redact_with_key_context(key, text, |t| {
+                aisix_guardrails::Guardrail::redact_output_text(chain, t)
+            })
+            .map(|r| {
                 crate::redact::merge_counts(&mut counts, r.counts);
                 r.text
             })
@@ -2125,6 +2152,116 @@ mod tests {
         // No hit → no allocation, original bytes forwarded.
         let clean = br#"{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"eda__echo","arguments":{"text":"Elapsed: 12.345s"}}}"#;
         assert!(rewrite_tool_arguments(&chain, clean).unwrap().is_none());
+    }
+
+    /// A mask guard whose rule is anchored on the FIELD NAME — the shape an
+    /// operator writes when the sensitive value is a real JSON field rather
+    /// than a number embedded in prose (AISIX-Cloud#1330 case B).
+    fn pii_json_key_guard(hook: &str) -> String {
+        format!(
+            r#"{{"name":"pii-key","kind":"pii","hook_point":"{hook}","custom_patterns":[{{"name":"eda_version_json","regex":"\"(?:version|版本)\"\\s*:\\s*\"([^\"]*)\"","action":"mask","replacement":"***"}}]}}"#,
+        )
+    }
+
+    /// AISIX-Cloud#1330 case B: when the sensitive value IS a JSON field, a
+    /// leaf-by-leaf rewrite hands the rule a bare `12.1` and the key-anchored
+    /// rule can never fire — the value ships unmasked with no signal. Offering
+    /// each `structuredContent` member as `"key": "value"` makes it fire, and
+    /// the discrimination is the point: same-shaped values under a field the
+    /// rule does not name survive byte-for-byte.
+    #[tokio::test]
+    async fn output_mask_reads_the_field_name_of_a_structured_value() {
+        let chain = env_chain_with(&pii_json_key_guard("output"));
+        let body = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"report ready"}],"#,
+            r#""structuredContent":{"version": "12.1","版本":"2022.4","elapsed":"12.345","#,
+            r#""port":"10.2.255.1","run":{"version":"9.0"},"tags":["12.1"],"cells": 1e3}}}"#,
+        );
+        let out = match apply_output_guardrails(&chain, body.as_bytes(), "report", &mut Vec::new())
+            .await
+        {
+            ToolResultOutcome::Allow(Some((bytes, counts))) => {
+                assert_eq!(counts.get("eda_version_json"), Some(&3));
+                String::from_utf8(bytes).unwrap()
+            }
+            _ => panic!("expected a rewritten Allow"),
+        };
+        assert_eq!(
+            out,
+            concat!(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"report ready"}],"#,
+                // en + zh field names hit; `elapsed`/`port` carry the same
+                // shapes under a different name and are untouched; a nested
+                // member takes its own key; an array element has no key and
+                // keeps plain-leaf behaviour; the number spelling survives.
+                r#""structuredContent":{"version": "***","版本":"***","elapsed":"12.345","#,
+                r#""port":"10.2.255.1","run":{"version":"***"},"tags":["12.1"],"cells": 1e3}}}"#,
+            ),
+        );
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["result"]["structuredContent"]["cells"], 1000.0);
+    }
+
+    /// The MCP envelope's own field names are NOT synthesized as context. The
+    /// scan path decodes the content blocks precisely so `content`/`type`/
+    /// `text` can't trip a rule; wrapping a prose block back up as
+    /// `"text": "…"` would reintroduce exactly that false positive. Only the
+    /// tool's own `structuredContent` keys are its data.
+    #[tokio::test]
+    async fn envelope_field_names_are_not_offered_as_key_context() {
+        let chain = env_chain_with(
+            r#"{"name":"pii-key","kind":"pii","hook_point":"output","custom_patterns":[{"name":"any_text","regex":"\"text\"\\s*:\\s*\"([^\"]*)\"","action":"mask","replacement":"***"}]}"#,
+        );
+        let body = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"harmless prose"},"#,
+            r#"{"type":"resource","resource":{"uri":"file:///a.log","text":"log line"}}],"#,
+            r#""structuredContent":{"text":"tool field"}}}"#,
+        );
+        match apply_output_guardrails(&chain, body.as_bytes(), "report", &mut Vec::new()).await {
+            ToolResultOutcome::Allow(Some((bytes, _))) => assert_eq!(
+                String::from_utf8(bytes).unwrap(),
+                concat!(
+                    // The two envelope-named blocks are untouched...
+                    r#"{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"harmless prose"},"#,
+                    r#"{"type":"resource","resource":{"uri":"file:///a.log","text":"log line"}}],"#,
+                    // ...only the tool's own field is offered with its key.
+                    r#""structuredContent":{"text":"***"}}}"#,
+                ),
+            ),
+            _ => panic!("expected a rewritten Allow"),
+        }
+    }
+
+    /// Request direction, same contract: a tool argument that IS a JSON field
+    /// reaches the rule with its name attached, so the upstream receives the
+    /// masked value; a same-shaped argument under another name does not.
+    #[test]
+    fn input_mask_reads_the_field_name_of_a_tool_argument() {
+        let chain = env_chain_with(&pii_json_key_guard("input"));
+        let body = concat!(
+            r#"{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"eda__run","#,
+            r#""arguments":{"version":"12.1","版本":"2022.4","elapsed":"12.345"}}}"#,
+        );
+        let (bytes, counts) = rewrite_tool_arguments(&chain, body.as_bytes())
+            .unwrap()
+            .expect("a hit rewrites");
+        assert_eq!(counts.get("eda_version_json"), Some(&2));
+        assert_eq!(
+            String::from_utf8(bytes).unwrap(),
+            concat!(
+                // `params.name` is outside `arguments` and never offered.
+                r#"{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"eda__run","#,
+                r#""arguments":{"version":"***","版本":"***","elapsed":"12.345"}}}"#,
+            ),
+        );
+        // Nothing but same-shaped negatives → no rewrite, original bytes.
+        let clean = concat!(
+            r#"{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"eda__run","#,
+            r#""arguments":{"elapsed":"12.345","port":"10.2.255.1"}}}"#,
+        );
+        assert!(rewrite_tool_arguments(&chain, clean.as_bytes())
+            .unwrap()
+            .is_none());
     }
 
     /// AISIX-Cloud#1330 audit chain: a mask that actually fired names the

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -55,63 +55,110 @@ fn redact_str(
     }
 }
 
-/// Offer an object member to `redact` as its JSON spelling — `"key": "value"`
-/// — so an operator rule anchored on the field NAME can fire on a value that
-/// is a real JSON field (AISIX-Cloud#1330 case B).
+/// The speculative twin of [`redact_str`]: same rewrite, nothing recorded
+/// to the per-request enforcement audit (see the trait method's docs).
+fn redact_str_unaudited(
+    chain: &dyn Guardrail,
+    dir: Direction,
+    text: &str,
+) -> Option<aisix_guardrails::Redaction> {
+    match dir {
+        Direction::Input => chain.redact_input_text_unaudited(text),
+        Direction::Output => chain.redact_output_text_unaudited(text),
+    }
+}
+
+/// The VALUE span of a rewritten `"key":"value"` synthetic, or `None` when
+/// the rule rewrote the synthesized context instead of the tool's data.
 ///
-/// A leaf-by-leaf rewrite hands the rule the bare value (`12.1`), which is
+/// `prefix` is valid UTF-8 and must match byte-for-byte, which puts its
+/// length on a char boundary; the trailing `"` is one ASCII byte.
+fn keyed_value_span<'a>(prefix: &str, rewritten: &'a str) -> Option<&'a str> {
+    (rewritten.len() > prefix.len()
+        && rewritten.as_bytes().starts_with(prefix.as_bytes())
+        && rewritten.ends_with('"'))
+    .then(|| &rewritten[prefix.len()..rewritten.len() - 1])
+}
+
+/// Redact one string member of a JSON object, offering the rules its field
+/// NAME as well as its value (AISIX-Cloud#1330 case B).
+///
+/// A leaf-by-leaf rewrite hands the rules the bare value (`12.1`), which is
 /// indistinguishable from any other dotted number. A rule keyed on the field
 /// (`"version"\s*:\s*"([^"]*)"`) then never matches and the value ships
-/// unmasked, while the same rule DOES fire when the tool happens to embed the
-/// document in a prose leaf — a difference the operator has no way to predict.
-/// Wrapping the leaf in its key restores the discriminator the rule was
-/// written around; because the value's bytes appear verbatim inside the
-/// synthetic text, a value-anchored rule still sees exactly what it saw
-/// before, in one pass.
+/// unmasked — while the same rule DOES fire when a tool happens to embed the
+/// document in a prose leaf, a difference the operator has no way to predict.
 ///
-/// Only the VALUE span survives. The synthetic prefix (`"key": "`) and the
-/// closing quote must come back byte-for-byte; a rule that swallowed either
-/// rewrote the synthesized context rather than the tool's data, so its result
-/// is discarded and the bare leaf is redacted instead — the pre-key-context
-/// behaviour. The same fallback catches a rule the wrapper hides (an `^…$`
-/// anchored pattern matches the bare value but not the wrapped one), at the
-/// cost of a second pass over leaves nothing matched.
+/// Two passes, composed the way a chain composes its members
+/// (`fold_redactions`), never raced against each other:
 ///
-/// Note on the audit log: a chain records an enforced mask hit as soon as a
-/// member rewrites, so a discarded out-of-bounds pass is still audited. That
-/// can over-count `guardrail_enforced_hits` on that rare path — the direction
-/// is fail-safe (a mask attempt is reported, never hidden).
+///  1. the BARE leaf, exactly the pre-key-context rewrite. Its result is
+///     always kept, so a rule anchored to the whole leaf (`^…$` — which can
+///     only ever match the bare form) keeps firing no matter what pass 2
+///     does. Racing the two instead would let any unanchored sibling rule
+///     steal the anchored rule's only chance: a `^\d{4}$` PIN mask silently
+///     became a one-character mask.
+///  2. the member's JSON spelling around pass 1's output, in the SAME
+///     compact form the MCP input scan hands `check_input`
+///     (`Value::to_string()`), so one operator rule covers block and mask.
 ///
-/// `key: None` (array element, document root) skips the synthesis entirely.
+/// Pass 2 is kept only when the synthesized prefix (`"key":"`) and the
+/// closing quote come back byte-for-byte AND the value actually changed —
+/// otherwise the rule rewrote the wrapper rather than the data, or matched
+/// its own mask token a second time, and the pass-1 result stands. Because
+/// that pass can be thrown away it runs UNAUDITED, and the kept rewrite is
+/// replayed through the audited path: an enforcement hit must describe a
+/// mask the client really saw.
+///
+/// The wrapped pass is skipped for an empty value, and for a key or value
+/// carrying `"` or `\`: their decoded bytes are not JSON string content, so
+/// the synthetic would not be the document's own spelling and a `"([^"]*)"`
+/// rule would frame on the embedded quote and mask only the head.
+///
+/// `key: None` (array element, document root) is pass 1 alone.
 pub fn redact_with_key_context(
+    chain: &dyn Guardrail,
+    dir: Direction,
     key: Option<&str>,
     text: &str,
-    mut redact: impl FnMut(&str) -> Option<aisix_guardrails::Redaction>,
 ) -> Option<aisix_guardrails::Redaction> {
+    let bare = redact_str(chain, dir, text);
     let Some(key) = key else {
-        return redact(text);
+        return bare;
     };
-    // JSON spelling with the key's DECODED bytes: the rule is written against
-    // what a reader sees, not against the document's escape choices.
-    let prefix = format!("\"{key}\": \"");
-    let mut synthetic = String::with_capacity(prefix.len() + text.len() + 1);
-    synthetic.push_str(&prefix);
-    synthetic.push_str(text);
-    synthetic.push('"');
-    if let Some(r) = redact(&synthetic) {
-        // `prefix` is valid UTF-8 and matched byte-for-byte, so its length is
-        // a char boundary in `r.text`; the trailing `"` is one ASCII byte.
-        if r.text.len() > prefix.len()
-            && r.text.as_bytes().starts_with(prefix.as_bytes())
-            && r.text.ends_with('"')
-        {
-            return Some(aisix_guardrails::Redaction {
-                text: r.text[prefix.len()..r.text.len() - 1].to_owned(),
-                counts: r.counts,
-            });
-        }
+    let base = bare.as_ref().map_or(text, |r| r.text.as_str());
+    if base.is_empty() || base.contains(['"', '\\']) || key.contains(['"', '\\']) {
+        return bare;
     }
-    redact(text)
+    let prefix = format!("\"{key}\":\"");
+    let mut synthetic = String::with_capacity(prefix.len() + base.len() + 1);
+    synthetic.push_str(&prefix);
+    synthetic.push_str(base);
+    synthetic.push('"');
+
+    let probed = match redact_str_unaudited(chain, dir, &synthetic) {
+        Some(probed) => probed,
+        None => return bare,
+    };
+    match keyed_value_span(&prefix, &probed.text) {
+        Some(masked) if masked != base => {}
+        _ => return bare,
+    }
+    // Replay through the audited path. The redactors are pure regex
+    // rewrites, so this repeats the accepted result exactly; anything else
+    // means the chain changed under us and pass 1 stands.
+    let Some(kept) = redact_str(chain, dir, &synthetic) else {
+        return bare;
+    };
+    let Some(masked) = keyed_value_span(&prefix, &kept.text).map(str::to_owned) else {
+        return bare;
+    };
+    let mut counts = bare.map(|b| b.counts).unwrap_or_default();
+    merge_counts(&mut counts, kept.counts);
+    Some(aisix_guardrails::Redaction {
+        text: masked,
+        counts,
+    })
 }
 
 // ─── Remote segment moderation (kind=bedrock mask write-back) ────────────────
@@ -369,7 +416,7 @@ fn redact_value_strings_under(
             // text once, verbatim (`redacts_positionally`) — the bedrock
             // segment bridge walks these same tool-argument documents.
             let key = key.filter(|_| !chain.redacts_positionally());
-            if let Some(r) = redact_with_key_context(key, s, |t| redact_str(chain, dir, t)) {
+            if let Some(r) = redact_with_key_context(chain, dir, key, s) {
                 *s = r.text;
                 merge_counts(counts, r.counts);
             }
@@ -1551,6 +1598,75 @@ mod tests {
         redact_value_strings(chain.as_ref(), Direction::Input, &mut v, &mut counts);
         assert_eq!(v, json!({"pin": "####", "note": "pin 1234 here"}));
         assert_eq!(counts.get("pin"), Some(&1));
+    }
+
+    /// A chain where one rule fires on the WRAPPED text and another is
+    /// anchored to the whole leaf. The wrapped hit must not consume the
+    /// leaf-anchored rule's only chance to see the bare value: before this
+    /// was composed, `"1234"` came back `Z234` — three of the four secret
+    /// digits shipped where the leaf rule had masked all four.
+    #[test]
+    fn a_wrapped_hit_does_not_steal_the_leaf_anchored_rule() {
+        let ctx = aisix_guardrails::PiiRule::new("ctx", r#""\s*:\s*"(\d)"#, PiiAction::Mask, None)
+            .unwrap()
+            .with_replacement(Some("Z".into()));
+        let pin = aisix_guardrails::PiiRule::new("pin", r"^\d{4}$", PiiAction::Mask, None)
+            .unwrap()
+            .with_replacement(Some("ZZZZ".into()));
+        let chain: Arc<dyn Guardrail> =
+            Arc::new(GuardrailChain::new(vec![Arc::new(PiiGuardrail::new(
+                vec![ctx, pin],
+                aisix_core::models::GuardrailHookPoint::Both,
+                262_144,
+                false,
+            ))]));
+        let mut v = json!({"pin": "1234"});
+        let mut counts = RedactionCounts::new();
+        redact_value_strings(chain.as_ref(), Direction::Input, &mut v, &mut counts);
+        assert_eq!(v, json!({"pin": "ZZZZ"}));
+        assert_eq!(counts.get("pin"), Some(&1));
+    }
+
+    /// A mask token its own rule matches again must not tally twice: the
+    /// wrapped pass is kept only when it actually changed the value, so a
+    /// second idempotent match neither inflates `redacted_entity_counts` nor
+    /// files a second enforced hit.
+    #[test]
+    fn a_wrapped_pass_that_changes_nothing_is_not_counted_twice() {
+        let chain = rule_chain("digits", r"(\d+)", "9");
+        let mut v = json!({"n": "12"});
+        let mut counts = RedactionCounts::new();
+        redact_value_strings(chain.as_ref(), Direction::Input, &mut v, &mut counts);
+        assert_eq!(v, json!({"n": "9"}));
+        assert_eq!(counts.get("digits"), Some(&1));
+    }
+
+    /// A value carrying a `"` has no faithful single-line JSON spelling, so
+    /// the canonical `"key":"([^"]*)"` rule would frame on the value's own
+    /// quote and mask the head while reporting a full hit. The wrapped pass
+    /// is skipped instead and the member keeps its bare-leaf outcome.
+    #[test]
+    fn a_value_carrying_a_quote_skips_the_wrapped_pass() {
+        let chain = rule_chain("eda_version", r#""version"\s*:\s*"([^"]*)""#, "***");
+        let mut v = json!({"version": "12.1\" and-the-tail"});
+        let mut counts = RedactionCounts::new();
+        redact_value_strings(chain.as_ref(), Direction::Input, &mut v, &mut counts);
+        assert_eq!(v, json!({"version": "12.1\" and-the-tail"}));
+        assert!(counts.is_empty(), "a partial mask must not be reported");
+    }
+
+    /// The synthesized spelling is the COMPACT one the MCP input scan
+    /// already hands `check_input` (`Value::to_string()`), so one operator
+    /// rule covers both the block decision and the mask. A rule written
+    /// without `\s*` would otherwise block but never mask.
+    #[test]
+    fn the_synthetic_uses_the_scan_paths_compact_spelling() {
+        let chain = rule_chain("compact", r#""version":"([^"]*)""#, "***");
+        let mut v = json!({"version": "12.1"});
+        let mut counts = RedactionCounts::new();
+        redact_value_strings(chain.as_ref(), Direction::Input, &mut v, &mut counts);
+        assert_eq!(v, json!({"version": "***"}));
+        assert_eq!(counts.get("compact"), Some(&1));
     }
 
     /// The segment-moderation bridge pairs walk slots BY INDEX, so its probes

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -55,6 +55,65 @@ fn redact_str(
     }
 }
 
+/// Offer an object member to `redact` as its JSON spelling — `"key": "value"`
+/// — so an operator rule anchored on the field NAME can fire on a value that
+/// is a real JSON field (AISIX-Cloud#1330 case B).
+///
+/// A leaf-by-leaf rewrite hands the rule the bare value (`12.1`), which is
+/// indistinguishable from any other dotted number. A rule keyed on the field
+/// (`"version"\s*:\s*"([^"]*)"`) then never matches and the value ships
+/// unmasked, while the same rule DOES fire when the tool happens to embed the
+/// document in a prose leaf — a difference the operator has no way to predict.
+/// Wrapping the leaf in its key restores the discriminator the rule was
+/// written around; because the value's bytes appear verbatim inside the
+/// synthetic text, a value-anchored rule still sees exactly what it saw
+/// before, in one pass.
+///
+/// Only the VALUE span survives. The synthetic prefix (`"key": "`) and the
+/// closing quote must come back byte-for-byte; a rule that swallowed either
+/// rewrote the synthesized context rather than the tool's data, so its result
+/// is discarded and the bare leaf is redacted instead — the pre-key-context
+/// behaviour. The same fallback catches a rule the wrapper hides (an `^…$`
+/// anchored pattern matches the bare value but not the wrapped one), at the
+/// cost of a second pass over leaves nothing matched.
+///
+/// Note on the audit log: a chain records an enforced mask hit as soon as a
+/// member rewrites, so a discarded out-of-bounds pass is still audited. That
+/// can over-count `guardrail_enforced_hits` on that rare path — the direction
+/// is fail-safe (a mask attempt is reported, never hidden).
+///
+/// `key: None` (array element, document root) skips the synthesis entirely.
+pub fn redact_with_key_context(
+    key: Option<&str>,
+    text: &str,
+    mut redact: impl FnMut(&str) -> Option<aisix_guardrails::Redaction>,
+) -> Option<aisix_guardrails::Redaction> {
+    let Some(key) = key else {
+        return redact(text);
+    };
+    // JSON spelling with the key's DECODED bytes: the rule is written against
+    // what a reader sees, not against the document's escape choices.
+    let prefix = format!("\"{key}\": \"");
+    let mut synthetic = String::with_capacity(prefix.len() + text.len() + 1);
+    synthetic.push_str(&prefix);
+    synthetic.push_str(text);
+    synthetic.push('"');
+    if let Some(r) = redact(&synthetic) {
+        // `prefix` is valid UTF-8 and matched byte-for-byte, so its length is
+        // a char boundary in `r.text`; the trailing `"` is one ASCII byte.
+        if r.text.len() > prefix.len()
+            && r.text.as_bytes().starts_with(prefix.as_bytes())
+            && r.text.ends_with('"')
+        {
+            return Some(aisix_guardrails::Redaction {
+                text: r.text[prefix.len()..r.text.len() - 1].to_owned(),
+                counts: r.counts,
+            });
+        }
+    }
+    redact(text)
+}
+
 // ─── Remote segment moderation (kind=bedrock mask write-back) ────────────────
 //
 // A Bedrock guardrail whose PII action is ANONYMIZE returns the masked
@@ -109,6 +168,9 @@ impl SegmentCollector {
 impl Guardrail for SegmentCollector {
     fn name(&self) -> &'static str {
         "segment-collector"
+    }
+    fn redacts_positionally(&self) -> bool {
+        true
     }
     fn redacts_input(&self) -> bool {
         true
@@ -175,6 +237,9 @@ impl SegmentApplier {
 impl Guardrail for SegmentApplier {
     fn name(&self) -> &'static str {
         "segment-applier"
+    }
+    fn redacts_positionally(&self) -> bool {
+        true
     }
     fn redacts_input(&self) -> bool {
         true
@@ -272,22 +337,51 @@ fn apply_to_value_string(
 /// tree stays structurally valid — a phone number stored as a JSON number
 /// is out of scope by design (rewriting it to a mask token would corrupt
 /// the document).
+///
+/// Every call site walks a TOOL-defined document (`function.arguments`, an
+/// Anthropic `tool_use.input`), so the object keys are the tool's own schema
+/// rather than envelope plumbing: each string member is offered with its key
+/// as context ([`redact_with_key_context`]) and a key-anchored rule can fire.
 pub fn redact_value_strings(
     chain: &dyn Guardrail,
     dir: Direction,
     v: &mut Value,
     counts: &mut RedactionCounts,
 ) {
+    redact_value_strings_under(chain, dir, None, v, counts);
+}
+
+/// [`redact_value_strings`], carrying the key of the object member `v` came
+/// from (`None` at the root and for array elements).
+fn redact_value_strings_under(
+    chain: &dyn Guardrail,
+    dir: Direction,
+    key: Option<&str>,
+    v: &mut Value,
+    counts: &mut RedactionCounts,
+) {
     match v {
-        Value::String(_) => apply_to_value_string(chain, dir, v, counts),
+        Value::String(s) => {
+            if s.is_empty() {
+                return;
+            }
+            // A positional probe pairs walk slots by index and must see each
+            // text once, verbatim (`redacts_positionally`) — the bedrock
+            // segment bridge walks these same tool-argument documents.
+            let key = key.filter(|_| !chain.redacts_positionally());
+            if let Some(r) = redact_with_key_context(key, s, |t| redact_str(chain, dir, t)) {
+                *s = r.text;
+                merge_counts(counts, r.counts);
+            }
+        }
         Value::Array(items) => {
             for item in items {
-                redact_value_strings(chain, dir, item, counts);
+                redact_value_strings_under(chain, dir, None, item, counts);
             }
         }
         Value::Object(map) => {
-            for (_, val) in map.iter_mut() {
-                redact_value_strings(chain, dir, val, counts);
+            for (k, val) in map.iter_mut() {
+                redact_value_strings_under(chain, dir, Some(k), val, counts);
             }
         }
         _ => {}
@@ -1371,6 +1465,107 @@ mod tests {
         assert_eq!(args, "{\"to\":\"[EMAIL_REDACTED]\"}");
         assert_eq!(counts.get("email"), Some(&2));
         assert_eq!(counts.get("china_mobile"), Some(&1));
+    }
+
+    // ─── key context for structured fields (AISIX-Cloud#1330 case B) ─────────
+
+    /// A one-rule mask chain, for the key-context tests.
+    fn rule_chain(name: &str, regex: &str, replacement: &str) -> Arc<dyn Guardrail> {
+        let rule = aisix_guardrails::PiiRule::new(name, regex, PiiAction::Mask, None)
+            .unwrap()
+            .with_replacement(Some(replacement.to_owned()));
+        Arc::new(GuardrailChain::new(vec![Arc::new(PiiGuardrail::new(
+            vec![rule],
+            aisix_core::models::GuardrailHookPoint::Both,
+            262_144,
+            false,
+        ))]))
+    }
+
+    /// The operator rule an EDA customer actually writes when the sensitive
+    /// value is a real JSON field: anchored on the field NAME. Fed the bare
+    /// leaf (`12.1`) it can never match — the value is indistinguishable from
+    /// any other dotted number. Fed the member's JSON spelling it does, and a
+    /// field the rule does not name stays untouched: that discrimination IS
+    /// the point of handing the rule both halves.
+    #[test]
+    fn key_context_lets_a_field_anchored_rule_fire_on_a_real_field() {
+        let chain = rule_chain(
+            "eda_version",
+            r#""(?:version|版本)"\s*:\s*"([^"]*)""#,
+            "***",
+        );
+        let mut v = json!({
+            "version": "12.1",
+            "版本": "2022.4",
+            "elapsed": "12.345",
+            "port": "10.2.255.1",
+            "nested": {"version": "9.0"},
+            "versions": ["13.0"],
+            "cells": 42
+        });
+        let mut counts = RedactionCounts::new();
+        redact_value_strings(chain.as_ref(), Direction::Input, &mut v, &mut counts);
+        assert_eq!(
+            v,
+            json!({
+                "version": "***",
+                "版本": "***",
+                // Same shape, different field — no hit. A leaf-only rewrite
+                // could not tell these apart from `version`.
+                "elapsed": "12.345",
+                "port": "10.2.255.1",
+                // The key of the member is the immediate parent's, at any depth.
+                "nested": {"version": "***"},
+                // An array element has no key of its own: plain-leaf behaviour.
+                "versions": ["13.0"],
+                "cells": 42
+            })
+        );
+        assert_eq!(counts.get("eda_version"), Some(&3));
+    }
+
+    /// A rule that swallows the synthesized context (its match runs past the
+    /// value's closing quote) rewrote the wrapper, not the tool's data — the
+    /// result is discarded and the bare leaf is redacted instead, so the
+    /// pre-key-context outcome is preserved exactly.
+    #[test]
+    fn out_of_bounds_rewrite_falls_back_to_the_bare_leaf() {
+        // `"?` lets the match extend over the synthetic closing quote.
+        let chain = rule_chain("greedy", r#"\d+(?:\.\d+)+"?"#, "###");
+        let mut v = json!({"version": "12.1"});
+        let mut counts = RedactionCounts::new();
+        redact_value_strings(chain.as_ref(), Direction::Input, &mut v, &mut counts);
+        // Not `"###` spliced into the value — the bare-leaf rewrite.
+        assert_eq!(v, json!({"version": "###"}));
+        assert_eq!(counts.get("greedy"), Some(&1));
+    }
+
+    /// A rule anchored to the whole leaf (`^…$`) matches the bare value but
+    /// not the wrapped one. The fallback keeps it working.
+    #[test]
+    fn whole_leaf_anchored_rule_still_fires_through_the_fallback() {
+        let chain = rule_chain("pin", r"^\d{4}$", "####");
+        let mut v = json!({"pin": "1234", "note": "pin 1234 here"});
+        let mut counts = RedactionCounts::new();
+        redact_value_strings(chain.as_ref(), Direction::Input, &mut v, &mut counts);
+        assert_eq!(v, json!({"pin": "####", "note": "pin 1234 here"}));
+        assert_eq!(counts.get("pin"), Some(&1));
+    }
+
+    /// The segment-moderation bridge pairs walk slots BY INDEX, so its probes
+    /// must see each text exactly once and exactly as it stands — no synthesized
+    /// key context, no second call. Without this the collect walk would record
+    /// two slots per tool-argument leaf and every later mask would land on the
+    /// wrong field.
+    #[test]
+    fn positional_probe_sees_each_tool_arg_leaf_once_verbatim() {
+        let collector = SegmentCollector::default();
+        let mut v = json!({"a_to": "slot one", "b_cc": "slot two", "n": 1});
+        let mut counts = RedactionCounts::new();
+        redact_value_strings(&collector, Direction::Input, &mut v, &mut counts);
+        assert_eq!(collector.take(), vec!["slot one", "slot two"]);
+        assert!(counts.is_empty());
     }
 
     #[test]

--- a/tests/e2e/src/cases/guardrail-mcp-mask-writeback-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-mcp-mask-writeback-e2e.test.ts
@@ -444,9 +444,23 @@ describe("mcp mask write-back e2e: /mcp", () => {
       for (const detector of detectors) {
         expect(["eda_version", "eda_version_json"]).toContain(detector);
       }
+      // The audit must not claim more masks than the bodies carry. Each
+      // request masks at most four spans, so a speculative pass that was
+      // discarded — or counted twice — shows up here.
+      for (const n of Object.values(hit.counts ?? {})) {
+        expect(n).toBeGreaterThan(0);
+        expect(n).toBeLessThanOrEqual(4);
+      }
       expect(JSON.stringify(hit)).not.toContain("12.1");
       expect(JSON.stringify(hit)).not.toContain("2022.4");
     }
+    // Across the request's events both detectors are represented: the prose
+    // shapes still fire `eda_version`, the real JSON fields fire
+    // `eda_version_json`. A regression that collapsed one into the other
+    // would keep every per-hit check above green.
+    expect(new Set(hits.flatMap((h) => Object.keys(h.counts ?? {})))).toEqual(
+      new Set(["eda_version", "eda_version_json"]),
+    );
     // Both hooks are represented across the request's events.
     expect(new Set(hits.map((h) => h.hook))).toEqual(new Set(["input", "output"]));
   });

--- a/tests/e2e/src/cases/guardrail-mcp-mask-writeback-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-mcp-mask-writeback-e2e.test.ts
@@ -37,6 +37,10 @@ import {
 //   - rewrite never blocks: HTTP 200, no JSON-RPC error, no `isError`;
 //   - the SOC export carries the POST-MASK content and the detector counts,
 //     never the raw values;
+//   - a value that is a REAL JSON field (`{"version": "12.1"}`) is offered to
+//     the rule with its field name attached, so a key-anchored rule fires —
+//     while same-shaped values under a field the rule does not name stay
+//     byte-identical (AISIX-Cloud#1330 case B);
 //   - Chinese and English label forms both rewrite.
 
 const KEY = "sk-mcp-writeback-e2e";
@@ -60,6 +64,16 @@ const ARG_MASKED = `${MARKER} build version: *** ${NEG} 工具版本：*** 完�
 const SUMMARY = `阶段汇总 版本：2022.4 用时 12.345s`;
 const LOG = `Compile OK version: 12.1\n${NEG}`;
 const STRUCT_LOG = `config {"version": "12.1"} ok`;
+
+// Real JSON fields (case B): the value alone is just a dotted number — only
+// the FIELD NAME says which one is a tool version. `elapsed`/`port` carry the
+// same shapes under names the rule does not cover and must survive verbatim.
+const STRUCT_FIELDS = {
+  version: "12.1",
+  版本: "2022.4",
+  elapsed: "12.345",
+  port: "10.2.255.1",
+};
 
 interface RpcReply {
   status: number;
@@ -167,8 +181,10 @@ describe("mcp mask write-back e2e: /mcp", () => {
             replacement: "***",
           },
           {
+            // Anchored on the FIELD NAME, en + zh: the shape an operator
+            // writes when the sensitive value is a real JSON field.
             name: "eda_version_json",
-            regex: '"version"\\s*:\\s*"([^"]*)"',
+            regex: '"(?:version|版本)"\\s*:\\s*"([^"]*)"',
             action: "mask",
             replacement: "***",
           },
@@ -192,7 +208,12 @@ describe("mcp mask write-back e2e: /mcp", () => {
     if (!etcdReachable) return;
 
     upstream = await startMcpUpstream("eda", {
-      reportContent: { summary: SUMMARY, log: LOG, structuredLog: STRUCT_LOG },
+      reportContent: {
+        summary: SUMMARY,
+        log: LOG,
+        structuredLog: STRUCT_LOG,
+        structuredFields: STRUCT_FIELDS,
+      },
     });
     sls = await startMockSls();
     appG = await spawnApp({
@@ -264,7 +285,9 @@ describe("mcp mask write-back e2e: /mcp", () => {
       baseline.body
         .replace("version: 12.1", "version: ***") // resource.text log line
         .replace("版本：2022.4", "版本：***") // summary text block
-        .replace('{\\"version\\": \\"12.1\\"}', '{\\"version\\": \\"***\\"}'), // structured leaf
+        .replace('{\\"version\\": \\"12.1\\"}', '{\\"version\\": \\"***\\"}') // structured leaf
+        .replace('"version":"12.1"', '"version":"***"') // structured FIELD, en
+        .replace('"版本":"2022.4"', '"版本":"***"'), // structured FIELD, zh
     );
     expect(guarded.body).not.toContain("12.1");
     expect(guarded.body).not.toContain("2022.4");
@@ -278,7 +301,67 @@ describe("mcp mask write-back e2e: /mcp", () => {
     expect(result?.structuredContent).toEqual({
       log: 'config {"version": "***"} ok',
       cells: 42,
+      // Case B: the field name is what made these two masked...
+      version: "***",
+      版本: "***",
+      // ...and what left these two alone.
+      elapsed: "12.345",
+      port: "10.2.255.1",
     });
+  });
+
+  test("structured field: the field NAME decides — same-shaped values under other names are untouched", async (ctx) => {
+    if (!etcdReachable || !appG) return ctx.skip();
+
+    // AISIX-Cloud#1330 case B. A leaf-by-leaf rewrite hands the rule the bare
+    // value `12.1`, which is indistinguishable from `12.345` or `10.2.255.1`:
+    // a key-anchored rule can never match and the value ships unmasked with no
+    // signal at all. Offering `"version": "12.1"` restores the discriminator —
+    // and the negatives below are the proof it discriminates rather than just
+    // masking more.
+    const guarded = await callTool(appG, "eda__report", { text: "go" });
+    expect(guarded.status).toBe(200);
+    expect(guarded.json?.error).toBeUndefined();
+    expect(guarded.json?.result?.isError).toBeFalsy();
+
+    const structured = guarded.json?.result?.structuredContent ?? {};
+    expect(structured.version).toBe("***");
+    expect(structured["版本"]).toBe("***");
+    // Zero hits: same dotted-number shapes, field names the rule never named.
+    expect(structured.elapsed).toBe("12.345");
+    expect(structured.port).toBe("10.2.255.1");
+    // A non-string leaf is out of scope by design and stays a number.
+    expect(structured.cells).toBe(42);
+  });
+
+  test("request: a structured tool argument reaches the upstream masked by field name", async (ctx) => {
+    if (!etcdReachable || !appG || !appP || !upstream) return ctx.skip();
+
+    const before = upstream.received.length;
+    // The same fields, this time as `tools/call` arguments.
+    const guarded = await callTool(appG, "eda__echo", STRUCT_FIELDS);
+    const baseline = await callTool(appP, "eda__echo", STRUCT_FIELDS);
+    expect(guarded.status).toBe(200);
+    expect(baseline.status).toBe(200);
+
+    const calls = upstream.received
+      .slice(before)
+      .filter((b) => b.includes('"tools/call"'));
+    expect(calls).toHaveLength(2);
+    const [guardedRaw, baselineRaw] = calls;
+    // The upstream saw the version fields masked and nothing else changed.
+    expect(stripIds(guardedRaw)).toBe(
+      stripIds(baselineRaw)
+        .replace('"version":"12.1"', '"version":"***"')
+        .replace('"版本":"2022.4"', '"版本":"***"'),
+    );
+    expect(guardedRaw).toContain('"version":"***"');
+    expect(guardedRaw).toContain('"版本":"***"');
+    expect(guardedRaw).not.toContain("12.1");
+    expect(guardedRaw).not.toContain("2022.4");
+    // The negatives reached the upstream verbatim.
+    expect(guardedRaw).toContain('"elapsed":"12.345"');
+    expect(guardedRaw).toContain('"port":"10.2.255.1"');
   });
 
   test("SOC export: captured content is the post-mask text with detector counts, never the raw values", async (ctx) => {
@@ -351,8 +434,16 @@ describe("mcp mask write-back e2e: /mcp", () => {
     for (const hit of hits) {
       expect(hit.action).toBe("masked");
       expect(["input", "output"]).toContain(hit.hook);
-      // Names and counts only — the matched value is never carried.
-      expect(Object.keys(hit.counts ?? {})).toContain("eda_version");
+      // Names and counts only — the matched value is never carried. Which
+      // detector fired depends on the shape that request carried (prose vs
+      // a real JSON field), so pin the SET the names may come from rather
+      // than one name: an unexpected key here is a leak, an empty map means
+      // the counts never rode the event.
+      const detectors = Object.keys(hit.counts ?? {});
+      expect(detectors.length).toBeGreaterThan(0);
+      for (const detector of detectors) {
+        expect(["eda_version", "eda_version_json"]).toContain(detector);
+      }
       expect(JSON.stringify(hit)).not.toContain("12.1");
       expect(JSON.stringify(hit)).not.toContain("2022.4");
     }

--- a/tests/e2e/src/harness/upstream-mcp.ts
+++ b/tests/e2e/src/harness/upstream-mcp.ts
@@ -38,8 +38,18 @@ export interface McpUpstreamOptions {
    * `log` as `resource.text` (the natural shape for a compile/sim log),
    * and a `structuredContent` object with a `log` string leaf plus a
    * numeric field. The mask write-back suite owns the strings.
+   *
+   * `structuredFields` are merged into `structuredContent` as further
+   * members — the shape where the sensitive value is a real JSON field
+   * (`{"version": "12.1"}`) rather than a number inside prose, so the
+   * field NAME is the only thing telling a rule what the value is.
    */
-  reportContent?: { summary: string; log: string; structuredLog: string };
+  reportContent?: {
+    summary: string;
+    log: string;
+    structuredLog: string;
+    structuredFields?: Record<string, string | number>;
+  };
 }
 
 /**
@@ -147,7 +157,8 @@ async function handle(
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const text = String(request.params.arguments?.text ?? "");
       if (request.params.name === "report" && options.reportContent) {
-        const { summary, log, structuredLog } = options.reportContent;
+        const { summary, log, structuredLog, structuredFields } =
+          options.reportContent;
         return {
           content: [
             { type: "text", text: summary },
@@ -160,7 +171,11 @@ async function handle(
               },
             },
           ],
-          structuredContent: { log: structuredLog, cells: 42 },
+          structuredContent: {
+            log: structuredLog,
+            cells: 42,
+            ...(structuredFields ?? {}),
+          },
         };
       }
       if (request.params.name === "lookup") {


### PR DESCRIPTION
## Problem

The mask write-back channel rewrites JSON string values **leaf by leaf**: each
leaf is decoded and handed to the redaction rules on its own. When the
sensitive value is a real JSON field — the shape a tool returns as
`structuredContent: {"version": "12.1"}` or takes as
`arguments: {"version": "12.1"}` — the rule receives the bare string `12.1`.
That is indistinguishable from `12.345` or `10.2.255.1`, so an operator rule
anchored on the field name can never match and the value ships unmasked.

The failure is silent, and it is inconsistent in a way an operator cannot
predict: the *same* rule fires when a tool happens to embed the document
inside a prose leaf (`"log": "config {\"version\": \"12.1\"} ok"`), because
there the key really is part of the text the rule sees.

## Change

Offer each object member to the redactor as its JSON spelling — `"key":"value"`,
the same compact form `Value::to_string()` already hands the `/mcp` input
**scan**, so one operator rule covers both the block decision and the mask.

Two passes, composed the way a chain composes its members (`fold_redactions`),
never raced against each other:

1. the **bare leaf** — exactly the pre-key-context rewrite. Always kept, so a
   rule anchored to the whole leaf (`^…$`, which can only ever match the bare
   form) keeps firing regardless of what pass 2 does.
2. the **member's JSON spelling** around pass 1's output.

Pass 2 is kept only when the synthesized prefix (`"key":"`) and the closing
quote come back byte-for-byte **and** the value actually changed — otherwise
the rule rewrote the wrapper rather than the data, or re-matched its own mask
token, and pass 1 stands. Because pass 2 can be discarded it runs through a new
unaudited channel (`Guardrail::redact_{input,output}_text_unaudited`) and the
kept rewrite is replayed through the audited path: an entry in
`guardrail_enforced_hits` must describe a mask the client really saw.

The wrapped pass is skipped for an empty value, and for a key or value carrying
`"` or `\` — their decoded bytes are not JSON string content, so the synthetic
would not be the document's own spelling and a `"([^"]*)"` rule would frame on
the embedded quote and mask only the head while reporting a full hit.

Applied where the object keys are the **tool's own schema**:

| surface | key context | why |
|---|---|---|
| `params.arguments.**` (`/mcp` request) | yes | the tool's input schema |
| `result.structuredContent.**` (`/mcp` response) | yes | the tool's output schema |
| `result.content[].text` / `description` / `title` / `resource.text` | no | MCP envelope names |
| `function.arguments` / `tool_use.input` (LLM families) | yes | the tool's input schema |

The envelope exclusion is deliberate: the scan path decodes content blocks
precisely so `content`/`type`/`text` cannot trip a rule, and wrapping a prose
block back up as `"text": "…"` would reintroduce that false positive. A unit
test pins it.

Array elements and the document root have no key and keep the previous
behaviour. JSON **number** leaves (`"version": 12.1`) remain out of scope by
design — rewriting one to a mask token would corrupt the document; that
decision is still open with the customer and is not touched here.

### Handler-family sweep

The same gap existed on the LLM families' JSON tool-argument walker
(`redact_value_strings`, reached from chat `function.arguments` and Anthropic
`tool_use.input`), so it is covered in this PR rather than deferred.

Doing so surfaced a real constraint worth pinning: the remote segment-moderation bridge (a remote guardrail whose PII action is anonymize) pairs its
collect and apply walks **by slot index**, so a walker must offer every text
exactly once and exactly as it stands. Key context would both change the text
sent to the provider and desynchronize the slots. The two probes now declare
that with `Guardrail::redacts_positionally()` (defaulted `false`) and keep the
bare-leaf walk; the existing positional test caught this before the guard
existed, and a new test pins the invariant directly. Remote entity detectors
take no field-name-anchored rules, so nothing is lost on that path.

## Verification

Real DP + etcd + a real MCP upstream (official SDK server) + the SLS mock, two
gateway instances sharing one upstream so the unguarded one is the
byte-for-byte baseline:

- **response** — `structuredContent: {version, 版本, elapsed, port, log, cells}`
  → `version`/`版本` masked, **full-body byte-diff** against the baseline proves
  `elapsed`, `port`, `cells` and every other byte are unchanged; the body still
  parses;
- **request** — the same fields as `tools/call` arguments → the upstream
  receives `"version":"***"` / `"版本":"***"`, negatives verbatim, byte-diff
  against the baseline instance;
- **false-positive suppression** — `{"elapsed": "12.345"}` and
  `{"port": "10.2.255.1"}` are zero-hit; that discrimination is the point of
  handing the rule the key;
- Chinese field name (`版本`) covered on both directions;
- unit: out-of-bounds rewrite falls back to the bare leaf; a wrapped hit does
  not steal a `^…$` leaf-anchored rule's turn; an idempotent second match is
  not counted twice; a discarded pass files no enforced hit; a value carrying
  `"` and an empty value skip the wrapped pass; the compact spelling matches
  the scan path; envelope names are not offered; the positional probe sees each
  leaf once verbatim.

`cargo test --workspace`, `cargo clippy --workspace --all-targets`, and the
guardrail/MCP e2e suites (20 files) pass.

## Independent audit

Audited cold by a separate agent per the repo's pre-merge rule. Findings and
what was done:

- **HIGH — a wrapped hit stole the leaf-anchored rule's turn.** With a chain
  carrying both an unanchored rule and a `^\d{4}$` rule, `"1234"` came back
  `Z234`: three of four secret digits shipped where the leaf rule had masked
  all four. Reproduced with a test, then fixed by the bare-first composition
  above. The test is kept as a regression.
- **MEDIUM — a discarded pass filed a phantom `masked` hit.** A key-anchored
  rule without a capture group swallows the wrapper, so the rewrite is dropped
  — but `fold_redactions` had already recorded an enforced hit, putting a mask
  on the usage event that no client ever saw. Fixed by the unaudited channel;
  verified the test fails without it.
- **MEDIUM — value containing `"` was masked only up to the embedded quote**
  while reporting a full hit. Fixed by the skip guard.
- **MEDIUM — spelling divergence** between the scan path (compact) and the mask
  path (spaced) meant a rule written without `\s*` blocked but never masked.
  Fixed by adopting the compact spelling; a unit test pins it.
- **MEDIUM — output-hook `action: block` is still key-blind** (`collect_string_leaves`
  drops keys). Filed as api7/aisix#1026 rather than folded in — it changes the
  block path and deserves its own review.
- **MEDIUM — monitor mode previews no would-mask hits** for field-anchored
  rules, because the probe runs over the scan text. Filed as api7/aisix#1027.
- **LOW — `redacts_positionally()` was not forwarded** by the chain or the three
  decorators. Added; harmless today (probes are passed bare) but the failure
  mode would be silent slot desync.
- **LOW — the relaxed e2e assertion** was legitimate but weaker. Strengthened
  with a count bound and a union assertion over both detectors.

Confirmed correct by the audit and left alone: UTF-8/char-boundary safety of
the value-span slice, JSON document integrity (the splice re-encodes), no new
remote exposure (the only concrete redactors are in-process), the segment
-bridge protection end to end, the path predicates, and the handler-family
sweep.

## Not in scope

- JSON number leaves — pending the customer decision.
- The semantic layer (AISIX-Cloud#1363).
- The LLM handler families' enforced-hit drain (aisix#1024) — separate work.
- Field names on the output-hook block decision (api7/aisix#1026) and monitor
  -mode preview of field-anchored rules (api7/aisix#1027) — both filed.
- A `api7/docs` page is owed: the synthesized `"key":"value"` spelling and the
  capture-group requirement are what an operator needs to write a working rule.
- No control-plane counterpart: this changes how existing `custom_patterns`
  rules are evaluated, not the config surface. No new field, no new enum.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added field-aware redaction for structured JSON values, including nested fields and multilingual keys.
  * MCP tool arguments and structured responses now provide object field names as redaction context.
  * Added support for configuring structured fields in MCP test responses.

* **Bug Fixes**
  * Prevented discarded masking attempts and duplicate matches from inflating enforcement audits.
  * Improved handling of positional redactors, escaped values, empty values, and anchored rules.
  * Preserved unrelated values, array elements, root values, and original wire formatting.

* **Tests**
  * Expanded end-to-end coverage for structured-field masking in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->