### PR TITLE
feat(guardrails): semantic kind — user-configurable categories on the local-model runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokenizers",
  "tokio",

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,6 +152,12 @@ RUN apt-get update \
 
 WORKDIR /bundle
 COPY docker/guardrail-model.manifest.json manifest.json
+# Apache-2.0 text for the redistributed model (the upstream repository
+# declares the license in its model-card metadata and carries no LICENSE
+# file of its own). Not part of manifest.json: that file is the model's
+# INTEGRITY unit, and adding entries to it would fail boot verification
+# for every already-imported bundle that predates the license copy.
+COPY docker/guardrail-model.LICENSE LICENSE
 
 ARG GUARDRAIL_MODEL_BASE=https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2/resolve/835ad14087e140460703cf0fae09f97d469d65c2
 RUN set -eu; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,11 @@
 # container restarts.
 
 # --- Stage 1: build ----------------------------------------------------------
-FROM rust:1.93-bookworm AS builder
+# Trixie (not bookworm): the semantic guardrail's prebuilt onnxruntime
+# static libraries are compiled against glibc >= 2.38 (`__isoc23_*`
+# symbols) and a GCC-13+ libstdc++ — bookworm's glibc 2.36 cannot link
+# them. The runtime stage must stay on the same-or-newer glibc.
+FROM rust:1.93-trixie AS builder
 
 # protoc is required by dependencies that use prost/tonic-build.
 RUN apt-get update \
@@ -140,7 +144,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #
 # Model: ibm-granite/granite-embedding-97m-multilingual-r2 (Apache-2.0),
 # official int8 ONNX export (`onnx/model_quint8_avx2.onnx`) + tokenizer.
-FROM debian:bookworm-slim AS guardrail-model
+FROM debian:trixie-slim AS guardrail-model
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl \
@@ -160,7 +164,9 @@ RUN set -eu; \
     done
 
 # --- Stage 2: runtime --------------------------------------------------------
-FROM debian:bookworm-slim AS runtime
+# trixie-slim to match the builder's glibc (see the builder stage note);
+# a binary linked against glibc 2.41 symbols cannot run on bookworm.
+FROM debian:trixie-slim AS runtime
 
 # Ownership-verification label for the MCP Registry: when this image is
 # published as an MCP server entry, the registry requires this label to

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,35 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         exit 2; \
     fi
 
+# --- Stage 1b: semantic guardrail model bundle -------------------------------
+# The semantic guardrail's embedding model (`kind: "semantic"`,
+# AISIX-Cloud#1363), fetched from the PINNED upstream revision and
+# verified file-by-file against the repo's manifest before it ships.
+# The manifest baked next to the files is the SAME document the gateway
+# re-verifies at boot, so a drifted download fails the image build here
+# — never the data plane. Runs in parallel with the Rust builder stage.
+#
+# Model: ibm-granite/granite-embedding-97m-multilingual-r2 (Apache-2.0),
+# official int8 ONNX export (`onnx/model_quint8_avx2.onnx`) + tokenizer.
+FROM debian:bookworm-slim AS guardrail-model
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /bundle
+COPY docker/guardrail-model.manifest.json manifest.json
+
+ARG GUARDRAIL_MODEL_BASE=https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2/resolve/835ad14087e140460703cf0fae09f97d469d65c2
+RUN set -eu; \
+    curl -fsSL --retry 3 -o model.onnx "$GUARDRAIL_MODEL_BASE/onnx/model_quint8_avx2.onnx"; \
+    curl -fsSL --retry 3 -o tokenizer.json "$GUARDRAIL_MODEL_BASE/tokenizer.json"; \
+    for f in model.onnx tokenizer.json; do \
+        want="$(sed -n 's/.*"'"$f"'": "sha256:\([0-9a-f]*\)".*/\1/p' manifest.json)"; \
+        [ -n "$want" ] || { echo "manifest carries no sha256 for $f" >&2; exit 2; }; \
+        echo "$want  $f" | sha256sum -c -; \
+    done
+
 # --- Stage 2: runtime --------------------------------------------------------
 FROM debian:bookworm-slim AS runtime
 
@@ -169,6 +198,14 @@ RUN --mount=type=bind,from=builder,source=/usr/local/bin/aisix,target=/mnt/aisix
        fi \
     && apt-get purge -y --auto-remove libcap2-bin \
     && rm -rf /var/lib/apt/lists/*
+
+# Bake the verified semantic-guardrail model bundle at the path the
+# binary defaults to (`DEFAULT_MODEL_DIR`), so `kind: "semantic"` rows
+# work out of the box — no download, no import step. Boot re-verifies
+# the manifest; the model stays cold (no sessions, no memory) until a
+# semantic guardrail row exists. GUARDRAIL_LOCAL_MODEL_DIR overrides
+# the path for model upgrades without an image rebuild.
+COPY --from=guardrail-model /bundle /usr/local/aisix/guardrail-model
 
 # Bake the managed-mode bootstrap config so AISIX gateways managed by
 # AISIX Cloud can `docker run` without mounting a configuration file.

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -2177,6 +2177,7 @@ fn add_variant_titles(doc: &mut Value) {
                 "Lakera Guard",
                 "OpenAI Moderation",
                 "Microsoft Presidio",
+                "Semantic Categories",
             ],
         ),
         (

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -762,11 +762,13 @@ pub struct SemanticCategory {
     #[serde(default)]
     #[schemars(length(min = 1, max = 10))]
     pub candidate_patterns: Vec<String>,
-    /// Regular expressions that are evidence AGAINST a candidate. Each
-    /// pattern is tried against the candidate span itself, the text
-    /// immediately before it, and the text immediately after it (anchor
-    /// with `^` or `$` to pin the position); any match counts once and
-    /// strongly lowers the span's score.
+    /// Regular expressions that are evidence AGAINST a candidate. Every
+    /// pattern is tried against the candidate span itself. A pattern
+    /// whose source ends with `$` is additionally tried against the text
+    /// immediately before the span (the `$` pins the match to the span's
+    /// left edge, as in `编号\s*$`), and one whose source starts with
+    /// `^` against the text immediately after it (as in `^\s*(?:ms|s)`).
+    /// Any match counts once and strongly lowers the span's score.
     #[serde(default)]
     #[schemars(length(max = 20))]
     pub negative_patterns: Vec<String>,
@@ -1019,8 +1021,9 @@ fn is_zero_u32(value: &u32) -> bool {
 pub struct GuardrailExecution<'a> {
     /// Configured (row) name of the guardrail.
     pub guardrail_name: &'a str,
-    /// The `kind` discriminator (`GuardrailKind::kind_str`). `keyword` and
-    /// `pii` run in-process; every other kind calls a remote service.
+    /// The `kind` discriminator (`GuardrailKind::kind_str`). `keyword`,
+    /// `pii`, and `semantic` run in-process; every other kind calls a
+    /// remote service.
     pub kind: &'a str,
     /// Which side ran: `input` or `output`.
     pub phase: &'static str,
@@ -1378,6 +1381,21 @@ mod tests {
             .remove("candidate_patterns");
         assert!(crate::models::validate_guardrail(&missing).is_err());
         assert!(crate::models::validate_guardrail_lenient(&missing).is_err());
+
+        // A semantic row with no categories detects nothing — the branch
+        // requires them, matching keyword's required `patterns`.
+        let bare = json!({"name": "sem", "kind": "semantic"});
+        assert!(crate::models::validate_guardrail(&bare).is_err());
+
+        // This kind rewrites and never blocks; `fail_open: false` has
+        // nothing to fail closed into and is pinned out of the schema
+        // rather than accepted-and-inert (#963).
+        let mut closed = valid.clone();
+        closed["fail_open"] = json!(false);
+        assert!(crate::models::validate_guardrail(&closed).is_err());
+        let mut open = valid.clone();
+        open["fail_open"] = json!(true);
+        assert!(crate::models::validate_guardrail(&open).is_ok());
     }
 
     #[test]

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -1345,6 +1345,42 @@ mod tests {
     }
 
     #[test]
+    fn semantic_kind_strict_schema_edges() {
+        let valid = json!({
+            "name": "sem",
+            "kind": "semantic",
+            "categories": [{
+                "name": "eda-version",
+                "description": "EDA tool version numbers",
+                "candidate_patterns": ["\\d+\\.\\d+"]
+            }]
+        });
+        assert!(crate::models::validate_guardrail(&valid).is_ok());
+
+        // `block` does not exist for this kind — pinned in the schema, not
+        // accepted-and-half-honored (#963).
+        let mut blocked = valid.clone();
+        blocked["categories"][0]["action"] = json!("block");
+        assert!(crate::models::validate_guardrail(&blocked).is_err());
+
+        // A category with no candidate patterns compiles to nothing and
+        // would skip the whole row DP-side; the schema must refuse it even
+        // when the property is ABSENT (serde default `[]` — `minItems`
+        // alone does not fire on a missing property). The requirement
+        // rides the shared producer, so the READ path rejects too — safe,
+        // because no strict writer can ever have stored such a row (the
+        // kind is new), and a hand-crafted one is better rejected
+        // RED-visible than silently skipped at category compile.
+        let mut missing = valid.clone();
+        missing["categories"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("candidate_patterns");
+        assert!(crate::models::validate_guardrail(&missing).is_err());
+        assert!(crate::models::validate_guardrail_lenient(&missing).is_err());
+    }
+
+    #[test]
     fn bedrock_kind_parses_with_serial_latency() {
         let v = json!({
             "name": "block-pii",

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -722,6 +722,99 @@ fn default_presidio_language() -> String {
     "en".to_owned()
 }
 
+/// One hotword group for a semantic category. Terms in a group are
+/// lexical evidence for the category: a term found next to a candidate
+/// span raises the span's rule score, and each group contributes at most
+/// once per span. Group terms by the role they play (for example trigger
+/// words, tool names) rather than listing every term in one group.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+pub struct SemanticHotwordGroup {
+    /// Literal terms. Terms containing CJK characters match as
+    /// substrings; ASCII terms match on word boundaries, and may run
+    /// directly into a digit (so a tool name fused to a version number
+    /// still counts).
+    #[schemars(length(min = 1, max = 50))]
+    pub terms: Vec<String>,
+}
+
+/// One user-defined category for `kind: "semantic"`: what to look for
+/// (regex candidate patterns), the lexical evidence that confirms or
+/// rejects a candidate (hotword groups and negative patterns), the
+/// natural-language description the embedding model judges uncertain
+/// candidates against, and how a confirmed span is rewritten.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+pub struct SemanticCategory {
+    /// Category name surfaced in the mask token (`[<NAME>_REDACTED]`),
+    /// telemetry counts, and audit records. Never the matched value.
+    /// Must be unique within the guardrail.
+    #[schemars(length(min = 1, max = 64))]
+    pub name: String,
+    /// Natural-language description of the category, such as
+    /// `EDA 软件的版本号`. Candidates that regex and hotword evidence
+    /// cannot decide are judged by embedding similarity between their
+    /// surrounding text and this description.
+    #[schemars(length(min = 1, max = 1000))]
+    pub description: String,
+    /// Regular expressions that generate candidate spans. Only text
+    /// matched by a candidate pattern can ever be masked, so patterns
+    /// should be broad — precision comes from the hotword and negative
+    /// evidence and from the embedding judgement.
+    #[serde(default)]
+    #[schemars(length(min = 1, max = 10))]
+    pub candidate_patterns: Vec<String>,
+    /// Regular expressions that are evidence AGAINST a candidate. Each
+    /// pattern is tried against the candidate span itself, the text
+    /// immediately before it, and the text immediately after it (anchor
+    /// with `^` or `$` to pin the position); any match counts once and
+    /// strongly lowers the span's score.
+    #[serde(default)]
+    #[schemars(length(max = 20))]
+    pub negative_patterns: Vec<String>,
+    /// Hotword groups — lexical evidence FOR a candidate. A group term
+    /// adjacent to the span is decisive; terms merely nearby are weak
+    /// evidence that routes the span to the embedding judgement.
+    #[serde(default)]
+    #[schemars(length(max = 10))]
+    pub hotword_groups: Vec<SemanticHotwordGroup>,
+    /// Action for spans confirmed as this category. Only `mask` is
+    /// supported: this guardrail rewrites content and never blocks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+    /// Literal text that replaces a masked span, such as `***`. When
+    /// omitted, the span is rewritten to `[<NAME>_REDACTED]`. An empty
+    /// string removes the span.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(max = 256))]
+    pub replacement: Option<String>,
+    /// Similarity threshold for the embedding judgement, in `[-1, 1]`
+    /// (cosine similarity against the category description). Omitted →
+    /// the calibrated default that ships with the bundled model. Raise
+    /// it to mask less, lower it to mask more; pair tuning with
+    /// `enforcement_mode: monitor` to preview the effect first.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = -1.0, max = 1.0))]
+    pub threshold: Option<f32>,
+}
+
+/// Config block for `kind: "semantic"`. Category-based semantic
+/// detection and redaction computed inside the gateway by a bundled CPU
+/// embedding model — no external service is called and no content leaves
+/// the gateway. Each category pipelines regex candidate generation,
+/// hotword/negative-evidence scoring, and an embedding similarity
+/// judgement for the remaining uncertain spans. Confirmed spans are
+/// masked in place; everything else is returned byte-identical. This
+/// guardrail rewrites content and never blocks traffic, so `fail_open`
+/// must stay `true`.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
+pub struct SemanticConfig {
+    /// The categories this guardrail detects. Categories are evaluated
+    /// in order; each category rewrites the text the previous one
+    /// produced.
+    #[serde(default)]
+    #[schemars(length(min = 1, max = 30))]
+    pub categories: Vec<SemanticCategory>,
+}
+
 /// Provider discriminator. The kind drives which `*_config` block is
 /// expected. Serde's `tag = "kind"` keeps us honest at parse time.
 ///
@@ -776,6 +869,15 @@ pub enum GuardrailKind {
     /// use the selected anonymize operator. Applies on input, output, or both,
     /// including buffered streaming output.
     Presidio(PresidioConfig),
+    /// Category-based semantic detection and redaction using a CPU
+    /// embedding model bundled with the gateway. User-defined categories
+    /// combine regex candidates, hotword evidence, and embedding
+    /// similarity against a natural-language description; confirmed
+    /// spans are masked in place. Rewrites only — never blocks. Applies
+    /// on input, output, or both, including buffered streaming output.
+    /// Requires the gateway's bundled model files; nodes without them
+    /// do not serve this kind.
+    Semantic(SemanticConfig),
 }
 
 impl GuardrailKind {
@@ -795,6 +897,7 @@ impl GuardrailKind {
             GuardrailKind::Lakera(_) => "lakera",
             GuardrailKind::OpenaiModeration(_) => "openai_moderation",
             GuardrailKind::Presidio(_) => "presidio",
+            GuardrailKind::Semantic(_) => "semantic",
         }
     }
 }
@@ -946,6 +1049,19 @@ pub struct GuardrailExecution<'a> {
 /// build time, so aisix-guardrails stays free of a metrics dependency.
 pub trait GuardrailMetricsSink: Send + Sync + 'static {
     fn record_guardrail_execution(&self, exec: &GuardrailExecution<'_>);
+
+    /// One embedding-model inference performed by the semantic
+    /// guardrail runtime. Default no-op so non-metrics sinks and tests
+    /// need not care.
+    fn record_semantic_model_call(&self) {}
+
+    /// One semantic-guardrail degrade: a span (or category) fell back
+    /// to the rule layers instead of getting its embedding judgement.
+    /// `reason` is a bounded vocabulary (see the semantic runtime's
+    /// degrade enum), never free text.
+    fn record_semantic_degrade(&self, reason: &'static str) {
+        let _ = reason;
+    }
 }
 
 /// Content policy evaluated before or after upstream calls.

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -52,7 +52,7 @@ pub use guardrail::{
     GuardrailExecution, GuardrailHookPoint, GuardrailKind, GuardrailMetricsSink,
     GuardrailMonitorHit, GuardrailScopeType, KeywordConfig, KeywordPattern, LakeraConfig,
     OpenaiModerationConfig, PiiConfig, PiiCustomPattern, PiiDetectorConfig, PresidioConfig,
-    PresidioEntityConfig,
+    PresidioEntityConfig, SemanticCategory, SemanticConfig, SemanticHotwordGroup,
 };
 pub use mcp_auth_settings::McpAuthSettings;
 pub use mcp_policy::{McpAccess, McpPolicy, McpPolicyScope};

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -1382,6 +1382,47 @@ pub fn guardrail_root_schema() -> Value {
                     set_property_enum(b, "default_action", json!(["mask", "block"]));
                     set_property_enum(b, "operator", json!(["replace", "mask", "hash", "redact"]));
                 }
+                "semantic" => {
+                    // A semantic row with no categories detects nothing;
+                    // the write path must see them spelled out (the serde
+                    // default keeps the Rust type read-tolerant), matching
+                    // the keyword branch's required `patterns`.
+                    match b.get_mut("required").and_then(Value::as_array_mut) {
+                        Some(list) => {
+                            if !list.iter().any(|v| v.as_str() == Some("categories")) {
+                                list.push(json!("categories"));
+                            }
+                        }
+                        None => {
+                            b.insert("required".to_string(), json!(["categories"]));
+                        }
+                    }
+                    // This kind rewrites and never blocks, so a runtime
+                    // failure has nothing to fail closed INTO —
+                    // `fail_open: false` would be accepted-but-inert
+                    // (#963). Pre-inserting the pinned property here wins
+                    // over the parent copy-in below (`entry().or_insert`),
+                    // so the branch keeps the closed value; omission still
+                    // gets the default.
+                    if let Some(props) = b
+                        .entry("properties".to_string())
+                        .or_insert_with(|| json!({}))
+                        .as_object_mut()
+                    {
+                        props.insert(
+                            "fail_open".to_string(),
+                            json!({
+                                "type": "boolean",
+                                "enum": [true],
+                                "default": true,
+                                "description": "Semantic guardrails always degrade open: \
+                                 an unavailable embedding model releases content \
+                                 unmasked and records the degradation, never blocks. \
+                                 Only `true` is accepted."
+                            }),
+                        );
+                    }
+                }
                 _ => {}
             }
         }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -1242,6 +1242,10 @@ pub fn guardrail_root_schema() -> Value {
             json!(["mask", "block"]),
         );
         set_definition_property_enum(defs, "PiiCustomPattern", "action", json!(["mask", "block"]));
+        // Semantic categories rewrite only — the `block` action does not
+        // exist for this kind, and the schema says so rather than letting
+        // a `block` value be accepted and half-honored (#963).
+        set_definition_property_enum(defs, "SemanticCategory", "action", json!(["mask"]));
         set_definition_property_enum(
             defs,
             "PresidioEntityConfig",
@@ -1472,6 +1476,9 @@ fn guardrail_kind_description(kind: &str) -> Option<&'static str> {
         "presidio" => {
             Some("Guardrail provider type for self-hosted Microsoft Presidio PII detection and anonymization.")
         }
+        "semantic" => Some(
+            "Guardrail provider type for in-process semantic category detection and redaction using the bundled embedding model.",
+        ),
         _ => None,
     }
 }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -1246,6 +1246,14 @@ pub fn guardrail_root_schema() -> Value {
         // exist for this kind, and the schema says so rather than letting
         // a `block` value be accepted and half-honored (#963).
         set_definition_property_enum(defs, "SemanticCategory", "action", json!(["mask"]));
+        // The write path must see candidate patterns spelled out: the
+        // serde default is `[]`, and JSON Schema's `minItems` does not
+        // apply to an ABSENT property — without `required`, a category
+        // with no patterns validates strictly and then fails category
+        // compilation, silently skipping the whole row (#963 class).
+        if let Some(cat) = defs.get_mut("SemanticCategory") {
+            require_property(cat, "candidate_patterns");
+        }
         set_definition_property_enum(
             defs,
             "PresidioEntityConfig",

--- a/crates/aisix-guardrails/Cargo.toml
+++ b/crates/aisix-guardrails/Cargo.toml
@@ -50,6 +50,8 @@ uuid = { workspace = true, optional = true }
 # experimental surface; builds opt in with `--features local-model`.
 ort = { workspace = true, optional = true }
 tokenizers = { workspace = true, optional = true }
+# manifest.json integrity verification for the model bundle (#1363).
+sha2 = { workspace = true, optional = true }
 
 [features]
 default = [
@@ -84,10 +86,11 @@ aliyun-text-moderation = [
 lakera = ["dep:reqwest"]
 openai-moderation = ["dep:reqwest"]
 presidio = ["dep:reqwest"]
-# Local CPU embedding-model guardrail MVP (AISIX-Cloud#1331). Off by
-# default: statically links ONNX Runtime and is activated only by env
-# config (no control-plane surface yet).
-local-model = ["dep:ort", "dep:tokenizers"]
+# Local CPU embedding-model semantic guardrail (AISIX-Cloud#1331 →
+# #1363, `kind: "semantic"`). Statically links ONNX Runtime; the server
+# crate enables it by default — the standard image ships the capability
+# and the model bundle, and rows activate it through the control plane.
+local-model = ["dep:ort", "dep:tokenizers", "dep:sha2"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -26,7 +26,8 @@ use crate::index::{GuardrailIndex, RequestContext, ScopeKind};
 use crate::keyword::{KeywordBlocklist, KeywordRule};
 use crate::pii::{builtin_rule, PiiAction, PiiGuardrail, PiiRule};
 use crate::{
-    Guardrail, GuardrailChain, GuardrailVerdict, Redaction, SegmentsOutcome, StreamOutputPolicy,
+    Guardrail, GuardrailChain, GuardrailVerdict, Redaction, SegmentsOutcome, SemanticRuntimeSlot,
+    StreamOutputPolicy,
 };
 
 /// A snapshot table's guardrail entries in deterministic chain order:
@@ -77,6 +78,7 @@ fn sorted_guardrail_entries(
 pub fn build_chain_from_snapshot(
     table: &ResourceTable<DomainGuardrail>,
     bedrock_endpoint_url: Option<&str>,
+    semantic: &SemanticRuntimeSlot,
 ) -> GuardrailChain {
     let mut chain: Vec<(String, Arc<dyn Guardrail>)> = Vec::new();
     // `applied` mirrors `chain` 1:1 — the `{kind, hook}` of each member that
@@ -91,7 +93,7 @@ pub fn build_chain_from_snapshot(
         if !row.enabled {
             continue;
         }
-        match build_one(row, bedrock_endpoint_url) {
+        match build_one(row, bedrock_endpoint_url, semantic) {
             Ok(Some(g)) => {
                 chain.push((row.name.clone(), g));
                 applied.push(applied_for(row));
@@ -140,8 +142,9 @@ fn applied_for(row: &DomainGuardrail) -> AppliedGuardrail {
 fn build_one(
     row: &DomainGuardrail,
     bedrock_endpoint_url: Option<&str>,
+    semantic: &SemanticRuntimeSlot,
 ) -> Result<Option<Arc<dyn Guardrail>>, BuildError> {
-    Ok(build_one_inner(row, bedrock_endpoint_url)?
+    Ok(build_one_inner(row, bedrock_endpoint_url, semantic)?
         .map(|g| apply_enforcement_mode(row, g))
         .map(|g| apply_mandatory(row, g)))
 }
@@ -184,7 +187,10 @@ fn apply_enforcement_mode(row: &DomainGuardrail, inner: Arc<dyn Guardrail>) -> A
 fn build_one_inner(
     row: &DomainGuardrail,
     bedrock_endpoint_url: Option<&str>,
+    semantic: &SemanticRuntimeSlot,
 ) -> Result<Option<Arc<dyn Guardrail>>, BuildError> {
+    #[cfg(not(feature = "local-model"))]
+    let _ = semantic;
     match &row.config {
         GuardrailKind::Keyword(cfg) => {
             if cfg.patterns.is_empty() {
@@ -454,6 +460,30 @@ fn build_one_inner(
         }
         #[cfg(not(feature = "presidio"))]
         GuardrailKind::Presidio(_) => Err(BuildError::FeatureDisabled("presidio")),
+        #[cfg(feature = "local-model")]
+        GuardrailKind::Semantic(cfg) => {
+            if cfg.categories.is_empty() {
+                return Ok(None);
+            }
+            // The kind is compiled in, but serving it also needs the
+            // node's verified model bundle — a RUNTIME capability. No
+            // bundle → the row is skipped + warned, the heartbeat stops
+            // advertising `semantic`, and the control plane surfaces
+            // the gap (capability warning + list badge). Never serve a
+            // semantic row without the model it judges with.
+            let Some(runtime) = semantic.get() else {
+                return Err(BuildError::RuntimeUnavailable);
+            };
+            let g = crate::local_model::SemanticGuardrail::from_config(
+                Arc::clone(runtime),
+                &cfg.categories,
+                row.hook_point,
+            )
+            .map_err(BuildError::SemanticCategory)?;
+            Ok(Some(Arc::new(g)))
+        }
+        #[cfg(not(feature = "local-model"))]
+        GuardrailKind::Semantic(_) => Err(BuildError::FeatureDisabled("local-model")),
     }
 }
 
@@ -489,6 +519,23 @@ enum BuildError {
     #[allow(dead_code)]
     #[error("guardrail kind {0:?} not compiled into this build; treating row as disabled")]
     FeatureDisabled(&'static str),
+    /// A `kind: "semantic"` row on a node whose model bundle is missing
+    /// or failed verification — the kind is compiled in but cannot be
+    /// served here. Distinct from [`BuildError::FeatureDisabled`] so
+    /// the warn log tells the operator which of the two gaps to fix
+    /// (rebuild vs. restore the bundle).
+    #[allow(dead_code)]
+    #[error(
+        "semantic guardrail runtime unavailable on this node \
+         (model bundle missing or failed verification); treating row as disabled"
+    )]
+    RuntimeUnavailable,
+    /// A `kind: "semantic"` category that does not compile (invalid
+    /// regex, duplicate name, unsupported action). The row is rejected
+    /// whole rather than half-honored (#963).
+    #[cfg(feature = "local-model")]
+    #[error(transparent)]
+    SemanticCategory(crate::local_model::CategoryCompileError),
 }
 
 /// `enforcement_mode: monitor` decorator. Runs the wrapped guardrail exactly
@@ -843,6 +890,7 @@ impl Guardrail for MandatoryGuardrail {
 pub struct LiveGuardrailChain {
     snapshot: SnapshotHandle<AisixSnapshot>,
     bedrock_endpoint_url: Option<String>,
+    semantic: SemanticRuntimeSlot,
     cache: Mutex<Cache>,
 }
 
@@ -855,6 +903,7 @@ impl LiveGuardrailChain {
     pub fn new(
         snapshot: SnapshotHandle<AisixSnapshot>,
         bedrock_endpoint_url: Option<String>,
+        semantic: SemanticRuntimeSlot,
     ) -> Arc<Self> {
         // Read version before load so that a concurrent store() between
         // the two reads causes current() to see a version bump and rebuild,
@@ -864,10 +913,12 @@ impl LiveGuardrailChain {
         let chain = Arc::new(build_chain_from_snapshot(
             &snap.guardrails,
             bedrock_endpoint_url.as_deref(),
+            &semantic,
         ));
         Arc::new(Self {
             snapshot,
             bedrock_endpoint_url,
+            semantic,
             cache: Mutex::new(Cache {
                 last_version,
                 chain,
@@ -886,6 +937,7 @@ impl LiveGuardrailChain {
             cache.chain = Arc::new(build_chain_from_snapshot(
                 &snap.guardrails,
                 self.bedrock_endpoint_url.as_deref(),
+                &self.semantic,
             ));
             cache.last_version = cur_version;
         }
@@ -959,6 +1011,7 @@ pub fn build_index_from_snapshot(
     guardrails: &ResourceTable<DomainGuardrail>,
     attachments: &ResourceTable<GuardrailAttachment>,
     bedrock_endpoint_url: Option<&str>,
+    semantic: &SemanticRuntimeSlot,
 ) -> GuardrailIndex {
     let mut entries = Vec::new();
     // Track guardrail IDs that have ANY attachment record (enabled or not).
@@ -1005,7 +1058,7 @@ pub fn build_index_from_snapshot(
             continue;
         }
 
-        let runtime_guardrail = match build_one(row, bedrock_endpoint_url) {
+        let runtime_guardrail = match build_one(row, bedrock_endpoint_url, semantic) {
             Ok(Some(g)) => g,
             Ok(None) => continue, // inert (e.g. empty keyword list)
             Err(err) => {
@@ -1069,7 +1122,7 @@ pub fn build_index_from_snapshot(
         if !row.enabled {
             continue;
         }
-        match build_one(row, bedrock_endpoint_url) {
+        match build_one(row, bedrock_endpoint_url, semantic) {
             Ok(Some(g)) => {
                 tracing::info!(
                     guardrail_id = %guardrail_arc.id,
@@ -1115,6 +1168,7 @@ pub fn build_index_from_snapshot(
 pub struct LiveGuardrailIndex {
     snapshot: SnapshotHandle<AisixSnapshot>,
     bedrock_endpoint_url: Option<String>,
+    semantic: SemanticRuntimeSlot,
     /// Per-execution telemetry receiver, attached to every resolved chain
     /// (AISIX-Cloud#1076). `None` (tests, standalone construction) records
     /// nothing; the server bootstrap wires the metrics layer's sink.
@@ -1132,15 +1186,22 @@ impl LiveGuardrailIndex {
         snapshot: SnapshotHandle<AisixSnapshot>,
         bedrock_endpoint_url: Option<String>,
     ) -> Arc<Self> {
-        Self::new_with_sink(snapshot, bedrock_endpoint_url, None)
+        Self::new_with_sink(
+            snapshot,
+            bedrock_endpoint_url,
+            None,
+            SemanticRuntimeSlot::none(),
+        )
     }
 
     /// Like [`LiveGuardrailIndex::new`], also attaching a metrics sink to
-    /// every chain [`LiveGuardrailIndex::resolve`] hands out.
+    /// every chain [`LiveGuardrailIndex::resolve`] hands out and the
+    /// process's semantic runtime (if any) for `kind: "semantic"` rows.
     pub fn new_with_sink(
         snapshot: SnapshotHandle<AisixSnapshot>,
         bedrock_endpoint_url: Option<String>,
         metrics_sink: Option<Arc<dyn aisix_core::GuardrailMetricsSink>>,
+        semantic: SemanticRuntimeSlot,
     ) -> Arc<Self> {
         // Read version before load — same ordering discipline as LiveGuardrailChain.
         let last_version = snapshot.version();
@@ -1149,10 +1210,12 @@ impl LiveGuardrailIndex {
             &snap.guardrails,
             &snap.guardrail_attachments,
             bedrock_endpoint_url.as_deref(),
+            &semantic,
         ));
         Arc::new(Self {
             snapshot,
             bedrock_endpoint_url,
+            semantic,
             metrics_sink,
             cache: Mutex::new(IndexCache {
                 last_version,
@@ -1182,6 +1245,7 @@ impl LiveGuardrailIndex {
             &snap.guardrails,
             &snap.guardrail_attachments,
             self.bedrock_endpoint_url.as_deref(),
+            &self.semantic,
         ));
 
         // Re-acquire and store. A concurrent rebuild (rare) is harmless —
@@ -1275,7 +1339,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         assert_eq!(chain.len(), 1);
         let v = chain.check_input(&req("here is AKIAEXAMPLE")).await;
         assert!(v.is_block());
@@ -1300,7 +1364,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         assert_eq!(chain.len(), 1, "monitor-mode row still materialises");
         // Would block under `block` mode; monitor downgrades to Allow.
         let v = chain.check_input(&req("here is AKIAEXAMPLE")).await;
@@ -1339,7 +1403,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
 
         // mask-action detector match → would_mask hit with counts.
         let (v, hits) = chain
@@ -1390,7 +1454,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         let (v, hits) = chain
             .check_input_observed(&req("here is AKIAEXAMPLE"))
             .await;
@@ -1428,7 +1492,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         let (v, hits) = chain
             .check_input_observed(&req("here is AKIAEXAMPLE"))
             .await;
@@ -1462,7 +1526,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         assert!(
             !chain.stream_output_policy().holds_back(),
             "monitor-mode output rule must not hold the stream back",
@@ -1485,7 +1549,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         assert!(
             chain
                 .check_input(&req("here is AKIAEXAMPLE"))
@@ -1516,7 +1580,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         assert_eq!(chain.len(), 1);
         let r = chain.redact_input_text("tool version: 12.1 done").unwrap();
         assert_eq!(r.text, "tool version: *** done");
@@ -1548,7 +1612,7 @@ mod tests {
         ] {
             let table: ResourceTable<DomainGuardrail> = ResourceTable::default();
             table.insert(entry("bad", "g-1", parse(row)));
-            let chain = build_chain_from_snapshot(&table, None);
+            let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
             assert!(
                 chain.is_empty(),
                 "replacement+block row must be skipped, not half-honored",
@@ -1708,7 +1772,9 @@ mod tests {
             &server.uri(),
             r#", "enforcement_mode": "monitor", "fail_open": false"#,
         );
-        let g = build_one(&row, None).unwrap().unwrap();
+        let g = build_one(&row, None, &SemanticRuntimeSlot::none())
+            .unwrap()
+            .unwrap();
         assert_eq!(
             g.check_input(&req("hello")).await,
             GuardrailVerdict::Allow,
@@ -1733,7 +1799,9 @@ mod tests {
             &server.uri(),
             r#", "enforcement_mode": "monitor", "mandatory": true"#,
         );
-        let g = build_one(&row, None).unwrap().unwrap();
+        let g = build_one(&row, None, &SemanticRuntimeSlot::none())
+            .unwrap()
+            .unwrap();
         assert!(
             g.check_input(&req("hello")).await.is_block(),
             "mandatory must keep provider unavailability fatal in monitor mode",
@@ -1757,7 +1825,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         assert_eq!(chain.len(), 0);
     }
 
@@ -1775,7 +1843,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         assert_eq!(chain.len(), 0, "empty list adds nothing to the chain");
     }
 
@@ -1809,7 +1877,7 @@ mod tests {
             ),
         ));
 
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         // Only the good row makes it in.
         assert_eq!(chain.len(), 1);
         let v = chain.check_input(&req("ok")).await;
@@ -1835,7 +1903,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         assert_eq!(chain.len(), 0, "out-of-range threshold row must be skipped");
     }
 
@@ -1878,7 +1946,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         // Both rows compose. We don't probe the bedrock arm — its
         // own tests cover the dispatch path; this one only pins the
         // chain composition contract.
@@ -1889,7 +1957,7 @@ mod tests {
     async fn live_chain_rebuilds_on_snapshot_swap() {
         let initial = AisixSnapshot::new();
         let handle = SnapshotHandle::new(initial);
-        let live = LiveGuardrailChain::new(handle.clone(), None);
+        let live = LiveGuardrailChain::new(handle.clone(), None, SemanticRuntimeSlot::none());
 
         // Empty snapshot → no rules → input passes.
         assert!(!live.check_input(&req("AKIA-EXAMPLE")).await.is_block());
@@ -1967,7 +2035,8 @@ mod tests {
     /// assertion fails intermittently (#519 B.4a).
     #[test]
     fn chain_order_is_created_at_ascending_with_id_tiebreak() {
-        let chain = build_chain_from_snapshot(&shuffled_table(), None);
+        let chain =
+            build_chain_from_snapshot(&shuffled_table(), None, &SemanticRuntimeSlot::none());
         assert_eq!(chain.member_names(), EXPECTED_ORDER);
     }
 
@@ -1979,7 +2048,7 @@ mod tests {
         for (id, name) in [("g-3", "z"), ("g-1", "y"), ("g-2", "x")] {
             table.insert(entry(name, id, keyword_row(name, None)));
         }
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         assert_eq!(chain.member_names(), ["y", "x", "z"]);
     }
 
@@ -1991,7 +2060,12 @@ mod tests {
     #[test]
     fn no_attachment_fallback_resolves_in_created_at_order() {
         let attachments: ResourceTable<GuardrailAttachment> = ResourceTable::default();
-        let index = build_index_from_snapshot(&shuffled_table(), &attachments, None);
+        let index = build_index_from_snapshot(
+            &shuffled_table(),
+            &attachments,
+            None,
+            &SemanticRuntimeSlot::none(),
+        );
         let chain = index.resolve(&RequestContext {
             passthrough_route_id: "",
             model_id: "m",
@@ -2041,7 +2115,12 @@ mod tests {
             ),
         ));
 
-        let index = build_index_from_snapshot(&guardrails, &attachments, None);
+        let index = build_index_from_snapshot(
+            &guardrails,
+            &attachments,
+            None,
+            &SemanticRuntimeSlot::none(),
+        );
         assert_eq!(index.len(), 1);
 
         let ctx = RequestContext {
@@ -2083,7 +2162,12 @@ mod tests {
             ),
         ));
 
-        let index = build_index_from_snapshot(&guardrails, &attachments, None);
+        let index = build_index_from_snapshot(
+            &guardrails,
+            &attachments,
+            None,
+            &SemanticRuntimeSlot::none(),
+        );
         assert_eq!(index.len(), 0);
         // Verify the guardrail does not fire (not just that the index is empty).
         let ctx = RequestContext {
@@ -2128,7 +2212,12 @@ mod tests {
             ),
         ));
 
-        let index = build_index_from_snapshot(&guardrails, &attachments, None);
+        let index = build_index_from_snapshot(
+            &guardrails,
+            &attachments,
+            None,
+            &SemanticRuntimeSlot::none(),
+        );
         // Exactly one entry — from the enabled attachment only.
         // The disabled attachment must NOT produce a second entry or trigger the fallback.
         assert_eq!(
@@ -2172,7 +2261,12 @@ mod tests {
         ));
         let attachments: ResourceTable<GuardrailAttachment> = ResourceTable::default();
 
-        let index = build_index_from_snapshot(&guardrails, &attachments, None);
+        let index = build_index_from_snapshot(
+            &guardrails,
+            &attachments,
+            None,
+            &SemanticRuntimeSlot::none(),
+        );
         assert_eq!(
             index.len(),
             1,
@@ -2213,7 +2307,12 @@ mod tests {
             ),
         ));
 
-        let index = build_index_from_snapshot(&guardrails, &attachments, None);
+        let index = build_index_from_snapshot(
+            &guardrails,
+            &attachments,
+            None,
+            &SemanticRuntimeSlot::none(),
+        );
         assert_eq!(index.len(), 0);
     }
 
@@ -2245,7 +2344,12 @@ mod tests {
             ),
         ));
 
-        let index = build_index_from_snapshot(&guardrails, &attachments, None);
+        let index = build_index_from_snapshot(
+            &guardrails,
+            &attachments,
+            None,
+            &SemanticRuntimeSlot::none(),
+        );
         assert_eq!(index.len(), 0);
     }
 
@@ -2376,8 +2480,12 @@ mod tests {
             ),
         ));
         let sink = Arc::new(RecordingSink::default());
-        let live =
-            LiveGuardrailIndex::new_with_sink(SnapshotHandle::new(snap), None, Some(sink.clone()));
+        let live = LiveGuardrailIndex::new_with_sink(
+            SnapshotHandle::new(snap),
+            None,
+            Some(sink.clone()),
+            SemanticRuntimeSlot::none(),
+        );
         let ctx = RequestContext {
             passthrough_route_id: "",
             model_id: "m1",
@@ -2450,7 +2558,7 @@ mod tests {
                 }"#,
             ),
         ));
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         // input check fires...
         assert!(chain.check_input(&req("secret")).await.is_block());
         // ...but output check is a noop on this rule.
@@ -2500,7 +2608,7 @@ mod tests {
             ),
         ));
 
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         // `applied` mirrors the chain 1:1 (pushed in lockstep); the absolute
         // member order is a `ResourceTable::entries()` concern tested
         // elsewhere, so sort by hook before comparing to pin only that BOTH
@@ -2558,7 +2666,7 @@ mod tests {
             ),
         ));
 
-        let chain = build_chain_from_snapshot(&table, None);
+        let chain = build_chain_from_snapshot(&table, None, &SemanticRuntimeSlot::none());
         assert_eq!(chain.len(), 1, "only the live row materialises");
         assert_eq!(
             chain.applied(),
@@ -2601,7 +2709,12 @@ mod tests {
             ),
         ));
 
-        let index = build_index_from_snapshot(&guardrails, &attachments, None);
+        let index = build_index_from_snapshot(
+            &guardrails,
+            &attachments,
+            None,
+            &SemanticRuntimeSlot::none(),
+        );
         let chain = index.resolve(&RequestContext {
             passthrough_route_id: "",
             model_id: "m-A",
@@ -2645,7 +2758,12 @@ mod tests {
             ),
         ));
 
-        let index = build_index_from_snapshot(&guardrails, &attachments, None);
+        let index = build_index_from_snapshot(
+            &guardrails,
+            &attachments,
+            None,
+            &SemanticRuntimeSlot::none(),
+        );
         assert_eq!(index.len(), 1, "the attachment must not be skipped");
 
         let matched = index.resolve(&RequestContext {
@@ -2702,7 +2820,12 @@ mod tests {
             ),
         ));
 
-        let index = build_index_from_snapshot(&guardrails, &attachments, None);
+        let index = build_index_from_snapshot(
+            &guardrails,
+            &attachments,
+            None,
+            &SemanticRuntimeSlot::none(),
+        );
         let chain = index.resolve(&RequestContext {
             passthrough_route_id: "",
             model_id: "m-OTHER",

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -480,6 +480,17 @@ fn build_one_inner(
                 row.hook_point,
             )
             .map_err(BuildError::SemanticCategory)?;
+            // Kick the engine load NOW, detached: creating a semantic row
+            // is the activation switch, so the multi-second session load
+            // happens at compile time — not on the first model-band
+            // request. Detached also means the load is uncancellable: a
+            // request-side awaiter that gives up (timeout, disconnect)
+            // abandons the OnceCell init, and without a persistent
+            // awaiter the next caller would start a SECOND load.
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                let rt = Arc::clone(runtime);
+                handle.spawn(async move { rt.warm_engine().await });
+            }
             Ok(Some(Arc::new(g)))
         }
         #[cfg(not(feature = "local-model"))]

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -153,7 +153,8 @@ pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
     parts.join("\n")
 }
 
-/// The guardrail `kind` discriminators compiled into this binary.
+/// The guardrail `kind` discriminators compiled into this binary whose
+/// availability is decided at COMPILE time.
 ///
 /// Every non-keyword kind sits behind a cargo feature (see `build.rs`'s
 /// `BuildError::FeatureDisabled` arms); a DP built without one silently
@@ -162,6 +163,11 @@ pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
 /// flag kinds the connected DP can't serve. Strings MUST stay equal to
 /// the serde `kind` tags in `aisix_core::models::GuardrailKind`
 /// (`GuardrailKind::kind_str`).
+///
+/// `semantic` is deliberately NOT here even when the `local-model`
+/// feature is compiled in: serving it also needs the model bundle on
+/// disk, a RUNTIME fact — heartbeat callers report
+/// [`supported_kinds_with`] instead.
 pub fn supported_kinds() -> &'static [&'static str] {
     &[
         "keyword",
@@ -185,6 +191,67 @@ pub fn supported_kinds() -> &'static [&'static str] {
     ]
 }
 
+/// [`supported_kinds`] plus the runtime-conditional `semantic` kind:
+/// advertised only while the node's model bundle stays verified (the
+/// `SemanticCapability` the runtime hands the heartbeat). Readiness
+/// means "could serve" — the control plane creating a semantic row is
+/// what triggers the lazy engine load, so gating the advert on "already
+/// active" would deadlock the create flow behind its own greying.
+pub fn supported_kinds_with(semantic_ready: bool) -> Vec<&'static str> {
+    let mut kinds = supported_kinds().to_vec();
+    #[cfg(feature = "local-model")]
+    if semantic_ready {
+        kinds.push("semantic");
+    }
+    #[cfg(not(feature = "local-model"))]
+    let _ = semantic_ready;
+    kinds
+}
+
+/// The process-wide semantic-guardrail runtime, passed to the chain
+/// builders. Always constructible — a build without the `local-model`
+/// feature, or a node without a verified model bundle, passes
+/// [`SemanticRuntimeSlot::none`] and every `kind: "semantic"` row is
+/// skipped with a warning (`BuildError::RuntimeUnavailable` /
+/// `FeatureDisabled`).
+#[derive(Clone, Default)]
+pub struct SemanticRuntimeSlot {
+    #[cfg(feature = "local-model")]
+    runtime: Option<std::sync::Arc<local_model::SemanticRuntime>>,
+}
+
+impl SemanticRuntimeSlot {
+    /// No runtime: semantic rows cannot be served.
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// A verified runtime: semantic rows compile against it.
+    #[cfg(feature = "local-model")]
+    pub fn new(runtime: std::sync::Arc<local_model::SemanticRuntime>) -> Self {
+        Self {
+            runtime: Some(runtime),
+        }
+    }
+
+    #[cfg(feature = "local-model")]
+    pub(crate) fn get(&self) -> Option<&std::sync::Arc<local_model::SemanticRuntime>> {
+        self.runtime.as_ref()
+    }
+}
+
+impl std::fmt::Debug for SemanticRuntimeSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[cfg(feature = "local-model")]
+        return f
+            .debug_struct("SemanticRuntimeSlot")
+            .field("present", &self.runtime.is_some())
+            .finish();
+        #[cfg(not(feature = "local-model"))]
+        f.debug_struct("SemanticRuntimeSlot").finish()
+    }
+}
+
 #[cfg(feature = "aliyun-text-moderation")]
 pub use aliyun::AliyunTextModerationGuardrail;
 #[cfg(feature = "aliyun-text-moderation")]
@@ -201,7 +268,11 @@ pub use keyword::{KeywordBlocklist, KeywordRule};
 #[cfg(feature = "lakera")]
 pub use lakera::LakeraGuardrail;
 #[cfg(feature = "local-model")]
-pub use local_model::{LocalModelConfig, LocalModelError, LocalModelGuardrail, MODEL_DIR_ENV};
+pub use local_model::{
+    parse_lanes, CategoryCompileError, LocalModelError, ModelManifest, SemanticCapability,
+    SemanticGuardrail, SemanticRuntime, DEFAULT_MODEL_DIR, LANES_ENV, MODEL_DIR_ENV,
+    PROTOTYPES_ENV, RULE_WINDOW_ENV, THRESHOLD_ENV,
+};
 #[cfg(feature = "openai-moderation")]
 pub use openai_moderation::OpenaiModerationGuardrail;
 pub use pii::{builtin_rule, PiiAction, PiiGuardrail, PiiRule, BUILTIN_DETECTORS};

--- a/crates/aisix-guardrails/src/local_model.rs
+++ b/crates/aisix-guardrails/src/local_model.rs
@@ -631,6 +631,14 @@ impl SemanticRuntime {
         }
     }
 
+    /// Drive the engine load to completion. Spawned detached at chain
+    /// build time (see `build.rs`): the load happens when a semantic
+    /// row appears, and this task is the persistent awaiter that keeps
+    /// the `OnceCell` init alive when request-side awaiters give up.
+    pub async fn warm_engine(&self) {
+        let _ = self.engine().await;
+    }
+
     /// The lazily loaded engine; `None` after a failed initialization
     /// (capability flips to failed, heartbeat stops advertising).
     async fn engine(&self) -> Option<Arc<Engine>> {
@@ -696,8 +704,14 @@ impl SemanticRuntime {
     /// cancellations would pile threads up toward the pool cap (audit
     /// finding on PR #999).
     async fn embed_text(&self, text: String) -> Result<Vec<f32>, SemanticDegradeReason> {
-        let Some(engine) = self.engine().await else {
-            return Err(SemanticDegradeReason::EngineFailed);
+        // The engine wait is bounded like the lane wait: while the
+        // detached warm task is still loading the session, a request
+        // releases its span after 500ms instead of stalling on the
+        // multi-second disk-bound load.
+        let engine = match tokio::time::timeout(LANE_WAIT_TIMEOUT, self.engine()).await {
+            Ok(Some(engine)) => engine,
+            Ok(None) => return Err(SemanticDegradeReason::EngineFailed),
+            Err(_) => return Err(SemanticDegradeReason::QueueTimeout),
         };
         let permit = match tokio::time::timeout(
             LANE_WAIT_TIMEOUT,
@@ -735,7 +749,7 @@ impl SemanticRuntime {
         if let Some(hit) = self
             .prototype_cache
             .lock()
-            .expect("prototype cache poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(text)
             .cloned()
         {
@@ -744,7 +758,7 @@ impl SemanticRuntime {
         let vector = Arc::new(self.embed_text(text.to_owned()).await?);
         self.prototype_cache
             .lock()
-            .expect("prototype cache poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(text.to_owned(), Arc::clone(&vector));
         Ok(vector)
     }
@@ -764,11 +778,13 @@ impl CandidateFinder {
     }
 
     /// Candidate spans (byte ranges) in `text`, ascending and
-    /// non-overlapping. When spans from different patterns overlap the
-    /// LONGER one wins (a broader token pattern must beat the dotted run
-    /// inside it — masking only the digits of `ICADV12.3` leaks the
-    /// `ICADV` identity); ties break toward the earlier pattern. Spans
-    /// longer than [`MAX_CANDIDATE_SPAN_BYTES`] are not candidates.
+    /// non-overlapping. When spans overlap, the EARLIEST start wins and
+    /// the LONGER one wins at equal starts (a broader token pattern
+    /// starts at-or-before the dotted run inside it, so it beats the
+    /// inner span — masking only the digits of `ICADV12.3` would leak
+    /// the `ICADV` identity); ties break toward the earlier pattern.
+    /// Spans longer than [`MAX_CANDIDATE_SPAN_BYTES`] are not
+    /// candidates.
     fn spans(&self, text: &str) -> Vec<Range<usize>> {
         let mut all: Vec<Range<usize>> = Vec::new();
         for re in &self.patterns {
@@ -1016,14 +1032,19 @@ impl SemanticGuardrail {
                         }
                         continue;
                     }
+                    // Only a PERMANENT failure (engine unavailable) may
+                    // cache `None`; a transient one (queue timeout under
+                    // burst, a one-off inference error) leaves the cell
+                    // empty so the next model-band span retries the
+                    // ~ms-scale prototype embed instead of degrading the
+                    // category until restart.
                     let prototype = cat
                         .prototype
-                        .get_or_init(|| async {
+                        .get_or_try_init(|| async {
                             match self.runtime.prototype_for(&cat.description).await {
-                                Ok(v) => Some(v),
-                                Err(reason) => {
-                                    // Record the UNDERLYING cause (engine
-                                    // failed, queue timeout, …) — that is
+                                Ok(v) => Ok(Some(v)),
+                                Err(reason @ SemanticDegradeReason::EngineFailed) => {
+                                    // Record the UNDERLYING cause — that is
                                     // what the operator has to fix.
                                     self.runtime.record_degrade(reason);
                                     tracing::warn!(
@@ -1032,20 +1053,27 @@ impl SemanticGuardrail {
                                         "semantic guardrail: description prototype \
                                          unavailable; category degrades to rule layers"
                                     );
-                                    None
+                                    Ok(None)
                                 }
+                                Err(reason) => Err(reason),
                             }
                         })
-                        .await
-                        .clone();
-                    let Some(prototype) = prototype else {
-                        // Already-failed category: keep the ongoing signal
-                        // alive — every span that would have been judged is
-                        // one more degrade sample, not a one-off at failure
-                        // time.
-                        self.runtime
-                            .record_degrade(SemanticDegradeReason::PrototypeUnavailable);
-                        continue;
+                        .await;
+                    let prototype = match prototype {
+                        Ok(Some(prototype)) => Arc::clone(prototype),
+                        Ok(None) => {
+                            // Permanently-failed category: keep the ongoing
+                            // signal alive — every span that would have been
+                            // judged is one more degrade sample, not a
+                            // one-off at failure time.
+                            self.runtime
+                                .record_degrade(SemanticDegradeReason::PrototypeUnavailable);
+                            continue;
+                        }
+                        Err(reason) => {
+                            self.runtime.record_degrade(reason);
+                            continue;
+                        }
                     };
                     *budget -= 1;
                     let window = text[window_bounds(text, &span, WINDOW_CONTEXT_CHARS)].to_owned();

--- a/crates/aisix-guardrails/src/local_model.rs
+++ b/crates/aisix-guardrails/src/local_model.rs
@@ -1,39 +1,52 @@
-//! Local CPU embedding-model guardrail — the second-tier guardrail
-//! (AISIX-Cloud#1331), grown from the MVP vertical slice.
+//! Local CPU embedding-model semantic guardrail — the runtime behind
+//! `kind: "semantic"` (AISIX-Cloud#1331 → #1363).
 //!
-//! Implements the design issue's three-layer pipeline for one hardcoded
-//! category (no prototype library resource, no standard risk categories
-//! yet). Pipeline per text segment:
-//!   1. regex finds candidate spans with exact byte offsets — two
-//!      shapes: dotted number runs (ASCII or fullwidth) and fused
-//!      version tokens (letters+digits in one token, `IC618`); the
-//!      layer is deliberately broad, precision lives in ② and ③;
-//!   2. rule scoring ([`rules`]): hotword proximity co-occurrence raises
-//!      a candidate's score, negative patterns lower it, and a double
-//!      threshold resolves decisive candidates right here — high scores
-//!      rewrite and low scores release WITHOUT a model call; only the
-//!      uncertain band continues;
+//! Implements the three-layer pipeline per user-configured category
+//! (`aisix_core::models::SemanticCategory`). Pipeline per text segment,
+//! per category:
+//!   1. the category's candidate regexes find spans with exact byte
+//!      offsets — the layer is deliberately broad, precision lives in
+//!      ② and ③;
+//!   2. rule scoring ([`rules`]): hotword-group proximity co-occurrence
+//!      raises a candidate's score, negative patterns lower it, and a
+//!      double threshold resolves decisive candidates right here — high
+//!      scores rewrite and low scores release WITHOUT a model call; only
+//!      the uncertain band continues;
 //!   3. a context window around each remaining candidate
 //!      (±[`WINDOW_CONTEXT_CHARS`] chars — the keyword-proximity window
 //!      magnitude mainstream DLP engines use, typically 50–300 chars) is
-//!      embedded by the local model and scored RELATIVELY against the
-//!      category's positive and negative prototype sets
-//!      (`max_pos − max_neg`; encoded at load time, see
-//!      [`PrototypeStrategy`] / [`PrototypeSet`]); above-threshold
-//!      candidates are rewritten in place to [`MASK_REPLACEMENT`].
+//!      embedded by the local model and its cosine similarity against
+//!      the category DESCRIPTION's embedding is gated by the category
+//!      threshold; above-threshold candidates are rewritten in place to
+//!      the category's replacement.
 //!
-//! Everything not rewritten is returned byte-identical.
+//! Everything not rewritten is returned byte-identical. Categories
+//! compose in config order: each category moderates the text the
+//! previous one produced (the same composition rule as chain members).
 //!
 //! The verdict is always `Allow` — this guardrail rewrites, never blocks
-//! (the design issue's "只改写不阻断" hard constraint).
+//! (the design issue's "只改写不阻断" hard constraint), and every
+//! resource cap degrades to doing less, never to blocking or stalling.
 //!
-//! Wire-in: implements the async segment-moderation hooks
-//! ([`Guardrail::moderate_input_segments`] /
+//! Wire-in: [`SemanticGuardrail`] rows implement the async
+//! segment-moderation hooks ([`Guardrail::moderate_input_segments`] /
 //! [`Guardrail::moderate_output_segments`]) — the same mask write-back
 //! channel the Bedrock ANONYMIZE pass uses — so the proxy's existing
-//! collect→moderate→apply walkers do the per-field rewrite and no proxy
-//! plumbing changes. The sync `redact_*_text` hooks stay unimplemented:
-//! inference must not run inline on a tokio worker.
+//! collect→moderate→apply walkers do the per-field rewrite. The sync
+//! `redact_*_text` hooks stay unimplemented: inference must not run
+//! inline on a tokio worker.
+//!
+//! Ownership: ONE process-wide [`SemanticRuntime`] (model bundle,
+//! session lanes, embedding cache) is verified at boot and shared by
+//! every `kind: "semantic"` row the chain builder compiles. The heavy
+//! state is lazy: boot only verifies the bundle's `manifest.json`
+//! (per-file sha256); ONNX sessions load on the first request that needs
+//! an embedding, and each category's description prototype is embedded
+//! on its first model-band judgement and cached by content, so a
+//! config-only change (say, a threshold tune) rebuilds the chain without
+//! re-embedding anything. A node with no valid bundle simply lacks the
+//! capability — rows are skipped at build with a warning and the
+//! heartbeat stops advertising `semantic`.
 //!
 //! Threading (inherited from the #1271 assessment): inference runs in
 //! `spawn_blocking`, bounded by a semaphore sized to the session pool —
@@ -48,47 +61,35 @@
 //! serving workers for scheduling; hard business/model core
 //! partitioning needs a dedicated pinned inference pool.
 //!
-//! Scaling notes (MVP review, measured on a 12-core avx2+vnni host):
+//! Scaling notes (measured on a 12-core avx2+vnni host):
 //! - One lane sustains ~50 inferences/s (p50 ≈ 19 ms per ~35-token
-//!   window; roughly linear in tokens). The acceptance shape spends TWO
-//!   inferences per request (input + output pass).
-//! - Throughput scales by adding lanes (api7/aisix#1001, implemented):
+//!   window; roughly linear in tokens).
+//! - Throughput scales by adding lanes (api7/aisix#1001):
 //!   `GUARDRAIL_LOCAL_MODEL_LANES` = N sessions behind
-//!   `Semaphore::new(N)`. `run(&mut self)` forbids concurrent runs on
-//!   one session even though the ONNX Runtime C API documents `Run` as
-//!   thread-safe with shared read-only weights; this crate forbids
-//!   `unsafe`, so the shared-weights form waits on an upstream `&self`
-//!   run, a thin unsafe shim crate, or the sidecar deployment form.
-//!   Until then each lane pays its own weight copy — measured: the
-//!   first lane costs ~192 MiB resident (weights + tokenizer + arena),
-//!   each additional lane ~102 MiB (its weight copy + arena).
-//!   Lane dispatch is a centralized free-list — deliberately NO
-//!   worker↔session binding (sessions are interchangeable; the central
-//!   queue load-balances the uneven per-worker accept distribution).
-//!   ONE ORT `Session` is a loaded model instance, not a conversation:
-//!   every `run` is stateless, so lanes are freely interchangeable.
-//! - Per-audit cost ≈ (#candidate windows × inference) + (#prototypes ×
-//!   384-dim dot ≈ 1 µs). A window embedding is category-agnostic: a
-//!   span matched by several categories embeds ONCE and compares
-//!   against the whole prototype library, so prototype count stays
-//!   latency-noise up to ~1e5 vectors (then: ANN index).
+//!   `Semaphore::new(N)`. Each lane pays its own weight copy —
+//!   measured: the first lane costs ~192 MiB resident, each additional
+//!   lane ~102 MiB. Lane dispatch is a centralized free-list —
+//!   deliberately NO worker↔session binding.
+//! - A window embedding is category-agnostic in principle, but v1 keeps
+//!   the per-category loop simple: overlapping windows across categories
+//!   may embed twice, bounded by the per-pass call cap.
 //! - The candidate-regex layer is the all-traffic cost. At many
-//!   categories the per-category patterns must merge into one
-//!   multi-pattern automaton (`RegexSet` / aho-corasick), compiled at
-//!   prototype-library build time and atomically swapped — never per
-//!   request. The rust regex engine is non-backtracking, so
+//!   categories the per-category patterns should merge into one
+//!   multi-pattern automaton compiled at build time — tracked on the
+//!   design issue. The rust regex engine is non-backtracking, so
 //!   operator-supplied patterns cannot ReDoS the data plane.
 //!
-//! Model contract (upstream docs): the model directory holds the two
-//! deliverables `model.onnx` + `tokenizer.json`. The MVP target is
+//! Model contract: the model directory holds `model.onnx` +
+//! `tokenizer.json` + `manifest.json`. The manifest pins each file's
+//! sha256, the embedding dimension, and the calibrated default
+//! threshold; a bundle that fails verification is refused rather than
+//! silently mis-scoring (a wrong-model prototype space invalidates every
+//! calibrated threshold). The reference bundle is
 //! `ibm-granite/granite-embedding-97m-multilingual-r2`'s official int8
-//! ONNX export (`onnx/model_quint8_avx2.onnx`, 93.7 MiB, standard
-//! `ai.onnx` opset only — the q4/q4f16/bnb4 variants carry
-//! `com.microsoft` ops and are ruled out). Per the repo's
-//! `1_Pooling/config.json` + `modules.json`, sentence embedding = CLS
-//! pooling over `last_hidden_state` followed by L2 normalization; the
-//! ModernBERT graph takes `input_ids` + `attention_mask` (no
-//! `token_type_ids`).
+//! ONNX export (`onnx/model_quint8_avx2.onnx`, standard `ai.onnx` opset
+//! only). Per the repo's `1_Pooling/config.json` + `modules.json`,
+//! sentence embedding = CLS pooling over `last_hidden_state` followed by
+//! L2 normalization; the graph takes `input_ids` + `attention_mask`.
 //! <https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2>
 //!
 //! Offline builds: `ort-sys` honors `ORT_OFFLINE=1` (skip the prebuilt
@@ -98,17 +99,23 @@
 #[cfg(test)]
 mod adversarial_corpus;
 mod rules;
+#[cfg(test)]
+mod tests;
 
 use std::collections::BTreeMap;
 use std::ops::Range;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use ort::session::Session;
 use ort::value::Tensor;
 use regex::Regex;
+use sha2::Digest;
+
+use aisix_core::models::{GuardrailHookPoint, GuardrailMetricsSink, SemanticCategory};
 
 use crate::{
     Guardrail, GuardrailVerdict, SegmentsOutcome, StreamOutputPolicy,
@@ -117,330 +124,66 @@ use crate::{
 
 use rules::{RuleDecision, RuleScorer};
 
-/// Environment variable holding the model directory (`model.onnx` +
-/// `tokenizer.json`). Set → the server bootstrap loads and injects the
-/// guardrail; unset → the feature is completely inert.
+/// Environment variable overriding the model-bundle directory
+/// (`model.onnx` + `tokenizer.json` + `manifest.json`). Unset → the
+/// image's bundled default path ([`DEFAULT_MODEL_DIR`]). Set, the
+/// bundle MUST verify — a failure is boot-fatal (an operator override
+/// that silently isn't there would leak the very content it exists to
+/// rewrite), whereas a missing/corrupt default bundle only marks the
+/// capability failed.
 pub const MODEL_DIR_ENV: &str = "GUARDRAIL_LOCAL_MODEL_DIR";
-/// Optional score-gate override (default: the configured strategy's
-/// calibrated `default_threshold`). NOTE the scale depends on the
-/// strategy: `description` scores absolute cosine in [-1, 1]; the
-/// sample strategies score the relative margin `max_pos − max_neg`
-/// in [-2, 2].
-pub const THRESHOLD_ENV: &str = "GUARDRAIL_LOCAL_MODEL_THRESHOLD";
 /// Optional inference-lane count (default 1, clamped to
 /// [`MAX_LANES`]). Each lane is one ONNX session — one more core the
-/// guardrail may use and roughly one more ~100 MiB weight copy resident (measured); see
-/// the module scaling notes and api7/aisix#1001.
+/// guardrail may use and roughly one more ~100 MiB weight copy
+/// resident (measured); see the module scaling notes.
 pub const LANES_ENV: &str = "GUARDRAIL_LOCAL_MODEL_LANES";
-/// Optional layer-② hotword proximity window override, in chars each
-/// side of a candidate (default [`rules::DEFAULT_PROXIMITY_CHARS`],
-/// clamped to [`rules::MAX_PROXIMITY_CHARS`]; malformed or zero →
-/// default). Zero is a misconfiguration, not a mode — the same rule as
-/// [`LANES_ENV`]: a zero window finds no hotword, so layer ② silently
-/// stops masking while looking configured.
-pub const RULE_WINDOW_ENV: &str = "GUARDRAIL_LOCAL_MODEL_RULE_WINDOW";
-/// Optional layer-③ prototype strategy: `description`, `max`, or
-/// `centroid` (default [`PrototypeStrategy::default`]; malformed →
-/// default with a warning — silently landing on the wrong vector space
-/// would invalidate the operator's calibrated threshold).
+/// Retired MVP env var: the score gate is per-category config now
+/// (`categories[].threshold`). Set → warned about and ignored.
+pub const THRESHOLD_ENV: &str = "GUARDRAIL_LOCAL_MODEL_THRESHOLD";
+/// Retired MVP env var: the prototype strategy is derived from the
+/// category data (v1: description only). Set → warned about and ignored.
 pub const PROTOTYPES_ENV: &str = "GUARDRAIL_LOCAL_MODEL_PROTOTYPES";
+/// Retired MVP env var: the rule proximity window is a fixed default
+/// pending per-category demand. Set → warned about and ignored.
+pub const RULE_WINDOW_ENV: &str = "GUARDRAIL_LOCAL_MODEL_RULE_WINDOW";
+
+/// The image's bundled model path — the Dockerfile bakes the bundle
+/// here, so a standard-image node has the capability out of the box.
+pub const DEFAULT_MODEL_DIR: &str = "/usr/local/aisix/guardrail-model";
 
 /// Upper clamp for [`LANES_ENV`]: lanes are cores, and no sane host
 /// grants the guardrail more than this.
 const MAX_LANES: usize = 32;
 
-/// The ONE category this module ships: EDA-software version numbers.
-/// Under [`PrototypeStrategy::Description`] the prototype vector is the
-/// load-time embedding of this sentence — the v1 "customer types one
-/// Chinese description" path from the design issue, collapsed to a
-/// compile-time constant.
-const PROTOTYPE_DESCRIPTION_ZH: &str = "EDA 软件的版本号";
-
-/// Positive sample sentences for the sample-based prototype strategies —
-/// the v2 "customer supplies example sentences" path from the design
-/// issue, collapsed to a compile-time constant set (synthesized; real
-/// customer corpus not yet available). Coverage is by SHAPE, not by
-/// string: upgrade/rollback phrasing, tool-name+version phrasing,
-/// anchor-free "we run X" phrasing, and FUSED version tokens, in Chinese
-/// and English. Tool names and numbers are deliberately DIFFERENT from
-/// the probe/adversarial corpora (Spectre/Genus and invented fused
-/// tokens here; Virtuoso/Xcelium-family tokens in the corpora) so the
-/// calibration probes measure shape generalization, not string overlap —
-/// which is also why the MVP's `Xcelium 23.09` sample left this list
-/// when `XCELIUM2309` entered the adversarial corpus.
-///
-/// Scale note: 24 positives + 90 negatives (~1:3.75). The ecosystem's
-/// published floor for trainable classifiers is 50–500 positives and
-/// ≥150 negatives at ~1:3 (Microsoft Purview,
-/// <https://learn.microsoft.com/en-us/purview/trainable-classifiers-get-started-with>);
-/// this set moves from 10:0 to a meaningful fraction of that floor and
-/// the ratio it prescribes, and the rest is the evaluation-set work
-/// (AISIX-Cloud#1332), not more synthesis.
-const PROTOTYPE_SAMPLES: &[&str] = &[
-    "布局布线工具升级到 21.15 之后跑得快多了",
-    "仿真器回退到 19.03 才恢复正常",
-    "这个后端工具的版本是 33.0",
-    "综合工具的版本号是 2020.09,不要外传",
-    "Spectre 23.1.0 在这个工艺角下会崩溃",
-    "签核工具装的是 22.4 这个版本",
-    "时序工具从 18.1 换到 20.2 就没再出过问题",
-    "现在生产环境跑的是 16.3 那个版本的布线器",
-    "形式验证工具还停在 10.6,太老了",
-    "装了 31.2 之后 license 就报错",
-    "版图工具的补丁版本是 QSV302",
-    "提取工具升级到 QRC1921 以后内存翻倍",
-    "DRC 用的签核包是 K-2019.06-SP1",
-    "那台机器装的仿真器是 v14.2-p004",
-    "We upgraded the place-and-route tool to 21.15",
-    "The simulator crashed on release 6.2.1",
-    "The sign-off tool version is 2020.09",
-    "Genus 19.13 fails on this floorplan",
-    "the flow needs tool build 30.4 or newer",
-    "we rolled back to 17.0 after the crash",
-    "they still run SPECTRE181 in production",
-    "the timing box has PT-2021.06-SP3 installed",
-    "our extraction flow is pinned to v19.1-s022_2",
-    "the older 14.7 install still passes DRC",
-];
-
-/// Negative sample sentences: numbers that LOOK like the candidate shape
-/// but carry non-software semantics. This is the other half of the
-/// relative scoring form — under the absolute form the model had to
-/// clear a fixed bar with no notion of what "not a version" looks like,
-/// and the measured margin on anchor-free windows was NEGATIVE (the MVP
-/// finding, reproduced on the adversarial corpus). Fifteen semantic
-/// families × 6, zh+en: math constants, exchange rates / finance, body
-/// measurements, dates, quantities/statistics, spelled durations,
-/// physical quantities, dimensions, process nodes, scores/ratios,
-/// section numbers, clock times, and bare number sequences (data rows /
-/// log dumps — the driving corpus is dense compile logs, and without
-/// this family a context-free run of numbers sits EXACTLY on the
-/// relative-score decision boundary, where int8 noise picks the sign),
-/// plus files/hashes/tickets/standard numbers and product/model
-/// identifiers (the fused-token relaxation makes everyday identifiers —
-/// filenames, commit hashes, GPU and LLM model names — candidates, and
-/// the audit measured them mis-masking without these two families).
-/// Numbers are disjoint from the corpora and the positive set.
-const NEGATIVE_PROTOTYPE_SAMPLES: &[&str] = &[
-    "圆周率约是 3.1416",
-    "自然常数 e 约等于 2.71828",
-    "黄金分割比大约是 1.618",
-    "根号二约等于 1.41421",
-    "pi is roughly 3.1416",
-    "the golden ratio is about 1.618",
-    "今天美元兑人民币汇率是 7.18",
-    "欧元汇率涨到 7.92",
-    "股价收在 24.35",
-    "年化利率是 3.65",
-    "the exchange rate moved to 7.15",
-    "the stock closed at 132.5 today",
-    "早上量体温 36.6,正常",
-    "孩子昨晚烧到 39.2",
-    "空腹血糖 5.2,没问题",
-    "体重降到 62.5 公斤了",
-    "her temperature was 37.8 last night",
-    "resting heart rate dropped to 58.5",
-    "会议改到 9.28 上午十点",
-    "项目截止日期是 2026.10.31",
-    "10.1 假期值班表出来了",
-    "发票日期写的 2025.12.05",
-    "the review is scheduled for 11.20",
-    "the contract was signed on 2026.4.30",
-    "这批晶圆一共 8.5 万片",
-    "平均每天触发 4.5 次告警",
-    "样本均值 6.35,标准差 1.2",
-    "库存还剩 3.5 箱",
-    "we shipped 2.4 million units last year",
-    "the average queue depth is 5.5",
-    "排队等了 3.5 个星期",
-    "面试聊了 1.5 个钟头",
-    "整个流程走了 4.5 个月",
-    "assembly 那步要等 2.5 个工作日",
-    "it took 2.5 weeks end to end",
-    "the outage lasted 3.5 days",
-    "结温升到 88.5 度就限频",
-    "内核电压是 0.72 伏",
-    "整机功耗 5.5 瓦左右",
-    "环境温度 23.5 度恒温",
-    "the die temperature hit 95.5 degrees",
-    "supply voltage sagged to 0.66 volts",
-    "die 面积是 15.21 平方毫米",
-    "键合线直径 25.4 微米",
-    "这条走线长 3.6 毫米",
-    "硅片厚度 0.775 毫米",
-    "the package is 10.5 by 10.5 millimeters",
-    "the wafer is 0.725 millimeters thick",
-    "主力工艺切到 N2 了",
-    "这个块还在 N16 上",
-    "新项目评估 4nm 的 PDK",
-    "老产品线停留在 14nm",
-    "the pilot line runs N6",
-    "we are qualifying the 3nm flow",
-    "客户满意度打了 9.2 分",
-    "评审平均分 8.65",
-    "基准测试跑分 456.5",
-    "良率这周爬到 91.5",
-    "the benchmark scores 78.5 overall",
-    "approval rating sits at 62.5",
-    "详见第 2.4 节",
-    "规范的 5.3.1 条款有说明",
-    "图 4.2 画的是数据通路",
-    "表 6.1 列出了引脚定义",
-    "see section 3.4.2 of the spec",
-    "chapter 12.3 covers the protocol",
-    "日志停在 11:42:07.333",
-    "[07:03:59.001] job finished",
-    "晚上 20.45 的班车",
-    "闹钟定在 6.30",
-    "the cron fires at 23.55 every night",
-    "the shuttle leaves at 8.15",
-    "0.2 0.4 0.6 0.8 1.0 1.2",
-    "数据列是 2.2 4.4 6.6 8.8",
-    "表里那列全是 1.3 2.6 3.9 5.2 这种数",
-    "the raw dump reads 0.5 1.5 2.5 3.5 4.5",
-    "column two is 9.1 8.2 7.3 6.4",
-    "坐标序列 10.5 20.5 30.5 40.5",
-    "配置都在 setup2.cfg 里",
-    "commit 是 f00dbabe42 那个",
-    "工单编号是 JIRA-1024",
-    "the log lives in run5.txt",
-    "the checksum is 9f8e7d6c5b",
-    "先过 802.3af 认证再说",
-    "换成 gpt-5.2 再试一次",
-    "这个 bug 用 llama-3.1 也能复现",
-    "显卡是 RTX4090",
-    "主控芯片是 BCM2712",
-    "the endpoint serves claude-haiku-4.5",
-    "the box ships with an RTX4080 inside",
-];
-
-/// How the category's prototype vector sets are built at load time.
-///
-/// All three strategies score through the same relative form
-/// ([`PrototypeSet::score`]): `max_pos − max_neg`, with an empty
-/// negative set contributing 0 — so `Description` (no negative
-/// material) keeps its MVP absolute-cosine semantics unchanged, and the
-/// sample strategies gain the contrastive term the adversarial corpus
-/// showed the absolute form cannot do without (its measured margin on
-/// anchor-free windows was negative under EVERY positive-only
-/// construction).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PrototypeStrategy {
-    /// One positive vector: the embedded category description (the MVP
-    /// form). No negative set.
-    Description,
-    /// One vector per [`PROTOTYPE_SAMPLES`] / [`NEGATIVE_PROTOTYPE_SAMPLES`]
-    /// entry; a window scores by max-cosine per set, nearest sample on
-    /// each side decides.
-    SampleMax,
-    /// One vector per side: the L2-renormalized mean of each sample set;
-    /// a window scores against the two class centroids.
-    SampleCentroid,
-}
-
-impl PrototypeStrategy {
-    fn parse(raw: Option<&str>) -> Self {
-        let Some(raw) = raw else {
-            return Self::default();
-        };
-        match raw.to_ascii_lowercase().as_str() {
-            "description" => Self::Description,
-            "max" => Self::SampleMax,
-            "centroid" => Self::SampleCentroid,
-            other => {
-                tracing::warn!(
-                    value = other,
-                    default = ?Self::default(),
-                    "unrecognized {PROTOTYPES_ENV}; using the default strategy"
-                );
-                Self::default()
-            }
-        }
-    }
-
-    /// Score gate calibrated per strategy with this module's
-    /// `#[ignore]` probe matrix and the adversarial-corpus report (the
-    /// score SCALE shifts with the prototype construction, so one
-    /// shared default would be wrong for two of the three).
-    /// - `Description` keeps the MVP absolute-cosine calibration
-    ///   (no negative set ⇒ score IS the positive cosine): acceptance
-    ///   positive ~0.90, every probed negative ≤0.76.
-    /// - `SampleMax` / `SampleCentroid` gate the RELATIVE margin
-    ///   `max_pos − max_neg`; the calibrated values are pinned by the
-    ///   probe matrix so model/sample drift fails the calibration test
-    ///   instead of silently shifting behavior.
-    ///
-    /// All three lean precision — a mask false-positive corrupts user
-    /// content; layer ② carries recall for anchored shapes.
-    fn default_threshold(self) -> f32 {
-        match self {
-            Self::Description => 0.80,
-            Self::SampleMax => 0.0,
-            Self::SampleCentroid => 0.0,
-        }
-    }
-}
-
-impl Default for PrototypeStrategy {
-    /// `SampleMax`: the probe matrix (module tests) measures the widest
-    /// relative hard margin here (+0.0355 vs +0.0341 for the centroid —
-    /// averaging shape-diverse samples into one vector costs
-    /// nearest-shape resolution).
-    fn default() -> Self {
-        Self::SampleMax
-    }
-}
-
-/// Candidate shape A: a dotted number run (`12.1`, `2022.4`, `6.1.8`),
-/// ASCII or fullwidth (`１２．１` — Chinese-IME phrasing is accidental,
-/// not adversarial, so it is in scope). Plain integers stay out of
-/// scope.
-const CANDIDATE_PATTERN: &str = r"[0-9０-９]+(?:[.．][0-9０-９]+)+";
-
-/// Candidate shape B: a fused version token — a maximal
-/// `[A-Za-z0-9._-]` run mixing ASCII letters and digits. Real EDA
-/// corpora fuse the version into one token the dotted shape cannot see
-/// (`IC618`, `ICADV12.3`, `XCELIUM2309`, `MMSIM151`, `E-2010.12-ICC-SP2`,
-/// `v16.12-s051_1`, `T-2022.03`, `20.09-s003`) — the adversarial-corpus
-/// finding this widens layer ① for. The shape is deliberately BROAD
-/// (`7nm`, `N5`, `sha256`-ish identifiers all qualify): a garbage
-/// candidate costs a rule score in microseconds and at worst one model
-/// call, while an invisible candidate is an unconditional leak — layers
-/// ②③ exist precisely so ① does not have to be precise. Leading and
-/// trailing `[._-]` are trimmed (sentence punctuation), and a token
-/// must mix letters AND digits — pure words and pure numbers fall back
-/// to shape A or drop out.
-const FUSED_TOKEN_PATTERN: &str = r"[A-Za-z0-9._-]+";
-
 /// Context chars kept on each side of a candidate when cutting the
 /// window the model judges.
 const WINDOW_CONTEXT_CHARS: usize = 50;
 
-/// Hard cap on model invocations per moderation pass (the design
-/// issue's "每请求模型调用次数上限" recommendation). Candidates past
-/// the cap are left untouched and a warning is logged — degrade to
-/// doing less, never to blocking or stalling.
+/// Hard cap on model invocations per moderation pass, SHARED across all
+/// categories of a row. Candidates past the cap are left untouched and
+/// a warning is logged — degrade to doing less, never to blocking or
+/// stalling.
 const MAX_MODEL_CALLS_PER_PASS: usize = 8;
 
-/// Hard cap on rule-scored candidates per SEGMENT. Rule scoring is
-/// µs-cheap per candidate but re-scans a proximity window each time, so
-/// a crafted body that is nothing but candidates (`1.1 1.1 …`) turns
-/// the per-segment scoring loop into a linear CPU amplifier on the
-/// async worker — measured ~91 ms of synchronous work per MiB at the
-/// default window and ~6× that at the window clamp (audit finding on
-/// this PR; the request-body limit defaults to unlimited). Candidates
-/// past the cap are RELEASED unscored with a warning — the same
-/// fail-open arm as every other cap here — and a segment with thousands
-/// of dotted-number runs is a log dump, not prose a version leaks
-/// through.
+/// Hard cap on rule-scored candidates per SEGMENT per category. Rule
+/// scoring is µs-cheap per candidate but re-scans a proximity window
+/// each time, so a crafted body that is nothing but candidates turns
+/// the scoring loop into a linear CPU amplifier on the async worker
+/// (measured ~91 ms/MiB at the default window). Candidates past the cap
+/// are RELEASED unscored with a warning.
 const MAX_RULE_SCORED_SPANS_PER_SEGMENT: usize = 4096;
 
-/// Hardcoded rewrite for an above-threshold candidate span.
-const MASK_REPLACEMENT: &str = "***";
+/// Hard byte cap on a single candidate span. A real sensitive value is
+/// short by definition; without this cap a crafted run matches as ONE
+/// giant span and each model call becomes a max-truncation inference
+/// stalling the lane (audit finding on PR #999). Over-cap spans are
+/// dropped BEFORE budget accounting.
+const MAX_CANDIDATE_SPAN_BYTES: usize = 64;
 
-/// Detector label used in redaction counts (never the matched value —
-/// #153 / #932 no-leak rule).
-const DETECTOR_NAME: &str = "eda_version";
+/// How long a pass waits for an inference lane before degrading that
+/// span to the rule layers. Bounds the guardrail's latency contribution
+/// under lane saturation — the queue never stalls a request.
+const LANE_WAIT_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Debug, thiserror::Error)]
 pub enum LocalModelError {
@@ -450,116 +193,168 @@ pub enum LocalModelError {
     Ort(#[from] ort::Error),
     #[error("local-model guardrail: {0}")]
     Model(String),
+    #[error("local-model guardrail: manifest: {0}")]
+    Manifest(String),
 }
 
-/// Load-time configuration. MVP surface: env vars only — deliberately
-/// NO control-plane resource; see the design issue for what the real
-/// config object must eventually carry (model id + dimension + prefix
-/// convention + threshold table + prototype-library version).
-///
-/// Target form (not built): the category data becomes a prototype
-/// LIBRARY resource — etcd stores category TEXT only (name, action,
-/// replacement, candidate patterns, description/sample sentences); the
-/// DP encodes vectors with its own loaded model off the hot path
-/// (cached by model id + text hash) and atomically swaps the compiled
-/// library on a watch tick, the same propagation the guardrail index
-/// already uses — so category updates land without a restart. Vectors
-/// never travel through config, which removes the "encoded by which
-/// model" mismatch for text-sourced prototypes; swapping the MODEL
-/// itself stays a cold operation (all vectors rebuilt).
-pub struct LocalModelConfig {
-    pub model_dir: PathBuf,
-    pub threshold: f32,
-    /// Inference lanes = ONNX sessions = max concurrent inferences.
-    pub lanes: usize,
-    /// Layer-② hotword proximity window (chars each side of a span).
-    pub rule_window: usize,
-    /// Layer-③ prototype-set construction.
-    pub prototypes: PrototypeStrategy,
+/// Reasons a span degrades to the rule layers instead of getting its
+/// embedding judgement. Bounded vocabulary — these land on a metric
+/// label (`aisix_guardrail_semantic_degraded_total{reason}`), never
+/// free text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SemanticDegradeReason {
+    /// The ONNX engine failed to initialize (bad bundle discovered at
+    /// first use, or the dimension probe disagreed with the manifest).
+    EngineFailed,
+    /// The category's description prototype could not be embedded.
+    PrototypeUnavailable,
+    /// The per-pass model-call budget was exhausted.
+    BudgetExhausted,
+    /// No inference lane freed up within [`LANE_WAIT_TIMEOUT`].
+    QueueTimeout,
+    /// A single inference failed.
+    InferenceFailed,
 }
 
-impl LocalModelConfig {
-    /// `None` when [`MODEL_DIR_ENV`] is unset (guardrail disabled). A
-    /// malformed or out-of-range threshold falls back to the strategy's
-    /// default rather than failing boot — the gate is a tuning knob, not
-    /// a correctness one. The range check matters: `"NaN"` parses as a
-    /// valid f32 and would make `score >= threshold` always false — a
-    /// configured-looking guardrail that silently never masks. The
-    /// accepted range is the RELATIVE-score span [-2, 2] (see
-    /// [`THRESHOLD_ENV`]); `description`'s meaningful values are its
-    /// [0, 1] subset. Lanes and the rule window follow the same lenient
-    /// rule (malformed → default).
-    pub fn from_env() -> Option<Self> {
-        let model_dir = PathBuf::from(std::env::var_os(MODEL_DIR_ENV)?);
-        let prototypes = PrototypeStrategy::parse(std::env::var(PROTOTYPES_ENV).ok().as_deref());
-        let threshold = std::env::var(THRESHOLD_ENV)
-            .ok()
-            .and_then(|s| s.parse::<f32>().ok())
-            .filter(|t| t.is_finite() && (-2.0..=2.0).contains(t))
-            .unwrap_or_else(|| prototypes.default_threshold());
-        // The sample strategies moved from absolute cosine to the
-        // relative margin scale: a pre-migration override (e.g. the old
-        // 0.82) is far above any reachable margin and would silently
-        // turn every model-band judgement into a release.
-        if prototypes != PrototypeStrategy::Description && threshold > 0.5 {
-            tracing::warn!(
-                threshold,
-                strategy = ?prototypes,
-                "{THRESHOLD_ENV} looks like an absolute-cosine value, but this \
-                 strategy gates the relative margin (max_pos − max_neg, ~±0.2): \
-                 the model band will likely never mask"
-            );
+impl SemanticDegradeReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::EngineFailed => "engine_failed",
+            Self::PrototypeUnavailable => "prototype_unavailable",
+            Self::BudgetExhausted => "budget_exhausted",
+            Self::QueueTimeout => "queue_timeout",
+            Self::InferenceFailed => "inference_failed",
         }
-        let lanes = parse_lanes(std::env::var(LANES_ENV).ok().as_deref());
-        let rule_window = std::env::var(RULE_WINDOW_ENV)
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .filter(|&w| w >= 1)
-            .unwrap_or(rules::DEFAULT_PROXIMITY_CHARS)
-            .min(rules::MAX_PROXIMITY_CHARS);
-        Some(Self {
-            model_dir,
-            threshold,
-            lanes,
-            rule_window,
-            prototypes,
-        })
     }
+}
+
+// ─── Manifest ────────────────────────────────────────────────────────────────
+
+/// `manifest.json` in the model directory: the version-consistency unit
+/// binding the model files, the embedding dimension, and the calibrated
+/// default threshold together (spec §5.5 of AISIX-Cloud#1363). The
+/// bundle is refused when any part disagrees — masking with a wrong
+/// model/threshold pairing silently mis-scores, which is worse than not
+/// masking at all.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct ModelManifest {
+    /// Manifest format version; this build understands version 1.
+    pub manifest_version: u32,
+    /// Upstream model identity, e.g.
+    /// `ibm-granite/granite-embedding-97m-multilingual-r2`.
+    pub model_id: String,
+    /// Upstream revision (commit hash) the files were fetched from.
+    #[serde(default)]
+    pub revision: Option<String>,
+    /// The embedding dimension the engine must produce; probed on the
+    /// first inference.
+    pub embedding_dim: usize,
+    /// File name → `sha256:<hex>` for every file in the bundle.
+    pub files: BTreeMap<String, String>,
+    /// Calibrated default thresholds for this model.
+    pub calibration: ManifestCalibration,
+}
+
+/// The calibrated default score gates that ship with a model bundle.
+/// Unknown fields are tolerated so a future strategy's calibration can
+/// ride the same manifest.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct ManifestCalibration {
+    /// Default absolute-cosine gate for the description strategy (the
+    /// v1 judgement form). Categories without their own `threshold` use
+    /// this.
+    pub description: f32,
+}
+
+impl ModelManifest {
+    /// Parse `manifest.json` under `dir` and verify every listed file's
+    /// sha256. Blocking (hashes ~120 MB) — call off the async runtime.
+    pub fn load_and_verify(dir: &Path) -> Result<Self, LocalModelError> {
+        let path = dir.join("manifest.json");
+        let raw = std::fs::read(&path)
+            .map_err(|e| LocalModelError::Manifest(format!("{}: {e}", path.display())))?;
+        let manifest: ModelManifest = serde_json::from_slice(&raw)
+            .map_err(|e| LocalModelError::Manifest(format!("{}: {e}", path.display())))?;
+        if manifest.manifest_version != 1 {
+            return Err(LocalModelError::Manifest(format!(
+                "unsupported manifest_version {} (this build understands 1)",
+                manifest.manifest_version
+            )));
+        }
+        for required in ["model.onnx", "tokenizer.json"] {
+            if !manifest.files.contains_key(required) {
+                return Err(LocalModelError::Manifest(format!(
+                    "manifest lists no {required}"
+                )));
+            }
+        }
+        if manifest.embedding_dim == 0 {
+            return Err(LocalModelError::Manifest("embedding_dim is 0".into()));
+        }
+        if !manifest.calibration.description.is_finite() {
+            return Err(LocalModelError::Manifest(
+                "calibration.description is not finite".into(),
+            ));
+        }
+        for (name, want) in &manifest.files {
+            // File names come from the manifest we just read; refuse
+            // anything that could escape the bundle directory.
+            if name.contains('/') || name.contains('\\') || name.starts_with('.') {
+                return Err(LocalModelError::Manifest(format!(
+                    "invalid file name {name:?}"
+                )));
+            }
+            let want_hex = want.strip_prefix("sha256:").ok_or_else(|| {
+                LocalModelError::Manifest(format!("{name}: digest must be sha256:<hex>"))
+            })?;
+            let path = dir.join(name);
+            let bytes = std::fs::read(&path)
+                .map_err(|e| LocalModelError::Manifest(format!("{}: {e}", path.display())))?;
+            let got_hex = hex_digest(&bytes);
+            if !got_hex.eq_ignore_ascii_case(want_hex) {
+                return Err(LocalModelError::Manifest(format!(
+                    "{name}: sha256 mismatch (manifest {want_hex}, file {got_hex})"
+                )));
+            }
+        }
+        Ok(manifest)
+    }
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    let digest = sha2::Sha256::digest(bytes);
+    let mut out = String::with_capacity(64);
+    for b in digest {
+        use std::fmt::Write;
+        let _ = write!(out, "{b:02x}");
+    }
+    out
 }
 
 /// [`LANES_ENV`] parse rule: default 1 when unset or malformed (zero
 /// included — a zero-lane guardrail is a misconfiguration, not a
-/// disable switch; disabling is unsetting [`MODEL_DIR_ENV`]), clamped
-/// to [`MAX_LANES`].
-fn parse_lanes(raw: Option<&str>) -> usize {
+/// disable switch), clamped to [`MAX_LANES`].
+pub fn parse_lanes(raw: Option<&str>) -> usize {
     raw.and_then(|s| s.parse::<usize>().ok())
         .filter(|&n| n >= 1)
         .unwrap_or(1)
         .min(MAX_LANES)
 }
 
-/// The blocking inference core: one shared tokenizer (`encode` takes
-/// `&self` and is thread-safe) + a pool of ONNX sessions — the
-/// inference LANES (api7/aisix#1001). Each session sits behind its own
-/// mutex (`Session::run` takes `&mut`); the guardrail's semaphore
-/// admits at most `sessions.len()` concurrent inferences, so an
-/// admitted task always finds a free session. Dispatch is a
-/// centralized free-list: any request takes whichever session is idle —
-/// deliberately NO worker↔session binding (sessions are stateless and
-/// interchangeable; a central queue load-balances the uneven per-worker
-/// accept distribution).
+// ─── Blocking inference core ─────────────────────────────────────────────────
+
+/// One shared tokenizer (`encode` takes `&self` and is thread-safe) + a
+/// pool of ONNX sessions — the inference LANES (api7/aisix#1001). Each
+/// session sits behind its own mutex (`Session::run` takes `&mut`); the
+/// engine's semaphore admits at most `sessions.len()` concurrent
+/// inferences, so an admitted task always finds a free session.
 struct Embedder {
     tokenizer: tokenizers::Tokenizer,
     sessions: Vec<Mutex<Session>>,
 }
 
 impl Embedder {
-    fn load(dir: &std::path::Path, lanes: usize) -> Result<Self, LocalModelError> {
-        // `parse_lanes` never yields 0, but `LocalModelConfig`'s fields
-        // are `pub` and a future programmatic constructor (the
-        // control-plane integration) could hand-build one; an empty
-        // pool would panic at the prototype embed with a confusing
-        // boot error instead of just working.
+    fn load(dir: &Path, lanes: usize) -> Result<Self, LocalModelError> {
         let lanes = lanes.max(1);
         let tokenizer_path = dir.join("tokenizer.json");
         let mut tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path).map_err(|e| {
@@ -579,9 +374,7 @@ impl Embedder {
         // scales by LANES (each lane single-threaded is the best
         // per-core efficiency for short windows), and the guardrail
         // must not tax a gateway that isn't sending it traffic (see
-        // module doc). Builder-stage errors carry the builder back for
-        // recovery (`ort::Error<SessionBuilder>`); this path never
-        // recovers, so they fold to their message.
+        // module doc).
         let build = |b: ort::session::builder::SessionBuilder| {
             b.with_intra_threads(1)?
                 .with_inter_threads(1)?
@@ -607,9 +400,7 @@ impl Embedder {
     /// that cannot deadlock (some lane always releases). A panic in a
     /// previous run poisons that lane's mutex; recover instead of
     /// panicking forever after — `Session::run` is stateless, so the
-    /// session itself is unharmed, and turning every later inference
-    /// into a panic would silently disable the operator's masking until
-    /// restart (the exact state load treats as boot-fatal).
+    /// session itself is unharmed.
     fn acquire_free_session(&self) -> std::sync::MutexGuard<'_, Session> {
         for lane in &self.sessions {
             match lane.try_lock() {
@@ -684,7 +475,10 @@ fn cosine(a: &[f32], b: &[f32]) -> f32 {
     a.iter().zip(b).map(|(x, y)| x * y).sum()
 }
 
-/// Max cosine over a prototype set (nearest prototype decides).
+/// Max cosine over a prototype set (nearest prototype decides). Kept for
+/// the calibration probes; the v1 runtime judges against a single
+/// description prototype.
+#[cfg(test)]
 fn max_cosine(prototypes: &[Vec<f32>], v: &[f32]) -> f32 {
     prototypes
         .iter()
@@ -692,139 +486,316 @@ fn max_cosine(prototypes: &[Vec<f32>], v: &[f32]) -> f32 {
         .fold(f32::NEG_INFINITY, f32::max)
 }
 
-/// The category's prototype material: a positive set and a negative set
-/// (either may be a single centroid; see [`PrototypeStrategy`]).
-struct PrototypeSet {
-    positive: Vec<Vec<f32>>,
-    negative: Vec<Vec<f32>>,
+// ─── The process-wide runtime ────────────────────────────────────────────────
+
+/// Boot-time capability state, shared with the heartbeat so the
+/// advertised `supported_guardrail_kinds` tracks reality (spec §5.4):
+/// `semantic` is advertised while the bundle stays verified and the
+/// engine has not failed.
+#[derive(Debug)]
+pub struct SemanticCapability {
+    /// 0 = verified (advertise), 1 = failed (stop advertising).
+    state: AtomicU8,
 }
 
-impl PrototypeSet {
-    /// The relative scoring form: `max_pos − max_neg`. Nearest-prototype
-    /// max-over-set on each side; an empty negative set contributes 0,
-    /// which collapses to the MVP's absolute form for `Description`.
-    /// This is the standard contrastive nearest-prototype shape (the
-    /// commercial precedent for sample-set semantic matching, Azure AI
-    /// Content Safety custom categories, likewise scores candidate
-    /// classes against each other rather than against a fixed bar).
-    fn score(&self, v: &[f32]) -> f32 {
-        let pos = max_cosine(&self.positive, v);
-        if self.negative.is_empty() {
-            pos
-        } else {
-            pos - max_cosine(&self.negative, v)
-        }
+impl SemanticCapability {
+    fn verified() -> Arc<Self> {
+        Arc::new(Self {
+            state: AtomicU8::new(0),
+        })
+    }
+
+    fn set_failed(&self) {
+        self.state.store(1, Ordering::Relaxed);
+    }
+
+    /// `true` while the node can serve `kind: "semantic"`.
+    pub fn is_ready(&self) -> bool {
+        self.state.load(Ordering::Relaxed) == 0
     }
 }
 
-/// L2-renormalized mean of a set of L2-normalized vectors — the
-/// [`PrototypeStrategy::SampleCentroid`] construction.
-fn centroid(vectors: &[Vec<f32>]) -> Vec<f32> {
-    let dim = vectors.first().map_or(0, Vec::len);
-    let mut mean = vec![0.0f32; dim];
-    for v in vectors {
-        for (m, x) in mean.iter_mut().zip(v) {
-            *m += x;
-        }
-    }
-    let norm = mean.iter().map(|v| v * v).sum::<f32>().sqrt();
-    if norm > 0.0 {
-        for m in &mut mean {
-            *m /= norm;
-        }
-    }
-    mean
+/// The loaded engine: sessions + the lane semaphore.
+struct Engine {
+    embedder: Arc<Embedder>,
+    /// Bounds in-flight `spawn_blocking` inference tasks. Sized to the
+    /// session-pool size: more permits would only queue on the session
+    /// mutexes from inside blocking threads.
+    permits: Arc<tokio::sync::Semaphore>,
 }
 
-/// Hard byte cap on a single candidate span. A real version number is
-/// short by definition; without this cap `\d+(?:\.\d+)+` matches an
-/// arbitrarily long `1.1.1...` run as ONE span, and since the window is
-/// span + context, a crafted request would turn each model call into a
-/// max-truncation inference and stall the single lane for everyone
-/// (audit finding on PR #999). Over-cap spans are dropped BEFORE the
-/// per-pass budget so they cannot starve legitimate candidates either.
-const MAX_CANDIDATE_SPAN_BYTES: usize = 64;
+/// The process-wide semantic-guardrail runtime: one verified model
+/// bundle, lazily loaded sessions, and a content-addressed prototype
+/// cache shared by every `kind: "semantic"` row.
+pub struct SemanticRuntime {
+    model_dir: PathBuf,
+    lanes: usize,
+    manifest: ModelManifest,
+    /// Lazily initialized engine. `Some(None)` = initialization failed
+    /// permanently (until restart) — retrying a multi-second session
+    /// load per request would amplify an outage.
+    engine: tokio::sync::OnceCell<Option<Arc<Engine>>>,
+    /// description text → embedded prototype, so chain rebuilds (config
+    /// churn) and repeated rows never re-embed unchanged text. Keyed by
+    /// the exact text — the manifest (and thus the model) is fixed for
+    /// the process lifetime.
+    prototype_cache: Mutex<std::collections::HashMap<String, Arc<Vec<f32>>>>,
+    capability: Arc<SemanticCapability>,
+    /// Metrics receiver for the semantic-specific series (model calls,
+    /// degrades). `None` records nothing (tests).
+    sink: Option<Arc<dyn GuardrailMetricsSink>>,
+}
 
-/// Layer ①: the compiled candidate generator — the two shapes above,
-/// merged and de-overlapped.
+impl std::fmt::Debug for SemanticRuntime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SemanticRuntime")
+            .field("model_dir", &self.model_dir)
+            .field("lanes", &self.lanes)
+            .field("model_id", &self.manifest.model_id)
+            .finish()
+    }
+}
+
+impl SemanticRuntime {
+    /// Verify the bundle under `model_dir` and construct the runtime.
+    /// Blocking (hashes the bundle) — the server bootstrap wraps it in
+    /// `spawn_blocking`. Does NOT load ONNX sessions; those load on
+    /// first use.
+    pub fn load(
+        model_dir: PathBuf,
+        lanes: usize,
+        sink: Option<Arc<dyn GuardrailMetricsSink>>,
+    ) -> Result<Self, LocalModelError> {
+        let manifest = ModelManifest::load_and_verify(&model_dir)?;
+        tracing::info!(
+            model_dir = %model_dir.display(),
+            model_id = %manifest.model_id,
+            revision = manifest.revision.as_deref().unwrap_or("unpinned"),
+            embedding_dim = manifest.embedding_dim,
+            lanes,
+            "semantic guardrail model bundle verified"
+        );
+        Ok(Self {
+            model_dir,
+            lanes,
+            manifest,
+            engine: tokio::sync::OnceCell::new(),
+            prototype_cache: Mutex::new(std::collections::HashMap::new()),
+            capability: SemanticCapability::verified(),
+            sink,
+        })
+    }
+
+    /// Test-only runtime with no verified bundle: the engine never
+    /// initializes, so every model-band judgement degrades to the rule
+    /// layers. Lets proxy/unit tests exercise `kind: "semantic"` rows
+    /// without the 120 MB model files.
+    pub fn for_tests_without_model() -> Self {
+        Self {
+            model_dir: PathBuf::from("/nonexistent"),
+            lanes: 1,
+            manifest: ModelManifest {
+                manifest_version: 1,
+                model_id: "test/none".into(),
+                revision: None,
+                embedding_dim: 1,
+                files: BTreeMap::new(),
+                calibration: ManifestCalibration { description: 0.80 },
+            },
+            engine: tokio::sync::OnceCell::new(),
+            prototype_cache: Mutex::new(std::collections::HashMap::new()),
+            capability: SemanticCapability::verified(),
+            sink: None,
+        }
+    }
+
+    /// The capability handle the heartbeat reads.
+    pub fn capability(&self) -> Arc<SemanticCapability> {
+        Arc::clone(&self.capability)
+    }
+
+    /// The verified manifest (calibration defaults, model identity).
+    pub fn manifest(&self) -> &ModelManifest {
+        &self.manifest
+    }
+
+    fn record_degrade(&self, reason: SemanticDegradeReason) {
+        if let Some(sink) = &self.sink {
+            sink.record_semantic_degrade(reason.as_str());
+        }
+    }
+
+    fn record_model_call(&self) {
+        if let Some(sink) = &self.sink {
+            sink.record_semantic_model_call();
+        }
+    }
+
+    /// The lazily loaded engine; `None` after a failed initialization
+    /// (capability flips to failed, heartbeat stops advertising).
+    async fn engine(&self) -> Option<Arc<Engine>> {
+        self.engine
+            .get_or_init(|| async {
+                let dir = self.model_dir.clone();
+                let lanes = self.lanes;
+                let dim = self.manifest.embedding_dim;
+                let loaded = tokio::task::spawn_blocking(move || {
+                    let embedder = Embedder::load(&dir, lanes)?;
+                    // Dimension probe: one inference proves the graph
+                    // produces what the manifest claims — a mismatched
+                    // model would otherwise silently mis-score every
+                    // judgement against the calibrated thresholds.
+                    let probe = embedder.embed("probe")?;
+                    if probe.len() != dim {
+                        return Err(LocalModelError::Manifest(format!(
+                            "model produces {}-dim embeddings, manifest says {dim}",
+                            probe.len()
+                        )));
+                    }
+                    Ok::<_, LocalModelError>(embedder)
+                })
+                .await;
+                match loaded {
+                    Ok(Ok(embedder)) => {
+                        tracing::info!(lanes = self.lanes, "semantic guardrail engine loaded");
+                        Some(Arc::new(Engine {
+                            embedder: Arc::new(embedder),
+                            permits: Arc::new(tokio::sync::Semaphore::new(self.lanes)),
+                        }))
+                    }
+                    Ok(Err(err)) => {
+                        tracing::warn!(
+                            error = %err,
+                            model_dir = %self.model_dir.display(),
+                            "semantic guardrail engine failed to load; \
+                             semantic rows degrade to rule layers until restart"
+                        );
+                        self.capability.set_failed();
+                        None
+                    }
+                    Err(join) => {
+                        tracing::warn!(
+                            error = %join,
+                            "semantic guardrail engine load task failed"
+                        );
+                        self.capability.set_failed();
+                        None
+                    }
+                }
+            })
+            .await
+            .clone()
+    }
+
+    /// Embed one text off the async runtime: bounded by the lane
+    /// semaphore (with [`LANE_WAIT_TIMEOUT`]), executed in
+    /// `spawn_blocking`. The permit MOVES INTO the blocking closure: a
+    /// `spawn_blocking` task keeps running when its awaiter is dropped
+    /// (client disconnect), so a permit held in the async scope would
+    /// release while the session is still busy and repeated
+    /// cancellations would pile threads up toward the pool cap (audit
+    /// finding on PR #999).
+    async fn embed_text(&self, text: String) -> Result<Vec<f32>, SemanticDegradeReason> {
+        let Some(engine) = self.engine().await else {
+            return Err(SemanticDegradeReason::EngineFailed);
+        };
+        let permit = match tokio::time::timeout(
+            LANE_WAIT_TIMEOUT,
+            Arc::clone(&engine.permits).acquire_owned(),
+        )
+        .await
+        {
+            Ok(Ok(permit)) => permit,
+            Ok(Err(_)) => return Err(SemanticDegradeReason::EngineFailed),
+            Err(_) => return Err(SemanticDegradeReason::QueueTimeout),
+        };
+        let embedder = Arc::clone(&engine.embedder);
+        self.record_model_call();
+        let joined = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            embedder.embed(&text)
+        })
+        .await;
+        match joined {
+            Ok(Ok(v)) => Ok(v),
+            Ok(Err(err)) => {
+                tracing::warn!(error = %err, "semantic guardrail inference failed");
+                Err(SemanticDegradeReason::InferenceFailed)
+            }
+            Err(join) => {
+                tracing::warn!(error = %join, "semantic guardrail inference task join failed");
+                Err(SemanticDegradeReason::InferenceFailed)
+            }
+        }
+    }
+
+    /// The cached prototype embedding for `text` (a category
+    /// description), embedding it on first use.
+    async fn prototype_for(&self, text: &str) -> Result<Arc<Vec<f32>>, SemanticDegradeReason> {
+        if let Some(hit) = self
+            .prototype_cache
+            .lock()
+            .expect("prototype cache poisoned")
+            .get(text)
+            .cloned()
+        {
+            return Ok(hit);
+        }
+        let vector = Arc::new(self.embed_text(text.to_owned()).await?);
+        self.prototype_cache
+            .lock()
+            .expect("prototype cache poisoned")
+            .insert(text.to_owned(), Arc::clone(&vector));
+        Ok(vector)
+    }
+}
+
+// ─── Candidate generation ────────────────────────────────────────────────────
+
+/// Layer ①: a category's compiled candidate generator — the union of
+/// its candidate patterns, de-overlapped.
 struct CandidateFinder {
-    dotted: Regex,
-    fused: Regex,
+    patterns: Vec<Regex>,
 }
 
 impl CandidateFinder {
-    fn new() -> Self {
-        let compile = |p: &str| Regex::new(p).expect("candidate pattern must compile");
-        Self {
-            dotted: compile(CANDIDATE_PATTERN),
-            fused: compile(FUSED_TOKEN_PATTERN),
-        }
+    fn new(patterns: Vec<Regex>) -> Self {
+        Self { patterns }
     }
 
     /// Candidate spans (byte ranges) in `text`, ascending and
-    /// non-overlapping. Fused tokens win overlaps with dotted runs (the
-    /// dotted digits of `ICADV12.3` are PART of the version — masking
-    /// only them leaks the `ICADV` identity, the pre-fix behavior).
-    /// Spans longer than [`MAX_CANDIDATE_SPAN_BYTES`] are not candidates
-    /// (see the constant).
+    /// non-overlapping. When spans from different patterns overlap the
+    /// LONGER one wins (a broader token pattern must beat the dotted run
+    /// inside it — masking only the digits of `ICADV12.3` leaks the
+    /// `ICADV` identity); ties break toward the earlier pattern. Spans
+    /// longer than [`MAX_CANDIDATE_SPAN_BYTES`] are not candidates.
     fn spans(&self, text: &str) -> Vec<Range<usize>> {
-        let mut spans: Vec<Range<usize>> = self
-            .fused
-            .find_iter(text)
-            .map(|m| trim_token(text, m.range()))
-            .filter(|s| {
-                let token = text[s.clone()].as_bytes();
-                s.len() <= MAX_CANDIDATE_SPAN_BYTES
-                    && token.iter().any(u8::is_ascii_digit)
-                    && token.iter().any(u8::is_ascii_alphabetic)
-            })
-            .collect();
-        // Maximal same-class runs never overlap each other; a dotted run
-        // either sits inside a fused token (drop it — the fused span
-        // masks more) or stands alone. The overlap (not containment)
-        // check also covers mixed-width pathologies (`12．3-s1`), where
-        // trimming could otherwise leave two intersecting spans.
-        //
-        // Both lists arrive ascending and internally disjoint
-        // (`find_iter` order), so the overlap check is a linear
-        // two-pointer walk over the FUSED prefix only — a growing-vector
-        // `iter().any()` here is O(n²) and turns a `"1.1 "`-flood
-        // megabyte into ~17 s of synchronous work on the async worker
-        // BEFORE the per-segment cap can meter anything (audit finding
-        // on this PR; measured quadratic: 1.37 s at 256 KiB, 17.6 s at
-        // 1 MiB — linear after the fix).
-        let fused_len = spans.len();
-        let mut fi = 0;
-        for m in self.dotted.find_iter(text) {
-            let r = m.range();
-            if r.len() > MAX_CANDIDATE_SPAN_BYTES {
-                continue;
-            }
-            while fi < fused_len && spans[fi].end <= r.start {
-                fi += 1;
-            }
-            if fi >= fused_len || spans[fi].start >= r.end {
-                spans.push(r);
+        let mut all: Vec<Range<usize>> = Vec::new();
+        for re in &self.patterns {
+            for m in re.find_iter(text) {
+                let r = m.range();
+                if r.len() <= MAX_CANDIDATE_SPAN_BYTES {
+                    all.push(r);
+                }
             }
         }
-        spans.sort_by_key(|s| s.start);
+        // Sort by start ascending, longer first at the same start (the
+        // per-pattern lists arrive in order, so equal (start, len) keeps
+        // the earlier pattern's span; duplicates collapse in the sweep).
+        all.sort_by(|a, b| a.start.cmp(&b.start).then(b.len().cmp(&a.len())));
+        let mut spans: Vec<Range<usize>> = Vec::with_capacity(all.len());
+        for r in all {
+            match spans.last() {
+                Some(last) if r.start < last.end => {
+                    // Overlap: the earlier span won either by position
+                    // (started first) or by length (same start, sorted
+                    // longer-first). Drop the newcomer.
+                }
+                _ => spans.push(r),
+            }
+        }
         spans
     }
-}
-
-/// Strip leading/trailing `[._-]` from a fused-token match: the char
-/// class must include them mid-token (`E-2010.12-ICC-SP2`), which makes
-/// sentence punctuation stick to a token at the rim (`v16.12-s051_1.`).
-/// ASCII-only, so byte trimming is char-safe.
-fn trim_token(text: &str, mut span: Range<usize>) -> Range<usize> {
-    let bytes = text.as_bytes();
-    while span.start < span.end && matches!(bytes[span.start], b'.' | b'_' | b'-') {
-        span.start += 1;
-    }
-    while span.start < span.end && matches!(bytes[span.end - 1], b'.' | b'_' | b'-') {
-        span.end -= 1;
-    }
-    span
 }
 
 /// The context window around `span`: `ctx` chars on each side, snapped
@@ -848,196 +819,284 @@ fn window_bounds(text: &str, span: &Range<usize>, ctx: usize) -> Range<usize> {
     start..end
 }
 
-/// Rewrite `spans` (ascending, non-overlapping — regex `find_iter`
-/// order) in `text` to [`MASK_REPLACEMENT`], right-to-left so earlier
-/// offsets stay valid.
-fn apply_masks(text: &str, spans: &[Range<usize>]) -> String {
+/// Rewrite `spans` (ascending, non-overlapping) in `text` to
+/// `replacement`, right-to-left so earlier offsets stay valid.
+fn apply_masks(text: &str, spans: &[Range<usize>], replacement: &str) -> String {
     let mut out = text.to_owned();
     for span in spans.iter().rev() {
-        out.replace_range(span.clone(), MASK_REPLACEMENT);
+        out.replace_range(span.clone(), replacement);
     }
     out
 }
 
-/// The runtime guardrail. Always-`Allow`; masks via the segment hooks.
-pub struct LocalModelGuardrail {
-    embedder: Arc<Embedder>,
-    /// L2-normalized prototype vector sets (see [`PrototypeStrategy`]).
-    prototypes: PrototypeSet,
-    threshold: f32,
-    finder: CandidateFinder,
-    /// Layer-② scorer (hotword proximity + negative patterns).
-    rules: RuleScorer,
-    /// Bounds in-flight `spawn_blocking` inference tasks. Sized to the
-    /// session-pool size (the configured lanes): more permits would
-    /// only queue on the session mutexes from inside blocking threads.
-    permits: Arc<tokio::sync::Semaphore>,
+/// The default mask token for a category without a configured
+/// `replacement`: `[<NAME>_REDACTED]`, name uppercased with
+/// non-alphanumerics folded to `_` — the same shape the pii kind uses.
+fn default_mask_token(name: &str) -> String {
+    let folded: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("[{folded}_REDACTED]")
 }
 
-impl LocalModelGuardrail {
-    /// Load tokenizer + the session pool and encode the category's
-    /// prototype set. Blocking (N model loads + up to
-    /// `PROTOTYPE_SAMPLES`-many inferences) — the server bootstrap
-    /// wraps it in `spawn_blocking`.
-    pub fn load(config: &LocalModelConfig) -> Result<Self, LocalModelError> {
-        let started = Instant::now();
-        let embedder = Embedder::load(&config.model_dir, config.lanes)?;
-        let embed_all = |samples: &[&str]| {
-            samples
-                .iter()
-                .map(|s| embedder.embed(s))
-                .collect::<Result<Vec<_>, LocalModelError>>()
+// ─── Compiled categories and the row guardrail ───────────────────────────────
+
+/// Why a category failed to compile. The chain builder maps these onto
+/// its own error type; the row is skipped with a warning either way.
+#[derive(Debug, thiserror::Error)]
+pub enum CategoryCompileError {
+    #[error("category {category:?}: invalid {field} regex {pattern:?}: {source}")]
+    InvalidRegex {
+        category: String,
+        field: &'static str,
+        pattern: String,
+        source: regex::Error,
+    },
+    #[error("category {category:?}: unsupported action {action:?} (only \"mask\")")]
+    UnsupportedAction { category: String, action: String },
+    #[error("duplicate category name {name:?}")]
+    DuplicateName { name: String },
+    #[error("category {category:?}: no candidate patterns")]
+    NoCandidatePatterns { category: String },
+}
+
+/// One compiled category: patterns and scorer ready to run, plus the
+/// lazily embedded description prototype.
+struct CompiledCategory {
+    name: String,
+    description: String,
+    replacement: String,
+    threshold: f32,
+    finder: CandidateFinder,
+    rules: RuleScorer,
+    /// Embedded description, resolved through the runtime's cache on the
+    /// first model-band judgement. `Some(None)` = unavailable (embedding
+    /// failed) — model-band spans release until restart resolves it.
+    prototype: tokio::sync::OnceCell<Option<Arc<Vec<f32>>>>,
+}
+
+/// Compile the categories of a `kind: "semantic"` row. `default_threshold`
+/// comes from the runtime's manifest calibration.
+fn compile_categories(
+    categories: &[SemanticCategory],
+    default_threshold: f32,
+) -> Result<Vec<CompiledCategory>, CategoryCompileError> {
+    let mut seen = std::collections::HashSet::new();
+    let mut compiled = Vec::with_capacity(categories.len());
+    for cat in categories {
+        if !seen.insert(cat.name.clone()) {
+            return Err(CategoryCompileError::DuplicateName {
+                name: cat.name.clone(),
+            });
+        }
+        if let Some(action) = cat.action.as_deref() {
+            if action != "mask" {
+                return Err(CategoryCompileError::UnsupportedAction {
+                    category: cat.name.clone(),
+                    action: action.to_owned(),
+                });
+            }
+        }
+        if cat.candidate_patterns.is_empty() {
+            return Err(CategoryCompileError::NoCandidatePatterns {
+                category: cat.name.clone(),
+            });
+        }
+        let compile = |field: &'static str, pattern: &str| {
+            Regex::new(pattern).map_err(|source| CategoryCompileError::InvalidRegex {
+                category: cat.name.clone(),
+                field,
+                pattern: pattern.to_owned(),
+                source,
+            })
         };
-        let prototypes = match config.prototypes {
-            PrototypeStrategy::Description => PrototypeSet {
-                positive: vec![embedder.embed(PROTOTYPE_DESCRIPTION_ZH)?],
-                negative: Vec::new(),
-            },
-            PrototypeStrategy::SampleMax => PrototypeSet {
-                positive: embed_all(PROTOTYPE_SAMPLES)?,
-                negative: embed_all(NEGATIVE_PROTOTYPE_SAMPLES)?,
-            },
-            PrototypeStrategy::SampleCentroid => PrototypeSet {
-                positive: vec![centroid(&embed_all(PROTOTYPE_SAMPLES)?)],
-                negative: vec![centroid(&embed_all(NEGATIVE_PROTOTYPE_SAMPLES)?)],
-            },
-        };
-        tracing::info!(
-            model_dir = %config.model_dir.display(),
-            threshold = config.threshold,
-            lanes = config.lanes,
-            rule_window = config.rule_window,
-            strategy = ?config.prototypes,
-            positive_prototypes = prototypes.positive.len(),
-            negative_prototypes = prototypes.negative.len(),
-            load_ms = started.elapsed().as_millis() as u64,
-            "local-model guardrail loaded (category: EDA software version)"
-        );
+        let mut candidates = Vec::with_capacity(cat.candidate_patterns.len());
+        for p in &cat.candidate_patterns {
+            candidates.push(compile("candidate_patterns", p)?);
+        }
+        let mut negatives = Vec::with_capacity(cat.negative_patterns.len());
+        for p in &cat.negative_patterns {
+            negatives.push((compile("negative_patterns", p)?, p.clone()));
+        }
+        let groups: Vec<Vec<String>> = cat.hotword_groups.iter().map(|g| g.terms.clone()).collect();
+        let rules = RuleScorer::compile(rules::DEFAULT_PROXIMITY_CHARS, &groups, negatives)
+            .map_err(|(pattern, source)| CategoryCompileError::InvalidRegex {
+                category: cat.name.clone(),
+                field: "hotword_groups",
+                pattern,
+                source,
+            })?;
+        compiled.push(CompiledCategory {
+            name: cat.name.clone(),
+            description: cat.description.clone(),
+            replacement: cat
+                .replacement
+                .clone()
+                .unwrap_or_else(|| default_mask_token(&cat.name)),
+            threshold: cat
+                .threshold
+                .filter(|t| t.is_finite())
+                .unwrap_or(default_threshold),
+            finder: CandidateFinder::new(candidates),
+            rules,
+            prototype: tokio::sync::OnceCell::new(),
+        });
+    }
+    Ok(compiled)
+}
+
+/// The runtime guardrail for one `kind: "semantic"` row. Always-`Allow`;
+/// masks via the segment hooks; honors the row's `hook_point`.
+pub struct SemanticGuardrail {
+    runtime: Arc<SemanticRuntime>,
+    categories: Vec<CompiledCategory>,
+    hook_point: GuardrailHookPoint,
+}
+
+impl SemanticGuardrail {
+    /// Compile a row's categories against the process runtime.
+    pub fn from_config(
+        runtime: Arc<SemanticRuntime>,
+        categories: &[SemanticCategory],
+        hook_point: GuardrailHookPoint,
+    ) -> Result<Self, CategoryCompileError> {
+        let compiled = compile_categories(categories, runtime.manifest.calibration.description)?;
         Ok(Self {
-            embedder: Arc::new(embedder),
-            prototypes,
-            threshold: config.threshold,
-            finder: CandidateFinder::new(),
-            rules: RuleScorer::new(config.rule_window),
-            permits: Arc::new(tokio::sync::Semaphore::new(config.lanes)),
+            runtime,
+            categories: compiled,
+            hook_point,
         })
     }
 
-    /// Embed one window off the async runtime: bounded by the
-    /// semaphore, executed in `spawn_blocking`. The permit MOVES INTO
-    /// the blocking closure: a `spawn_blocking` task keeps running when
-    /// its awaiter is dropped (client disconnect), so a permit held in
-    /// this async scope would release while the session is still busy —
-    /// letting the next request park a second blocking-pool thread on
-    /// the session mutex, and repeated cancellations pile threads up
-    /// toward the pool cap (audit finding on PR #999). Held by the
-    /// closure, the permit releases only when the inference actually
-    /// finishes.
-    async fn embed_window(&self, window: String) -> Result<Vec<f32>, LocalModelError> {
-        let permit = Arc::clone(&self.permits)
-            .acquire_owned()
-            .await
-            .expect("inference semaphore never closed");
-        let embedder = Arc::clone(&self.embedder);
-        tokio::task::spawn_blocking(move || {
-            let _permit = permit;
-            embedder.embed(&window)
-        })
-        .await
-        .map_err(|e| LocalModelError::Model(format!("inference task join: {e}")))?
-    }
-
-    /// Mask one segment. Returns the rewritten text and how many spans
-    /// were masked; `budget` is the shared per-pass model-call cap —
-    /// layer-② decisions are budget-free (µs of regex work), so the cap
-    /// only meters candidates that reach layer ③, and an exhausted
-    /// budget skips THOSE while later rule-decided candidates still
-    /// resolve. Model failure on a candidate leaves that span untouched
-    /// (rewrite less, never block — the fail-open arm of "只改写不阻断"
-    /// that also answers "model unavailable": the pipeline degrades to
-    /// ①+②).
-    async fn mask_segment(&self, text: &str, budget: &mut usize) -> (String, u32) {
-        let mut hits: Vec<Range<usize>> = Vec::new();
-        let (mut rule_masked, mut rule_passed, mut model_judged) = (0u32, 0u32, 0u32);
-        let mut over_budget = false;
-        let spans = self.finder.spans(text);
+    /// Mask one segment with one category. Returns the rewritten text
+    /// and how many spans were masked; `budget` is the row's shared
+    /// per-pass model-call cap — layer-② decisions are budget-free, so
+    /// the cap only meters candidates that reach layer ③. Every failure
+    /// arm leaves the span untouched (rewrite less, never block).
+    async fn mask_segment_category(
+        &self,
+        cat: &CompiledCategory,
+        text: &str,
+        budget: &mut usize,
+    ) -> (String, u32) {
+        let spans = cat.finder.spans(text);
         if spans.len() > MAX_RULE_SCORED_SPANS_PER_SEGMENT {
             tracing::warn!(
+                category = %cat.name,
                 candidates = spans.len(),
                 cap = MAX_RULE_SCORED_SPANS_PER_SEGMENT,
-                "local-model guardrail: candidate cap reached; the tail is released unscored"
+                "semantic guardrail: candidate cap reached; the tail is released unscored"
             );
         }
+        let mut hits: Vec<Range<usize>> = Vec::new();
+        let mut over_budget = false;
         for span in spans.into_iter().take(MAX_RULE_SCORED_SPANS_PER_SEGMENT) {
-            match self.rules.decide(text, &span) {
-                RuleDecision::Mask => {
-                    rule_masked += 1;
-                    hits.push(span);
-                }
-                RuleDecision::Pass => rule_passed += 1,
+            match cat.rules.decide(text, &span) {
+                RuleDecision::Mask => hits.push(span),
+                RuleDecision::Pass => {}
                 RuleDecision::Model => {
                     if *budget == 0 {
                         if !over_budget {
                             over_budget = true;
+                            self.runtime
+                                .record_degrade(SemanticDegradeReason::BudgetExhausted);
                             tracing::warn!(
+                                category = %cat.name,
                                 cap = MAX_MODEL_CALLS_PER_PASS,
-                                "local-model guardrail: model-call cap reached; uncertain candidates left unmasked"
+                                "semantic guardrail: model-call cap reached; \
+                                 uncertain candidates left unmasked"
                             );
                         }
                         continue;
                     }
+                    let prototype = cat
+                        .prototype
+                        .get_or_init(|| async {
+                            match self.runtime.prototype_for(&cat.description).await {
+                                Ok(v) => Some(v),
+                                Err(reason) => {
+                                    // Record the UNDERLYING cause (engine
+                                    // failed, queue timeout, …) — that is
+                                    // what the operator has to fix.
+                                    self.runtime.record_degrade(reason);
+                                    tracing::warn!(
+                                        category = %cat.name,
+                                        reason = reason.as_str(),
+                                        "semantic guardrail: description prototype \
+                                         unavailable; category degrades to rule layers"
+                                    );
+                                    None
+                                }
+                            }
+                        })
+                        .await
+                        .clone();
+                    let Some(prototype) = prototype else {
+                        // Already-failed category: keep the ongoing signal
+                        // alive — every span that would have been judged is
+                        // one more degrade sample, not a one-off at failure
+                        // time.
+                        self.runtime
+                            .record_degrade(SemanticDegradeReason::PrototypeUnavailable);
+                        continue;
+                    };
                     *budget -= 1;
-                    model_judged += 1;
                     let window = text[window_bounds(text, &span, WINDOW_CONTEXT_CHARS)].to_owned();
-                    match self.embed_window(window).await {
+                    match self.runtime.embed_text(window).await {
                         Ok(vector) => {
-                            let score = self.prototypes.score(&vector);
+                            let score = cosine(&prototype, &vector);
                             tracing::debug!(
+                                category = %cat.name,
                                 score,
-                                threshold = self.threshold,
-                                "local-model window judged"
+                                threshold = cat.threshold,
+                                "semantic guardrail window judged"
                             );
-                            if score >= self.threshold {
+                            if score >= cat.threshold {
                                 hits.push(span);
                             }
                         }
-                        Err(err) => {
-                            tracing::warn!(error = %err, "local-model guardrail inference failed; span left unmasked");
+                        Err(reason) => {
+                            self.runtime.record_degrade(reason);
                         }
                     }
                 }
             }
         }
-        if rule_masked + rule_passed + model_judged > 0 {
-            tracing::debug!(
-                rule_masked,
-                rule_passed,
-                model_judged,
-                "local-model segment candidates resolved"
-            );
-        }
         if hits.is_empty() {
             (text.to_owned(), 0)
         } else {
             let count = hits.len() as u32;
-            (apply_masks(text, &hits), count)
+            (apply_masks(text, &hits, &cat.replacement), count)
         }
     }
 
     /// One moderation pass over a request's (or response's) text
-    /// segments — the shared body of both segment hooks.
+    /// segments — the shared body of both segment hooks. Categories
+    /// compose in config order over each segment.
     async fn moderate(&self, texts: &[String]) -> SegmentsOutcome {
         let mut budget = MAX_MODEL_CALLS_PER_PASS;
         let mut masked: Vec<String> = Vec::with_capacity(texts.len());
+        let mut counts: BTreeMap<String, u32> = BTreeMap::new();
         let mut total = 0u32;
         for text in texts {
-            let (rewritten, count) = self.mask_segment(text, &mut budget).await;
-            masked.push(rewritten);
-            total += count;
-        }
-        let mut counts = BTreeMap::new();
-        if total > 0 {
-            counts.insert(DETECTOR_NAME.to_owned(), total);
+            let mut current = text.clone();
+            for cat in &self.categories {
+                let (rewritten, count) =
+                    self.mask_segment_category(cat, &current, &mut budget).await;
+                if count > 0 {
+                    *counts.entry(cat.name.clone()).or_insert(0) += count;
+                    total += count;
+                    current = rewritten;
+                }
+            }
+            masked.push(current);
         }
         SegmentsOutcome {
             verdict: GuardrailVerdict::Allow,
@@ -1046,12 +1105,20 @@ impl LocalModelGuardrail {
             monitor_hits: Vec::new(),
         }
     }
+
+    fn runs_on(&self, output: bool) -> bool {
+        match self.hook_point {
+            GuardrailHookPoint::Both => true,
+            GuardrailHookPoint::Input => !output,
+            GuardrailHookPoint::Output => output,
+        }
+    }
 }
 
 #[async_trait]
-impl Guardrail for LocalModelGuardrail {
+impl Guardrail for SemanticGuardrail {
     fn name(&self) -> &'static str {
-        "local_model"
+        "semantic"
     }
 
     /// Consulted through the segment hooks only (the mask write-back
@@ -1060,15 +1127,17 @@ impl Guardrail for LocalModelGuardrail {
         true
     }
 
+    fn runs_on_output(&self) -> bool {
+        self.hook_point != GuardrailHookPoint::Input
+    }
+
     /// Masking a streamed response needs the whole response held back (a
     /// span can cross any chunk boundary) — but past the buffer cap this
-    /// guardrail must release UNMASKED, not block: the trait default's
-    /// fail-closed overflow would turn a >cap streamed response into a
-    /// `content_filter` error from a guardrail whose contract is
-    /// "rewrite, never block" (audit finding on PR #999). Past-cap
-    /// content degrades to fewer masks, the same fail-open arm as
-    /// inference failure and the per-pass call cap. A chain member with
-    /// a stricter policy (e.g. fail-closed pii) still wins the fold.
+    /// guardrail must release UNMASKED, not block: its contract is
+    /// "rewrite, never block", so past-cap content degrades to fewer
+    /// masks, the same fail-open arm as every other cap here. A chain
+    /// member with a stricter policy (e.g. fail-closed pii) still wins
+    /// the fold.
     fn stream_output_policy(&self) -> StreamOutputPolicy {
         StreamOutputPolicy::BufferFull {
             max_buffer_bytes: DEFAULT_STREAM_OUTPUT_BUFFER_BYTES,
@@ -1077,514 +1146,16 @@ impl Guardrail for LocalModelGuardrail {
     }
 
     async fn moderate_input_segments(&self, texts: &[String]) -> SegmentsOutcome {
+        if !self.runs_on(false) {
+            return SegmentsOutcome::allow();
+        }
         self.moderate(texts).await
     }
 
     async fn moderate_output_segments(&self, texts: &[String]) -> SegmentsOutcome {
+        if !self.runs_on(true) {
+            return SegmentsOutcome::allow();
+        }
         self.moderate(texts).await
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn spans_of(text: &str) -> Vec<Range<usize>> {
-        CandidateFinder::new().spans(text)
-    }
-
-    fn values_of(text: &str) -> Vec<&str> {
-        spans_of(text).into_iter().map(|s| &text[s]).collect()
-    }
-
-    #[test]
-    fn candidate_spans_find_dotted_runs_only() {
-        let text = "版本是 12.1,构建号 2022.4.1,端口 8080";
-        // Plain integers are still not candidates.
-        assert_eq!(values_of(text), vec!["12.1", "2022.4.1"]);
-    }
-
-    #[test]
-    fn candidate_spans_find_fused_tokens_whole() {
-        // The adversarial-corpus shapes: version fused with the tool
-        // name / letter affixes into ONE token — the candidate is the
-        // whole token, not its dotted substring.
-        for (text, want) in [
-            ("Virtuoso IC618 又崩了", "IC618"),
-            ("版图工具用的是 ICADV12.3", "ICADV12.3"),
-            ("XCELIUM2309 的仿真结果对不上", "XCELIUM2309"),
-            ("MMSIM151 装在新机器上了", "MMSIM151"),
-            ("综合用的 T-2022.03 有已知问题", "T-2022.03"),
-            ("回退到 E-2010.12-ICC-SP2 就不崩了", "E-2010.12-ICC-SP2"),
-            ("装的是 v16.12-s051_1 这个版本", "v16.12-s051_1"),
-            ("hotfix 20.09-s003 已经推送了", "20.09-s003"),
-            ("7nm 工艺下功耗有点高", "7nm"),
-            ("这个块是 N5 工艺的", "N5"),
-        ] {
-            assert_eq!(values_of(text), vec![want], "text: {text}");
-        }
-    }
-
-    #[test]
-    fn candidate_spans_find_fullwidth_dotted_runs() {
-        assert_eq!(values_of("版本是 １２．１,不要外传"), vec!["１２．１"]);
-        // Mixed-width digits with a fullwidth dot still form one run.
-        assert_eq!(values_of("旧版是 ２０２２．4"), vec!["２０２２．4"]);
-    }
-
-    #[test]
-    fn fused_tokens_trim_rim_punctuation() {
-        // Sentence punctuation from the token char class must not stick.
-        assert_eq!(values_of("pinned to v16.12-s051_1."), vec!["v16.12-s051_1"]);
-        // A pure word and a pure dash-number never become fused tokens.
-        assert_eq!(values_of("high-performance run -3.5 offset"), vec!["3.5"]);
-    }
-
-    #[test]
-    fn candidate_dedupe_keeps_standalone_dotted_runs_between_fused_tokens() {
-        // Interleaved fused and dotted candidates: the two-pointer
-        // dedupe must drop exactly the dotted runs inside fused tokens
-        // and keep the standalone ones (regression for the O(n²)
-        // rewrite — audit finding).
-        let text = "v1.2-a 3.4 IC5.6 7.8 soc9.9x 10.11";
-        assert_eq!(
-            values_of(text),
-            vec!["v1.2-a", "3.4", "IC5.6", "7.8", "soc9.9x", "10.11"]
-        );
-    }
-
-    #[test]
-    fn candidate_generation_stays_linear_on_floods() {
-        // The audit measured the pre-fix quadratic dedupe at 17.6 s of
-        // synchronous CPU for a 1 MiB `"1.1 "` flood (1.37 s at
-        // 256 KiB) — BEFORE the per-segment cap could meter anything.
-        // Linear generation does this in tens of milliseconds; the
-        // bound leaves two orders of magnitude of CI headroom while
-        // sitting far below the quadratic's floor.
-        let flood = "1.1 ".repeat(256 * 1024); // 1 MiB
-        let started = Instant::now();
-        let spans = CandidateFinder::new().spans(&flood);
-        assert_eq!(spans.len(), 256 * 1024);
-        assert!(
-            started.elapsed() < std::time::Duration::from_secs(10),
-            "candidate generation took {:?} on a 1 MiB flood",
-            started.elapsed()
-        );
-    }
-
-    #[test]
-    fn candidate_spans_drop_oversized_runs() {
-        // A crafted `1.1.1...` run over the byte cap is one regex match
-        // but NOT a candidate — it must vanish before budget accounting
-        // so it can neither stall the lane nor starve real candidates.
-        let bomb = "1.1".repeat(60); // 180 bytes, single match
-        let text = format!("前缀 {bomb} 中缀 12.1 后缀");
-        assert_eq!(values_of(&text), vec!["12.1"]);
-    }
-
-    #[test]
-    fn window_bounds_snap_to_char_boundaries() {
-        let text = "这个 EDA 软件的版本是 12.1,请勿外传";
-        let span = spans_of(text).remove(0);
-        // A tiny context still lands on char boundaries around CJK.
-        let w = window_bounds(text, &span, 3);
-        let window = &text[w];
-        assert!(window.contains("12.1"), "window: {window}");
-        assert_eq!(window, "本是 12.1,请勿");
-    }
-
-    #[test]
-    fn window_bounds_clamp_to_text_edges() {
-        let text = "12.1 只有后文";
-        let span = spans_of(text).remove(0);
-        let w = window_bounds(text, &span, 50);
-        assert_eq!(&text[w], text);
-    }
-
-    #[test]
-    fn apply_masks_rewrites_right_to_left() {
-        let text = "从 12.1 升到 13.0 了";
-        let spans = spans_of(text);
-        assert_eq!(apply_masks(text, &spans), "从 *** 升到 *** 了");
-    }
-
-    #[test]
-    fn config_from_env_requires_model_dir() {
-        // Isolated var names are process-global; this test only checks the
-        // parse fallback path via the public constructor contract.
-        let cfg = LocalModelConfig {
-            model_dir: PathBuf::from("/nonexistent"),
-            threshold: PrototypeStrategy::default().default_threshold(),
-            lanes: 1,
-            rule_window: rules::DEFAULT_PROXIMITY_CHARS,
-            prototypes: PrototypeStrategy::default(),
-        };
-        assert!(LocalModelGuardrail::load(&cfg).is_err());
-    }
-
-    #[test]
-    fn prototype_strategy_parses_and_defaults() {
-        assert_eq!(PrototypeStrategy::parse(None), PrototypeStrategy::default());
-        assert_eq!(
-            PrototypeStrategy::parse(Some("description")),
-            PrototypeStrategy::Description
-        );
-        assert_eq!(
-            PrototypeStrategy::parse(Some("max")),
-            PrototypeStrategy::SampleMax
-        );
-        assert_eq!(
-            PrototypeStrategy::parse(Some("centroid")),
-            PrototypeStrategy::SampleCentroid
-        );
-        // Case-insensitive: an operator typing `Description` means it.
-        assert_eq!(
-            PrototypeStrategy::parse(Some("Description")),
-            PrototypeStrategy::Description
-        );
-        assert_eq!(
-            PrototypeStrategy::parse(Some("MAX")),
-            PrototypeStrategy::SampleMax
-        );
-        assert_eq!(
-            PrototypeStrategy::parse(Some("bogus")),
-            PrototypeStrategy::default()
-        );
-    }
-
-    #[test]
-    fn centroid_is_the_renormalized_mean() {
-        let c = centroid(&[vec![1.0, 0.0], vec![0.0, 1.0]]);
-        let inv_sqrt2 = 1.0 / 2.0_f32.sqrt();
-        assert!((c[0] - inv_sqrt2).abs() < 1e-6 && (c[1] - inv_sqrt2).abs() < 1e-6);
-        // Max-over-set picks the nearest prototype.
-        let set = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
-        assert!((max_cosine(&set, &[0.0, 1.0]) - 1.0).abs() < 1e-6);
-    }
-
-    #[test]
-    fn prototype_set_scores_relatively() {
-        let set = PrototypeSet {
-            positive: vec![vec![1.0, 0.0]],
-            negative: vec![vec![0.0, 1.0]],
-        };
-        // Aligned with the positive prototype: margin +1 − 0.
-        assert!((set.score(&[1.0, 0.0]) - 1.0).abs() < 1e-6);
-        // Aligned with the negative prototype: margin 0 − 1.
-        assert!((set.score(&[0.0, 1.0]) + 1.0).abs() < 1e-6);
-        // No negative material collapses to the absolute form.
-        let desc = PrototypeSet {
-            positive: vec![vec![1.0, 0.0]],
-            negative: Vec::new(),
-        };
-        assert!((desc.score(&[1.0, 0.0]) - 1.0).abs() < 1e-6);
-    }
-
-    #[test]
-    fn parse_lanes_defaults_and_clamps() {
-        // Unset / malformed / zero → 1 (zero is a misconfiguration, not
-        // a disable switch); valid values pass; huge values clamp.
-        assert_eq!(parse_lanes(None), 1);
-        assert_eq!(parse_lanes(Some("")), 1);
-        assert_eq!(parse_lanes(Some("abc")), 1);
-        assert_eq!(parse_lanes(Some("-2")), 1);
-        assert_eq!(parse_lanes(Some("0")), 1);
-        assert_eq!(parse_lanes(Some("4")), 4);
-        assert_eq!(parse_lanes(Some("9999")), MAX_LANES);
-    }
-
-    // ── model-backed tests (need the real model files) ──────────────────
-    //
-    // Run explicitly with the model directory present:
-    //   GUARDRAIL_LOCAL_MODEL_DIR=~/.cache/aisix-local-guardrail-mvp \
-    //     cargo test -p aisix-guardrails --features local-model -- --ignored
-
-    fn load_from_env() -> Option<LocalModelGuardrail> {
-        let cfg = LocalModelConfig::from_env()?;
-        Some(LocalModelGuardrail::load(&cfg).expect("model files present but load failed"))
-    }
-
-    /// The probe matrix, re-run for the relative-scoring form: the same
-    /// 7 probe windows as the MVP sweep (1 acceptance-style positive,
-    /// 2 hard positives, 4 hard negatives) scored against 5
-    /// single-description prototype phrasings (the MVP sweep that
-    /// measured NEGATIVE margin in every column) plus the two
-    /// sample-based strategies, each in BOTH scoring forms — `abs` is
-    /// the old positive-only max cosine, `rel` the shipped
-    /// `max_pos − max_neg`. Prints the full matrix and each column's
-    /// hard margin (min over hard positives − max over negatives) per
-    /// form; the calibration assertion pins the shipped (relative) form.
-    #[tokio::test]
-    #[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with model.onnx + tokenizer.json"]
-    async fn probe_similarity_matrix() {
-        let Some(g) = load_from_env() else { return };
-        let phrasings = [
-            PROTOTYPE_DESCRIPTION_ZH,
-            "软件版本号",
-            "芯片设计软件的版本号",
-            "提到了 EDA 工具的具体版本号",
-            "EDA 软件的版本信息,比如某个工具的版本是 12.1",
-        ];
-        let windows = [
-            ("ACC", "这个 EDA 软件的版本是 12.1,请确认兼容性"),
-            ("POS", "我们把仿真工具升级到 2022.4 之后速度快了很多"),
-            ("POS", "Virtuoso IC6.1.8 出现了崩溃"),
-            ("NEG", "Elapsed: 12.345s, Memory: 4.2 GB"),
-            ("NEG", "服务器的 IP 地址是 10.2.255.1"),
-            ("NEG", "圆周率约等于 3.14159"),
-            ("NEG", "工艺节点是 0.13um,良率还行"),
-        ];
-
-        let mut columns: Vec<(String, PrototypeSet)> = Vec::new();
-        for p in phrasings {
-            let v = g.embed_window(p.to_owned()).await.unwrap();
-            columns.push((
-                format!("desc:{p}"),
-                PrototypeSet {
-                    positive: vec![v],
-                    negative: Vec::new(),
-                },
-            ));
-        }
-        let mut pos = Vec::new();
-        for s in PROTOTYPE_SAMPLES {
-            pos.push(g.embed_window((*s).to_owned()).await.unwrap());
-        }
-        let mut neg = Vec::new();
-        for s in NEGATIVE_PROTOTYPE_SAMPLES {
-            neg.push(g.embed_window((*s).to_owned()).await.unwrap());
-        }
-        columns.push((
-            "samples-max".to_owned(),
-            PrototypeSet {
-                positive: pos.clone(),
-                negative: neg.clone(),
-            },
-        ));
-        columns.push((
-            "samples-centroid".to_owned(),
-            PrototypeSet {
-                positive: vec![centroid(&pos)],
-                negative: vec![centroid(&neg)],
-            },
-        ));
-
-        for (name, set) in &columns {
-            let mut margins = [(f32::INFINITY, f32::NEG_INFINITY); 2]; // abs, rel
-            println!("── column: {name}");
-            for (kind, text) in windows {
-                let v = g.embed_window(text.to_owned()).await.unwrap();
-                let abs = max_cosine(&set.positive, &v);
-                let rel = set.score(&v);
-                println!("  {kind} abs {abs:.4} rel {rel:+.4}  {text}");
-                for (m, s) in margins.iter_mut().zip([abs, rel]) {
-                    match kind {
-                        "POS" => m.0 = m.0.min(s),
-                        "NEG" => m.1 = m.1.max(s),
-                        _ => {}
-                    }
-                }
-            }
-            let [abs_m, rel_m] = margins.map(|(p, n)| p - n);
-            println!("  hard margin (min POS − max NEG): abs {abs_m:+.4} rel {rel_m:+.4}");
-
-            // Pin the calibration contract for the sample strategies:
-            // the relative margin the fix claims stays open, and the
-            // shipped default gate sits strictly inside it. The
-            // description columns stay unasserted — their negative
-            // margin is the documented MVP finding, not a contract.
-            let gate = match name.as_str() {
-                "samples-max" => Some(PrototypeStrategy::SampleMax.default_threshold()),
-                "samples-centroid" => Some(PrototypeStrategy::SampleCentroid.default_threshold()),
-                _ => None,
-            };
-            if let Some(gate) = gate {
-                let (rel_pos_min, rel_neg_max) = margins[1];
-                assert!(
-                    rel_neg_max < gate && gate <= rel_pos_min,
-                    "{name}: default gate {gate} outside the measured relative band ({rel_neg_max:.4}, {rel_pos_min:.4}]"
-                );
-            }
-        }
-    }
-
-    /// A candidate flood past [`MAX_RULE_SCORED_SPANS_PER_SEGMENT`]
-    /// releases the tail unscored: a rule-maskable sentence hidden
-    /// beyond the cap stays untouched (fail-open — rewrite less, never
-    /// stall), and the flood burns at most the model-call budget.
-    #[tokio::test]
-    #[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with model.onnx + tokenizer.json"]
-    async fn candidate_flood_releases_the_tail() {
-        let Some(g) = load_from_env() else { return };
-        let flood = "1.1 ".repeat(MAX_RULE_SCORED_SPANS_PER_SEGMENT);
-        // Padding wider than the ±50-char context window between the
-        // flood and the bait sentence: the model judges WINDOWS, so a
-        // pre-cap flood span whose window overlaps the bait would be
-        // (semantically correctly!) masked, and the test would measure
-        // window contamination instead of the cap. The padding word is
-        // letters-only — not a candidate.
-        let text = format!("{flood}{} 这个 EDA 软件的版本是 12.1", "x".repeat(60));
-        let outcome = g.moderate_input_segments(&[text]).await;
-        assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
-        assert!(
-            outcome.masked.is_none(),
-            "the over-cap tail must be released unscored"
-        );
-    }
-
-    /// The acceptance matrix end to end through the segment hook, on the
-    /// default configuration: both hard positives and the MVP acceptance
-    /// positive are rewritten; every hard negative comes back untouched
-    /// (`masked == None` ⇒ byte-identical passthrough upstream).
-    #[tokio::test]
-    #[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with model.onnx + tokenizer.json"]
-    async fn acceptance_matrix_end_to_end() {
-        let Some(g) = load_from_env() else { return };
-        let masked_cases = [
-            ("这个 EDA 软件的版本是 12.1", "这个 EDA 软件的版本是 ***"),
-            (
-                "我们把仿真工具升级到 2022.4 之后速度快了很多",
-                "我们把仿真工具升级到 *** 之后速度快了很多",
-            ),
-            // Whole-token rewrite: the fused `IC6.1.8` is ONE candidate
-            // now, so the tool-fused prefix no longer survives (the MVP
-            // masked only the dotted digits: `Virtuoso IC***`).
-            ("Virtuoso IC6.1.8 出现了崩溃", "Virtuoso *** 出现了崩溃"),
-            ("Virtuoso IC618 又崩了", "Virtuoso *** 又崩了"),
-            ("版本是 １２．１,不要外传", "版本是 ***,不要外传"),
-        ];
-        for (input, want) in masked_cases {
-            let outcome = g.moderate_input_segments(&[input.to_owned()]).await;
-            assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
-            let masked = outcome
-                .masked
-                .unwrap_or_else(|| panic!("must mask: {input}"));
-            assert_eq!(masked[0], want);
-        }
-        let passthrough_cases = [
-            "Elapsed: 12.345s, Memory: 4.2 GB",
-            "服务器的 IP 地址是 10.2.255.1",
-            "圆周率约等于 3.14159",
-            "工艺节点是 0.13um,良率还行",
-            // The Chinese-unit / timestamp defect classes this PR fixes.
-            "整个 build 花了 45.5 秒",
-            "[10:23:45.123] build started",
-        ];
-        for input in passthrough_cases {
-            let outcome = g.moderate_input_segments(&[input.to_owned()]).await;
-            assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
-            assert!(
-                outcome.masked.is_none(),
-                "negative must pass untouched: {input} → {:?}",
-                outcome.masked
-            );
-        }
-    }
-
-    /// The acceptance path in miniature: the segment hook masks the
-    /// version number and only the version number.
-    #[tokio::test]
-    #[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with model.onnx + tokenizer.json"]
-    async fn masks_acceptance_sentence() {
-        let Some(g) = load_from_env() else { return };
-        let texts = vec!["这个 EDA 软件的版本是 12.1".to_owned()];
-        let outcome = g.moderate_input_segments(&texts).await;
-        assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
-        let masked = outcome.masked.expect("must mask the version number");
-        assert_eq!(masked[0], "这个 EDA 软件的版本是 ***");
-        assert_eq!(outcome.counts.get(DETECTOR_NAME), Some(&1));
-    }
-
-    /// Lanes are interchangeable and safe under concurrency: with a
-    /// 2-lane pool, 8 concurrent embeds of the same window all succeed
-    /// and agree (sessions share nothing but identical weights, and a
-    /// single-threaded run is deterministic).
-    #[tokio::test]
-    #[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with model.onnx + tokenizer.json"]
-    async fn lanes_run_concurrently_and_agree() {
-        let Some(mut cfg) = LocalModelConfig::from_env() else {
-            return;
-        };
-        cfg.lanes = 2;
-        let g = std::sync::Arc::new(
-            LocalModelGuardrail::load(&cfg).expect("model files present but load failed"),
-        );
-        let window = "这个 EDA 软件的版本是 12.1,请确认兼容性";
-        let tasks: Vec<_> = (0..8)
-            .map(|_| {
-                let g = std::sync::Arc::clone(&g);
-                tokio::spawn(async move { g.embed_window(window.to_owned()).await })
-            })
-            .collect();
-        let mut vectors = Vec::new();
-        for t in tasks {
-            vectors.push(t.await.unwrap().expect("concurrent embed failed"));
-        }
-        let reference = &vectors[0];
-        for v in &vectors[1..] {
-            let agreement = cosine(v, reference);
-            assert!(agreement > 0.9999, "lanes disagree: cosine {agreement}");
-        }
-    }
-
-    /// Throughput calibration for api7/aisix#1001: lanes come from
-    /// GUARDRAIL_LOCAL_MODEL_LANES, so one binary sweeps 1/2/4 lanes.
-    /// Prints inferences/s over a saturating concurrent batch.
-    #[tokio::test]
-    #[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with model.onnx + tokenizer.json"]
-    async fn probe_lane_throughput() {
-        let Some(g) = load_from_env().map(std::sync::Arc::new) else {
-            return;
-        };
-        let window = "这个 EDA 软件的版本是 12.1,请确认与工艺库的兼容性之后再安排回归测试";
-        // Warm-up.
-        for _ in 0..3 {
-            g.embed_window(window.to_owned()).await.unwrap();
-        }
-        let total = 64usize;
-        let started = Instant::now();
-        let tasks: Vec<_> = (0..total)
-            .map(|_| {
-                let g = std::sync::Arc::clone(&g);
-                tokio::spawn(async move { g.embed_window(window.to_owned()).await })
-            })
-            .collect();
-        for t in tasks {
-            t.await.unwrap().expect("embed failed");
-        }
-        let secs = started.elapsed().as_secs_f64();
-        println!(
-            "lanes={} total={} wall={:.2}s throughput={:.1} inferences/s",
-            g.embedder.sessions.len(),
-            total,
-            secs,
-            total as f64 / secs
-        );
-    }
-
-    /// Rough single-inference latency figure for the MVP report.
-    #[tokio::test]
-    #[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with model.onnx + tokenizer.json"]
-    async fn probe_inference_latency() {
-        let Some(g) = load_from_env() else { return };
-        let window =
-            "这个 EDA 软件的版本是 12.1,请确认与工艺库的兼容性之后再安排回归测试".to_owned();
-        // Warm-up, then timed runs.
-        for _ in 0..3 {
-            g.embed_window(window.clone()).await.unwrap();
-        }
-        let mut samples = Vec::new();
-        for _ in 0..20 {
-            let t = Instant::now();
-            g.embed_window(window.clone()).await.unwrap();
-            samples.push(t.elapsed().as_micros() as u64);
-        }
-        samples.sort_unstable();
-        println!(
-            "inference us over 20 runs: p50={} min={} max={}",
-            samples[samples.len() / 2],
-            samples[0],
-            samples[samples.len() - 1]
-        );
     }
 }

--- a/crates/aisix-guardrails/src/local_model/adversarial_corpus.rs
+++ b/crates/aisix-guardrails/src/local_model/adversarial_corpus.rs
@@ -225,12 +225,17 @@ async fn adversarial_corpus_report() {
     // is v2 material — its probe lives in `probe_similarity_matrix`.)
     let mut model_items: Vec<(f32, bool)> = Vec::new();
     let (mut lines_correct, mut cand_correct) = (0usize, 0usize);
-    let mut wrong_lines: Vec<(&str, String, String)> = Vec::new();
+    // (category, text, actual output, corrupted): `corrupted` = a masked
+    // span no label covers. A multi-positive line where the model masks
+    // one labeled positive and releases another is a RECALL miss, not a
+    // corruption — `actual != text` alone cannot tell the two apart.
+    let mut wrong_lines: Vec<(&str, String, String, bool)> = Vec::new();
 
     for case in CORPUS {
         let labels = sensitive_ranges(case);
         let spans = cat.finder.spans(case.text);
         let mut hits: Vec<Range<usize>> = Vec::new();
+        let mut corrupted = false;
         for span in spans {
             n_candidates += 1;
             let positive = labels.iter().any(|l| overlaps(l, &span));
@@ -257,6 +262,7 @@ async fn adversarial_corpus_report() {
             };
             cand_correct += usize::from(masked == positive);
             if masked {
+                corrupted |= !positive;
                 hits.push(span);
             }
         }
@@ -278,7 +284,7 @@ async fn adversarial_corpus_report() {
         if actual == want {
             lines_correct += 1;
         } else {
-            wrong_lines.push((case.cat, case.text.to_owned(), actual));
+            wrong_lines.push((case.cat, case.text.to_owned(), actual, corrupted));
         }
     }
 
@@ -300,8 +306,9 @@ async fn adversarial_corpus_report() {
         lines_correct,
         CORPUS.len(),
     );
-    for (cat, text, actual) in &wrong_lines {
-        println!("  WRONG [{cat}] {text:?} -> {actual:?}");
+    for (cat, text, actual, corrupted) in &wrong_lines {
+        let tag = if *corrupted { "CORRUPTED" } else { "MISSED" };
+        println!("  WRONG/{tag} [{cat}] {text:?} -> {actual:?}");
     }
 
     let n_pos = model_items.iter().filter(|(_, p)| *p).count();
@@ -358,7 +365,7 @@ async fn adversarial_corpus_report() {
     // the description form's margin negative on anchor-free windows).
     let wrongly_masked = wrong_lines
         .iter()
-        .filter(|(_, text, actual)| actual != text)
+        .filter(|(_, _, _, corrupted)| *corrupted)
         .count();
     assert_eq!(
         wrongly_masked, 0,

--- a/crates/aisix-guardrails/src/local_model/adversarial_corpus.rs
+++ b/crates/aisix-guardrails/src/local_model/adversarial_corpus.rs
@@ -169,7 +169,7 @@ fn overlaps(a: &Range<usize>, b: &Range<usize>) -> bool {
 fn expected_output(case: &Case) -> String {
     let mut ranges = sensitive_ranges(case);
     ranges.sort_by_key(|r| r.start);
-    apply_masks(case.text, &ranges)
+    apply_masks(case.text, &ranges, "***")
 }
 
 /// Best 0/1 accuracy over all thresholds for `(score, is_positive)`
@@ -205,32 +205,36 @@ fn pct(part: usize, whole: usize) -> f64 {
 /// reproduce the real pipeline output) so the SAME test measures the
 /// before and after states without encoding either as a contract.
 #[tokio::test]
-#[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with model.onnx + tokenizer.json"]
+#[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with the model bundle"]
 async fn adversarial_corpus_report() {
-    let Some(cfg) = LocalModelConfig::from_env() else {
+    let Some(g) = super::tests::fixtures::model_guardrail() else {
         return;
     };
-    let g = LocalModelGuardrail::load(&cfg).expect("model files present but load failed");
+    let cat = &g.categories[0];
+    let prototype = g
+        .runtime
+        .prototype_for(&cat.description)
+        .await
+        .expect("description embeds");
 
     let mut n_candidates = 0usize;
     let (mut rule_masked, mut rule_passed, mut model_band) = (0usize, 0usize, 0usize);
     let (mut rule_masked_correct, mut rule_passed_correct) = (0usize, 0usize);
-    // Model-band scores in BOTH forms: `abs` — the old positive-only max
-    // cosine; `rel` — the shipped `max_pos − max_neg`. Same embeddings,
-    // so the comparison isolates the scoring FORM.
-    let mut model_items_abs: Vec<(f32, bool)> = Vec::new();
-    let mut model_items_rel: Vec<(f32, bool)> = Vec::new();
+    // Model-band scores under the v1 judgement form: absolute cosine
+    // against the description prototype. (The sample-set relative form
+    // is v2 material — its probe lives in `probe_similarity_matrix`.)
+    let mut model_items: Vec<(f32, bool)> = Vec::new();
     let (mut lines_correct, mut cand_correct) = (0usize, 0usize);
     let mut wrong_lines: Vec<(&str, String, String)> = Vec::new();
 
     for case in CORPUS {
         let labels = sensitive_ranges(case);
-        let spans = g.finder.spans(case.text);
+        let spans = cat.finder.spans(case.text);
         let mut hits: Vec<Range<usize>> = Vec::new();
         for span in spans {
             n_candidates += 1;
             let positive = labels.iter().any(|l| overlaps(l, &span));
-            let masked = match g.rules.decide(case.text, &span) {
+            let masked = match cat.rules.decide(case.text, &span) {
                 RuleDecision::Mask => {
                     rule_masked += 1;
                     rule_masked_correct += usize::from(positive);
@@ -245,11 +249,10 @@ async fn adversarial_corpus_report() {
                     model_band += 1;
                     let window =
                         case.text[window_bounds(case.text, &span, WINDOW_CONTEXT_CHARS)].to_owned();
-                    let v = g.embed_window(window).await.expect("embed failed");
-                    model_items_abs.push((max_cosine(&g.prototypes.positive, &v), positive));
-                    let score = g.prototypes.score(&v);
-                    model_items_rel.push((score, positive));
-                    score >= g.threshold
+                    let v = g.runtime.embed_text(window).await.expect("embed failed");
+                    let score = cosine(&prototype, &v);
+                    model_items.push((score, positive));
+                    score >= cat.threshold
                 }
             };
             cand_correct += usize::from(masked == positive);
@@ -260,7 +263,7 @@ async fn adversarial_corpus_report() {
         // Instrument consistency: the replication above must reproduce
         // the real pipeline byte for byte.
         hits.sort_by_key(|r| r.start);
-        let replicated = apply_masks(case.text, &hits);
+        let replicated = apply_masks(case.text, &hits, "***");
         let outcome = g.moderate_input_segments(&[case.text.to_owned()]).await;
         let actual = outcome
             .masked
@@ -301,38 +304,35 @@ async fn adversarial_corpus_report() {
         println!("  WRONG [{cat}] {text:?} -> {actual:?}");
     }
 
-    let n_pos = model_items_rel.iter().filter(|(_, p)| *p).count();
+    let n_pos = model_items.iter().filter(|(_, p)| *p).count();
     println!(
         "── model band: {} items ({} pos / {} neg)  shipped threshold {:.4}",
-        model_items_rel.len(),
+        model_items.len(),
         n_pos,
-        model_items_rel.len() - n_pos,
-        g.threshold,
+        model_items.len() - n_pos,
+        cat.threshold,
     );
-    for (name, items) in [("abs", &model_items_abs), ("rel", &model_items_rel)] {
-        let (acc, cut) = best_threshold_accuracy(items);
-        let min_pos = items
+    {
+        let (acc, cut) = best_threshold_accuracy(&model_items);
+        let min_pos = model_items
             .iter()
             .filter(|(_, p)| *p)
             .map(|(s, _)| *s)
             .fold(f32::INFINITY, f32::min);
-        let max_neg = items
+        let max_neg = model_items
             .iter()
             .filter(|(_, p)| !*p)
             .map(|(s, _)| *s)
             .fold(f32::NEG_INFINITY, f32::max);
         println!(
-            "  form {name}: margin (min pos − max neg) {:+.4}  best-threshold accuracy {:.1}% at {:.4}",
+            "  margin (min pos − max neg) {:+.4}  best-threshold accuracy {:.1}% at {:.4}",
             min_pos - max_neg,
             100.0 * acc,
             cut,
         );
     }
-    for ((abs, p), (rel, _)) in model_items_abs.iter().zip(&model_items_rel) {
-        println!(
-            "  {} abs {abs:.4} rel {rel:+.4}",
-            if *p { "POS" } else { "NEG" }
-        );
+    for (score, p) in &model_items {
+        println!("  {} score {score:.4}", if *p { "POS" } else { "NEG" });
     }
 
     // Quality floor, asserted LAST so a regression still prints the full
@@ -341,8 +341,7 @@ async fn adversarial_corpus_report() {
     // green). The rule layer must be EXACT on this corpus — a rule
     // decision never consults the model, so a wrong one is an
     // unconditional mis-rewrite (mask side) or a silent leak (pass
-    // side). The end-to-end floor allows exactly the two disclosed
-    // model-band misses.
+    // side).
     assert_eq!(
         rule_masked_correct, rule_masked,
         "rule-mask precision must stay 100% on the corpus"
@@ -351,9 +350,22 @@ async fn adversarial_corpus_report() {
         rule_passed_correct, rule_passed,
         "rule-pass must not release a labeled positive"
     );
-    assert!(
-        lines_correct >= CORPUS.len() - 2,
-        "line accuracy fell below the pinned floor: {lines_correct}/{}",
-        CORPUS.len()
+    // v1's model band judges absolute cosine against the description
+    // prototype (no sample set yet), which leans precision: it must
+    // never CORRUPT a negative line (a wrong mask rewrites user
+    // content), while anchor-free positives may release — that recall
+    // is exactly what the v2 sample sets buy back (the sweep measured
+    // the description form's margin negative on anchor-free windows).
+    let wrongly_masked = wrong_lines
+        .iter()
+        .filter(|(_, text, actual)| actual != text)
+        .count();
+    assert_eq!(
+        wrongly_masked, 0,
+        "the description-form model band must not mis-mask a negative: {wrong_lines:?}"
+    );
+    println!(
+        "missed (released) positive lines: {}",
+        wrong_lines.len() - wrongly_masked
     );
 }

--- a/crates/aisix-guardrails/src/local_model/rules.rs
+++ b/crates/aisix-guardrails/src/local_model/rules.rs
@@ -223,13 +223,17 @@ impl RuleScorer {
             score += WINDOW_EVIDENCE_SCORE;
         }
 
-        // Negative patterns: span-local shape checks, independent of the
-        // proximity window. Each pattern counts once no matter which
-        // slice it hits.
+        // Negative patterns: span-local shape checks. Each pattern counts
+        // once no matter which slice it hits. The prefix/suffix slices are
+        // clipped to the proximity window: a `$`-anchored pattern matches
+        // at the slice END (= the span edge) and a `^`-anchored one at the
+        // slice START, so clipping cannot change the verdict of any
+        // pattern shorter than the window — it only stops every span from
+        // rescanning the whole segment.
         for neg in &self.negatives {
             let hit = neg.regex.is_match(&text[span.clone()])
-                || (neg.try_prefix && neg.regex.is_match(&text[..span.start]))
-                || (neg.try_suffix && neg.regex.is_match(&text[span.end..]));
+                || (neg.try_prefix && neg.regex.is_match(&text[window.start..span.start]))
+                || (neg.try_suffix && neg.regex.is_match(&text[span.end..window.end]));
             if hit {
                 score += NEGATIVE_CLASS_SCORE;
             }
@@ -595,5 +599,35 @@ mod tests {
         assert!(cat.candidate_patterns.len() <= 10);
         assert!(cat.negative_patterns.len() <= 20);
         assert!(cat.hotword_groups.len() <= 10);
+    }
+
+    #[test]
+    fn anchored_negative_scans_clip_to_the_proximity_window() {
+        // A `$`-anchored pattern matches at the prefix slice's END (the
+        // span's left edge), so for any pattern shorter than the window
+        // the clip is invisible. This pins the boundary: a match LONGER
+        // than the window no longer fires — the price of not rescanning
+        // the whole segment per span — and window-local behavior is
+        // unchanged.
+        let negatives = vec![(
+            Regex::new("aaaaaaaaaa$").expect("compiles"),
+            "aaaaaaaaaa$".to_owned(),
+        )];
+        let scorer = RuleScorer::compile(5, &[], negatives).expect("compiles");
+
+        // 10 `a`s directly before the span, window of 5 chars: the
+        // clipped prefix holds only 5 of them, so the negative does not
+        // fire and the score stays 0.
+        let text = "aaaaaaaaaa12.1";
+        let span = 10..14;
+        assert_eq!(scorer.score(text, &span), 0);
+
+        // A pattern that fits the window still fires.
+        let negatives = vec![(
+            Regex::new("aaa$").expect("compiles"),
+            "aaa$".to_owned(),
+        )];
+        let scorer = RuleScorer::compile(5, &[], negatives).expect("compiles");
+        assert_eq!(scorer.score(text, &span), NEGATIVE_CLASS_SCORE);
     }
 }

--- a/crates/aisix-guardrails/src/local_model/rules.rs
+++ b/crates/aisix-guardrails/src/local_model/rules.rs
@@ -623,10 +623,7 @@ mod tests {
         assert_eq!(scorer.score(text, &span), 0);
 
         // A pattern that fits the window still fires.
-        let negatives = vec![(
-            Regex::new("aaa$").expect("compiles"),
-            "aaa$".to_owned(),
-        )];
+        let negatives = vec![(Regex::new("aaa$").expect("compiles"), "aaa$".to_owned())];
         let scorer = RuleScorer::compile(5, &[], negatives).expect("compiles");
         assert_eq!(scorer.score(text, &span), NEGATIVE_CLASS_SCORE);
     }

--- a/crates/aisix-guardrails/src/local_model/rules.rs
+++ b/crates/aisix-guardrails/src/local_model/rules.rs
@@ -17,7 +17,10 @@
 //!     evidence: +2 per group. Terms merely within the proximity window
 //!     are weak evidence: +1 total, regardless of group count — distant
 //!     co-occurrence alone must never mask, only route to the model.
-//!   - negative patterns LOWER the score: -4 per pattern. Each pattern
+//!   - negative patterns LOWER the score: -4 per pattern. (The MVP
+//!     scored -4 once per matched negative CLASS; counting per pattern
+//!     is a deliberate generalization — user categories have no class
+//!     grouping — pinned unchanged on the ported corpus.) Each pattern
 //!     is tried against the span itself (always), against the text
 //!     BEFORE the span when the pattern is `$`-anchored, and against the
 //!     text AFTER the span when it is `^`-anchored — the anchors pin the

--- a/crates/aisix-guardrails/src/local_model/rules.rs
+++ b/crates/aisix-guardrails/src/local_model/rules.rs
@@ -1,60 +1,56 @@
-//! Layer ② of the three-layer pipeline (AISIX-Cloud#1331): rule scoring
-//! between the regex candidate layer (①) and the model judgement (③).
+//! Layer ② of the three-layer pipeline (AISIX-Cloud#1331 → #1363): rule
+//! scoring between the regex candidate layer (①) and the model
+//! judgement (③), compiled from a category's configured hotword groups
+//! and negative patterns.
 //!
 //! The MVP shipped ① → ③ directly, which put the whole separation burden
 //! on zero-shot cosine — measured unable to split the hard positives
-//! (`升级到 2022.4`, `Virtuoso IC6.1.8`, 0.75–0.79) from the compile-log
-//! hard negatives (≤0.77). This layer restores the design's division of
-//! labor: candidates with decisive lexical evidence are resolved here in
-//! microseconds, and ONLY the genuinely ambiguous band pays a model call.
+//! from compile-log hard negatives. This layer restores the design's
+//! division of labor: candidates with decisive lexical evidence are
+//! resolved here in microseconds, and ONLY the genuinely ambiguous band
+//! pays a model call.
 //!
 //! Per candidate span:
-//!   - hotword co-occurrence RAISES the score. Three hotword classes
-//!     (Chinese triggers, English triggers, EDA tool names), each counted
-//!     once. A hotword ADJACENT to the span (≤ [`ADJACENT_GAP_CHARS`]
-//!     chars away — `版本是 12.1`, `Virtuoso IC6.1.8`) is decisive
-//!     evidence: +2 per class. Hotwords merely within the proximity
-//!     window are weak evidence: +1 total, regardless of class count —
-//!     distant co-occurrence alone must never mask, only route to the
-//!     model.
-//!   - negative patterns LOWER the score: -4 per class. A measurement
-//!     unit right after the number, an IPv4-shaped span, or a source
-//!     location is stronger evidence of "not a version" than any nearby
-//!     hotword is of the opposite, so one negative class (-4) outweighs
-//!     one decisive positive class (+2) — `版本升级后耗时 12.5s` must
-//!     not mask the timing.
+//!   - hotword co-occurrence RAISES the score. Each configured hotword
+//!     GROUP is counted once. A group term ADJACENT to the span
+//!     (≤ [`ADJACENT_GAP_CHARS`] chars away — `版本是 12.1`) is decisive
+//!     evidence: +2 per group. Terms merely within the proximity window
+//!     are weak evidence: +1 total, regardless of group count — distant
+//!     co-occurrence alone must never mask, only route to the model.
+//!   - negative patterns LOWER the score: -4 per pattern. Each pattern
+//!     is tried against the span itself (always), against the text
+//!     BEFORE the span when the pattern is `$`-anchored, and against the
+//!     text AFTER the span when it is `^`-anchored — the anchors pin the
+//!     position, so `^\s*(?:ms|s)` means "a unit right after the span"
+//!     and `编号\s*$` means "a tag right before it". One negative
+//!     pattern (-4) outweighs one decisive positive group (+2): a
+//!     measurement unit after the number is stronger evidence of "not
+//!     this category" than any nearby hotword is of the opposite.
 //!   - the double threshold turns the score into a [`RuleDecision`]:
 //!     ≥ [`MASK_SCORE`] rewrites without consulting the model,
 //!     ≤ [`PASS_SCORE`] releases without consulting the model, and only
-//!     the band in between (no evidence, or weak/conflicting evidence)
-//!     goes to layer ③.
+//!     the band in between goes to layer ③.
 //!
 //! This is the mainstream DLP shape — hotword-proximity confidence
-//! adjustment over a strong-format base pattern (Google Cloud DLP hotword
-//! rules, Microsoft Purview supporting elements, AWS Macie
-//! `maximumMatchDistance`, Palo Alto proximity keywords) — not an
-//! invention of this crate. The proximity window default of
+//! adjustment over a strong-format base pattern — not an invention of
+//! this crate. The proximity window default of
 //! [`DEFAULT_PROXIMITY_CHARS`] sits at the tight end of the range those
-//! engines use (Macie defaults to 50 chars, Palo Alto to 200, Purview
-//! recommends 300, Google caps at 1000): the driving corpus is dense
-//! compile logs where a wide window manufactures accidental
-//! co-occurrence, and 50 also matches the ±50-char window layer ③ judges,
-//! so the two layers reason about the same context. Override with
-//! [`RULE_WINDOW_ENV`][super::RULE_WINDOW_ENV] (clamped to
-//! [`MAX_PROXIMITY_CHARS`], the Google DLP hard cap).
+//! engines use, and matches the ±50-char window layer ③ judges, so the
+//! two layers reason about the same context.
+//!
+//! Term matching: terms containing any non-ASCII character are matched
+//! as SUBSTRINGS (no word boundaries in CJK); pure-ASCII terms compile
+//! to case-insensitive word-bounded regexes whose right edge may run
+//! into a digit (`INNOVUS211` — real corpora fuse a tool name straight
+//! into a version, and `\b` never fires between two word chars).
 //!
 //! Threat-model boundary, inherited from the design issue's "只能防无意
-//! 泄漏" line and inherent to score-subtraction DLP: a sender (or a
-//! hostile upstream, on the output side) can defeat the rule layer by
-//! FORMATTING — appending a unit-looking suffix (`升级到 2022.4s`) or a
-//! `:digit` tail. The layer scores accidental phrasing, not adversarial
-//! encoding. (Fullwidth digits left this list: layer ① now candidates
-//! them, because they occur in ACCIDENTAL Chinese-IME phrasing, which is
-//! in scope.)
+//! 泄漏" line and inherent to score-subtraction DLP: a sender can defeat
+//! the rule layer by FORMATTING. The layer scores accidental phrasing,
+//! not adversarial encoding.
 //!
-//! Everything here is pure text work — no model, no I/O — so the layer is
-//! unit-testable standalone, which is also how the "rules alone" halves
-//! of the acceptance matrix are measured.
+//! Everything here is pure text work — no model, no I/O — so the layer
+//! is unit-testable standalone.
 
 use std::ops::Range;
 
@@ -65,138 +61,29 @@ use super::window_bounds;
 /// Default hotword proximity window (chars each side of the span).
 pub(super) const DEFAULT_PROXIMITY_CHARS: usize = 50;
 
-/// Upper clamp for the proximity window override.
+/// Upper clamp for the proximity window.
 pub(super) const MAX_PROXIMITY_CHARS: usize = 1000;
 
 /// A hotword within this many chars of the span edge is ADJACENT —
 /// decisive rather than weak evidence. 8 chars covers the connective
-/// tissue of every acceptance shape (`版本是 12.1` gap 2, `Virtuoso
-/// IC6.1.8` gap 3, `upgrade to 21.15` gap 1, `version: v2022.4` gap 3)
-/// while staying too small for an unrelated number to drift inside.
+/// tissue of every acceptance shape while staying too small for an
+/// unrelated number to drift inside.
 const ADJACENT_GAP_CHARS: usize = 8;
 
-/// Score for each hotword class with an adjacent match.
+/// Score for each hotword group with an adjacent match.
 const ADJACENT_CLASS_SCORE: i32 = 2;
 /// Score when hotwords exist only at window distance (flat, not per
-/// class — distant co-occurrence stays weak no matter how many classes).
+/// group — distant co-occurrence stays weak no matter how many groups).
 const WINDOW_EVIDENCE_SCORE: i32 = 1;
-/// Score for each negative-pattern class that hits.
+/// Score for each negative pattern that hits.
 const NEGATIVE_CLASS_SCORE: i32 = -4;
 
 /// Decision bands: `score >= MASK_SCORE` masks without the model — one
-/// adjacent hotword class alone is enough.
+/// adjacent hotword group alone is enough.
 const MASK_SCORE: i32 = 2;
-/// `score <= PASS_SCORE` releases without the model — one negative class
-/// alone is enough, even against an adjacent hotword (-4 + 2).
+/// `score <= PASS_SCORE` releases without the model — one negative
+/// pattern alone is enough, even against an adjacent hotword (-4 + 2).
 const PASS_SCORE: i32 = -1;
-
-/// Chinese trigger hotwords (substring match — no word boundaries in
-/// CJK). `版本号` is a substring of no other entry but kept explicit so
-/// the list reads as the configured vocabulary.
-const ZH_TRIGGERS: &[&str] = &["版本号", "版本", "升级到", "回退到"];
-
-/// English trigger hotwords: word-bounded so `conversion` never fires
-/// `version`. `upgraded? to` covers the bare and inflected forms.
-const EN_TRIGGER_PATTERN: &str = r"(?i)\b(?:version|release|build|upgraded?\s+to)\b";
-
-/// EDA tool names — the strongest anchors (`Virtuoso IC6.1.8` needs no
-/// model). Word-bounded on the left, case-insensitive (`vcs` / `VCS`).
-/// On the right, either a word boundary or a DIGIT continuation: real
-/// corpora fuse the tool name straight into the version (`INNOVUS211`),
-/// and `\b` never fires between two word chars, so the plain `\b` form
-/// was blind to exactly the fused tokens layer ① now produces. The
-/// digit alternative consumes one char, which only matters to the gap
-/// computation by one char inside an already-overlapping span.
-const TOOL_PATTERN: &str = r"(?i)\b(?:virtuoso|calibre|vcs|innovus|icc2|primetime)(?:[0-9]|\b)";
-
-/// Negative: a measurement unit right after the span (`12.345s`,
-/// `4.2 GB`, `0.13um`, `99.9%`, `0.5ns`, `0.5 纳秒`, `3.5 小时`). Beyond
-/// the design brief's minimum list, this covers the full timing-unit
-/// family (`us/ns/ps/fs`, the `Hz` family, spelled-out durations)
-/// because the driving corpus — STA/timing logs — is ns/ps-dense, and a
-/// unit the list misses next to a tool name would RULE-MASK a slack
-/// value (audit finding on PR #1005). The CHINESE unit vocabulary is the
-/// adversarial-corpus finding this PR fixes: the customer's dominant
-/// corpus is Chinese logs, and under the double threshold a rule-mask
-/// never consults the model, so `0.5ns` released while `0.5 纳秒` was
-/// rewritten. Covered families: durations (纳秒→天), lengths (纳米/微米/
-/// 毫米), byte sizes (兆/吉/太字节), the Hz family (千/兆/吉赫兹), and
-/// percentages (`％`, `个百分点`; the `百分之` PREFIX form is
-/// [`CN_PERCENT_PREFIX_PATTERN`]).
-/// Anchored to the span end with optional whitespace; ASCII letter units
-/// must not continue into a longer word (`12.1 subsystem` is NOT an `s`
-/// hit), checked with an explicit ASCII-alnum guard rather than `\b`
-/// because the regex crate's Unicode `\b` treats a following CJK char as
-/// a word char. Chinese units are substring-matched (no word boundaries
-/// in CJK); durations also carry the measure-word form (`3.5 个小时`,
-/// `2.5 个星期` — the audit found the bare forms alone still rule-masked
-/// next to a trigger), and thermal/electrical units (`度`, `伏特`,
-/// `瓦特`, `安培`) cover the power/temperature lines EDA logs are full
-/// of. Single-char units with heavy compound ambiguity are deliberately
-/// excluded — `分` (points vs minutes) and bare `安` (`12.1 安装之后`
-/// would systematically RELEASE real versions next to the extremely
-/// common 安装), and `度` must not continue into `度过` (verification
-/// audit: `版本 12.1 度过了回归测试` released a real version; the
-/// negated-char form costs one lookahead-free char, harmless for
-/// `is_match`) — and the residual compound risk of the kept ones
-/// (`12.1 天线`) is accepted: a wrong release is fail-open, a wrong
-/// rewrite corrupts content.
-const UNIT_SUFFIX_PATTERN: &str = r"^\s*(?:%|％|(?i:ms|us|ns|ps|fs|s|secs?|seconds?|mins?|minutes?|hours?|[kmgt]i?b|um|nm|[kmg]?hz)(?:[^0-9A-Za-z]|$)|纳秒|微秒|毫秒|秒|分钟|个?(?:小时|钟头|星期|月)|天|纳米|微米|毫米|[兆吉太]字节|[千兆吉]?赫兹|[千兆吉]赫|个?百分点|摄氏度|度(?:[^过]|$)|伏特?|瓦特?|安培|毫安)";
-
-/// Negative: the span itself ENDS in an ASCII measurement unit. Fused
-/// candidate tokens (`12.345s`, `3.2GHz`, `7nm`, `0.13um` as ONE span)
-/// carry the unit evidence INSIDE the span rather than after it, so the
-/// suffix check above never sees it. Same class as
-/// [`UNIT_SUFFIX_PATTERN`] — either placement counts once.
-const FUSED_UNIT_SUFFIX_PATTERN: &str = r"(?i)[0-9](?:%|ms|us|ns|ps|fs|s|secs?|seconds?|mins?|minutes?|hours?|[kmgt]i?b|um|nm|[kmg]?hz)$";
-
-/// Negative: the Chinese percentage PREFIX form (`百分之 3.5`) — the
-/// percent evidence precedes the number. Same class as the unit suffix.
-const CN_PERCENT_PREFIX_PATTERN: &str = r"百分之\s*$";
-
-/// Negative: the span itself is IPv4-shaped (`10.2.255.1`). Shape only —
-/// no octet range check, matching how DLP engines treat dotted quads.
-/// Known recall tradeoff (recorded on the design issue): real EDA
-/// sub-versions can run to 4 dotted groups (`IC6.1.8.500`), and this
-/// class releases them even next to an adjacent tool name. Kept anyway:
-/// weakening the class when positive evidence is adjacent would mask
-/// ACTUAL addresses (`Virtuoso 主机 10.2.255.1`), and a mask
-/// false-positive corrupts content while a release only defers recall to
-/// the sample corpus.
-const IPV4_PATTERN: &str = r"^\d{1,3}(?:\.\d{1,3}){3}$";
-
-/// Negative: source-location context — the span directly follows a
-/// `file.ext:` prefix or is directly followed by `:digit` (`top.v:12.1`,
-/// `12.1:3`-style diagnostics).
-const FILE_COLON_PREFIX_PATTERN: &str = r"[\w.-]+\.[A-Za-z0-9]+:$";
-const COLON_DIGIT_SUFFIX_PATTERN: &str = r"^:\d";
-
-/// Negative: time-of-day context, same class as the source location —
-/// the span completes an `HH:MM:SS.mmm` clock reading. Log lines open
-/// with these (`[10:23:45.123] build started`), and the trigger word
-/// right after the bracket (`build`, `version`) is ADJACENT by distance,
-/// so without this class the whole timestamp family rule-masks — the
-/// adversarial-corpus finding. ASCII and fullwidth colons both count.
-const TIME_OF_DAY_PREFIX_PATTERN: &str = r"[0-9]{1,2}[:：][0-9]{1,2}[:：]$";
-
-/// Negative: the span is FILENAME-shaped — a fused token ending in a
-/// dot plus a 2–4 letter extension (`report3.txt`, `setup2.cfg`).
-/// Audit finding: everyday filenames are fused-token candidates now,
-/// and `GH-2048`-class identifiers sit too close to the weakest
-/// anchor-free version positives for the embedding to separate — but a
-/// trailing alphabetic extension is decisive LEXICAL evidence, which is
-/// this layer's job, not the model's. Version tokens never end in a
-/// dot-plus-letters segment (`802.11ac`'s last segment starts with
-/// digits; `…-SP2` has no dot before the letters), so the shape is
-/// precise. Same class as the source-location patterns.
-const FILE_EXTENSION_SUFFIX_PATTERN: &str = r"(?i)\.[a-z]{2,4}$";
-
-/// Negative: an identifier tag right before the span — `编号 GH-2048`,
-/// `编号: JIRA-1024`, optionally through `是/为`. `版本编号` is carved
-/// out (the char before `编号` must not be `本`): that compound means
-/// "version number" and must keep masking. Same class as the source
-/// location — a tagged identifier is a locator, not a version.
-const ID_TAG_PREFIX_PATTERN: &str = r"(?:^|[^本])编号[:：]?(?:是|为)?\s*$";
 
 /// What layer ② decided for one candidate span.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -209,121 +96,140 @@ pub(super) enum RuleDecision {
     Model,
 }
 
-/// The compiled layer-② scorer. Hotword vocabulary and weights are
-/// compile-time constants (the MVP's env-or-hardcoded config posture);
-/// only the proximity window is operator-tunable.
+/// One compiled hotword group: substring terms (CJK) + word-bounded
+/// regexes (ASCII). The group counts once toward the score.
+struct HotwordGroup {
+    substrings: Vec<String>,
+    word_patterns: Vec<Regex>,
+}
+
+/// One compiled negative pattern and which slices it applies to,
+/// derived from its anchors (see the module doc).
+struct NegativePattern {
+    regex: Regex,
+    try_prefix: bool,
+    try_suffix: bool,
+}
+
+/// The compiled layer-② scorer for one category.
 pub(super) struct RuleScorer {
     proximity_chars: usize,
-    en_trigger: Regex,
-    tool: Regex,
-    unit_suffix: Regex,
-    fused_unit_suffix: Regex,
-    cn_percent_prefix: Regex,
-    ipv4: Regex,
-    file_colon_prefix: Regex,
-    colon_digit_suffix: Regex,
-    time_of_day_prefix: Regex,
-    file_extension_suffix: Regex,
-    id_tag_prefix: Regex,
+    groups: Vec<HotwordGroup>,
+    negatives: Vec<NegativePattern>,
 }
 
 impl RuleScorer {
-    pub(super) fn new(proximity_chars: usize) -> Self {
-        let compile = |p: &str| Regex::new(p).expect("rule pattern must compile");
-        Self {
-            // The env parse already rejects zero (a zero window finds no
-            // hotword — layer ② would silently stop masking), but the
-            // config fields are `pub`; clamp defensively like the lane
-            // pool does.
-            proximity_chars: proximity_chars.clamp(1, MAX_PROXIMITY_CHARS),
-            en_trigger: compile(EN_TRIGGER_PATTERN),
-            tool: compile(TOOL_PATTERN),
-            unit_suffix: compile(UNIT_SUFFIX_PATTERN),
-            fused_unit_suffix: compile(FUSED_UNIT_SUFFIX_PATTERN),
-            cn_percent_prefix: compile(CN_PERCENT_PREFIX_PATTERN),
-            ipv4: compile(IPV4_PATTERN),
-            file_colon_prefix: compile(FILE_COLON_PREFIX_PATTERN),
-            colon_digit_suffix: compile(COLON_DIGIT_SUFFIX_PATTERN),
-            time_of_day_prefix: compile(TIME_OF_DAY_PREFIX_PATTERN),
-            file_extension_suffix: compile(FILE_EXTENSION_SUFFIX_PATTERN),
-            id_tag_prefix: compile(ID_TAG_PREFIX_PATTERN),
+    /// Compile a category's hotword groups and negative patterns.
+    /// `negatives` carries `(compiled, source)` so the anchor-derived
+    /// slice selection can inspect the source text. Term-compile errors
+    /// return `(offending_term, error)`.
+    pub(super) fn compile(
+        proximity_chars: usize,
+        groups: &[Vec<String>],
+        negatives: Vec<(Regex, String)>,
+    ) -> Result<Self, (String, regex::Error)> {
+        let mut compiled_groups = Vec::with_capacity(groups.len());
+        for terms in groups {
+            let mut substrings = Vec::new();
+            let mut word_patterns = Vec::new();
+            for term in terms {
+                if term.is_empty() {
+                    continue;
+                }
+                if term.is_ascii() {
+                    // Word-bounded, case-insensitive, digit-continuation
+                    // on the right (fused tool names).
+                    let pattern = format!(r"(?i)\b{}(?:[0-9]|\b)", regex::escape(term));
+                    word_patterns.push(Regex::new(&pattern).map_err(|e| (term.clone(), e))?);
+                } else {
+                    substrings.push(term.clone());
+                }
+            }
+            compiled_groups.push(HotwordGroup {
+                substrings,
+                word_patterns,
+            });
         }
+        let negatives = negatives
+            .into_iter()
+            .map(|(regex, source)| NegativePattern {
+                try_prefix: source.ends_with('$'),
+                try_suffix: source.starts_with('^'),
+                regex,
+            })
+            .collect();
+        Ok(Self {
+            proximity_chars: proximity_chars.clamp(1, MAX_PROXIMITY_CHARS),
+            groups: compiled_groups,
+            negatives,
+        })
     }
 
     /// Score one candidate span of `text`.
     pub(super) fn score(&self, text: &str, span: &Range<usize>) -> i32 {
         let window = window_bounds(text, span, self.proximity_chars);
-        let mut adjacent_classes = 0i32;
-        let mut window_only = false;
-
-        // Hotword classes: matches are searched inside the proximity
-        // window; a match within ADJACENT_GAP_CHARS of the span edge
-        // upgrades its class to decisive.
-        let mut tally = |ranges: &mut dyn Iterator<Item = Range<usize>>| {
-            let mut any = false;
-            let mut adjacent = false;
-            for r in ranges {
-                any = true;
-                if gap_chars(text, span, &r) <= ADJACENT_GAP_CHARS {
-                    adjacent = true;
-                    break;
-                }
-            }
-            if adjacent {
-                adjacent_classes += 1;
-            } else if any {
-                window_only = true;
-            }
-        };
         let win = &text[window.clone()];
-        tally(&mut ZH_TRIGGERS.iter().flat_map(|t| {
-            win.match_indices(t)
-                .map(|(i, m)| window.start + i..window.start + i + m.len())
-        }));
         // A clipped window edge can bisect a word and hand `\b` a false
         // boundary at the slice rim (`…conversion` clipped to a slice
         // ending in `version`), so word-bounded matches flush with a
-        // CLIPPED edge are discarded. Substring (zh) matching has no
-        // boundary semantics, so it needs no such guard.
+        // CLIPPED edge are discarded. Substring matching has no boundary
+        // semantics, so it needs no such guard.
         let clipped_start = window.start > 0;
         let clipped_end = window.end < text.len();
-        let mut bounded = |re: &Regex| {
-            tally(
-                &mut re
-                    .find_iter(win)
-                    .filter(|m| !(clipped_start && m.start() == 0))
-                    .filter(|m| !(clipped_end && m.end() == win.len()))
-                    .map(|m| window.start + m.start()..window.start + m.end()),
-            );
-        };
-        bounded(&self.en_trigger);
-        bounded(&self.tool);
 
-        let mut score = adjacent_classes * ADJACENT_CLASS_SCORE;
-        if adjacent_classes == 0 && window_only {
+        let mut adjacent_groups = 0i32;
+        let mut window_only = false;
+        for group in &self.groups {
+            let mut any = false;
+            let mut adjacent = false;
+            'group: {
+                for term in &group.substrings {
+                    for (i, m) in win.match_indices(term.as_str()) {
+                        any = true;
+                        let r = window.start + i..window.start + i + m.len();
+                        if gap_chars(text, span, &r) <= ADJACENT_GAP_CHARS {
+                            adjacent = true;
+                            break 'group;
+                        }
+                    }
+                }
+                for re in &group.word_patterns {
+                    for m in re
+                        .find_iter(win)
+                        .filter(|m| !(clipped_start && m.start() == 0))
+                        .filter(|m| !(clipped_end && m.end() == win.len()))
+                    {
+                        any = true;
+                        let r = window.start + m.start()..window.start + m.end();
+                        if gap_chars(text, span, &r) <= ADJACENT_GAP_CHARS {
+                            adjacent = true;
+                            break 'group;
+                        }
+                    }
+                }
+            }
+            if adjacent {
+                adjacent_groups += 1;
+            } else if any {
+                window_only = true;
+            }
+        }
+
+        let mut score = adjacent_groups * ADJACENT_CLASS_SCORE;
+        if adjacent_groups == 0 && window_only {
             score += WINDOW_EVIDENCE_SCORE;
         }
 
-        // Negative classes: span-local shape checks, independent of the
-        // proximity window. Unit evidence counts once no matter where it
-        // sits (after the span, fused into its tail, or the Chinese
-        // percent prefix before it).
-        if self.unit_suffix.is_match(&text[span.end..])
-            || self.fused_unit_suffix.is_match(&text[span.clone()])
-            || self.cn_percent_prefix.is_match(&text[..span.start])
-        {
-            score += NEGATIVE_CLASS_SCORE;
-        }
-        if self.ipv4.is_match(&text[span.clone()]) {
-            score += NEGATIVE_CLASS_SCORE;
-        }
-        if self.file_colon_prefix.is_match(&text[..span.start])
-            || self.colon_digit_suffix.is_match(&text[span.end..])
-            || self.time_of_day_prefix.is_match(&text[..span.start])
-            || self.file_extension_suffix.is_match(&text[span.clone()])
-            || self.id_tag_prefix.is_match(&text[..span.start])
-        {
-            score += NEGATIVE_CLASS_SCORE;
+        // Negative patterns: span-local shape checks, independent of the
+        // proximity window. Each pattern counts once no matter which
+        // slice it hits.
+        for neg in &self.negatives {
+            let hit = neg.regex.is_match(&text[span.clone()])
+                || (neg.try_prefix && neg.regex.is_match(&text[..span.start]))
+                || (neg.try_suffix && neg.regex.is_match(&text[span.end..]));
+            if hit {
+                score += NEGATIVE_CLASS_SCORE;
+            }
         }
         score
     }
@@ -355,12 +261,12 @@ fn gap_chars(text: &str, span: &Range<usize>, hotword: &Range<usize>) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::super::CandidateFinder;
+    use super::super::tests::fixtures::{eda_category, eda_finder, eda_scorer};
     use super::*;
 
     fn decisions(text: &str) -> Vec<(String, RuleDecision)> {
-        let scorer = RuleScorer::new(DEFAULT_PROXIMITY_CHARS);
-        CandidateFinder::new()
+        let scorer = eda_scorer(DEFAULT_PROXIMITY_CHARS);
+        eda_finder()
             .spans(text)
             .into_iter()
             .map(|s| (text[s.clone()].to_owned(), scorer.decide(text, &s)))
@@ -394,8 +300,8 @@ mod tests {
 
     #[test]
     fn hard_negatives_pass_by_rules_alone() {
-        // `12.345s` is now ONE fused candidate (unit evidence inside the
-        // span); the decision is unchanged.
+        // `12.345s` is ONE fused candidate (unit evidence inside the
+        // span).
         assert_eq!(
             decisions("Elapsed: 12.345s, Memory: 4.2 GB"),
             vec![
@@ -456,8 +362,8 @@ mod tests {
         // clipped-edge guard drops the match and the candidate stays in
         // the model band.
         let text = "big conversion 3.5 result";
-        let span = &CandidateFinder::new().spans(text)[0];
-        let tight = RuleScorer::new(8);
+        let span = &eda_finder().spans(text)[0];
+        let tight = eda_scorer(8);
         assert_eq!(tight.decide(text, span), RuleDecision::Model);
     }
 
@@ -482,7 +388,7 @@ mod tests {
     #[test]
     fn timing_units_outweigh_adjacent_tool_names() {
         // The driving corpus is ns/ps-dense STA logs: a slack value next
-        // to a tool name must NOT rule-mask (audit finding on this PR).
+        // to a tool name must NOT rule-mask.
         assert_eq!(only("PrimeTime slack 0.5ns 违例"), RuleDecision::Pass);
         assert_eq!(only("版本升级后耗时 12.5ns,可以接受"), RuleDecision::Pass);
         assert_eq!(only("clock period 1.25ps setup ok"), RuleDecision::Pass);
@@ -496,10 +402,7 @@ mod tests {
         assert_eq!(only("版本是 12.1 seconds 之外的话题"), RuleDecision::Pass);
     }
 
-    // ── the Chinese-unit defect class (adversarial-corpus finding):
-    //    `0.5ns` released while `0.5 纳秒` rewrote. One assertion per
-    //    unit family the brief names; the duration rows carry a trigger
-    //    hotword nearby, so the negative must OUTWEIGH it. ─────────────
+    // ── the Chinese-unit defect class (adversarial-corpus finding) ──────
 
     #[test]
     fn chinese_duration_units_are_negative_evidence() {
@@ -517,9 +420,6 @@ mod tests {
 
     #[test]
     fn measure_word_durations_are_negative_evidence() {
-        // The measure-word (`个`) forms, each next to a trigger — the
-        // audit's finding: the bare-unit list alone still rule-masked
-        // these.
         assert_eq!(only("版本升级花了 3.5 个小时"), RuleDecision::Pass);
         assert_eq!(only("升级到新机器后等了 1.5 个钟头"), RuleDecision::Pass);
         assert_eq!(only("等了 2.5 个星期才排上机时"), RuleDecision::Pass);
@@ -536,8 +436,7 @@ mod tests {
         // Bare 安 is deliberately NOT a unit: 安装 right after a version
         // must not release it (安装 is everywhere in the driving corpus).
         assert_eq!(only("版本是 12.1 安装之后报错"), RuleDecision::Mask);
-        // 度 must not fire inside 度过 (verification-audit regression:
-        // this real version released as a "degrees" reading).
+        // 度 must not fire inside 度过 (verification-audit regression).
         assert_eq!(only("版本 12.1 度过了回归测试"), RuleDecision::Mask);
     }
 
@@ -563,9 +462,6 @@ mod tests {
 
     #[test]
     fn log_timestamps_release_even_next_to_triggers() {
-        // The trigger right after the bracket is ADJACENT by distance —
-        // the clock context must win (adversarial-corpus finding: the
-        // whole `[HH:MM:SS.mmm]` family rule-masked).
         assert_eq!(only("[10:23:45.123] build started"), RuleDecision::Pass);
         assert_eq!(
             only("[09:01:07.500] version check passed"),
@@ -581,11 +477,10 @@ mod tests {
         );
     }
 
-    // ── fused-token candidates (layer-① relaxation) through the rules ──
+    // ── fused-token candidates through the rules ────────────────────────
 
     #[test]
     fn fused_tokens_ending_in_units_release() {
-        // One fused span each; the unit evidence is INSIDE the span.
         assert_eq!(only("7nm 工艺下功耗有点高"), RuleDecision::Pass);
         assert_eq!(only("先在 28nm 上验证流程"), RuleDecision::Pass);
         assert_eq!(only("跑到 3.2GHz 依然稳定"), RuleDecision::Pass);
@@ -594,7 +489,7 @@ mod tests {
     #[test]
     fn fused_tool_prefix_is_decisive() {
         // The tool name fused straight into the version: the digit
-        // continuation in TOOL_PATTERN makes the anchor visible.
+        // continuation on ASCII terms makes the anchor visible.
         assert_eq!(only("INNOVUS211 的时序报告在附件里"), RuleDecision::Mask);
     }
 
@@ -614,13 +509,10 @@ mod tests {
 
     #[test]
     fn filename_shaped_tokens_release() {
-        // Trailing dot-plus-letters extension is decisive lexical
-        // evidence (audit finding: `report3.txt` mis-masked in the
-        // model band — but it never needed the model).
         assert_eq!(only("把 report3.txt 发我一下"), RuleDecision::Pass);
         assert_eq!(only("参数都写在 sim7.cfg 里面"), RuleDecision::Pass);
         // Decisive even against an ADJACENT trigger: the extension must
-        // outweigh 版本 (bot-review example).
+        // outweigh 版本.
         assert_eq!(only("版本是 build_2023.log 里说的那个"), RuleDecision::Pass);
     }
 
@@ -628,8 +520,6 @@ mod tests {
     fn id_tag_prefix_releases_tagged_identifiers() {
         assert_eq!(only("对应 issue 编号 GH-2048"), RuleDecision::Pass);
         assert_eq!(only("工单编号: AB-3072 已建好"), RuleDecision::Pass);
-        // Fullwidth colon after the tag (bot-review finding: the class
-        // had two ASCII colons and no fullwidth one).
         assert_eq!(only("工单编号：AB-3072 已建好"), RuleDecision::Pass);
         // 版本编号 is carved out — it means "version number" and must
         // keep masking (the char before 编号 is 本).
@@ -638,7 +528,6 @@ mod tests {
 
     #[test]
     fn bare_fused_tokens_stay_in_the_model_band() {
-        // No lexical anchor either way: exactly what layer ③ exists for.
         assert_eq!(only("XCELIUM2309 的仿真结果对不上"), RuleDecision::Model);
         assert_eq!(only("这个块是 N5 工艺的"), RuleDecision::Model);
     }
@@ -657,9 +546,9 @@ mod tests {
         // Same sentence, tool name pushed outside a tiny window: the
         // evidence disappears and the candidate falls to the model band.
         let text = "Innovus 的运行日志我贴在下面了,请帮忙看看统计值 21.12";
-        let tight = RuleScorer::new(4);
-        let wide = RuleScorer::new(DEFAULT_PROXIMITY_CHARS);
-        let span = &CandidateFinder::new().spans(text)[0];
+        let tight = eda_scorer(4);
+        let wide = eda_scorer(DEFAULT_PROXIMITY_CHARS);
+        let span = &eda_finder().spans(text)[0];
         assert_eq!(tight.decide(text, span), RuleDecision::Model);
         assert_eq!(wide.decide(text, span), RuleDecision::Model);
         // At window distance the tool is weak (+1) evidence, not a mask.
@@ -691,5 +580,17 @@ mod tests {
         assert_eq!(all.len(), 8);
         let to_model = all.iter().filter(|d| **d == RuleDecision::Model).count();
         assert_eq!(to_model, 1, "decisions: {all:?}");
+    }
+
+    /// The fixture's decisions are pinned above; this pins that the
+    /// fixture itself round-trips through the public config type — the
+    /// factory template ships these exact values.
+    #[test]
+    fn eda_fixture_is_valid_config() {
+        let cat = eda_category();
+        assert!(!cat.candidate_patterns.is_empty());
+        assert!(cat.candidate_patterns.len() <= 10);
+        assert!(cat.negative_patterns.len() <= 20);
+        assert!(cat.hotword_groups.len() <= 10);
     }
 }

--- a/crates/aisix-guardrails/src/local_model/tests.rs
+++ b/crates/aisix-guardrails/src/local_model/tests.rs
@@ -1,0 +1,931 @@
+//! Unit + model-backed tests for the semantic guardrail runtime.
+//!
+//! Everything above the `model-backed` marker runs modelless: the rule
+//! layers are pure text work, and [`SemanticRuntime::for_tests_without_model`]
+//! exercises the degrade arms (engine unavailable → model-band spans
+//! release). The `#[ignore]` tests need the real bundle:
+//!   GUARDRAIL_LOCAL_MODEL_DIR=~/.cache/aisix-local-guardrail-mvp \
+//!     cargo test -p aisix-guardrails --features local-model -- --ignored
+//! (`fixtures::ensure_manifest` writes a `manifest.json` next to the
+//! model files on first use, hashing whatever is there.)
+
+use super::*;
+
+/// The factory EDA-version template — the exact category the control
+/// plane ships as its "create from template" preset, kept here as the
+/// fixture every rule/corpus test pins its decisions against. Values
+/// are the MVP's compile-time constants, expressed as config.
+pub(crate) mod fixtures {
+    use super::super::rules::RuleScorer;
+    use super::*;
+
+    pub(crate) const EDA_DOTTED: &str = r"[0-9０-９]+(?:[.．][0-9０-９]+)+";
+    /// Fused version token, letter-before-digit (`IC618`, `T-2022.03`).
+    /// Alnum rims by construction, so sentence punctuation never sticks.
+    pub(crate) const EDA_FUSED_LD: &str =
+        r"[A-Za-z][A-Za-z0-9._-]*[0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?";
+    /// Fused version token, digit-before-letter (`7nm`, `20.09-s003`).
+    pub(crate) const EDA_FUSED_DL: &str =
+        r"[0-9][A-Za-z0-9._-]*[A-Za-z](?:[A-Za-z0-9._-]*[A-Za-z0-9])?";
+
+    pub(crate) fn eda_category() -> SemanticCategory {
+        SemanticCategory {
+            name: "eda_version".into(),
+            description: "EDA 软件的版本号".into(),
+            candidate_patterns: vec![
+                EDA_DOTTED.into(),
+                EDA_FUSED_LD.into(),
+                EDA_FUSED_DL.into(),
+            ],
+            negative_patterns: vec![
+                // Measurement unit right after the span (`12.345 s`,
+                // `4.2 GB`, `0.5 纳秒`, `3.5 个小时`).
+                r"^\s*(?:%|％|(?i:ms|us|ns|ps|fs|s|secs?|seconds?|mins?|minutes?|hours?|[kmgt]i?b|um|nm|[kmg]?hz)(?:[^0-9A-Za-z]|$)|纳秒|微秒|毫秒|秒|分钟|个?(?:小时|钟头|星期|月)|天|纳米|微米|毫米|[兆吉太]字节|[千兆吉]?赫兹|[千兆吉]赫|个?百分点|摄氏度|度(?:[^过]|$)|伏特?|瓦特?|安培|毫安)".into(),
+                // Unit fused into the span's tail (`12.345s`, `3.2GHz`).
+                r"(?i)[0-9](?:%|ms|us|ns|ps|fs|s|secs?|seconds?|mins?|minutes?|hours?|[kmgt]i?b|um|nm|[kmg]?hz)$".into(),
+                // Chinese percent PREFIX form (`百分之 3.5`).
+                r"百分之\s*$".into(),
+                // IPv4-shaped span.
+                r"^\d{1,3}(?:\.\d{1,3}){3}$".into(),
+                // Source location: `file.ext:` before, `:digit` after.
+                r"[\w.-]+\.[A-Za-z0-9]+:$".into(),
+                r"^:\d".into(),
+                // Clock reading prefix (`[10:23:45.123]`).
+                r"[0-9]{1,2}[:：][0-9]{1,2}[:：]$".into(),
+                // Filename-shaped span (dot + 2-4 letter extension).
+                r"(?i)\.[a-z]{2,4}$".into(),
+                // Identifier tag before the span (`编号 GH-2048`);
+                // 版本编号 is carved out and keeps masking.
+                r"(?:^|[^本])编号[:：]?(?:是|为)?\s*$".into(),
+            ],
+            hotword_groups: vec![
+                aisix_core::models::SemanticHotwordGroup {
+                    terms: vec![
+                        "版本号".into(),
+                        "版本".into(),
+                        "升级到".into(),
+                        "回退到".into(),
+                    ],
+                },
+                aisix_core::models::SemanticHotwordGroup {
+                    terms: vec![
+                        "version".into(),
+                        "release".into(),
+                        "build".into(),
+                        "upgrade to".into(),
+                        "upgraded to".into(),
+                    ],
+                },
+                aisix_core::models::SemanticHotwordGroup {
+                    terms: vec![
+                        "virtuoso".into(),
+                        "calibre".into(),
+                        "vcs".into(),
+                        "innovus".into(),
+                        "icc2".into(),
+                        "primetime".into(),
+                    ],
+                },
+            ],
+            action: Some("mask".into()),
+            replacement: Some("***".into()),
+            threshold: None,
+        }
+    }
+
+    pub(crate) fn eda_finder() -> CandidateFinder {
+        let cat = eda_category();
+        CandidateFinder::new(
+            cat.candidate_patterns
+                .iter()
+                .map(|p| Regex::new(p).expect("fixture pattern compiles"))
+                .collect(),
+        )
+    }
+
+    pub(crate) fn eda_scorer(proximity_chars: usize) -> RuleScorer {
+        let cat = eda_category();
+        let groups: Vec<Vec<String>> = cat.hotword_groups.iter().map(|g| g.terms.clone()).collect();
+        let negatives = cat
+            .negative_patterns
+            .iter()
+            .map(|p| (Regex::new(p).expect("fixture pattern compiles"), p.clone()))
+            .collect();
+        RuleScorer::compile(proximity_chars, &groups, negatives).expect("fixture terms compile")
+    }
+
+    /// Write a `manifest.json` next to the model files when absent,
+    /// hashing whatever the directory holds — the test-side counterpart
+    /// of the release bundle's pinned manifest.
+    pub(crate) fn ensure_manifest(dir: &Path) {
+        let path = dir.join("manifest.json");
+        if path.exists() {
+            return;
+        }
+        let mut files = serde_json::Map::new();
+        for name in ["model.onnx", "tokenizer.json"] {
+            let bytes = std::fs::read(dir.join(name)).expect("model file present");
+            files.insert(
+                name.to_owned(),
+                serde_json::Value::String(format!("sha256:{}", hex_digest(&bytes))),
+            );
+        }
+        let manifest = serde_json::json!({
+            "manifest_version": 1,
+            "model_id": "ibm-granite/granite-embedding-97m-multilingual-r2",
+            "embedding_dim": 384,
+            "files": files,
+            "calibration": { "description": 0.80 },
+        });
+        std::fs::write(&path, serde_json::to_vec_pretty(&manifest).unwrap())
+            .expect("write test manifest");
+    }
+
+    /// The real-model runtime, or `None` when [`MODEL_DIR_ENV`] is
+    /// unset (the `#[ignore]` tests no-op then).
+    pub(crate) fn model_runtime(lanes: usize) -> Option<SemanticRuntime> {
+        let dir = PathBuf::from(std::env::var_os(MODEL_DIR_ENV)?);
+        ensure_manifest(&dir);
+        Some(SemanticRuntime::load(dir, lanes, None).expect("model bundle verifies"))
+    }
+
+    pub(crate) fn model_guardrail() -> Option<SemanticGuardrail> {
+        let rt = Arc::new(model_runtime(1)?);
+        Some(
+            SemanticGuardrail::from_config(rt, &[eda_category()], GuardrailHookPoint::Both)
+                .expect("fixture compiles"),
+        )
+    }
+}
+
+use fixtures::*;
+
+fn spans_of(text: &str) -> Vec<Range<usize>> {
+    eda_finder().spans(text)
+}
+
+fn values_of(text: &str) -> Vec<&str> {
+    spans_of(text).into_iter().map(|s| &text[s]).collect()
+}
+
+fn modelless_guardrail() -> SemanticGuardrail {
+    SemanticGuardrail::from_config(
+        Arc::new(SemanticRuntime::for_tests_without_model()),
+        &[eda_category()],
+        GuardrailHookPoint::Both,
+    )
+    .expect("fixture compiles")
+}
+
+#[test]
+fn candidate_spans_find_dotted_runs_only() {
+    let text = "版本是 12.1,构建号 2022.4.1,端口 8080";
+    // Plain integers are still not candidates.
+    assert_eq!(values_of(text), vec!["12.1", "2022.4.1"]);
+}
+
+#[test]
+fn candidate_spans_find_fused_tokens_whole() {
+    // The adversarial-corpus shapes: version fused with the tool
+    // name / letter affixes into ONE token — the candidate is the
+    // whole token, not its dotted substring.
+    for (text, want) in [
+        ("Virtuoso IC618 又崩了", "IC618"),
+        ("版图工具用的是 ICADV12.3", "ICADV12.3"),
+        ("XCELIUM2309 的仿真结果对不上", "XCELIUM2309"),
+        ("MMSIM151 装在新机器上了", "MMSIM151"),
+        ("综合用的 T-2022.03 有已知问题", "T-2022.03"),
+        ("回退到 E-2010.12-ICC-SP2 就不崩了", "E-2010.12-ICC-SP2"),
+        ("装的是 v16.12-s051_1 这个版本", "v16.12-s051_1"),
+        ("hotfix 20.09-s003 已经推送了", "20.09-s003"),
+        ("7nm 工艺下功耗有点高", "7nm"),
+        ("这个块是 N5 工艺的", "N5"),
+    ] {
+        assert_eq!(values_of(text), vec![want], "text: {text}");
+    }
+}
+
+#[test]
+fn candidate_spans_find_fullwidth_dotted_runs() {
+    assert_eq!(values_of("版本是 １２．１,不要外传"), vec!["１２．１"]);
+    // Mixed-width digits with a fullwidth dot still form one run.
+    assert_eq!(values_of("旧版是 ２０２２．4"), vec!["２０２２．4"]);
+}
+
+#[test]
+fn fused_tokens_exclude_rim_punctuation() {
+    // Sentence punctuation must not stick to a fused token — the
+    // template patterns require alphanumeric rims by construction.
+    assert_eq!(values_of("pinned to v16.12-s051_1."), vec!["v16.12-s051_1"]);
+    // A pure word and a pure dash-number never become fused tokens.
+    assert_eq!(values_of("high-performance run -3.5 offset"), vec!["3.5"]);
+}
+
+#[test]
+fn candidate_dedupe_keeps_standalone_dotted_runs_between_fused_tokens() {
+    // Interleaved fused and dotted candidates: the de-overlap must drop
+    // exactly the dotted runs inside fused tokens and keep the
+    // standalone ones.
+    let text = "v1.2-a 3.4 IC5.6 7.8 soc9.9x 10.11";
+    assert_eq!(
+        values_of(text),
+        vec!["v1.2-a", "3.4", "IC5.6", "7.8", "soc9.9x", "10.11"]
+    );
+}
+
+#[test]
+fn candidate_generation_stays_linear_on_floods() {
+    // The audit measured a pre-fix quadratic dedupe at 17.6 s of
+    // synchronous CPU for a 1 MiB `"1.1 "` flood. Linear generation
+    // does this in tens of milliseconds; the bound leaves two orders
+    // of magnitude of CI headroom.
+    let flood = "1.1 ".repeat(256 * 1024); // 1 MiB
+    let started = Instant::now();
+    let spans = eda_finder().spans(&flood);
+    assert_eq!(spans.len(), 256 * 1024);
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(10),
+        "candidate generation took {:?} on a 1 MiB flood",
+        started.elapsed()
+    );
+}
+
+#[test]
+fn candidate_spans_drop_oversized_runs() {
+    // A crafted `1.1.1...` run over the byte cap is one regex match
+    // but NOT a candidate — it must vanish before budget accounting.
+    let bomb = "1.1".repeat(60); // 180 bytes, single match
+    let text = format!("前缀 {bomb} 中缀 12.1 后缀");
+    assert_eq!(values_of(&text), vec!["12.1"]);
+}
+
+#[test]
+fn window_bounds_snap_to_char_boundaries() {
+    let text = "这个 EDA 软件的版本是 12.1,请勿外传";
+    let span = spans_of(text).remove(0);
+    // A tiny context still lands on char boundaries around CJK.
+    let w = window_bounds(text, &span, 3);
+    let window = &text[w];
+    assert!(window.contains("12.1"), "window: {window}");
+    assert_eq!(window, "本是 12.1,请勿");
+}
+
+#[test]
+fn window_bounds_clamp_to_text_edges() {
+    let text = "12.1 只有后文";
+    let span = spans_of(text).remove(0);
+    let w = window_bounds(text, &span, 50);
+    assert_eq!(&text[w], text);
+}
+
+#[test]
+fn apply_masks_rewrites_right_to_left() {
+    let text = "从 12.1 升到 13.0 了";
+    let spans = spans_of(text);
+    assert_eq!(apply_masks(text, &spans, "***"), "从 *** 升到 *** 了");
+}
+
+#[test]
+fn default_mask_token_folds_the_name() {
+    assert_eq!(default_mask_token("eda_version"), "[EDA_VERSION_REDACTED]");
+    assert_eq!(default_mask_token("身份证"), "[____REDACTED]");
+}
+
+#[test]
+fn parse_lanes_defaults_and_clamps() {
+    assert_eq!(parse_lanes(None), 1);
+    assert_eq!(parse_lanes(Some("")), 1);
+    assert_eq!(parse_lanes(Some("abc")), 1);
+    assert_eq!(parse_lanes(Some("-2")), 1);
+    assert_eq!(parse_lanes(Some("0")), 1);
+    assert_eq!(parse_lanes(Some("4")), 4);
+    assert_eq!(parse_lanes(Some("9999")), MAX_LANES);
+}
+
+// ── category compilation ─────────────────────────────────────────────────
+
+#[test]
+fn compile_rejects_duplicate_category_names() {
+    let cats = vec![eda_category(), eda_category()];
+    assert!(matches!(
+        compile_categories(&cats, 0.8),
+        Err(CategoryCompileError::DuplicateName { .. })
+    ));
+}
+
+#[test]
+fn compile_rejects_non_mask_actions() {
+    let mut cat = eda_category();
+    cat.action = Some("block".into());
+    assert!(matches!(
+        compile_categories(&[cat], 0.8),
+        Err(CategoryCompileError::UnsupportedAction { .. })
+    ));
+}
+
+#[test]
+fn compile_rejects_invalid_regex_and_empty_candidates() {
+    let mut cat = eda_category();
+    cat.candidate_patterns = vec!["(".into()];
+    assert!(matches!(
+        compile_categories(&[cat], 0.8),
+        Err(CategoryCompileError::InvalidRegex { .. })
+    ));
+    let mut cat = eda_category();
+    cat.candidate_patterns.clear();
+    assert!(matches!(
+        compile_categories(&[cat], 0.8),
+        Err(CategoryCompileError::NoCandidatePatterns { .. })
+    ));
+}
+
+#[test]
+fn compile_resolves_threshold_and_replacement_defaults() {
+    let mut cat = eda_category();
+    cat.replacement = None;
+    cat.threshold = None;
+    let compiled = compile_categories(&[cat], 0.75).unwrap();
+    assert_eq!(compiled[0].threshold, 0.75);
+    assert_eq!(compiled[0].replacement, "[EDA_VERSION_REDACTED]");
+    let mut cat = eda_category();
+    cat.threshold = Some(0.9);
+    let compiled = compile_categories(&[cat], 0.75).unwrap();
+    assert_eq!(compiled[0].threshold, 0.9);
+}
+
+// ── manifest verification ────────────────────────────────────────────────
+
+fn write_bundle(dir: &Path, corrupt: bool) {
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(dir.join("model.onnx"), b"fake model bytes").unwrap();
+    std::fs::write(dir.join("tokenizer.json"), b"{}").unwrap();
+    let model_hash = if corrupt {
+        "0".repeat(64)
+    } else {
+        hex_digest(b"fake model bytes")
+    };
+    let manifest = serde_json::json!({
+        "manifest_version": 1,
+        "model_id": "test/fake",
+        "embedding_dim": 4,
+        "files": {
+            "model.onnx": format!("sha256:{model_hash}"),
+            "tokenizer.json": format!("sha256:{}", hex_digest(b"{}")),
+        },
+        "calibration": { "description": 0.80 },
+    });
+    std::fs::write(
+        dir.join("manifest.json"),
+        serde_json::to_vec(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn manifest_verifies_and_rejects_corruption() {
+    let dir = std::env::temp_dir().join(format!(
+        "aisix-semantic-manifest-test-{}",
+        std::process::id()
+    ));
+    let good = dir.join("good");
+    write_bundle(&good, false);
+    let m = ModelManifest::load_and_verify(&good).expect("good bundle verifies");
+    assert_eq!(m.model_id, "test/fake");
+    assert_eq!(m.embedding_dim, 4);
+    assert!((m.calibration.description - 0.80).abs() < f32::EPSILON);
+
+    let bad = dir.join("bad");
+    write_bundle(&bad, true);
+    let err = ModelManifest::load_and_verify(&bad).unwrap_err();
+    assert!(
+        err.to_string().contains("sha256 mismatch"),
+        "unexpected error: {err}"
+    );
+
+    let missing = dir.join("missing");
+    assert!(ModelManifest::load_and_verify(&missing).is_err());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn manifest_rejects_traversal_file_names() {
+    let dir = std::env::temp_dir().join(format!(
+        "aisix-semantic-manifest-traversal-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let manifest = serde_json::json!({
+        "manifest_version": 1,
+        "model_id": "test/fake",
+        "embedding_dim": 4,
+        "files": {
+            "model.onnx": "sha256:00",
+            "tokenizer.json": "sha256:00",
+            "../escape": "sha256:00",
+        },
+        "calibration": { "description": 0.80 },
+    });
+    std::fs::write(
+        dir.join("manifest.json"),
+        serde_json::to_vec(&manifest).unwrap(),
+    )
+    .unwrap();
+    let err = ModelManifest::load_and_verify(&dir).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid file name"),
+        "unexpected error: {err}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ── modelless guardrail behavior (rule layers + degrade arms) ────────────
+
+#[tokio::test]
+async fn rule_layer_masks_without_a_model() {
+    let g = modelless_guardrail();
+    let outcome = g
+        .moderate_input_segments(&["这个 EDA 软件的版本是 12.1".to_owned()])
+        .await;
+    assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
+    let masked = outcome.masked.expect("rule layer masks");
+    assert_eq!(masked[0], "这个 EDA 软件的版本是 ***");
+    assert_eq!(outcome.counts.get("eda_version"), Some(&1));
+}
+
+#[tokio::test]
+async fn model_band_releases_when_engine_unavailable() {
+    // No lexical evidence → model band; the test runtime's engine never
+    // initializes, so the span degrades to release (fail-open) instead
+    // of blocking or stalling.
+    let g = modelless_guardrail();
+    let outcome = g
+        .moderate_input_segments(&["圆周率约等于 3.14159".to_owned()])
+        .await;
+    assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
+    assert!(outcome.masked.is_none());
+    assert!(outcome.counts.is_empty());
+}
+
+#[tokio::test]
+async fn hook_point_gates_the_segment_hooks() {
+    let g = SemanticGuardrail::from_config(
+        Arc::new(SemanticRuntime::for_tests_without_model()),
+        &[eda_category()],
+        GuardrailHookPoint::Input,
+    )
+    .unwrap();
+    let texts = vec!["版本是 12.1".to_owned()];
+    assert!(g.moderate_input_segments(&texts).await.masked.is_some());
+    assert!(g.moderate_output_segments(&texts).await.masked.is_none());
+    assert!(!g.runs_on_output());
+}
+
+#[tokio::test]
+async fn categories_compose_and_count_separately() {
+    let mut second = eda_category();
+    second.name = "ticket_id".into();
+    second.description = "工单编号".into();
+    second.candidate_patterns = vec![r"JIRA-\d+".into()];
+    second.negative_patterns = vec![];
+    second.hotword_groups = vec![aisix_core::models::SemanticHotwordGroup {
+        terms: vec!["工单".into()],
+    }];
+    second.replacement = None; // default token
+    let g = SemanticGuardrail::from_config(
+        Arc::new(SemanticRuntime::for_tests_without_model()),
+        &[eda_category(), second],
+        GuardrailHookPoint::Both,
+    )
+    .unwrap();
+    let outcome = g
+        .moderate_input_segments(&["版本是 12.1,工单 JIRA-1024".to_owned()])
+        .await;
+    let masked = outcome.masked.expect("both categories mask");
+    assert_eq!(masked[0], "版本是 ***,工单 [TICKET_ID_REDACTED]");
+    assert_eq!(outcome.counts.get("eda_version"), Some(&1));
+    assert_eq!(outcome.counts.get("ticket_id"), Some(&1));
+}
+
+// ── model-backed tests (need the real model files) ──────────────────────
+
+fn load_model_guardrail() -> Option<SemanticGuardrail> {
+    fixtures::model_guardrail()
+}
+
+/// A candidate flood past [`MAX_RULE_SCORED_SPANS_PER_SEGMENT`]
+/// releases the tail unscored: a rule-maskable sentence hidden
+/// beyond the cap stays untouched (fail-open — rewrite less, never
+/// stall), and the flood burns at most the model-call budget.
+#[tokio::test]
+#[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with the model bundle"]
+async fn candidate_flood_releases_the_tail() {
+    let Some(g) = load_model_guardrail() else {
+        return;
+    };
+    let flood = "1.1 ".repeat(MAX_RULE_SCORED_SPANS_PER_SEGMENT);
+    // Padding wider than the ±50-char context window between the
+    // flood and the bait sentence, so the test measures the cap, not
+    // window contamination. The padding word is letters-only — not a
+    // candidate.
+    let text = format!("{flood}{} 这个 EDA 软件的版本是 12.1", "x".repeat(60));
+    let outcome = g.moderate_input_segments(&[text]).await;
+    assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
+    assert!(
+        outcome.masked.is_none(),
+        "the over-cap tail must be released unscored"
+    );
+}
+
+/// The acceptance matrix end to end through the segment hook, on the
+/// default configuration: both hard positives and the MVP acceptance
+/// positive are rewritten; every hard negative comes back untouched
+/// (`masked == None` ⇒ byte-identical passthrough upstream).
+#[tokio::test]
+#[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with the model bundle"]
+async fn acceptance_matrix_end_to_end() {
+    let Some(g) = load_model_guardrail() else {
+        return;
+    };
+    let masked_cases = [
+        ("这个 EDA 软件的版本是 12.1", "这个 EDA 软件的版本是 ***"),
+        (
+            "我们把仿真工具升级到 2022.4 之后速度快了很多",
+            "我们把仿真工具升级到 *** 之后速度快了很多",
+        ),
+        // Whole-token rewrite: the fused `IC6.1.8` is ONE candidate,
+        // so the tool-fused prefix does not survive.
+        ("Virtuoso IC6.1.8 出现了崩溃", "Virtuoso *** 出现了崩溃"),
+        ("Virtuoso IC618 又崩了", "Virtuoso *** 又崩了"),
+        ("版本是 １２．１,不要外传", "版本是 ***,不要外传"),
+    ];
+    for (input, want) in masked_cases {
+        let outcome = g.moderate_input_segments(&[input.to_owned()]).await;
+        assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
+        let masked = outcome
+            .masked
+            .unwrap_or_else(|| panic!("must mask: {input}"));
+        assert_eq!(masked[0], want);
+    }
+    let passthrough_cases = [
+        "Elapsed: 12.345s, Memory: 4.2 GB",
+        "服务器的 IP 地址是 10.2.255.1",
+        "圆周率约等于 3.14159",
+        "工艺节点是 0.13um,良率还行",
+        "整个 build 花了 45.5 秒",
+        "[10:23:45.123] build started",
+    ];
+    for input in passthrough_cases {
+        let outcome = g.moderate_input_segments(&[input.to_owned()]).await;
+        assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
+        assert!(
+            outcome.masked.is_none(),
+            "negative must pass untouched: {input} → {:?}",
+            outcome.masked
+        );
+    }
+}
+
+/// The acceptance path in miniature: the segment hook masks the
+/// version number and only the version number.
+#[tokio::test]
+#[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with the model bundle"]
+async fn masks_acceptance_sentence() {
+    let Some(g) = load_model_guardrail() else {
+        return;
+    };
+    let texts = vec!["这个 EDA 软件的版本是 12.1".to_owned()];
+    let outcome = g.moderate_input_segments(&texts).await;
+    assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
+    let masked = outcome.masked.expect("must mask the version number");
+    assert_eq!(masked[0], "这个 EDA 软件的版本是 ***");
+    assert_eq!(outcome.counts.get("eda_version"), Some(&1));
+}
+
+/// Lanes are interchangeable and safe under concurrency: with a
+/// 2-lane pool, 8 concurrent embeds of the same window all succeed
+/// and agree (sessions share nothing but identical weights, and a
+/// single-threaded run is deterministic).
+#[tokio::test]
+#[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with the model bundle"]
+async fn lanes_run_concurrently_and_agree() {
+    let Some(rt) = fixtures::model_runtime(2).map(Arc::new) else {
+        return;
+    };
+    let window = "这个 EDA 软件的版本是 12.1,请确认兼容性";
+    let tasks: Vec<_> = (0..8)
+        .map(|_| {
+            let rt = Arc::clone(&rt);
+            tokio::spawn(async move { rt.embed_text(window.to_owned()).await })
+        })
+        .collect();
+    let mut vectors = Vec::new();
+    for t in tasks {
+        vectors.push(t.await.unwrap().expect("concurrent embed failed"));
+    }
+    let reference = &vectors[0];
+    for v in &vectors[1..] {
+        let agreement = cosine(v, reference);
+        assert!(agreement > 0.9999, "lanes disagree: cosine {agreement}");
+    }
+}
+
+/// Throughput calibration: lanes come from the runtime constructor, so
+/// one binary sweeps 1/2/4 lanes via GUARDRAIL_LOCAL_MODEL_LANES.
+#[tokio::test]
+#[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with the model bundle"]
+async fn probe_lane_throughput() {
+    let lanes = parse_lanes(std::env::var(LANES_ENV).ok().as_deref());
+    let Some(rt) = fixtures::model_runtime(lanes).map(Arc::new) else {
+        return;
+    };
+    let window = "这个 EDA 软件的版本是 12.1,请确认与工艺库的兼容性之后再安排回归测试";
+    for _ in 0..3 {
+        rt.embed_text(window.to_owned()).await.unwrap();
+    }
+    // Saturating batches sized under LANE_WAIT_TIMEOUT (the runtime
+    // sheds queue waits past 500ms by design, so an unbounded burst
+    // would measure the shed path, not throughput).
+    let total = 64usize;
+    let batch = 8usize;
+    let started = Instant::now();
+    for _ in 0..total / batch {
+        let tasks: Vec<_> = (0..batch)
+            .map(|_| {
+                let rt = Arc::clone(&rt);
+                tokio::spawn(async move { rt.embed_text(window.to_owned()).await })
+            })
+            .collect();
+        for t in tasks {
+            t.await.unwrap().expect("embed failed");
+        }
+    }
+    let secs = started.elapsed().as_secs_f64();
+    println!(
+        "lanes={lanes} total={total} wall={secs:.2}s throughput={:.1} inferences/s",
+        total as f64 / secs
+    );
+}
+
+/// Rough single-inference latency figure.
+#[tokio::test]
+#[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with the model bundle"]
+async fn probe_inference_latency() {
+    let Some(rt) = fixtures::model_runtime(1) else {
+        return;
+    };
+    let window = "这个 EDA 软件的版本是 12.1,请确认与工艺库的兼容性之后再安排回归测试".to_owned();
+    for _ in 0..3 {
+        rt.embed_text(window.clone()).await.unwrap();
+    }
+    let mut samples = Vec::new();
+    for _ in 0..20 {
+        let t = Instant::now();
+        rt.embed_text(window.clone()).await.unwrap();
+        samples.push(t.elapsed().as_micros() as u64);
+    }
+    samples.sort_unstable();
+    println!(
+        "inference us over 20 runs: p50={} min={} max={}",
+        samples[samples.len() / 2],
+        samples[0],
+        samples[samples.len() - 1]
+    );
+}
+
+/// The calibration probe matrix, kept as the report instrument for the
+/// sample-based strategies (v2 material): the same 7 probe windows as
+/// the MVP sweep scored against 5 single-description prototype
+/// phrasings plus the two sample-set constructions, in both the
+/// absolute and relative scoring forms.
+#[tokio::test]
+#[ignore = "needs GUARDRAIL_LOCAL_MODEL_DIR with the model bundle"]
+async fn probe_similarity_matrix() {
+    /// The v2 sample material (probe fixtures): positive phrasings by
+    /// SHAPE and negative number-semantics families. See the design
+    /// issue for the curation rules.
+    const PROTOTYPE_SAMPLES: &[&str] = &[
+        "布局布线工具升级到 21.15 之后跑得快多了",
+        "仿真器回退到 19.03 才恢复正常",
+        "这个后端工具的版本是 33.0",
+        "综合工具的版本号是 2020.09,不要外传",
+        "Spectre 23.1.0 在这个工艺角下会崩溃",
+        "签核工具装的是 22.4 这个版本",
+        "时序工具从 18.1 换到 20.2 就没再出过问题",
+        "现在生产环境跑的是 16.3 那个版本的布线器",
+        "形式验证工具还停在 10.6,太老了",
+        "装了 31.2 之后 license 就报错",
+        "版图工具的补丁版本是 QSV302",
+        "提取工具升级到 QRC1921 以后内存翻倍",
+        "DRC 用的签核包是 K-2019.06-SP1",
+        "那台机器装的仿真器是 v14.2-p004",
+        "We upgraded the place-and-route tool to 21.15",
+        "The simulator crashed on release 6.2.1",
+        "The sign-off tool version is 2020.09",
+        "Genus 19.13 fails on this floorplan",
+        "the flow needs tool build 30.4 or newer",
+        "we rolled back to 17.0 after the crash",
+        "they still run SPECTRE181 in production",
+        "the timing box has PT-2021.06-SP3 installed",
+        "our extraction flow is pinned to v19.1-s022_2",
+        "the older 14.7 install still passes DRC",
+    ];
+    const NEGATIVE_PROTOTYPE_SAMPLES: &[&str] = &[
+        "圆周率约是 3.1416",
+        "自然常数 e 约等于 2.71828",
+        "黄金分割比大约是 1.618",
+        "根号二约等于 1.41421",
+        "pi is roughly 3.1416",
+        "the golden ratio is about 1.618",
+        "今天美元兑人民币汇率是 7.18",
+        "欧元汇率涨到 7.92",
+        "股价收在 24.35",
+        "年化利率是 3.65",
+        "the exchange rate moved to 7.15",
+        "the stock closed at 132.5 today",
+        "早上量体温 36.6,正常",
+        "孩子昨晚烧到 39.2",
+        "空腹血糖 5.2,没问题",
+        "体重降到 62.5 公斤了",
+        "her temperature was 37.8 last night",
+        "resting heart rate dropped to 58.5",
+        "会议改到 9.28 上午十点",
+        "项目截止日期是 2026.10.31",
+        "10.1 假期值班表出来了",
+        "发票日期写的 2025.12.05",
+        "the review is scheduled for 11.20",
+        "the contract was signed on 2026.4.30",
+        "这批晶圆一共 8.5 万片",
+        "平均每天触发 4.5 次告警",
+        "样本均值 6.35,标准差 1.2",
+        "库存还剩 3.5 箱",
+        "we shipped 2.4 million units last year",
+        "the average queue depth is 5.5",
+        "排队等了 3.5 个星期",
+        "面试聊了 1.5 个钟头",
+        "整个流程走了 4.5 个月",
+        "assembly 那步要等 2.5 个工作日",
+        "it took 2.5 weeks end to end",
+        "the outage lasted 3.5 days",
+        "结温升到 88.5 度就限频",
+        "内核电压是 0.72 伏",
+        "整机功耗 5.5 瓦左右",
+        "环境温度 23.5 度恒温",
+        "the die temperature hit 95.5 degrees",
+        "supply voltage sagged to 0.66 volts",
+        "die 面积是 15.21 平方毫米",
+        "键合线直径 25.4 微米",
+        "这条走线长 3.6 毫米",
+        "硅片厚度 0.775 毫米",
+        "the package is 10.5 by 10.5 millimeters",
+        "the wafer is 0.725 millimeters thick",
+        "主力工艺切到 N2 了",
+        "这个块还在 N16 上",
+        "新项目评估 4nm 的 PDK",
+        "老产品线停留在 14nm",
+        "the pilot line runs N6",
+        "we are qualifying the 3nm flow",
+        "客户满意度打了 9.2 分",
+        "评审平均分 8.65",
+        "基准测试跑分 456.5",
+        "良率这周爬到 91.5",
+        "the benchmark scores 78.5 overall",
+        "approval rating sits at 62.5",
+        "详见第 2.4 节",
+        "规范的 5.3.1 条款有说明",
+        "图 4.2 画的是数据通路",
+        "表 6.1 列出了引脚定义",
+        "see section 3.4.2 of the spec",
+        "chapter 12.3 covers the protocol",
+        "日志停在 11:42:07.333",
+        "[07:03:59.001] job finished",
+        "晚上 20.45 的班车",
+        "闹钟定在 6.30",
+        "the cron fires at 23.55 every night",
+        "the shuttle leaves at 8.15",
+        "0.2 0.4 0.6 0.8 1.0 1.2",
+        "数据列是 2.2 4.4 6.6 8.8",
+        "表里那列全是 1.3 2.6 3.9 5.2 这种数",
+        "the raw dump reads 0.5 1.5 2.5 3.5 4.5",
+        "column two is 9.1 8.2 7.3 6.4",
+        "坐标序列 10.5 20.5 30.5 40.5",
+        "配置都在 setup2.cfg 里",
+        "commit 是 f00dbabe42 那个",
+        "工单编号是 JIRA-1024",
+        "the log lives in run5.txt",
+        "the checksum is 9f8e7d6c5b",
+        "先过 802.3af 认证再说",
+        "换成 gpt-5.2 再试一次",
+        "这个 bug 用 llama-3.1 也能复现",
+        "显卡是 RTX4090",
+        "主控芯片是 BCM2712",
+        "the endpoint serves claude-haiku-4.5",
+        "the box ships with an RTX4080 inside",
+    ];
+
+    /// L2-renormalized mean of a set of L2-normalized vectors.
+    fn centroid(vectors: &[Vec<f32>]) -> Vec<f32> {
+        let dim = vectors.first().map_or(0, Vec::len);
+        let mut mean = vec![0.0f32; dim];
+        for v in vectors {
+            for (m, x) in mean.iter_mut().zip(v) {
+                *m += x;
+            }
+        }
+        let norm = mean.iter().map(|v| v * v).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for m in &mut mean {
+                *m /= norm;
+            }
+        }
+        mean
+    }
+
+    struct PrototypeSet {
+        positive: Vec<Vec<f32>>,
+        negative: Vec<Vec<f32>>,
+    }
+    impl PrototypeSet {
+        fn score(&self, v: &[f32]) -> f32 {
+            let pos = max_cosine(&self.positive, v);
+            if self.negative.is_empty() {
+                pos
+            } else {
+                pos - max_cosine(&self.negative, v)
+            }
+        }
+    }
+
+    let Some(rt) = fixtures::model_runtime(1) else {
+        return;
+    };
+    let phrasings = [
+        "EDA 软件的版本号",
+        "软件版本号",
+        "芯片设计软件的版本号",
+        "提到了 EDA 工具的具体版本号",
+        "EDA 软件的版本信息,比如某个工具的版本是 12.1",
+    ];
+    let windows = [
+        ("ACC", "这个 EDA 软件的版本是 12.1,请确认兼容性"),
+        ("POS", "我们把仿真工具升级到 2022.4 之后速度快了很多"),
+        ("POS", "Virtuoso IC6.1.8 出现了崩溃"),
+        ("NEG", "Elapsed: 12.345s, Memory: 4.2 GB"),
+        ("NEG", "服务器的 IP 地址是 10.2.255.1"),
+        ("NEG", "圆周率约等于 3.14159"),
+        ("NEG", "工艺节点是 0.13um,良率还行"),
+    ];
+
+    let mut columns: Vec<(String, PrototypeSet)> = Vec::new();
+    for p in phrasings {
+        let v = rt.embed_text(p.to_owned()).await.unwrap();
+        columns.push((
+            format!("desc:{p}"),
+            PrototypeSet {
+                positive: vec![v],
+                negative: Vec::new(),
+            },
+        ));
+    }
+    let mut pos = Vec::new();
+    for s in PROTOTYPE_SAMPLES {
+        pos.push(rt.embed_text((*s).to_owned()).await.unwrap());
+    }
+    let mut neg = Vec::new();
+    for s in NEGATIVE_PROTOTYPE_SAMPLES {
+        neg.push(rt.embed_text((*s).to_owned()).await.unwrap());
+    }
+    columns.push((
+        "samples-max".to_owned(),
+        PrototypeSet {
+            positive: pos.clone(),
+            negative: neg.clone(),
+        },
+    ));
+    columns.push((
+        "samples-centroid".to_owned(),
+        PrototypeSet {
+            positive: vec![centroid(&pos)],
+            negative: vec![centroid(&neg)],
+        },
+    ));
+
+    for (name, set) in &columns {
+        let mut margins = [(f32::INFINITY, f32::NEG_INFINITY); 2]; // abs, rel
+        println!("── column: {name}");
+        for (kind, text) in windows {
+            let v = rt.embed_text(text.to_owned()).await.unwrap();
+            let abs = max_cosine(&set.positive, &v);
+            let rel = set.score(&v);
+            println!("  {kind} abs {abs:.4} rel {rel:+.4}  {text}");
+            for (m, s) in margins.iter_mut().zip([abs, rel]) {
+                match kind {
+                    "POS" => m.0 = m.0.min(s),
+                    "NEG" => m.1 = m.1.max(s),
+                    _ => {}
+                }
+            }
+        }
+        let [abs_m, rel_m] = margins.map(|(p, n)| p - n);
+        println!("  hard margin (min POS − max NEG): abs {abs_m:+.4} rel {rel_m:+.4}");
+    }
+}

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -158,6 +158,20 @@ pub const M_USAGE_EVENT_DROPS_TOTAL: &str = "aisix_usage_event_drops_total";
 /// `/v1/messages` path in — read these as chat-path, not gateway-wide.
 pub const M_GUARDRAIL_BLOCKS_TOTAL: &str = "aisix_guardrail_blocks_total";
 pub const M_GUARDRAIL_BYPASSES_TOTAL: &str = "aisix_guardrail_bypasses_total";
+
+/// Semantic guardrail runtime series (#1363).
+/// `aisix_guardrail_semantic_model_calls_total` counts embedding-model
+/// inferences (window judgements and description-prototype embeds).
+/// `aisix_guardrail_semantic_degraded_total{reason}` counts spans or
+/// categories that fell back to the rule layers instead of getting
+/// their embedding judgement; `reason` is the runtime's bounded degrade
+/// vocabulary (`engine_failed` / `prototype_unavailable` /
+/// `budget_exhausted` / `queue_timeout` / `inference_failed`). A
+/// non-zero degrade rate is the operator's signal that semantic rows
+/// are running on lexical evidence alone.
+pub const M_GUARDRAIL_SEMANTIC_MODEL_CALLS_TOTAL: &str =
+    "aisix_guardrail_semantic_model_calls_total";
+pub const M_GUARDRAIL_SEMANTIC_DEGRADED_TOTAL: &str = "aisix_guardrail_semantic_degraded_total";
 /// Per-request inbound authentication decisions
 /// (AISIX-Cloud#1080/#1081). Before this series, a rejected credential
 /// was invisible: the auth extractor short-circuits ahead of every
@@ -2076,6 +2090,29 @@ impl Metrics {
 impl aisix_core::GuardrailMetricsSink for Metrics {
     fn record_guardrail_execution(&self, exec: &aisix_core::GuardrailExecution<'_>) {
         Metrics::record_guardrail_execution(self, exec);
+    }
+
+    fn record_semantic_model_call(&self) {
+        self.cached_counter(
+            M_GUARDRAIL_SEMANTIC_MODEL_CALLS_TOTAL,
+            1,
+            |_| {},
+            || metrics::counter!(M_GUARDRAIL_SEMANTIC_MODEL_CALLS_TOTAL),
+        );
+    }
+
+    fn record_semantic_degrade(&self, reason: &'static str) {
+        self.cached_counter(
+            M_GUARDRAIL_SEMANTIC_DEGRADED_TOTAL,
+            1,
+            |k| k.label(reason),
+            || {
+                metrics::counter!(
+                    M_GUARDRAIL_SEMANTIC_DEGRADED_TOTAL,
+                    "reason" => reason,
+                )
+            },
+        );
     }
 }
 

--- a/crates/aisix-proxy/Cargo.toml
+++ b/crates/aisix-proxy/Cargo.toml
@@ -32,6 +32,10 @@ aisix-obs = { path = "../aisix-obs" }
 aisix-ratelimit = { path = "../aisix-ratelimit" }
 aisix-cache = { path = "../aisix-cache" }
 aisix-guardrails = { path = "../aisix-guardrails" }
+# NOTE: the `local-model-guardrail` feature below forwards to
+# aisix-guardrails/local-model so `kind: "semantic"` rows can be
+# exercised in this crate's tests; the server crate enables it by
+# default (#1363).
 tokio.workspace = true
 axum.workspace = true
 reqwest.workspace = true
@@ -88,3 +92,10 @@ tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
 wiremock.workspace = true
 # Captures the auth-denial log lines so their per-request fields are pinned.
 tracing-subscriber.workspace = true
+
+[features]
+# Forwarded to the guardrails crate so `kind: "semantic"` rows resolve
+# to a real runtime guardrail (#1363). The server crate enables this by
+# default; it is a feature here only so `cargo test -p aisix-proxy`
+# stays buildable without the ONNX Runtime link.
+local-model-guardrail = ["aisix-guardrails/local-model"]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1285,30 +1285,14 @@ async fn dispatch(
     let applied_guardrails = resolved.applied().to_vec();
     *applied_out = applied_guardrails.clone();
     // Taken HERE for the same reason `applied()` is: below, the concrete
-    // chain is erased to `Arc<dyn Guardrail>` and — when a local-model
-    // guardrail is configured — re-wrapped with `GuardrailChain::new`,
-    // which leaves the new outer chain's audit log unset. Reading the
-    // handle after that point would return `None` and every enforced hit
-    // on the chat path would go unattributed while every other endpoint
-    // reported normally. The inner chain keeps its own recorders, so its
-    // members still write here (AISIX-Cloud#1330 / #1024).
+    // chain is erased to `Arc<dyn Guardrail>`, which has no `audit_log()`
+    // (AISIX-Cloud#1330 / #1024). The semantic guardrail rides the
+    // resolved chain as an ordinary `kind: "semantic"` row (#1363) —
+    // the MVP-era env-injected re-wrap that used to lose this handle is
+    // gone.
     *audit_out = resolved.audit_log();
     let resolved_chain: std::sync::Arc<dyn aisix_guardrails::Guardrail> =
         std::sync::Arc::new(resolved);
-    // AISIX-Cloud#1331 MVP: the env-injected local-model guardrail joins
-    // AFTER the attachment-resolved chain (its segment masks compose on
-    // the chain's output; nested-chain folds filter their own members, so
-    // wrapping is safe). Deployment-wide + mask-only, not a row: it has no
-    // `applied()` entry and never blocks. MVP wiring is chat-only; the
-    // sibling endpoint families are a tracked gap on the design issue.
-    let resolved_chain: std::sync::Arc<dyn aisix_guardrails::Guardrail> =
-        match state.local_model_guardrail.as_ref() {
-            Some(local) => std::sync::Arc::new(aisix_guardrails::GuardrailChain::new(vec![
-                std::sync::Arc::clone(&resolved_chain),
-                std::sync::Arc::clone(local),
-            ])),
-            None => resolved_chain,
-        };
 
     // Input guardrails. Run before reservation so a blocked prompt
     // doesn't burn an RPM slot — content-policy refusals shouldn't

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -10144,35 +10144,17 @@ data: [DONE]\n\n";
         assert_masked_by_eda(&event, "output");
     }
 
-    /// Pitfall (2) of #1024, chat-only. When a local-model guardrail is
-    /// configured, `dispatch` re-wraps the resolved chain with
-    /// `GuardrailChain::new(vec![resolved, local])` — and `new` leaves the
-    /// OUTER chain's audit log unset. Reading the handle after that point
-    /// yields `None`, so every attachment-row hit on the chat path would
-    /// go unattributed while every sibling endpoint reported normally.
-    /// The handle is therefore taken from the attachment-resolved chain,
-    /// at the same line `applied()` is snapshotted.
+    /// Successor of the #1024 pitfall-(2) regression: the semantic
+    /// guardrail is an ordinary `kind: "semantic"` row on the standard
+    /// chain now (#1363) — no re-wrap exists to lose the audit handle —
+    /// and its enforced mask must be attributed to the ROW name with
+    /// per-category counts on the usage event, exactly like every other
+    /// kind. Runs the rule layer only (adjacent hotword → mask), so no
+    /// model files are needed; the test runtime's engine never loads.
+    #[cfg(feature = "local-model-guardrail")]
     #[tokio::test]
-    async fn chat_enforced_hits_survive_the_local_model_rewrap() {
+    async fn chat_enforced_hits_attribute_the_semantic_row() {
         use aisix_obs::UsageSink;
-
-        /// Stands in for the env-injected local-model guardrail: a member
-        /// that never blocks and never masks, present only to force the
-        /// re-wrap branch. Its own verdicts are irrelevant here — what is
-        /// under test is that wrapping does not lose the INNER chain's log.
-        struct InertLocalModel;
-        #[axum::async_trait]
-        impl aisix_guardrails::Guardrail for InertLocalModel {
-            fn name(&self) -> &'static str {
-                "local-model"
-            }
-            async fn check_input(
-                &self,
-                _req: &aisix_gateway::ChatFormat,
-            ) -> aisix_guardrails::GuardrailVerdict {
-                aisix_guardrails::GuardrailVerdict::Allow
-            }
-        }
 
         let upstream = MockServer::start().await;
         Mock::given(method("POST"))
@@ -10194,20 +10176,65 @@ data: [DONE]\n\n";
         let hub = Arc::new(Hub::new());
         hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
         let snap = seed_snapshot("my-gpt4", &["my-gpt4"], &upstream.uri());
-        let state = build_state(snap, hub).with_local_model_guardrail(
-            Arc::new(InertLocalModel) as Arc<dyn aisix_guardrails::Guardrail>
+        let state = build_state(snap, hub);
+        seed_guardrail(
+            &state.snapshot,
+            "g-semantic",
+            r#"{
+                "name": "eda-semantic",
+                "kind": "semantic",
+                "hook_point": "both",
+                "categories": [{
+                    "name": "eda_version",
+                    "description": "EDA 软件的版本号",
+                    "candidate_patterns": ["\\d+(?:\\.\\d+)+"],
+                    "hotword_groups": [{"terms": ["version"]}],
+                    "replacement": "***"
+                }]
+            }"#,
         );
-        seed_guardrail(&state.snapshot, "g-mask", MASKING_GUARDRAIL);
-        let app = build_router(state.with_usage_sink(UsageSink::new(tx)));
+        // The state constructors carry no semantic runtime; rebuild the
+        // index with the modelless test runtime so the row compiles.
+        let index = aisix_guardrails::LiveGuardrailIndex::new_with_sink(
+            state.snapshot.clone(),
+            None,
+            None,
+            aisix_guardrails::SemanticRuntimeSlot::new(Arc::new(
+                aisix_guardrails::SemanticRuntime::for_tests_without_model(),
+            )),
+        );
+        let app = build_router(
+            state
+                .with_guardrail_index(index)
+                .with_usage_sink(UsageSink::new(tx)),
+        );
 
         let resp = run(app, chat_request("my-gpt4", false)).await;
         assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains("***"), "the response was not masked: {body}");
+        assert!(!body.contains("9.9.9"), "the value leaked: {body}");
 
         let event = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
             .await
             .expect("usage event was never emitted")
             .expect("sender dropped without sending");
-        assert_masked_by_eda(&event, "output");
+        let hits = &event.guardrail_enforced_hits;
+        let hit = hits
+            .iter()
+            .find(|h| h.hook == "output")
+            .unwrap_or_else(|| panic!("no output-hook enforced hit in {hits:?}"));
+        assert_eq!(hit.guardrail_name, "eda-semantic");
+        assert_eq!(hit.action, "masked");
+        assert_eq!(hit.counts.get("eda_version").copied(), Some(1));
+        assert_eq!(
+            event.redacted_entity_counts.get("eda_version").copied(),
+            Some(1),
+            "{event:?}"
+        );
+        let wire = serde_json::to_string(&event).expect("event serialises");
+        assert!(!wire.contains("9.9.9"), "masked value reached the event");
     }
 
     /// The refusal path: a guardrail BLOCK leaves through `Err`, so the

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -408,7 +408,12 @@ async fn dispatch(
             .unwrap_or_default();
         let chat =
             aisix_gateway::ChatFormat::new("", vec![aisix_gateway::ChatMessage::user(args_text)]);
-        let (verdict, hits) = aisix_guardrails::Guardrail::check_input_observed(chain, &chat).await;
+        // Segment-moderating members (semantic, Bedrock ANONYMIZE) are
+        // consulted through the segment pass below instead — the same
+        // check/moderate split every LLM family uses, so a member is
+        // never consulted (or billed) twice per hook.
+        let (verdict, hits) =
+            aisix_guardrails::Guardrail::check_input_non_segment_observed(chain, &chat).await;
         monitor_hits.extend(hits);
         if let aisix_guardrails::GuardrailVerdict::Block {
             reason,
@@ -511,7 +516,50 @@ async fn dispatch(
         }
         _ => bytes,
     };
-    // Post-mask by construction: cloned AFTER the write-back above, so a
+    // Async segment-moderation pass over the same `params.arguments`
+    // string leaves the sync write-back covers (#1363): semantic rows —
+    // and any other segment-moderating member — mask through here. The
+    // pass reuses the byte-splice walker, so the scan slots and the
+    // write-back slots are the same set by construction (no fourth text
+    // shape; the aisix#1027 scan/rewrite divergence is not widened).
+    let bytes = match &guardrail_chain {
+        Some(chain) if aisix_guardrails::Guardrail::moderates_segments(chain) => {
+            match moderate_tool_arguments(chain, &bytes, &mut monitor_hits, &mut redaction_counts)
+                .await
+            {
+                SegmentPassOutcome::Keep => bytes,
+                SegmentPassOutcome::Rewritten(rewritten) => {
+                    parts.headers.insert(
+                        axum::http::header::CONTENT_LENGTH,
+                        axum::http::HeaderValue::from(rewritten.len()),
+                    );
+                    axum::body::Bytes::from(rewritten)
+                }
+                SegmentPassOutcome::Block(guardrail_name) => {
+                    emit_tool_call_usage(
+                        state,
+                        &snapshot,
+                        &auth,
+                        request_id,
+                        &mcp_server,
+                        &mcp_tool,
+                        StatusCode::OK.as_u16(),
+                        Duration::ZERO,
+                        true,
+                        monitor_hits,
+                        redaction_counts,
+                        guardrail_chain.as_ref(),
+                        None,
+                        trace,
+                        /* dispatched */ false,
+                    );
+                    return jsonrpc_guardrail_block(rpc_id, "tool call", guardrail_name.as_deref());
+                }
+            }
+        }
+        _ => bytes,
+    };
+    // Post-mask by construction: cloned AFTER the write-backs above, so a
     // capturing exporter can never archive a value the mask removed
     // (same ordering rule as the LLM path — mask first, capture after).
     let captured_args = capture_cap.map(|_| bytes.clone());
@@ -656,20 +704,152 @@ fn rewrite_tool_arguments(
     body: &[u8],
 ) -> Result<Option<(Vec<u8>, crate::redact::RedactionCounts)>, crate::json_splice::SpliceError> {
     let mut counts = crate::redact::RedactionCounts::new();
-    let out = crate::json_splice::rewrite_string_values(
-        body,
-        |path| {
-            path.first().is_some_and(|s| s.is_key("params"))
-                && path.get(1).is_some_and(|s| s.is_key("arguments"))
-        },
-        |text| {
-            aisix_guardrails::Guardrail::redact_input_text(chain, text).map(|r| {
-                crate::redact::merge_counts(&mut counts, r.counts);
-                r.text
-            })
-        },
-    )?;
+    let out = crate::json_splice::rewrite_string_values(body, tool_argument_path, |text| {
+        aisix_guardrails::Guardrail::redact_input_text(chain, text).map(|r| {
+            crate::redact::merge_counts(&mut counts, r.counts);
+            r.text
+        })
+    })?;
     Ok(out.map(|bytes| (bytes, counts)))
+}
+
+/// Path predicate for the `params.arguments` string leaves — shared by
+/// the sync write-back and both walks of the segment pass, so the scan
+/// slots and the write-back slots can never drift.
+fn tool_argument_path(path: &[crate::json_splice::PathSeg]) -> bool {
+    path.first().is_some_and(|s| s.is_key("params"))
+        && path.get(1).is_some_and(|s| s.is_key("arguments"))
+}
+
+/// Path predicate for the tool-result surfaces:
+/// `result.content[i].{text,description,title}`,
+/// `result.content[i].resource.text`, and every string leaf under
+/// `result.structuredContent`. (`name`/`uri` stay untouched — they
+/// address a resource.)
+fn tool_result_path(path: &[crate::json_splice::PathSeg]) -> bool {
+    if !path.first().is_some_and(|s| s.is_key("result")) {
+        return false;
+    }
+    match path.get(1) {
+        Some(seg) if seg.is_key("structuredContent") => true,
+        Some(seg) if seg.is_key("content") => {
+            matches!(path.get(2), Some(crate::json_splice::PathSeg::Index(_)))
+                && ((path.len() == 4
+                    && (path[3].is_key("text")
+                        || path[3].is_key("description")
+                        || path[3].is_key("title")))
+                    || (path.len() == 5 && path[3].is_key("resource") && path[4].is_key("text")))
+        }
+        _ => false,
+    }
+}
+
+/// Outcome of one async segment-moderation pass over a JSON-RPC body.
+enum SegmentPassOutcome {
+    /// Nothing changed; keep the current bytes.
+    Keep,
+    /// Masked replacements were spliced in.
+    Rewritten(Vec<u8>),
+    /// A segment-moderating member blocked; the value is the firing
+    /// guardrail's name (`None` for a fail-closed walk failure).
+    Block(Option<String>),
+}
+
+/// Segment pass over the request's `params.arguments` string leaves.
+async fn moderate_tool_arguments(
+    chain: &aisix_guardrails::GuardrailChain,
+    body: &[u8],
+    monitor_hits: &mut Vec<aisix_core::GuardrailMonitorHit>,
+    counts_out: &mut crate::redact::RedactionCounts,
+) -> SegmentPassOutcome {
+    moderate_selected_segments(
+        chain,
+        body,
+        tool_argument_path,
+        true,
+        monitor_hits,
+        counts_out,
+    )
+    .await
+}
+
+/// Run the chain's segment-moderating members (semantic rows, Bedrock
+/// ANONYMIZE) over the string leaves `pred` selects (#1363): collect
+/// the decoded slots with the same byte-splice walker the write-back
+/// uses, moderate them in ONE chain pass, and splice the positionally
+/// aligned masked texts back. Every byte outside a masked span reaches
+/// the peer verbatim.
+async fn moderate_selected_segments(
+    chain: &aisix_guardrails::GuardrailChain,
+    body: &[u8],
+    pred: fn(&[crate::json_splice::PathSeg]) -> bool,
+    input: bool,
+    monitor_hits: &mut Vec<aisix_core::GuardrailMonitorHit>,
+    counts_out: &mut crate::redact::RedactionCounts,
+) -> SegmentPassOutcome {
+    // Collect: a rewrite walk that rewrites nothing.
+    let mut texts: Vec<String> = Vec::new();
+    if let Err(err) = crate::json_splice::rewrite_string_values(body, pred, |t| {
+        texts.push(t.to_owned());
+        None
+    }) {
+        // Structurally impossible (every caller's body already parsed as
+        // JSON) — fail closed rather than let content bypass the pass.
+        tracing::warn!(error = %err, "mcp segment collect walk failed; blocking");
+        return SegmentPassOutcome::Block(None);
+    }
+    if texts.is_empty() {
+        return SegmentPassOutcome::Keep;
+    }
+    let mut outcome = if input {
+        aisix_guardrails::Guardrail::moderate_input_segments(chain, &texts).await
+    } else {
+        aisix_guardrails::Guardrail::moderate_output_segments(chain, &texts).await
+    };
+    monitor_hits.append(&mut outcome.monitor_hits);
+    if let aisix_guardrails::GuardrailVerdict::Block {
+        reason,
+        guardrail_name,
+        ..
+    } = outcome.verdict
+    {
+        tracing::warn!(
+            guardrail_hook = if input { "input" } else { "output" },
+            reason = %reason,
+            "guardrail blocked MCP content in the segment pass"
+        );
+        return SegmentPassOutcome::Block(guardrail_name);
+    }
+    let Some(masked) = outcome.masked else {
+        return SegmentPassOutcome::Keep;
+    };
+    if masked.len() != texts.len() {
+        tracing::warn!(
+            offered = texts.len(),
+            masked = masked.len(),
+            "mcp segment mask drifted from the collect walk; keeping originals"
+        );
+        return SegmentPassOutcome::Keep;
+    }
+    let mut cursor = 0usize;
+    match crate::json_splice::rewrite_string_values(body, pred, |t| {
+        let i = cursor;
+        cursor += 1;
+        match masked.get(i) {
+            Some(m) if m != t => Some(m.clone()),
+            _ => None,
+        }
+    }) {
+        Ok(None) => SegmentPassOutcome::Keep,
+        Ok(Some(bytes)) => {
+            crate::redact::merge_counts(counts_out, outcome.counts);
+            SegmentPassOutcome::Rewritten(bytes)
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "mcp segment mask splice failed; blocking");
+            SegmentPassOutcome::Block(None)
+        }
+    }
 }
 
 /// The post-mask content-capture pair for a tool call: `prompt` is the
@@ -793,7 +973,9 @@ async fn apply_output_guardrails(
         finish_reason: aisix_gateway::FinishReason::Stop,
         usage: aisix_gateway::UsageStats::new(0, 0),
     };
-    let (verdict, hits) = aisix_guardrails::Guardrail::check_output_observed(chain, &resp).await;
+    // Segment-moderating members answer through the segment pass below.
+    let (verdict, hits) =
+        aisix_guardrails::Guardrail::check_output_non_segment_observed(chain, &resp).await;
     monitor_hits.extend(hits);
     if let aisix_guardrails::GuardrailVerdict::Block {
         reason,
@@ -809,57 +991,58 @@ async fn apply_output_guardrails(
         );
         return ToolResultOutcome::Block(guardrail_name);
     }
-    // Mask write-back over the same surface the scan covers:
-    // `result.content[i].{text,description,title}`,
-    // `result.content[i].resource.text`, and every string leaf under
-    // `result.structuredContent`. (`name`/`uri` stay untouched — they
-    // address a resource; see the scan-loop comment.)
-    if !aisix_guardrails::Guardrail::redacts_output(chain) {
-        return ToolResultOutcome::Allow(None);
-    }
+    // Mask write-back over the same surface the scan covers
+    // (`tool_result_path`; `name`/`uri` stay untouched — they address a
+    // resource; see the scan-loop comment). Two write-back channels
+    // compose: the sync per-field redactors (kind=pii mask rules), then
+    // the async segment pass (semantic rows, Bedrock ANONYMIZE) over
+    // whatever the sync pass produced.
     let mut counts = crate::redact::RedactionCounts::new();
-    let rewritten = crate::json_splice::rewrite_string_values(
-        response_bytes,
-        |path| {
-            if !path.first().is_some_and(|s| s.is_key("result")) {
-                return false;
+    let mut current: Option<Vec<u8>> = None;
+    if aisix_guardrails::Guardrail::redacts_output(chain) {
+        let rewritten =
+            crate::json_splice::rewrite_string_values(response_bytes, tool_result_path, |text| {
+                aisix_guardrails::Guardrail::redact_output_text(chain, text).map(|r| {
+                    crate::redact::merge_counts(&mut counts, r.counts);
+                    r.text
+                })
+            });
+        match rewritten {
+            Ok(None) => {}
+            Ok(Some(bytes)) => current = Some(bytes),
+            Err(err) => {
+                // Structurally impossible (the body parsed above); fail
+                // closed rather than release a result the mask policy
+                // should rewrite.
+                tracing::warn!(
+                    tool = %tool,
+                    error = %err,
+                    "mcp output mask splice failed; blocking tool result",
+                );
+                return ToolResultOutcome::Block(None);
             }
-            match path.get(1) {
-                Some(seg) if seg.is_key("structuredContent") => true,
-                Some(seg) if seg.is_key("content") => {
-                    matches!(path.get(2), Some(crate::json_splice::PathSeg::Index(_)))
-                        && ((path.len() == 4
-                            && (path[3].is_key("text")
-                                || path[3].is_key("description")
-                                || path[3].is_key("title")))
-                            || (path.len() == 5
-                                && path[3].is_key("resource")
-                                && path[4].is_key("text")))
-                }
-                _ => false,
-            }
-        },
-        |text| {
-            aisix_guardrails::Guardrail::redact_output_text(chain, text).map(|r| {
-                crate::redact::merge_counts(&mut counts, r.counts);
-                r.text
-            })
-        },
-    );
-    match rewritten {
-        Ok(None) => ToolResultOutcome::Allow(None),
-        Ok(Some(bytes)) => ToolResultOutcome::Allow(Some((bytes, counts))),
-        Err(err) => {
-            // Structurally impossible (the body parsed above); fail closed
-            // rather than release a result the mask policy should rewrite.
-            tracing::warn!(
-                tool = %tool,
-                error = %err,
-                "mcp output mask splice failed; blocking tool result",
-            );
-            ToolResultOutcome::Block(None)
         }
     }
+    if aisix_guardrails::Guardrail::moderates_segments(chain) {
+        let body_now: &[u8] = current.as_deref().unwrap_or(response_bytes);
+        match moderate_selected_segments(
+            chain,
+            body_now,
+            tool_result_path,
+            false,
+            monitor_hits,
+            &mut counts,
+        )
+        .await
+        {
+            SegmentPassOutcome::Keep => {}
+            SegmentPassOutcome::Rewritten(bytes) => current = Some(bytes),
+            SegmentPassOutcome::Block(guardrail_name) => {
+                return ToolResultOutcome::Block(guardrail_name)
+            }
+        }
+    }
+    ToolResultOutcome::Allow(current.map(|bytes| (bytes, counts)))
 }
 
 /// Push every non-empty string leaf of `value` — walking objects and arrays —

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -823,13 +823,17 @@ async fn moderate_selected_segments(
     let Some(masked) = outcome.masked else {
         return SegmentPassOutcome::Keep;
     };
+    // The chain fold already refuses a member whose rewrite drifts from
+    // the offered count, so a drift HERE means the chain itself broke its
+    // contract — the same invariant-violation class as a splice failure,
+    // and it takes the same fail-closed arm.
     if masked.len() != texts.len() {
         tracing::warn!(
             offered = texts.len(),
             masked = masked.len(),
-            "mcp segment mask drifted from the collect walk; keeping originals"
+            "mcp segment mask drifted from the collect walk; blocking"
         );
-        return SegmentPassOutcome::Keep;
+        return SegmentPassOutcome::Block(None);
     }
     let mut cursor = 0usize;
     match crate::json_splice::rewrite_string_values(body, pred, |t| {

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -190,13 +190,6 @@ pub struct ProxyStateInner {
     pub health: Arc<HealthTracker>,
     /// Public liveness state served on `GET /livez`.
     pub livez: Arc<LivezState>,
-    /// Env-injected local CPU embedding-model guardrail (AISIX-Cloud#1331
-    /// MVP vertical slice). `None` (the default) = inactive. When present,
-    /// the chat handler composes it AFTER the per-request resolved chain:
-    /// it is deployment-wide experimental surface, not an
-    /// attachment-scoped guardrail row, and it only masks (never blocks).
-    /// MVP wiring covers `/v1/chat/completions` only.
-    pub local_model_guardrail: Option<Arc<dyn aisix_guardrails::Guardrail>>,
     /// Runtime model-status tracker keyed by resolved direct-model id.
     /// Used for request-path cooldown/background health exclusion and
     /// surfaced by `GET /admin/v1/models/status`.
@@ -272,8 +265,12 @@ const TEST_RATE_LIMIT_CLOCK_SECS: u64 = 1_763_000_000;
 impl ProxyState {
     pub fn new(snapshot: SnapshotHandle<AisixSnapshot>, hub: Arc<Hub>, cfg: &ProxyConfig) -> Self {
         let metrics = Arc::new(Metrics::new(false));
-        let guardrail_index =
-            LiveGuardrailIndex::new_with_sink(snapshot.clone(), None, Some(metrics.clone()));
+        let guardrail_index = LiveGuardrailIndex::new_with_sink(
+            snapshot.clone(),
+            None,
+            Some(metrics.clone()),
+            aisix_guardrails::SemanticRuntimeSlot::none(),
+        );
         // Unit tests get a frozen rate-limit clock: on the wall clock, any
         // "the next request 429s" assertion silently races the fixed-window
         // minute boundary — a test that straddles :00 lands its two requests
@@ -301,7 +298,6 @@ impl ProxyState {
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
             livez: Arc::new(LivezState::new()),
-            local_model_guardrail: None,
             config_apply_age: None,
             runtime_status: Arc::new(ModelRuntimeStatusTracker::new()),
             usage_sink: UsageSink::disabled(),
@@ -330,8 +326,12 @@ impl ProxyState {
         cfg: &ProxyConfig,
     ) -> Self {
         let metrics = Arc::new(Metrics::new(false));
-        let guardrail_index =
-            LiveGuardrailIndex::new_with_sink(snapshot.clone(), None, Some(metrics.clone()));
+        let guardrail_index = LiveGuardrailIndex::new_with_sink(
+            snapshot.clone(),
+            None,
+            Some(metrics.clone()),
+            aisix_guardrails::SemanticRuntimeSlot::none(),
+        );
         Self::from_inner(ProxyStateInner {
             snapshot,
             hub,
@@ -344,7 +344,6 @@ impl ProxyState {
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
             livez: Arc::new(LivezState::new()),
-            local_model_guardrail: None,
             config_apply_age: None,
             runtime_status: Arc::new(ModelRuntimeStatusTracker::new()),
             usage_sink: UsageSink::disabled(),
@@ -375,8 +374,12 @@ impl ProxyState {
         cache: Option<CacheBackends>,
         cfg: &ProxyConfig,
     ) -> Self {
-        let guardrail_index =
-            LiveGuardrailIndex::new_with_sink(snapshot.clone(), None, Some(metrics.clone()));
+        let guardrail_index = LiveGuardrailIndex::new_with_sink(
+            snapshot.clone(),
+            None,
+            Some(metrics.clone()),
+            aisix_guardrails::SemanticRuntimeSlot::none(),
+        );
         // The bootstrap constructor is the one place the tracker gets a
         // metrics sink + snapshot handle, so cooldown transitions emit
         // `aisix_deployment_*`. Clone both before they are moved into the
@@ -401,7 +404,6 @@ impl ProxyState {
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::with_flags(bookkeeping_flags)),
             livez: Arc::new(LivezState::new()),
-            local_model_guardrail: None,
             config_apply_age: None,
             runtime_status,
             usage_sink: UsageSink::disabled(),
@@ -439,20 +441,6 @@ impl ProxyState {
     /// deterministic one via `LiveGuardrailIndex::new(stub_handle, None)`.
     pub fn with_guardrail_index(mut self, index: Arc<LiveGuardrailIndex>) -> Self {
         Arc::make_mut(&mut self.inner).guardrail_index = index;
-        self
-    }
-
-    /// Inject the env-configured local-model guardrail (AISIX-Cloud#1331
-    /// MVP). Wired by the server bootstrap when
-    /// `GUARDRAIL_LOCAL_MODEL_DIR` is set on a binary built with the
-    /// `local-model-guardrail` feature (non-`AISIX_` prefix on purpose:
-    /// the config loader maps every `AISIX_*` env var onto a config
-    /// field and strictly rejects unknown ones).
-    pub fn with_local_model_guardrail(
-        mut self,
-        guardrail: Arc<dyn aisix_guardrails::Guardrail>,
-    ) -> Self {
-        Arc::make_mut(&mut self.inner).local_model_guardrail = Some(guardrail);
         self
     }
 

--- a/crates/aisix-server/Cargo.toml
+++ b/crates/aisix-server/Cargo.toml
@@ -69,12 +69,16 @@ tikv-jemallocator = "0.6"
 tikv-jemalloc-ctl = "0.6"
 
 [features]
-# Local CPU embedding-model guardrail MVP (AISIX-Cloud#1331). Off by
-# default (statically links ONNX Runtime); the guardrail additionally
-# activates only when GUARDRAIL_LOCAL_MODEL_DIR is set (non-AISIX_
-# prefix on purpose: the config loader claims the AISIX_* env namespace
-# and strictly rejects unknown fields).
-local-model-guardrail = ["aisix-guardrails/local-model"]
+# The semantic guardrail runtime is part of the standard build (#1363):
+# the release image ships the capability plus the model bundle, and
+# `kind: "semantic"` rows activate it through the control plane —
+# nothing runs (and no model memory is spent) until a row exists.
+# `--no-default-features` remains the minimal build that skips the
+# static ONNX Runtime link. GUARDRAIL_LOCAL_MODEL_DIR overrides the
+# bundled model path (non-AISIX_ prefix on purpose: the config loader
+# claims the AISIX_* env namespace and strictly rejects unknown fields).
+default = ["local-model-guardrail"]
+local-model-guardrail = ["aisix-guardrails/local-model", "aisix-proxy/local-model-guardrail"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aisix-server/src/heartbeat.rs
+++ b/crates/aisix-server/src/heartbeat.rs
@@ -102,6 +102,13 @@ pub type ConfigHashFetcher = Arc<dyn Fn() -> Option<String> + Send + Sync>;
 /// signal that a fleet is mid-rollout behind a newer control plane.
 pub type PartialCompatFetcher = Arc<dyn Fn() -> Vec<PartialCompatEntry> + Send + Sync>;
 
+/// Source of the advertised guardrail-kind list. Most kinds are fixed
+/// at compile time, but `semantic` also needs the node's verified model
+/// bundle — a runtime fact that can flip to "failed" after boot — so
+/// the list is re-read on every beat (#1363). `None` falls back to the
+/// compile-time list.
+pub type SupportedKindsFetcher = Arc<dyn Fn() -> Vec<&'static str> + Send + Sync>;
+
 /// File paths to the on-disk mTLS bundle the heartbeat client presents
 /// to cp-api. Same three files written by cert-bundle provisioning and
 /// re-used on every subsequent boot when the bundle is already on disk.
@@ -162,6 +169,9 @@ pub struct HeartbeatConfig {
     /// aggregate. `None` (tests / no supervisor) omits the field, same
     /// tolerance contract as the other optional fields. See #871.
     pub partial_compat_fetcher: Option<PartialCompatFetcher>,
+    /// Optional source of the advertised guardrail-kind list (#1363).
+    /// `None` (tests) reports the compile-time list.
+    pub supported_kinds_fetcher: Option<SupportedKindsFetcher>,
 }
 
 impl std::fmt::Debug for HeartbeatConfig {
@@ -193,6 +203,10 @@ impl std::fmt::Debug for HeartbeatConfig {
                 "partial_compat_fetcher",
                 &self.partial_compat_fetcher.as_ref().map(|_| "<fn>"),
             )
+            .field(
+                "supported_kinds_fetcher",
+                &self.supported_kinds_fetcher.as_ref().map(|_| "<fn>"),
+            )
             .finish()
     }
 }
@@ -221,6 +235,7 @@ impl HeartbeatConfig {
             exporter_health_fetcher: None,
             config_hash_fetcher: None,
             partial_compat_fetcher: None,
+            supported_kinds_fetcher: None,
         }
     }
 
@@ -252,6 +267,12 @@ impl HeartbeatConfig {
     /// Wire the supervisor's partially-compatible aggregate source (#871).
     pub fn with_partial_compat_fetcher(mut self, fetcher: PartialCompatFetcher) -> Self {
         self.partial_compat_fetcher = Some(fetcher);
+        self
+    }
+
+    /// Wire the advertised guardrail-kind source (#1363).
+    pub fn with_supported_kinds_fetcher(mut self, fetcher: SupportedKindsFetcher) -> Self {
+        self.supported_kinds_fetcher = Some(fetcher);
         self
     }
 }
@@ -323,10 +344,12 @@ struct HeartbeatBody<'a> {
     hostname: &'a str,
     uptime_seconds: i64,
     version: &'a str,
-    /// Guardrail `kind` discriminators compiled into this binary
-    /// (#519 B.6). Always present so cp-api can hide / flag kinds the
-    /// DP can't serve (e.g. a build without the `bedrock` feature).
-    supported_guardrail_kinds: &'static [&'static str],
+    /// Guardrail `kind` discriminators this node can serve (#519 B.6).
+    /// Always present so cp-api can hide / flag kinds the DP can't
+    /// serve. Mostly compile-time (a build without the `bedrock`
+    /// feature), except `semantic`, which also needs the node's
+    /// verified model bundle and is re-evaluated per beat (#1363).
+    supported_guardrail_kinds: Vec<&'static str>,
     /// Highest etcd/kine revision the watch supervisor has applied
     /// (#519 B.3). `0` = snapshot not loaded yet. cp-api compares this
     /// against the revision returned by its own kine writes: a DP with
@@ -505,7 +528,11 @@ async fn send(client: &reqwest::Client, cfg: &HeartbeatConfig, uptime: i64) -> a
             hostname: &cfg.hostname,
             uptime_seconds: uptime,
             version: &BUILD_VERSION,
-            supported_guardrail_kinds: aisix_guardrails::supported_kinds(),
+            supported_guardrail_kinds: cfg
+                .supported_kinds_fetcher
+                .as_ref()
+                .map(|fetcher| fetcher())
+                .unwrap_or_else(|| aisix_guardrails::supported_kinds().to_vec()),
             applied_revision,
             config_hash,
             exporter_health,

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -917,34 +917,101 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // doesn't accidentally redirect Bedrock calls into thin air.
     let bedrock_endpoint_url = cfg.bedrock_endpoint_url.clone().filter(|s| !s.is_empty());
     let guardrail_metrics_sink = proxy_state.metrics.clone();
+    // Semantic guardrail runtime (#1363, `kind: "semantic"`): verify the
+    // model bundle's manifest at boot — nothing else. ONNX sessions and
+    // category prototypes load lazily on the first semantic row, so a
+    // node with no semantic guardrails pays no memory for the
+    // capability. An explicit GUARDRAIL_LOCAL_MODEL_DIR that fails
+    // verification is boot-fatal (a masking guardrail the operator asked
+    // for that silently isn't there would leak the very content it
+    // exists to rewrite); the image's bundled default path degrades to
+    // "capability absent" so a bare-metal run without the bundle still
+    // boots — the heartbeat then simply doesn't advertise `semantic`.
+    #[cfg(feature = "local-model-guardrail")]
+    let (semantic_slot, semantic_capability) = {
+        for retired in [
+            aisix_guardrails::THRESHOLD_ENV,
+            aisix_guardrails::PROTOTYPES_ENV,
+            aisix_guardrails::RULE_WINDOW_ENV,
+        ] {
+            if std::env::var_os(retired).is_some() {
+                tracing::warn!(
+                    var = retired,
+                    "retired MVP env var is set and ignored; the semantic guardrail \
+                     is configured per category on the guardrail resource (kind \"semantic\")"
+                );
+            }
+        }
+        let explicit =
+            std::env::var_os(aisix_guardrails::MODEL_DIR_ENV).map(std::path::PathBuf::from);
+        let dir = explicit
+            .clone()
+            .unwrap_or_else(|| std::path::PathBuf::from(aisix_guardrails::DEFAULT_MODEL_DIR));
+        let lanes = aisix_guardrails::parse_lanes(
+            std::env::var(aisix_guardrails::LANES_ENV).ok().as_deref(),
+        );
+        let sink: Arc<dyn aisix_core::models::GuardrailMetricsSink> =
+            guardrail_metrics_sink.clone();
+        let verified = {
+            let dir = dir.clone();
+            tokio::task::spawn_blocking(move || {
+                aisix_guardrails::SemanticRuntime::load(dir, lanes, Some(sink))
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("semantic guardrail bundle verification task: {e}"))?
+        };
+        match verified {
+            Ok(runtime) => {
+                let runtime = Arc::new(runtime);
+                let capability = runtime.capability();
+                (
+                    aisix_guardrails::SemanticRuntimeSlot::new(runtime),
+                    Some(capability),
+                )
+            }
+            Err(err) if explicit.is_some() => {
+                return Err(anyhow::anyhow!(
+                    "semantic guardrail model bundle at {} (from {}) failed verification: {err}",
+                    dir.display(),
+                    aisix_guardrails::MODEL_DIR_ENV,
+                ));
+            }
+            Err(err) => {
+                if dir.exists() {
+                    tracing::warn!(
+                        model_dir = %dir.display(),
+                        error = %err,
+                        "bundled semantic guardrail model failed verification; \
+                         this node will not serve kind \"semantic\""
+                    );
+                } else {
+                    tracing::info!(
+                        model_dir = %dir.display(),
+                        "no semantic guardrail model bundle; \
+                         this node will not serve kind \"semantic\""
+                    );
+                }
+                (aisix_guardrails::SemanticRuntimeSlot::none(), None)
+            }
+        }
+    };
+    #[cfg(not(feature = "local-model-guardrail"))]
+    let semantic_slot = {
+        if std::env::var_os("GUARDRAIL_LOCAL_MODEL_DIR").is_some() {
+            tracing::warn!(
+                "GUARDRAIL_LOCAL_MODEL_DIR is set, but this binary was built without the \
+                 `local-model-guardrail` feature; ignoring"
+            );
+        }
+        aisix_guardrails::SemanticRuntimeSlot::none()
+    };
     proxy_state =
         proxy_state.with_guardrail_index(aisix_guardrails::LiveGuardrailIndex::new_with_sink(
             snapshot_handle.clone(),
             bedrock_endpoint_url,
             Some(guardrail_metrics_sink),
+            semantic_slot,
         ));
-    // Local CPU embedding-model guardrail MVP (AISIX-Cloud#1331):
-    // env-activated, no control-plane surface yet. Load failure with the
-    // env var set is boot-fatal — a masking guardrail the operator asked
-    // for that silently isn't there would leak the very content it exists
-    // to rewrite. Model load + prototype inference block, so they run off
-    // the async bootstrap thread.
-    #[cfg(feature = "local-model-guardrail")]
-    if let Some(local_cfg) = aisix_guardrails::LocalModelConfig::from_env() {
-        let guardrail = tokio::task::spawn_blocking(move || {
-            aisix_guardrails::LocalModelGuardrail::load(&local_cfg)
-        })
-        .await
-        .map_err(|e| anyhow::anyhow!("local-model guardrail load task: {e}"))??;
-        proxy_state = proxy_state.with_local_model_guardrail(Arc::new(guardrail));
-    }
-    #[cfg(not(feature = "local-model-guardrail"))]
-    if std::env::var_os("GUARDRAIL_LOCAL_MODEL_DIR").is_some() {
-        tracing::warn!(
-            "GUARDRAIL_LOCAL_MODEL_DIR is set, but this binary was built without the \
-             `local-model-guardrail` feature; ignoring"
-        );
-    }
     // Heartbeat worker — spawned after proxy_state exists so it can read
     // the exporter fan-out's delivery counters. Each tick reports:
     //   - rejected_resources: the supervisor's loader rejections (#115)
@@ -978,6 +1045,26 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         }));
         let fan_out = proxy_state.otlp_fan_out.clone();
         h = h.with_exporter_health_fetcher(Arc::new(move || fan_out.exporter_stats()));
+        // Advertised guardrail kinds (#1363): `semantic` rides along
+        // only while the node's model bundle stays verified — readiness
+        // means "could serve"; the CP creating a semantic row is what
+        // triggers the lazy engine load, and an engine that later fails
+        // drops the advert on the next beat.
+        #[cfg(feature = "local-model-guardrail")]
+        {
+            let capability = semantic_capability.clone();
+            h = h.with_supported_kinds_fetcher(Arc::new(move || {
+                aisix_guardrails::supported_kinds_with(
+                    capability.as_ref().is_some_and(|c| c.is_ready()),
+                )
+            }));
+        }
+        #[cfg(not(feature = "local-model-guardrail"))]
+        {
+            h = h.with_supported_kinds_fetcher(Arc::new(|| {
+                aisix_guardrails::supported_kinds_with(false)
+            }));
+        }
         heartbeat::spawn(h, cancel_rx.clone())
     });
 

--- a/crates/aisix-server/tests/guardrail_read_path_forward_compat.rs
+++ b/crates/aisix-server/tests/guardrail_read_path_forward_compat.rs
@@ -13,7 +13,7 @@
 
 use aisix_etcd::loader::{build_snapshot, PartialCompatEntry};
 use aisix_etcd::provider::RawEntry;
-use aisix_guardrails::{build_chain_from_snapshot, Guardrail};
+use aisix_guardrails::{build_chain_from_snapshot, Guardrail, SemanticRuntimeSlot};
 
 /// A `kind: "pii"` guardrail whose custom pattern carries one field this
 /// build does not know — the shape `custom_patterns[].replacement` had
@@ -51,7 +51,7 @@ fn guardrail_with_an_unknown_nested_field_loads_and_still_masks() {
         "the row loads, and the operator is told which field was ignored"
     );
 
-    let chain = build_chain_from_snapshot(&snapshot.guardrails, None);
+    let chain = build_chain_from_snapshot(&snapshot.guardrails, None, &SemanticRuntimeSlot::none());
     assert_eq!(chain.len(), 1, "the loaded row must reach the chain");
     let redacted = chain
         .redact_input_text("tool version: 12.1 done")

--- a/docker/guardrail-model.LICENSE
+++ b/docker/guardrail-model.LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docker/guardrail-model.manifest.json
+++ b/docker/guardrail-model.manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 1,
+  "model_id": "ibm-granite/granite-embedding-97m-multilingual-r2",
+  "revision": "835ad14087e140460703cf0fae09f97d469d65c2",
+  "embedding_dim": 384,
+  "files": {
+    "model.onnx": "sha256:a6022dd8220ea6f6595562a1328ee216f4a94faa55362f2f4747c80f1e78772e",
+    "tokenizer.json": "sha256:4f2842d568e2724370aec203652a42ac783c7937f8347a1a2cc7506d71f1582f"
+  },
+  "calibration": { "description": 0.8 }
+}

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -247,6 +247,95 @@
         "type"
       ],
       "type": "object"
+    },
+    "SemanticCategory": {
+      "additionalProperties": false,
+      "description": "One user-defined category for `kind: \"semantic\"`: what to look for (regex candidate patterns), the lexical evidence that confirms or rejects a candidate (hotword groups and negative patterns), the natural-language description the embedding model judges uncertain candidates against, and how a confirmed span is rewritten.",
+      "properties": {
+        "action": {
+          "description": "Action for spans confirmed as this category. Only `mask` is supported: this guardrail rewrites content and never blocks.",
+          "enum": [
+            "mask"
+          ],
+          "type": "string"
+        },
+        "candidate_patterns": {
+          "default": [],
+          "description": "Regular expressions that generate candidate spans. Only text matched by a candidate pattern can ever be masked, so patterns should be broad — precision comes from the hotword and negative evidence and from the embedding judgement.",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 10,
+          "minItems": 1,
+          "type": "array"
+        },
+        "description": {
+          "description": "Natural-language description of the category, such as `EDA 软件的版本号`. Candidates that regex and hotword evidence cannot decide are judged by embedding similarity between their surrounding text and this description.",
+          "maxLength": 1000,
+          "minLength": 1,
+          "type": "string"
+        },
+        "hotword_groups": {
+          "default": [],
+          "description": "Hotword groups — lexical evidence FOR a candidate. A group term adjacent to the span is decisive; terms merely nearby are weak evidence that routes the span to the embedding judgement.",
+          "items": {
+            "$ref": "#/definitions/SemanticHotwordGroup"
+          },
+          "maxItems": 10,
+          "type": "array"
+        },
+        "name": {
+          "description": "Category name surfaced in the mask token (`[<NAME>_REDACTED]`), telemetry counts, and audit records. Never the matched value. Must be unique within the guardrail.",
+          "maxLength": 64,
+          "minLength": 1,
+          "type": "string"
+        },
+        "negative_patterns": {
+          "default": [],
+          "description": "Regular expressions that are evidence AGAINST a candidate. Each pattern is tried against the candidate span itself, the text immediately before it, and the text immediately after it (anchor with `^` or `$` to pin the position); any match counts once and strongly lowers the span's score.",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "type": "array"
+        },
+        "replacement": {
+          "description": "Literal text that replaces a masked span, such as `***`. When omitted, the span is rewritten to `[<NAME>_REDACTED]`. An empty string removes the span.",
+          "maxLength": 256,
+          "type": "string"
+        },
+        "threshold": {
+          "description": "Similarity threshold for the embedding judgement, in `[-1, 1]` (cosine similarity against the category description). Omitted → the calibrated default that ships with the bundled model. Raise it to mask less, lower it to mask more; pair tuning with `enforcement_mode: monitor` to preview the effect first.",
+          "format": "float",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "description",
+        "name"
+      ],
+      "type": "object"
+    },
+    "SemanticHotwordGroup": {
+      "additionalProperties": false,
+      "description": "One hotword group for a semantic category. Terms in a group are lexical evidence for the category: a term found next to a candidate span raises the span's rule score, and each group contributes at most once per span. Group terms by the role they play (for example trigger words, tool names) rather than listing every term in one group.",
+      "properties": {
+        "terms": {
+          "description": "Literal terms. Terms containing CJK characters match as substrings; ASCII terms match on word boundaries, and may run directly into a digit (so a tool name fused to a version number still counts).",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 50,
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "terms"
+      ],
+      "type": "object"
     }
   },
   "description": "Content policy evaluated before or after upstream calls.",
@@ -1419,6 +1508,77 @@
       "required": [
         "analyzer_url",
         "anonymizer_url",
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "description": "Category-based semantic detection and redaction using a CPU embedding model bundled with the gateway. User-defined categories combine regex candidates, hotword evidence, and embedding similarity against a natural-language description; confirmed spans are masked in place. Rewrites only — never blocks. Applies on input, output, or both, including buffered streaming output. Requires the gateway's bundled model files; nodes without them do not serve this kind.",
+      "properties": {
+        "categories": {
+          "default": [],
+          "description": "The categories this guardrail detects. Categories are evaluated in order; each category rewrites the text the previous one produced.",
+          "items": {
+            "$ref": "#/definitions/SemanticCategory"
+          },
+          "maxItems": 30,
+          "minItems": 1,
+          "type": "array"
+        },
+        "created_at": {
+          "description": "RFC3339 creation timestamp. When present, guardrails are evaluated from oldest to newest. Resources without this timestamp sort after resources that have it.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "direction": {
+          "default": "both",
+          "description": "Attachment direction hint. Guardrail execution still follows `hook_point`.",
+          "type": "string"
+        },
+        "enabled": {
+          "default": true,
+          "description": "When false, the chain skips this rule entirely. Allows operators to stage a rule before enabling it.",
+          "type": "boolean"
+        },
+        "enforcement_mode": {
+          "default": "block",
+          "description": "How AISIX handles matching content. Enforcing mode applies the guardrail verdict; monitor mode records what would have happened without blocking or redacting the caller-visible response.",
+          "type": "string"
+        },
+        "fail_open": {
+          "default": true,
+          "description": "Behavior when a remote API guardrail cannot reach its upstream. `true` allows the request and records the bypass reason in `usage_events.guardrail_bypassed_reason`. `false` blocks with 422. Keyword guardrails do not use this setting.",
+          "type": "boolean"
+        },
+        "hook_point": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailHookPoint"
+            }
+          ],
+          "default": "both",
+          "description": "Where in the lifecycle this rule runs."
+        },
+        "kind": {
+          "description": "Guardrail provider type for in-process semantic category detection and redaction using the bundled embedding model.",
+          "enum": [
+            "semantic"
+          ],
+          "type": "string"
+        },
+        "mandatory": {
+          "default": false,
+          "description": "Whether guardrail evaluation errors are fatal. When `true`, a remote guardrail that cannot reach its upstream blocks the request instead of failing open, overriding `fail_open` on the failure path. The default `false` keeps the `fail_open` behavior.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Operator-facing name that surfaces in metric labels and error reasons.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
         "kind"
       ],
       "type": "object"

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -292,7 +292,7 @@
         },
         "negative_patterns": {
           "default": [],
-          "description": "Regular expressions that are evidence AGAINST a candidate. Each pattern is tried against the candidate span itself, the text immediately before it, and the text immediately after it (anchor with `^` or `$` to pin the position); any match counts once and strongly lowers the span's score.",
+          "description": "Regular expressions that are evidence AGAINST a candidate. Every pattern is tried against the candidate span itself. A pattern whose source ends with `$` is additionally tried against the text immediately before the span (the `$` pins the match to the span's left edge, as in `编号\\s*$`), and one whose source starts with `^` against the text immediately after it (as in `^\\s*(?:ms|s)`). Any match counts once and strongly lowers the span's score.",
           "items": {
             "type": "string"
           },
@@ -1549,7 +1549,10 @@
         },
         "fail_open": {
           "default": true,
-          "description": "Behavior when a remote API guardrail cannot reach its upstream. `true` allows the request and records the bypass reason in `usage_events.guardrail_bypassed_reason`. `false` blocks with 422. Keyword guardrails do not use this setting.",
+          "description": "Semantic guardrails always degrade open: an unavailable embedding model releases content unmasked and records the degradation, never blocks. Only `true` is accepted.",
+          "enum": [
+            true
+          ],
           "type": "boolean"
         },
         "hook_point": {
@@ -1580,7 +1583,8 @@
         }
       },
       "required": [
-        "kind"
+        "kind",
+        "categories"
       ],
       "type": "object"
     }

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -314,7 +314,8 @@
       },
       "required": [
         "description",
-        "name"
+        "name",
+        "candidate_patterns"
       ],
       "type": "object"
     },

--- a/tests/e2e/src/cases/guardrail-local-model-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-local-model-e2e.test.ts
@@ -1,44 +1,37 @@
 import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import OpenAI from "openai";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
   ProxyClient,
+  scrapeMetrics,
   SeedClient,
   spawnApp,
   startOpenAiUpstream,
+  sumMetric,
   waitConfigPropagation,
   type OpenAiUpstream,
   type SpawnedApp,
 } from "../harness/index.js";
 
-// E2E: local CPU embedding-model guardrail (AISIX-Cloud#1331).
+// E2E: the semantic guardrail against the REAL embedding model
+// (AISIX-Cloud#1331 → #1363). The kind-level contract — wiring, scoping,
+// sibling families, /mcp, monitor mode, degrade metrics — is pinned
+// model-free in guardrail-semantic-kind-e2e.test.ts; this opt-in suite
+// adds the layer-③ acceptance path: a live in-process inference judges
+// the model band, and the model-call metric family counts it.
 //
-// Two acceptance paths through `/v1/chat/completions`, each asserted on
-// both sides (request: what the upstream received; response: what the
-// caller got back):
-// - the MVP acceptance sentence: an EDA-software version number in
-//   natural-language Chinese is rewritten to `***`;
-// - the layer-② acceptance matrix: one message carrying both hard
-//   positives (`升级到 2022.4`, `Virtuoso IC6.1.8` — the shapes the MVP
-//   measurably missed) and the hard negatives (compile-log timing,
-//   memory size, IPv4, bare number); the positives are rewritten, the
-//   negatives come back byte-identical, and the bare number traverses a
-//   live layer-③ inference (no lexical evidence → model band).
-//
-// SCOPE PINS (deliberate, per the MVP brief — not accidental gaps):
-// - non-streaming only: streamed output rides the guardrail's default
-//   BufferFull hold-back + the same segment pass, but is not pinned here;
-// - /v1/chat/completions only: the sibling families (/v1/messages,
-//   /v1/responses, legacy completions, MCP) are explicitly unwired —
-//   tracked on the design issue, not silently missing.
+// The guardrail is a standard `kind: "semantic"` ROW (the factory EDA
+// template) resolved through attachments — the MVP-era env-activated
+// global is gone.
 //
 // OPT-IN SPEC: skipped unless AISIX_LOCAL_GUARDRAIL_MODEL_DIR points at
-// the model directory (model.onnx + tokenizer.json). Setting it implies
-// the binary under test was built with `--features local-model-guardrail`
-// (a default build would warn, serve unmasked, and fail this spec).
-// The opt-in var deliberately carries the harness-stripped AISIX_ prefix
-// so it can never leak into OTHER specs' spawned binaries; this spec
+// the model bundle (model.onnx + tokenizer.json; a manifest.json is
+// generated next to them on first run by hashing what is there). The
+// opt-in var deliberately carries the harness-stripped AISIX_ prefix so
+// it can never leak into OTHER specs' spawned binaries; this spec
 // forwards it explicitly as the binary's own GUARDRAIL_LOCAL_MODEL_DIR
 // (non-AISIX on purpose — the config loader maps every AISIX_* env var
 // onto a config field and strictly rejects unknown ones).
@@ -52,12 +45,10 @@ const SENSITIVE = "这个 EDA 软件的版本是 12.1";
 const MASKED = "这个 EDA 软件的版本是 ***";
 
 // The layer-② acceptance matrix in one message: both hard positives, the
-// hard negatives (including the Chinese-unit and timestamp classes the
-// defect-fix round added), and a bare number with no lexical evidence at
-// all (the model band — this candidate pays a real in-process inference).
-// `Virtuoso IC6.1.8` masks as the WHOLE fused token now: layer ① sees
-// fused version tokens since the defect-fix round, so the `IC` identity
-// prefix no longer survives (the MVP-era output was `Virtuoso IC***`).
+// hard negatives (including the Chinese-unit and timestamp classes), and
+// a bare number with no lexical evidence at all — the model band, which
+// on THIS suite pays a real in-process inference and releases (the
+// description prototype leans precision).
 const MIXED =
   "我们把仿真工具升级到 2022.4 之后,Virtuoso IC6.1.8 反而开始频繁崩溃," +
   "完整的运行日志我贴在下面了,麻烦帮忙看看到底是哪一步出了问题: " +
@@ -71,7 +62,63 @@ const MIXED_MASKED =
   "Elapsed: 12.345s, Memory: 4.2 GB, 服务器 IP 是 10.2.255.1, " +
   "另外圆周率约等于 3.14159";
 
+/** The factory EDA-version category (the CP template's exact shape). */
+const EDA_CATEGORY = {
+  name: "eda_version",
+  description: "EDA 软件的版本号",
+  candidate_patterns: [
+    "[0-9０-９]+(?:[.．][0-9０-９]+)+",
+    "[A-Za-z][A-Za-z0-9._-]*[0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?",
+    "[0-9][A-Za-z0-9._-]*[A-Za-z](?:[A-Za-z0-9._-]*[A-Za-z0-9])?",
+  ],
+  negative_patterns: [
+    "^\\s*(?:%|％|(?i:ms|us|ns|ps|fs|s|secs?|seconds?|mins?|minutes?|hours?|[kmgt]i?b|um|nm|[kmg]?hz)(?:[^0-9A-Za-z]|$)|纳秒|微秒|毫秒|秒|分钟|个?(?:小时|钟头|星期|月)|天|纳米|微米|毫米|[兆吉太]字节|[千兆吉]?赫兹|[千兆吉]赫|个?百分点|摄氏度|度(?:[^过]|$)|伏特?|瓦特?|安培|毫安)",
+    "(?i)[0-9](?:%|ms|us|ns|ps|fs|s|secs?|seconds?|mins?|minutes?|hours?|[kmgt]i?b|um|nm|[kmg]?hz)$",
+    "百分之\\s*$",
+    "^\\d{1,3}(?:\\.\\d{1,3}){3}$",
+    "[\\w.-]+\\.[A-Za-z0-9]+:$",
+    "^:\\d",
+    "[0-9]{1,2}[:：][0-9]{1,2}[:：]$",
+    "(?i)\\.[a-z]{2,4}$",
+    "(?:^|[^本])编号[:：]?(?:是|为)?\\s*$",
+  ],
+  hotword_groups: [
+    { terms: ["版本号", "版本", "升级到", "回退到"] },
+    { terms: ["version", "release", "build", "upgrade to", "upgraded to"] },
+    { terms: ["virtuoso", "calibre", "vcs", "innovus", "icc2", "primetime"] },
+  ],
+  action: "mask",
+  replacement: "***",
+};
+
 const MODEL_DIR = process.env.AISIX_LOCAL_GUARDRAIL_MODEL_DIR;
+
+/** Generate `manifest.json` next to the model files when absent — the
+ * test-side counterpart of the release bundle's pinned manifest. */
+function ensureManifest(dir: string): void {
+  const path = join(dir, "manifest.json");
+  if (existsSync(path)) return;
+  const files: Record<string, string> = {};
+  for (const name of ["model.onnx", "tokenizer.json"]) {
+    files[name] = `sha256:${createHash("sha256")
+      .update(readFileSync(join(dir, name)))
+      .digest("hex")}`;
+  }
+  writeFileSync(
+    path,
+    JSON.stringify(
+      {
+        manifest_version: 1,
+        model_id: "ibm-granite/granite-embedding-97m-multilingual-r2",
+        embedding_dim: 384,
+        files,
+        calibration: { description: 0.8 },
+      },
+      null,
+      2,
+    ),
+  );
+}
 
 describe("local-model guardrail e2e: EDA version number masked on request and response", () => {
   let app: SpawnedApp | undefined;
@@ -97,6 +144,7 @@ describe("local-model guardrail e2e: EDA version number masked on request and re
 
   beforeAll(async () => {
     if (!MODEL_DIR) return;
+    ensureManifest(MODEL_DIR);
     etcd = new EtcdClient();
     etcdReachable = await etcd.ping();
     if (!etcdReachable) return;
@@ -139,6 +187,16 @@ describe("local-model guardrail e2e: EDA version number masked on request and re
       provider: "openai",
       model_name: "gpt-4o-mini",
       provider_key_id: mixedPk.id,
+    });
+    // The guardrail is an ordinary semantic ROW, env-scoped through the
+    // implicit fallback (no attachment rows — the file-source posture);
+    // scoped-attachment behavior is pinned in the kind suite.
+    await seed.createGuardrail({
+      name: "local-model-semantic",
+      enabled: true,
+      hook_point: "both",
+      kind: "semantic",
+      categories: [EDA_CATEGORY],
     });
     // Caller key last: it authenticating implies the whole seed set is in
     // the DP snapshot (per this suite's readiness-gate rule).
@@ -185,12 +243,16 @@ describe("local-model guardrail e2e: EDA version number masked on request and re
     expect(lastReq!.body).not.toContain("12.1");
   });
 
-  test("hard positives are rewritten while hard negatives pass byte-identical", async (ctx) => {
+  test("hard positives are rewritten while hard negatives pass byte-identical, through a live inference", async (ctx) => {
     if (!MODEL_DIR || !etcdReachable || !app || !mixedUpstream) {
       ctx.skip();
       return;
     }
 
+    const before = sumMetric(
+      await scrapeMetrics(app.metricsUrl),
+      "aisix_guardrail_semantic_model_calls_total",
+    );
     const res = await new OpenAI({
       apiKey: CALLER,
       baseURL: `${app.proxyUrl}/v1`,
@@ -211,5 +273,15 @@ describe("local-model guardrail e2e: EDA version number masked on request and re
     expect(lastReq!.body).toContain(MIXED_MASKED);
     expect(lastReq!.body).not.toContain("2022.4");
     expect(lastReq!.body).not.toContain("6.1.8");
+
+    // The bare number traversed a LIVE layer-③ inference, and the
+    // model-call metric family counted it (the /metrics shipping rule —
+    // this is the real-model half; the degrade half is asserted in the
+    // kind suite).
+    const after = sumMetric(
+      await scrapeMetrics(app.metricsUrl),
+      "aisix_guardrail_semantic_model_calls_total",
+    );
+    expect(after).toBeGreaterThan(before);
   });
 });

--- a/tests/e2e/src/cases/guardrail-local-model-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-local-model-e2e.test.ts
@@ -253,35 +253,50 @@ describe("local-model guardrail e2e: EDA version number masked on request and re
       await scrapeMetrics(app.metricsUrl),
       "aisix_guardrail_semantic_model_calls_total",
     );
-    const res = await new OpenAI({
+    const client = new OpenAI({
       apiKey: CALLER,
       baseURL: `${app.proxyUrl}/v1`,
       maxRetries: 0,
-    }).chat.completions.create({
-      model: "local-model-e2e-mixed",
-      messages: [{ role: "user", content: MIXED }],
     });
 
-    // Response side: versions masked, everything else — the compile-log
-    // numbers, the IP, the bare number the model judged — byte-identical.
-    expect(res.choices[0]?.message?.content).toBe(MIXED_MASKED);
+    // The engine loads detached when the semantic row first compiles, and
+    // a request only waits 500ms for it before releasing the span
+    // (fail-open). Drive the same request until a model call is counted:
+    // every iteration must already produce the full rewrite (the masked
+    // spans are rule-band; the model band only RELEASES here), and within
+    // the deadline one iteration rides the warmed engine.
+    const deadline = Date.now() + 30_000;
+    let after = before;
+    for (;;) {
+      const res = await client.chat.completions.create({
+        model: "local-model-e2e-mixed",
+        messages: [{ role: "user", content: MIXED }],
+      });
 
-    // Request side: the upstream saw the same rewrite and neither
-    // version value.
-    const lastReq = mixedUpstream.receivedRequests.at(-1);
-    expect(lastReq).toBeDefined();
-    expect(lastReq!.body).toContain(MIXED_MASKED);
-    expect(lastReq!.body).not.toContain("2022.4");
-    expect(lastReq!.body).not.toContain("6.1.8");
+      // Response side: versions masked, everything else — the compile-log
+      // numbers, the IP, the bare number the model judged — byte-identical.
+      expect(res.choices[0]?.message?.content).toBe(MIXED_MASKED);
+
+      // Request side: the upstream saw the same rewrite and neither
+      // version value.
+      const lastReq = mixedUpstream.receivedRequests.at(-1);
+      expect(lastReq).toBeDefined();
+      expect(lastReq!.body).toContain(MIXED_MASKED);
+      expect(lastReq!.body).not.toContain("2022.4");
+      expect(lastReq!.body).not.toContain("6.1.8");
+
+      after = sumMetric(
+        await scrapeMetrics(app.metricsUrl),
+        "aisix_guardrail_semantic_model_calls_total",
+      );
+      if (after > before || Date.now() > deadline) break;
+      await new Promise((r) => setTimeout(r, 500));
+    }
 
     // The bare number traversed a LIVE layer-③ inference, and the
     // model-call metric family counted it (the /metrics shipping rule —
     // this is the real-model half; the degrade half is asserted in the
     // kind suite).
-    const after = sumMetric(
-      await scrapeMetrics(app.metricsUrl),
-      "aisix_guardrail_semantic_model_calls_total",
-    );
     expect(after).toBeGreaterThan(before);
   });
 });

--- a/tests/e2e/src/cases/guardrail-semantic-kind-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-semantic-kind-e2e.test.ts
@@ -1,0 +1,538 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  scrapeMetrics,
+  SeedClient,
+  spawnApp,
+  startMcpUpstream,
+  startOpenAiUpstream,
+  sumMetric,
+  waitConfigPropagation,
+  type McpUpstream,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: `kind: "semantic"` guardrail rows (AISIX-Cloud#1363) as STANDARD
+// attachment-scoped config, against a real DP + etcd + real upstreams.
+//
+// This suite runs WITHOUT the 120 MB embedding model: the gateway boots
+// on a fake model bundle whose manifest verifies (so the node has the
+// capability and semantic rows compile) but whose engine fails on first
+// use. That split is the point — the rule layers (candidate regex +
+// hotword/negative evidence) carry every decisive case with zero model
+// involvement, and the model band DEGRADES OPEN (release + a counted
+// `engine_failed` degrade) instead of blocking or stalling. The
+// real-model acceptance path lives in guardrail-local-model-e2e.test.ts
+// (opt-in).
+//
+// Pinned contract:
+// - a semantic row masks on chat, /v1/messages, /v1/responses AND /mcp
+//   (both directions) — the endpoint families move in lockstep;
+// - scoping is real: an mcp_server-scoped row fires on that server only
+//   (MCP-07), and a model-scoped row fires on that model only;
+// - hard negatives return byte-identical inside the rewritten text;
+// - `enforcement_mode: monitor` observes without rewriting;
+// - the degrade and per-execution metric families are visible in
+//   `GET /metrics` after real traffic (the "a metric family is shipped
+//   when an e2e asserts it in /metrics" rule).
+
+const CALLER = "sk-semantic-kind-e2e";
+const sha256hex = (s: string | Buffer) =>
+  createHash("sha256").update(s).digest("hex");
+
+const SENSITIVE = "这个 EDA 软件的版本是 12.1";
+const MASKED = "这个 EDA 软件的版本是 ***";
+
+// Rule-layer acceptance matrix in one message: hard positives (adjacent
+// trigger / tool anchor), hard negatives (units, timestamp, IPv4), and a
+// bare number with no lexical evidence — the model band, which on this
+// suite's fake bundle degrades to a released span + an `engine_failed`
+// degrade sample.
+const MIXED =
+  "我们把仿真工具升级到 2022.4 之后,Virtuoso IC6.1.8 反而开始频繁崩溃," +
+  "[10:23:45.123] build started, 整个 build 花了 45.5 秒, " +
+  "Elapsed: 12.345s, Memory: 4.2 GB, 服务器 IP 是 10.2.255.1, " +
+  "另外圆周率约等于 3.14159";
+const MIXED_MASKED =
+  "我们把仿真工具升级到 *** 之后,Virtuoso *** 反而开始频繁崩溃," +
+  "[10:23:45.123] build started, 整个 build 花了 45.5 秒, " +
+  "Elapsed: 12.345s, Memory: 4.2 GB, 服务器 IP 是 10.2.255.1, " +
+  "另外圆周率约等于 3.14159";
+
+// MCP surfaces (rule-decidable hits + byte-identical negatives).
+const MCP_NEG = "Elapsed: 12.345s Memory: 4.2 GB 10.2.255.1";
+const MCP_ARG = `build version: 12.1 ${MCP_NEG} 工具版本：2022.4 完成`;
+const MCP_ARG_MASKED = `build version: *** ${MCP_NEG} 工具版本：*** 完成`;
+const MCP_SUMMARY = "阶段汇总 版本：2022.4 用时 12.345s";
+const MCP_SUMMARY_MASKED = "阶段汇总 版本：*** 用时 12.345s";
+
+/** The factory EDA-version category (the CP template's exact shape). */
+const EDA_CATEGORY = {
+  name: "eda_version",
+  description: "EDA 软件的版本号",
+  candidate_patterns: [
+    "[0-9０-９]+(?:[.．][0-9０-９]+)+",
+    "[A-Za-z][A-Za-z0-9._-]*[0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?",
+    "[0-9][A-Za-z0-9._-]*[A-Za-z](?:[A-Za-z0-9._-]*[A-Za-z0-9])?",
+  ],
+  negative_patterns: [
+    "^\\s*(?:%|％|(?i:ms|us|ns|ps|fs|s|secs?|seconds?|mins?|minutes?|hours?|[kmgt]i?b|um|nm|[kmg]?hz)(?:[^0-9A-Za-z]|$)|纳秒|微秒|毫秒|秒|分钟|个?(?:小时|钟头|星期|月)|天|纳米|微米|毫米|[兆吉太]字节|[千兆吉]?赫兹|[千兆吉]赫|个?百分点|摄氏度|度(?:[^过]|$)|伏特?|瓦特?|安培|毫安)",
+    "(?i)[0-9](?:%|ms|us|ns|ps|fs|s|secs?|seconds?|mins?|minutes?|hours?|[kmgt]i?b|um|nm|[kmg]?hz)$",
+    "百分之\\s*$",
+    "^\\d{1,3}(?:\\.\\d{1,3}){3}$",
+    "[\\w.-]+\\.[A-Za-z0-9]+:$",
+    "^:\\d",
+    "[0-9]{1,2}[:：][0-9]{1,2}[:：]$",
+    "(?i)\\.[a-z]{2,4}$",
+    "(?:^|[^本])编号[:：]?(?:是|为)?\\s*$",
+  ],
+  hotword_groups: [
+    { terms: ["版本号", "版本", "升级到", "回退到"] },
+    { terms: ["version", "release", "build", "upgrade to", "upgraded to"] },
+    { terms: ["virtuoso", "calibre", "vcs", "innovus", "icc2", "primetime"] },
+  ],
+  action: "mask",
+  replacement: "***",
+};
+
+/** A bundle that VERIFIES (manifest hashes match) but cannot serve an
+ * engine — model.onnx is not a real graph. Boot succeeds, the node has
+ * the capability, and the first model-band judgement flips the engine to
+ * failed: exactly the degrade arm this suite pins. */
+function writeFakeBundle(): string {
+  const dir = mkdtempSync(join(tmpdir(), "aisix-semantic-e2e-bundle-"));
+  const model = Buffer.from("not a real onnx graph");
+  const tokenizer = Buffer.from("{}");
+  writeFileSync(join(dir, "model.onnx"), model);
+  writeFileSync(join(dir, "tokenizer.json"), tokenizer);
+  writeFileSync(
+    join(dir, "manifest.json"),
+    JSON.stringify({
+      manifest_version: 1,
+      model_id: "e2e/fake-bundle",
+      embedding_dim: 4,
+      files: {
+        "model.onnx": `sha256:${sha256hex(model)}`,
+        "tokenizer.json": `sha256:${sha256hex(tokenizer)}`,
+      },
+      calibration: { description: 0.8 },
+    }),
+  );
+  return dir;
+}
+
+interface RpcReply {
+  status: number;
+  body: string;
+  json?: {
+    result?: {
+      content?: Array<{
+        type: string;
+        text?: string;
+        resource?: { text?: string };
+      }>;
+      structuredContent?: Record<string, unknown>;
+      isError?: boolean;
+    };
+    error?: { code: number; message: string };
+  };
+}
+
+describe("semantic guardrail kind e2e", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let responsesUpstream: OpenAiUpstream | undefined;
+  let mcpUpstream: McpUpstream | undefined;
+  let mcpSibling: McpUpstream | undefined;
+  let etcdReachable = false;
+
+  const reply = (content: string) => ({
+    id: "cmpl-semantic-kind",
+    object: "chat.completion",
+    created: 1_700_000_000,
+    model: "gpt-4o-mini",
+    choices: [
+      { index: 0, message: { role: "assistant", content }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 5, completion_tokens: 8, total_tokens: 13 },
+  });
+
+  const openai = () =>
+    new OpenAI({
+      apiKey: CALLER,
+      baseURL: `${app!.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+  const post = async (path: string, body: unknown): Promise<Response> =>
+    fetch(`${app!.proxyUrl}${path}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER}`,
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify(body),
+    });
+
+  const rpc = async (body: unknown): Promise<RpcReply> => {
+    const res = await post("/mcp", body);
+    const text = await res.text();
+    let json: RpcReply["json"];
+    try {
+      json = text ? (JSON.parse(text) as RpcReply["json"]) : undefined;
+    } catch {
+      json = undefined;
+    }
+    return { status: res.status, body: text, json };
+  };
+
+  const callTool = async (
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<RpcReply> => {
+    await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "semantic-kind-e2e", version: "0.1" },
+      },
+    });
+    return rpc({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name, arguments: args },
+    });
+  };
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({ nonStreamBody: reply(SENSITIVE) });
+    // /v1/responses on an OpenAI-compatible provider forwards the
+    // Responses API natively, so its mock must answer in the Responses
+    // shape (the chat mock's canned chat.completion is unmappable there).
+    responsesUpstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "resp-semantic-kind",
+        object: "response",
+        status: "completed",
+        model: "gpt-4o-mini",
+        output: [
+          {
+            type: "message",
+            id: "msg-1",
+            role: "assistant",
+            content: [{ type: "output_text", text: SENSITIVE, annotations: [] }],
+          },
+        ],
+        usage: { input_tokens: 5, output_tokens: 8, total_tokens: 13 },
+      },
+    });
+    mcpUpstream = await startMcpUpstream("eda", {
+      reportContent: {
+        summary: MCP_SUMMARY,
+        log: `Compile OK version: 12.1\n${MCP_NEG}`,
+        structuredLog: 'config {"version": "12.1"} ok',
+      },
+    });
+    mcpSibling = await startMcpUpstream("beta");
+
+    app = await spawnApp({
+      extraEnv: { GUARDRAIL_LOCAL_MODEL_DIR: writeFakeBundle() },
+    });
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "semantic-kind-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    const guarded = await seed.createModel({
+      display_name: "sem-guarded",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    const monitored = await seed.createModel({
+      display_name: "sem-monitored",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    const unguarded = await seed.createModel({
+      display_name: "sem-unguarded",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    const responsesPk = await seed.createProviderKey({
+      display_name: "semantic-kind-responses-pk",
+      secret: "sk-mock",
+      api_base: `${responsesUpstream.baseUrl}/v1`,
+    });
+    const guardedResponses = await seed.createModel({
+      display_name: "sem-guarded-resp",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: responsesPk.id,
+    });
+
+    const alphaId = randomUUID();
+    await seed.update("mcp_servers", alphaId, {
+      display_name: "eda",
+      url: mcpUpstream.url,
+      enabled: true,
+    });
+    const betaId = randomUUID();
+    await seed.update("mcp_servers", betaId, {
+      display_name: "beta",
+      url: mcpSibling.url,
+      enabled: true,
+    });
+
+    const enforcing = await seed.createGuardrail({
+      name: "sem-guard",
+      enabled: true,
+      hook_point: "both",
+      kind: "semantic",
+      categories: [EDA_CATEGORY],
+    });
+    const monitor = await seed.createGuardrail({
+      name: "sem-monitor",
+      enabled: true,
+      hook_point: "both",
+      enforcement_mode: "monitor",
+      kind: "semantic",
+      categories: [EDA_CATEGORY],
+    });
+
+    // Scoped attachments only — no env scope, so the unguarded model and
+    // the beta MCP server are the isolation baselines (MCP-07).
+    await seed.update("guardrail_attachments", randomUUID(), {
+      guardrail_id: enforcing.id,
+      scope_type: "model",
+      scope_id: guarded.id,
+      priority: 100,
+    });
+    await seed.update("guardrail_attachments", randomUUID(), {
+      guardrail_id: enforcing.id,
+      scope_type: "model",
+      scope_id: guardedResponses.id,
+      priority: 100,
+    });
+    await seed.update("guardrail_attachments", randomUUID(), {
+      guardrail_id: enforcing.id,
+      scope_type: "mcp_server",
+      scope_id: alphaId,
+      priority: 100,
+    });
+    await seed.update("guardrail_attachments", randomUUID(), {
+      guardrail_id: monitor.id,
+      scope_type: "model",
+      scope_id: monitored.id,
+      priority: 100,
+    });
+
+    // Caller key LAST: it authenticating implies the rows above are in
+    // the snapshot.
+    await seed.createApiKey({
+      key_hash: sha256hex(CALLER),
+      allowed_models: [
+        "sem-guarded",
+        "sem-guarded-resp",
+        "sem-monitored",
+        "sem-unguarded",
+      ],
+      mcp_access: { allow: ["*"] },
+    });
+    await waitConfigPropagation(async () => {
+      const r = await new ProxyClient(app!.proxyUrl, CALLER).listModels();
+      return r.status === 200;
+    });
+  }, 90_000);
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await responsesUpstream?.close();
+    await mcpUpstream?.close();
+    await mcpSibling?.close();
+  });
+
+  test("chat: version masked in both directions by the rule layer, no model needed", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) return ctx.skip();
+
+    const res = await openai().chat.completions.create({
+      model: "sem-guarded",
+      messages: [{ role: "user", content: SENSITIVE }],
+    });
+    expect(res.choices[0]?.message?.content).toBe(MASKED);
+    const lastReq = upstream.receivedRequests.at(-1);
+    expect(lastReq).toBeDefined();
+    expect(lastReq!.body).toContain(MASKED);
+    expect(lastReq!.body).not.toContain("12.1");
+  });
+
+  test("chat: hard positives rewritten, negatives byte-identical, model band degrades open", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) return ctx.skip();
+
+    const before = sumMetric(
+      await scrapeMetrics(app.metricsUrl),
+      "aisix_guardrail_semantic_degraded_total",
+    );
+    const res = await openai().chat.completions.create({
+      model: "sem-guarded",
+      messages: [{ role: "user", content: MIXED }],
+    });
+    // Response side is the echoed SENSITIVE reply, masked; the REQUEST
+    // side carries the matrix.
+    expect(res.choices[0]?.message?.content).toBe(MASKED);
+    const lastReq = upstream.receivedRequests.at(-1);
+    expect(lastReq).toBeDefined();
+    expect(lastReq!.body).toContain(MIXED_MASKED);
+    expect(lastReq!.body).not.toContain("2022.4");
+    expect(lastReq!.body).not.toContain("6.1.8");
+
+    // The bare number hit the model band; on this fake bundle the engine
+    // fails, the span releases, and the degrade is COUNTED — the
+    // operator's signal that semantic rows run on lexical evidence only.
+    // (The first failure records the underlying cause, e.g.
+    // `engine_failed`; later spans on the failed category count as
+    // `prototype_unavailable` — either way the family moves.)
+    const after = sumMetric(
+      await scrapeMetrics(app.metricsUrl),
+      "aisix_guardrail_semantic_degraded_total",
+    );
+    expect(after).toBeGreaterThan(before);
+  });
+
+  test("metrics: the semantic row reports per-execution samples under its kind", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    // Driven by the chat tests above; scraped as a total because the
+    // family is cumulative across them (delta discipline lives in the
+    // degrade test).
+    const samples = await scrapeMetrics(app.metricsUrl);
+    expect(
+      sumMetric(samples, "aisix_guardrail_latency_seconds_count", {
+        kind: "semantic",
+        guardrail: "sem-guard",
+      }),
+    ).toBeGreaterThan(0);
+  });
+
+  test("/v1/messages and /v1/responses ride the same row (family lockstep)", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) return ctx.skip();
+
+    const messages = await post("/v1/messages", {
+      model: "sem-guarded",
+      max_tokens: 64,
+      messages: [{ role: "user", content: SENSITIVE }],
+    });
+    expect(messages.status).toBe(200);
+    const messagesBody = (await messages.json()) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+    expect(messagesBody.content?.[0]?.text).toBe(MASKED);
+    let lastReq = upstream.receivedRequests.at(-1);
+    expect(lastReq).toBeDefined();
+    expect(lastReq!.body).toContain(MASKED);
+    expect(lastReq!.body).not.toContain("12.1");
+
+    const responses = await post("/v1/responses", {
+      model: "sem-guarded-resp",
+      input: SENSITIVE,
+    });
+    expect(responses.status).toBe(200);
+    const responsesBody = (await responses.json()) as {
+      output?: Array<{
+        type: string;
+        content?: Array<{ type: string; text?: string }>;
+      }>;
+    };
+    const outputText = responsesBody.output
+      ?.flatMap((o) => o.content ?? [])
+      .find((c) => typeof c.text === "string")?.text;
+    expect(outputText).toBe(MASKED);
+    lastReq = responsesUpstream!.receivedRequests.at(-1);
+    expect(lastReq).toBeDefined();
+    expect(lastReq!.body).toContain(MASKED);
+    expect(lastReq!.body).not.toContain("12.1");
+  });
+
+  test("model scope is real: the unguarded model passes the value through", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) return ctx.skip();
+
+    await openai().chat.completions.create({
+      model: "sem-unguarded",
+      messages: [{ role: "user", content: SENSITIVE }],
+    });
+    const lastReq = upstream.receivedRequests.at(-1);
+    expect(lastReq).toBeDefined();
+    expect(lastReq!.body).toContain("12.1");
+  });
+
+  test("monitor mode observes without rewriting", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) return ctx.skip();
+
+    const res = await openai().chat.completions.create({
+      model: "sem-monitored",
+      messages: [{ role: "user", content: SENSITIVE }],
+    });
+    // Nothing rewritten on either side.
+    expect(res.choices[0]?.message?.content).toBe(SENSITIVE);
+    const lastReq = upstream.receivedRequests.at(-1);
+    expect(lastReq).toBeDefined();
+    expect(lastReq!.body).toContain("12.1");
+  });
+
+  test("/mcp input: the guarded server's tool sees masked arguments; the sibling server does not (MCP-07)", async (ctx) => {
+    if (!etcdReachable || !app || !mcpUpstream) return ctx.skip();
+
+    const guarded = await callTool("eda__echo", { text: MCP_ARG });
+    expect(guarded.status).toBe(200);
+    expect(guarded.json?.result?.isError).toBeFalsy();
+    // The echo reflects what the upstream actually received: masked
+    // spans rewritten, negatives byte-identical inside the same string.
+    expect(guarded.json?.result?.content?.[0]?.text).toBe(`eda:${MCP_ARG_MASKED}`);
+
+    const sibling = await callTool("beta__echo", { text: MCP_ARG });
+    expect(sibling.status).toBe(200);
+    expect(sibling.json?.result?.content?.[0]?.text).toBe(`beta:${MCP_ARG}`);
+  });
+
+  test("/mcp output: text, embedded resource and structuredContent masked in place, still JSON", async (ctx) => {
+    if (!etcdReachable || !app || !mcpUpstream) return ctx.skip();
+
+    const reply = await callTool("eda__report", { text: "go" });
+    expect(reply.status).toBe(200);
+    expect(reply.json?.error).toBeUndefined();
+    expect(reply.json?.result?.isError).toBeFalsy();
+
+    const result = reply.json?.result;
+    expect(result?.content?.[0]?.text).toBe(MCP_SUMMARY_MASKED);
+    expect(result?.content?.[1]?.resource?.text).toBe(
+      `Compile OK version: ***\n${MCP_NEG}`,
+    );
+    expect(result?.structuredContent).toEqual({
+      log: 'config {"version": "***"} ok',
+      cells: 42,
+    });
+    expect(reply.body).not.toContain("12.1");
+    expect(reply.body).not.toContain("2022.4");
+  });
+});

--- a/tests/e2e/src/cases/guardrail-semantic-kind-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-semantic-kind-e2e.test.ts
@@ -198,7 +198,7 @@ describe("semantic guardrail kind e2e", () => {
     name: string,
     args: Record<string, unknown>,
   ): Promise<RpcReply> => {
-    await rpc({
+    const init = await rpc({
       jsonrpc: "2.0",
       id: 1,
       method: "initialize",
@@ -208,6 +208,8 @@ describe("semantic guardrail kind e2e", () => {
         clientInfo: { name: "semantic-kind-e2e", version: "0.1" },
       },
     });
+    expect(init.status).toBe(200);
+    expect(init.json?.error).toBeUndefined();
     return rpc({
       jsonrpc: "2.0",
       id: 3,
@@ -423,16 +425,26 @@ describe("semantic guardrail kind e2e", () => {
   test("metrics: the semantic row reports per-execution samples under its kind", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
 
-    // Driven by the chat tests above; scraped as a total because the
-    // family is cumulative across them (delta discipline lives in the
-    // degrade test).
-    const samples = await scrapeMetrics(app.metricsUrl);
-    expect(
-      sumMetric(samples, "aisix_guardrail_latency_seconds_count", {
-        kind: "semantic",
-        guardrail: "sem-guard",
-      }),
-    ).toBeGreaterThan(0);
+    // Self-driving: one guarded request inside this test, asserted as a
+    // delta — a focused run of this file's single test must pass without
+    // riding traffic from the chat tests above.
+    const labels = { kind: "semantic", guardrail: "sem-guard" };
+    const before = sumMetric(
+      await scrapeMetrics(app.metricsUrl),
+      "aisix_guardrail_latency_seconds_count",
+      labels,
+    );
+    const res = await post("/v1/chat/completions", {
+      model: "sem-guarded",
+      messages: [{ role: "user", content: SENSITIVE }],
+    });
+    expect(res.status).toBe(200);
+    const after = sumMetric(
+      await scrapeMetrics(app.metricsUrl),
+      "aisix_guardrail_latency_seconds_count",
+      labels,
+    );
+    expect(after).toBeGreaterThan(before);
   });
 
   test("/v1/messages and /v1/responses ride the same row (family lockstep)", async (ctx) => {


### PR DESCRIPTION
## Summary

Data-plane half of the semantic-guardrail feature (design: AISIX-Cloud#1363; DP work order: api7/aisix#1031; paired CP work order: api7/AISIX-Cloud#1371). The local CPU embedding-model guardrail graduates from an env-activated MVP with one compile-time category into the standard **`kind: "semantic"`**: categories are user configuration, rows scope through `guardrail_attachments`, the capability ships in the default build and image, and nothing runs (no sessions, no model memory) until a semantic row exists — the control plane creating/deleting rows is the on/off switch.

## What changed

**Config model** — `GuardrailKind::Semantic(SemanticConfig)`: 1–30 categories, each `{name (unique in row), description, candidate_patterns (1–10), negative_patterns (0–20), hotword_groups (0–10), action ("mask" only — this kind rewrites, never blocks), replacement (≤256), threshold ([-1,1], optional)}`. The strict write schema closes the branch and pins `action` to `["mask"]`; the lenient loader stays tolerant. `threshold` defaults to the model bundle's calibrated value and is per-category, live-tunable (a threshold edit rebuilds the chain without re-embedding anything); pair tuning with `enforcement_mode: monitor`.

**Runtime** — one process-wide `SemanticRuntime`. Boot verifies the bundle's `manifest.json` (per-file sha256 + embedding dim + calibrated default threshold — the model/prototype/threshold version-consistency unit; a mismatched bundle is refused rather than silently mis-scoring). ONNX sessions and description prototypes load lazily and cache by content. Every cap and failure arm **degrades open** (release the span, count a bounded-vocabulary degrade reason) — never blocks, never stalls; lane waits time out at 500 ms. An engine failure flips the capability flag and the heartbeat stops advertising `semantic` in `supported_guardrail_kinds` (readiness = *could serve*: the advert must not wait for activation, or the create flow would deadlock behind its own greying).

**Wiring** — semantic rows are ordinary chain members: chat, `/v1/messages`, `/v1/responses`, legacy completions ride the existing `moderate_body` segment pass; **`/mcp` gains an async segment-moderation pass** (both directions) that collects, moderates, and splices through the same byte-splice walker as the sync mask write-back — one slot set by construction, no new text shape (the aisix#1027 scan/rewrite divergence is deliberately not widened; its fix stays independent). `/mcp` checks move to the `check_*_non_segment` variants so segment members are consulted exactly once per hook — remote segment moderators (Bedrock ANONYMIZE) now mask on `/mcp` instead of degrading to Block. The chat-only env-injected re-wrap (the #1028/#1024 audit-handle workaround) is deleted; enforced hits attribute the semantic **row name** with per-category counts like every other kind.

**Metrics** — `aisix_guardrail_semantic_model_calls_total` and `aisix_guardrail_semantic_degraded_total{reason}` (closed vocabulary: `engine_failed | prototype_unavailable | budget_exhausted | queue_timeout | inference_failed`), both asserted in `GET /metrics` by e2e after real traffic. Per-execution latency series (`aisix_guardrail_latency_seconds{kind="semantic"}`) come from the standard chain fold.

**Packaging** — the server feature defaults ON, and a new Docker stage downloads the pinned upstream revision, verifies it file-by-file against `docker/guardrail-model.manifest.json` (the same document the gateway re-verifies at boot — a drifted download fails the image build, never the data plane), and bakes the bundle at the binary's default path. `kind: "semantic"` works out of the box; `GUARDRAIL_LOCAL_MODEL_DIR` overrides for model upgrades without an image rebuild. `--no-default-features` remains the minimal build. Retired MVP env vars (`GUARDRAIL_LOCAL_MODEL_THRESHOLD/PROTOTYPES/RULE_WINDOW`) warn and are ignored; `…_DIR`/`…_LANES` stay node-level.

## Ecosystem comparison (per the reference-implementations rule)

- **Custom-category shape**: the category object follows AWS Bedrock Guardrails denied topics — natural-language `name` + `definition`-style description, ≤30 per guardrail, no exposed model score in the base tier (<https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GuardrailTopicConfig.html>) — combined with the deterministic triple every DLP engine converges on (regex candidates + proximity hotwords + confidence adjustment: Microsoft Presidio `PatternRecognizer` context words, <https://microsoft.github.io/presidio/analyzer/adding_recognizers/>; Google Sensitive Data Protection custom infoTypes + `hotwordRule`, <https://docs.cloud.google.com/sensitive-data-protection/docs/creating-custom-infotypes-rules>). Where we diverge: `threshold` is an exposed raw float (band-style presets can layer on later) because live field calibration on customer corpora needs the fine knob before any bands can be defined.
- **In-process inference is a deliberate divergence**: none of the surveyed gateways run neural inference in the gateway process — Kong's ai-semantic-prompt-guard calls an external embedding provider and its PII sanitizer is a vendor sidecar container (<https://developer.konghq.com/plugins/ai-semantic-prompt-guard/>, <https://developer.konghq.com/plugins/ai-sanitizer/>); a leading OSS proxy integrates Presidio as separate containers (<https://docs.litellm.ai/docs/proxy/guardrails/pii_masking_v2>). We run in-process because the driving deployment is air-gapped, single-box, no-GPU (a sidecar is an extra delivery artifact and failure surface there), and the three-layer pipeline keeps the model on the uncertain band only (~12.5 % of candidates measured), inside `spawn_blocking` behind a lane-sized semaphore with spin disabled — the #1271 objections to in-process inference are inherited and addressed, and the runtime is a single seam if a sidecar form is ever wanted.
- **Fail-open-by-design is a divergence from the fail-closed defaults elsewhere** (Kong `stop_on_error: true`, LiteLLM `unreachable_fallback: fail_closed`): this kind's contract is *rewrite, never block* — a fail-closed arm would turn a model outage into a traffic outage, the exact opposite of the design constraint. The CP validator rejects `fail_open: false` for this kind rather than half-honoring it.
- **Capability advertising** follows the Envoy xDS `client_features` / Kong hybrid-mode pattern (node reports upward; control plane greys and warns): <https://www.envoyproxy.io/docs/envoy/latest/api/client_features>, <https://developer.konghq.com/gateway/data-plane-version-compatibility/>.

## Compatibility

A new `kind` enum value row-rejects on older DPs (whole row into `rejected_resources`, RED-visible) — the standard new-kind class; a skipped guardrail row is a missing feature, not an outage. Upgrade order: **control plane first** (AISIX-Cloud#1371 registers the `dpCompatGate` entry `{guardrails, kind=semantic, row_rejected}` plus the save-time capability warning). The heartbeat body's `supported_guardrail_kinds` stays a JSON string array on the wire; only its Rust-side type opened up.

## Testing

- `cargo test --workspace` green (827 tests); clippy clean; schema + OpenAPI regenerated (`dump-schema`, `dump-openapi` verified — the new branch is titled and described).
- Rule-layer fidelity: the MVP's acceptance matrix and 88-line adversarial corpus run against the factory EDA template expressed as config — rule decisions are pinned unchanged, and the corpus keeps its rule-exactness floors (100 % rule-mask precision, zero rule-pass leaks). The v1 model band (absolute cosine vs the description prototype) is pinned to **never mis-mask** a negative; anchor-free positives may release — that recall is exactly what the v2 sample sets buy back, as measured and disclosed on the design issue.
- e2e (real DP + etcd): new `guardrail-semantic-kind-e2e` runs **without** the model (fake bundle that verifies but has no servable engine): chat/messages/responses/mcp masking in both directions, byte-identical negatives, mcp_server + model scope isolation (MCP-07), monitor mode, and the degrade metric family in `/metrics`. The rewritten `guardrail-local-model-e2e` (opt-in, real model) drives a live layer-③ inference through a semantic row and asserts the model-call metric family. Neighboring suites (mcp-guardrail, mcp-mask-writeback, enforced-hits-llm-family) re-run green on the new binary.

## Deferred (explicit, tracked)

- Endpoint families without a segment walker (embeddings, rerank, audio, images, passthrough): posture decision + wiring tracked in api7/aisix#1032.
- Heartbeat-advert and old-DP row-rejection e2e need the CP side — they land with AISIX-Cloud#1371's CP↔DP integration tests.
- Monitor `would_mask` count-equality on the segment channel is unit-pinned (`MonitorGuardrail::observe_segments`); the e2e asserts the behavioral half (no rewrite).
- v2 scope per the design record: positive/negative sample sets, sensitivity bands, idle engine unload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added semantic guardrails for category-based detection and masking using an embedding model.
  - Added configurable categories, hotwords, patterns, thresholds, and replacement text.
  - Added support across chat, Messages, Responses, and MCP traffic.
  - Added verified model bundles with integrity checks and bundled runtime support.
  - Added capability reporting and metrics for model calls and degraded processing.

- **Bug Fixes**
  - Improved MCP scanning and masking for structured content while preserving unaffected fields.
  - Added graceful fallback when semantic model processing is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- User documentation (`api7/docs`) ships with the control-plane half (AISIX-Cloud#1371) — the feature is not user-reachable until the CP lands.

## Independent audit

The audit ran per the repo merge gate: no HIGH; three MEDIUMs fixed in `da701b0` (detached engine warm at chain build + bounded request-side wait; no caching of transient prototype failures; `candidate_patterns` required in the strict schema); LOW resolutions and justifications in the audit comment below.
