### PR TITLE
docs(guardrails): call the presidio guardrail Presidio, not Microsoft Presidio

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -2176,7 +2176,7 @@ fn add_variant_titles(doc: &mut Value) {
                 "PII Detection and Redaction",
                 "Lakera Guard",
                 "OpenAI Moderation",
-                "Microsoft Presidio",
+                "Presidio",
                 "Semantic Categories",
             ],
         ),
@@ -2324,7 +2324,7 @@ fn add_missing_property_descriptions(doc: &mut Value) {
         ),
         (
             "/components/schemas/Guardrail/oneOf/8/properties/kind",
-            "Guardrail provider type for self-hosted Microsoft Presidio PII detection and anonymization.",
+            "Guardrail provider type for PII detection and anonymization by a customer-run Presidio.",
         ),
         (
             "/components/schemas/KeywordPattern/oneOf/0/properties/kind",

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -649,8 +649,8 @@ pub struct PresidioEntityConfig {
     pub action: Option<String>,
 }
 
-/// Config block for `kind: "presidio"`. Calls a self-hosted Microsoft
-/// Presidio analyzer to find PII entities and, when the effective action is
+/// Config block for `kind: "presidio"`. Calls a customer-run Presidio
+/// analyzer to find PII entities and, when the effective action is
 /// `mask`, calls the anonymizer to rewrite text before traffic continues.
 /// `block` rejects with the standard 422 content-filter envelope.
 ///
@@ -866,7 +866,7 @@ pub enum GuardrailKind {
     /// guardrail is detection-only and never rewrites content. Applies on
     /// input, output, or both, including buffered streaming output.
     OpenaiModeration(OpenaiModerationConfig),
-    /// Self-hosted Microsoft Presidio PII detection and anonymization.
+    /// PII detection and anonymization by a customer-run Presidio.
     /// Analyzer entities can mask or block per entity, and masked entities
     /// use the selected anonymize operator. Applies on input, output, or both,
     /// including buffered streaming output.

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -1523,7 +1523,7 @@ fn guardrail_kind_description(kind: &str) -> Option<&'static str> {
         "lakera" => Some("Guardrail provider type for Lakera Guard screening."),
         "openai_moderation" => Some("Guardrail provider type for the OpenAI Moderation API."),
         "presidio" => {
-            Some("Guardrail provider type for self-hosted Microsoft Presidio PII detection and anonymization.")
+            Some("Guardrail provider type for PII detection and anonymization by a customer-run Presidio.")
         }
         "semantic" => Some(
             "Guardrail provider type for in-process semantic category detection and redaction using the bundled embedding model.",

--- a/crates/aisix-guardrails/src/presidio.rs
+++ b/crates/aisix-guardrails/src/presidio.rs
@@ -1,5 +1,5 @@
-//! kind=presidio guardrail dispatcher (#52) — self-hosted Microsoft
-//! Presidio PII detection + anonymization.
+//! kind=presidio guardrail dispatcher (#52) — PII detection +
+//! anonymization by a customer-run Presidio.
 //!
 //! Two-step API (customer-run containers, no vendor secret):
 //! - `POST {analyzer_url}/analyze` `{ text, language, entities?,
@@ -7,7 +7,7 @@
 //! - `POST {anonymizer_url}/anonymize` `{ text, analyzer_results,
 //!   anonymizers }` → `{ text, items: [{ entity_type, ... }] }`
 //!
-//! Source: <https://microsoft.github.io/presidio/api-docs/api-docs.html>
+//! Source: <https://presidio.dataprivacystack.org/api-docs/api-docs.html>
 //!
 //! Decision rule (per-entity actions, same shape as `kind: "pii"`):
 //! - any detected entity whose effective action is `block` → Block;
@@ -90,7 +90,7 @@ pub struct PresidioGuardrail {
 /// The anonymizer operator payload for one operator name. Presidio's
 /// `/anonymize` takes `{"anonymizers": {"DEFAULT": { "type": ... }}}`;
 /// unknown names are rejected at build time (`BuildError::InvalidValue`).
-/// Source: <https://microsoft.github.io/presidio/anonymizer/>
+/// Source: <https://presidio.dataprivacystack.org/anonymizer/>
 pub fn operator_config(operator: &str) -> Option<serde_json::Value> {
     match operator {
         // Presidio's default: replace the span with `<ENTITY_TYPE>`.

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -1376,7 +1376,7 @@
     },
     {
       "additionalProperties": false,
-      "description": "Self-hosted Microsoft Presidio PII detection and anonymization. Analyzer entities can mask or block per entity, and masked entities use the selected anonymize operator. Applies on input, output, or both, including buffered streaming output.",
+      "description": "PII detection and anonymization by a customer-run Presidio. Analyzer entities can mask or block per entity, and masked entities use the selected anonymize operator. Applies on input, output, or both, including buffered streaming output.",
       "properties": {
         "analyzer_url": {
           "description": "Presidio analyzer base URL, e.g. `http://presidio-analyzer:3000`. The gateway appends `/analyze`.",
@@ -1440,7 +1440,7 @@
           "description": "Where in the lifecycle this rule runs."
         },
         "kind": {
-          "description": "Guardrail provider type for self-hosted Microsoft Presidio PII detection and anonymization.",
+          "description": "Guardrail provider type for PII detection and anonymization by a customer-run Presidio.",
           "enum": [
             "presidio"
           ],

--- a/tests/e2e/src/cases/guardrail-presidio-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-presidio-e2e.test.ts
@@ -13,8 +13,8 @@ import {
   type SpawnedApp,
 } from "../harness/index.js";
 
-// E2E: the `presidio` guardrail (#52) — self-hosted Microsoft Presidio
-// PII detection + anonymization, two-step analyze→anonymize. We stand up
+// E2E: the `presidio` guardrail (#52) — PII detection + anonymization
+// by a customer-run Presidio, two-step analyze→anonymize. We stand up
 // ONE mock server implementing both `/analyze` (detects EMAIL occurrences
 // as EMAIL_ADDRESS with offsets, SSN-shaped digits as US_SSN) and
 // `/anonymize` (applies the requested operator: replace → <ENTITY_TYPE>,
@@ -24,7 +24,7 @@ import {
 // reassembly catches it); the hash operator; analyzer 5xx fail-open.
 //
 // References:
-// - Presidio API <https://microsoft.github.io/presidio/api-docs/api-docs.html>
+// - Presidio API <https://presidio.dataprivacystack.org/api-docs/api-docs.html>
 // - LiteLLM `presidio` (behavior baseline): per-entity MASK/BLOCK,
 //   language, skip-empty-text. Operator selection is our superset.
 


### PR DESCRIPTION
Fixes api7/AISIX-Cloud#1374

Presidio is no longer a Microsoft project. It is community-governed under the Data Privacy Stack organization, its releases publish to `ghcr.io/data-privacy-stack` because the `mcr.microsoft.com` images no longer receive them, and its documentation moved off `microsoft.github.io`. The product documentation (api7/docs#2176, api7/docs.apiseven.com#491) and the control plane (api7/AISIX-Cloud#1376) already use the new name; this is the data-plane half, so the strings an operator reads here say the same thing.

Changes:

- The ReDoc `oneOf` tab label for the presidio variant, and the `kind` descriptions in the admin OpenAPI and the schema description table.
- The `Presidio` variant and `PresidioConfig` doc comments, which is what `schemas/resources/guardrail.schema.json` renders from; the schema is regenerated with `cargo run -p aisix-core --bin dump-schema` and its diff is exactly those two description strings.
- The upstream API reference links the guardrail module cites, which now resolve to `presidio.dataprivacystack.org`.

The guardrail kind, every config field, validation, and the analyzer and anonymizer call shapes are untouched, so nothing about how a `kind: presidio` row loads or behaves changes.

No test changes: the strings are descriptions rather than behavior, and the schema regeneration is verified by the existing schema tests plus the generated-file check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Presidio guardrail descriptions to reflect customer-run Presidio deployments.
  * Updated references to the Presidio Data Privacy Stack documentation.
  * Improved Presidio terminology across API documentation, schemas, and supporting materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->