### PR TITLE
fix(guardrails): tell a too-big payload apart from a throttle, and re-send it

### DIFF
--- a/crates/aisix-guardrails/AGENTS.md
+++ b/crates/aisix-guardrails/AGENTS.md
@@ -22,9 +22,26 @@ is how the same defect shipped twice (#448, then AISIX-Cloud#1381):
 - **Count characters, not bytes.** The vendor limits are documented in
   characters, and byte slicing halves a multi-byte character.
 
-A kind whose provider documents no limit (bedrock, lakera, presidio,
-openai_moderation) submits whole — its bound is the provider's own. Do
-not invent a local one for it.
+A kind whose provider documents no usable limit submits whole — its
+bound is the provider's own. Do not invent a local one for it, and do
+not treat "we could not find the number" as "nobody looked": the numbers
+were looked for, and they are not there to hold (AISIX-Cloud#1386).
+Bedrock's ceiling is a service quota that varies by region, policy type
+and tier and is adjustable per account; Lakera publishes no size limit
+and no error shape at all; OpenAI documents no input limit for
+`/moderations` (the real constraint is the tokens-per-minute budget, so
+its refusal is a genuine 429 and chunking would not help); Presidio's
+ceiling is whichever spaCy pipeline the operator deployed. `crate::
+too_large` carries the sources.
+
+When a provider refuses a payload for its size, that is its own failure
+class — never `Throttled` and never `ConfigError`. Both mislead: waiting
+does not help, and neither does fixing credentials. Bedrock goes further
+and re-sends the content in pieces rather than failing; the recursion is
+only safe because every step is guaranteed to make progress (batch →
+halve the slots → halve the text), so keep that property if you touch
+it. A batch budget is not a limit — it is what to try after a refusal,
+and it may be larger than the account's real ceiling.
 
 ## Fail policies default closed
 

--- a/crates/aisix-guardrails/src/bedrock.rs
+++ b/crates/aisix-guardrails/src/bedrock.rs
@@ -24,6 +24,7 @@
 //! | timeout (`latency_mode=timed`)  | false       | Block { "bedrock timeout" }    |
 //! | throttle (4xx ThrottlingException) | true     | Bypass { "bedrock_throttled" } |
 //! | throttle                        | false       | Block { "bedrock throttled" }  |
+//! | payload refused for its size    | n/a         | re-sent in pieces; only a refusal that cannot be made smaller surfaces, as Bypass { "bedrock_too_large" } / Block |
 //!
 //! `latency_mode=serial` waits unconditionally — the timeout row
 //! never fires.
@@ -51,6 +52,21 @@ use aws_smithy_runtime_api::client::result::SdkError;
 use aws_smithy_runtime_api::http::Response;
 
 use crate::{Guardrail, GuardrailVerdict, SegmentsOutcome};
+
+/// Batch size, in characters, used to re-send content AWS has already
+/// refused as too large.
+///
+/// Not a limit: AWS's real per-request ceiling is a service quota that
+/// varies by region, by policy type, by tier, and is adjustable per
+/// account (25–1 000 text units of 1 000 characters each), so it cannot
+/// be known here — see `crate::too_large`. Requests AWS accepts are
+/// always sent whole, in a single call, and this value only takes effect
+/// after a refusal. 25 000 is the smallest ceiling any region publishes
+/// (25 text units), so a batch built to it is one AWS will take
+/// everywhere; a batch that is somehow still refused is split again, so
+/// the value trades round trips against batch size and cannot fail a
+/// request on its own.
+const BEDROCK_REFUSAL_BATCH_CHARS: usize = 25_000;
 
 /// One Bedrock guardrail row, materialised into a request-time
 /// dispatcher. Built once per snapshot from
@@ -217,6 +233,147 @@ impl BedrockGuardrail {
         }
     }
 
+    /// `send`, splitting the payload only if AWS refuses it as too large.
+    ///
+    /// The whole payload goes first, so a request AWS would have accepted
+    /// still costs exactly one call. Packing into fixed batches up front
+    /// instead would split conversations AWS was happy to take whole and
+    /// multiply both billed text units and guardrail latency on traffic
+    /// that never had a size problem — and no fixed budget could avoid
+    /// that, because the real ceiling is account-specific and unknowable
+    /// here (see [`BEDROCK_REFUSAL_BATCH_CHARS`]).
+    ///
+    /// Once a refusal proves the payload is over the ceiling, a
+    /// multi-slot payload is re-sent as batches of whole slots. Batching
+    /// by slot rather than bisecting is what keeps the mask write-back
+    /// aligned: each batch's `outputs[]` lines up with the slots that
+    /// batch carried, so concatenating the batches reproduces a vector
+    /// aligned with `texts`. A single slot that is itself over the
+    /// ceiling has no slots left to divide, so its own text is split and
+    /// the pieces' replacements are joined back into that one slot.
+    ///
+    /// A real block on any piece returns immediately: callers must not
+    /// lose that verdict by continuing with the rest.
+    async fn apply_split(
+        &self,
+        source: GuardrailContentSource,
+        texts: &[String],
+    ) -> Result<SplitOutcome, BedrockFailure> {
+        match self.send(source.clone(), texts).await {
+            Ok(resp) => Ok(SplitOutcome::from_response(
+                &resp,
+                texts,
+                &self.guardrail_id,
+                &self.row_name,
+            )),
+            Err(BedrockFailure::TooLarge { detail }) => {
+                let batches = batch_by_chars(texts, BEDROCK_REFUSAL_BATCH_CHARS);
+                if batches.len() > 1 {
+                    tracing::warn!(
+                        row = %self.row_name,
+                        guardrail_id = %self.guardrail_id,
+                        slots = texts.len(),
+                        batches = batches.len(),
+                        budget = BEDROCK_REFUSAL_BATCH_CHARS,
+                        detail = %detail,
+                        "bedrock refused the payload as too large; re-sending in batches",
+                    );
+                    let mut combined = SplitOutcome::Allow {
+                        masked: Vec::new(),
+                        counts: Default::default(),
+                    };
+                    for batch in batches {
+                        let part = Box::pin(self.apply_split(source.clone(), &batch)).await?;
+                        combined = match combined.merge(part) {
+                            Some(c) => c,
+                            None => return Ok(SplitOutcome::Block),
+                        };
+                    }
+                    return Ok(combined);
+                }
+                if texts.len() > 1 {
+                    // Bin-packing made no progress: the account's real
+                    // ceiling is below our batch budget, which we cannot
+                    // know (see BEDROCK_REFUSAL_BATCH_CHARS). Halve the
+                    // slot list instead. This is also what guarantees
+                    // termination — a payload that packs back to itself
+                    // keeps halving until one slot is left, and that slot
+                    // is divided by its own text below.
+                    let (left, right) = texts.split_at(texts.len() / 2);
+                    tracing::warn!(
+                        row = %self.row_name,
+                        guardrail_id = %self.guardrail_id,
+                        slots = texts.len(),
+                        detail = %detail,
+                        "bedrock refused a payload already inside the batch budget; \
+                         halving the content blocks",
+                    );
+                    let a = Box::pin(self.apply_split(source.clone(), left)).await?;
+                    let b = Box::pin(self.apply_split(source.clone(), right)).await?;
+                    return Ok(a.merge(b).unwrap_or(SplitOutcome::Block));
+                }
+                // One slot, still too large: divide its own text.
+                let [only] = texts else {
+                    // Zero slots and a refusal: nothing to divide.
+                    return Err(BedrockFailure::TooLarge { detail });
+                };
+                // Aim for the batch budget, but never for a target that
+                // would leave the text in one piece: a slot already
+                // inside the budget and still refused has to be halved,
+                // for the same reason the slot list above does — the
+                // real ceiling is lower than anything we can assume.
+                let len = only.chars().count();
+                if len < 2 {
+                    return Err(BedrockFailure::TooLarge { detail });
+                }
+                let target = BEDROCK_REFUSAL_BATCH_CHARS.min(len.div_ceil(2));
+                let pieces = crate::chunk::chunk_text(only, target);
+                if pieces.len() < 2 {
+                    return Err(BedrockFailure::TooLarge { detail });
+                }
+                tracing::warn!(
+                    row = %self.row_name,
+                    guardrail_id = %self.guardrail_id,
+                    pieces = pieces.len(),
+                    budget = BEDROCK_REFUSAL_BATCH_CHARS,
+                    detail = %detail,
+                    "bedrock refused a single content block as too large; splitting its text",
+                );
+                let mut rebuilt = String::with_capacity(only.len());
+                let mut counts: std::collections::BTreeMap<String, u32> = Default::default();
+                for piece in &pieces {
+                    let part =
+                        Box::pin(self.apply_split(source.clone(), std::slice::from_ref(piece)))
+                            .await?;
+                    match part {
+                        SplitOutcome::Block => return Ok(SplitOutcome::Block),
+                        SplitOutcome::Allow {
+                            masked,
+                            counts: more,
+                        } => match masked.first() {
+                            // A piece AWS rewrote contributes its
+                            // replacement; one it left alone contributes
+                            // its original text, so the slot is rebuilt
+                            // whole either way.
+                            Some(m) if m != piece => {
+                                for (k, v) in more {
+                                    *counts.entry(k).or_insert(0) += v;
+                                }
+                                rebuilt.push_str(m);
+                            }
+                            _ => rebuilt.push_str(piece),
+                        },
+                    }
+                }
+                Ok(SplitOutcome::Allow {
+                    masked: vec![rebuilt],
+                    counts,
+                })
+            }
+            Err(other) => Err(other),
+        }
+    }
+
     /// Blob-mode `ApplyGuardrail`: one joined content block, verdict only.
     /// Serves `check_input`/`check_output` — the families with no mask
     /// write-back channel — so an ANONYMIZE disposition maps to Block
@@ -224,18 +381,24 @@ impl BedrockGuardrail {
     /// policy; the segment path is where masking is honored).
     async fn apply(&self, source: GuardrailContentSource, text: String) -> GuardrailVerdict {
         let fail_open = self.fail_open_for(&source);
-        match self.send(source, std::slice::from_ref(&text)).await {
-            Ok(resp) => match classify_response(&resp, &self.guardrail_id) {
-                BedrockOutcome::Allow => GuardrailVerdict::Allow,
-                BedrockOutcome::Block => GuardrailVerdict::block(format!(
-                    "bedrock guardrail {} intervened",
-                    self.guardrail_id
-                )),
-                BedrockOutcome::Mask(_) => GuardrailVerdict::block(format!(
-                    "bedrock guardrail {} anonymized content",
-                    self.guardrail_id
-                )),
-            },
+        let texts = std::slice::from_ref(&text);
+        match self.apply_split(source, texts).await {
+            Ok(SplitOutcome::Block) => GuardrailVerdict::block(format!(
+                "bedrock guardrail {} intervened",
+                self.guardrail_id
+            )),
+            Ok(outcome) => {
+                if outcome.rewrote(texts) {
+                    // No write-back channel on this path — fail toward
+                    // the policy, as before the split existed.
+                    GuardrailVerdict::block(format!(
+                        "bedrock guardrail {} anonymized content",
+                        self.guardrail_id
+                    ))
+                } else {
+                    GuardrailVerdict::Allow
+                }
+            }
             Err(failure) => self.handle_failure(failure, fail_open),
         }
     }
@@ -253,33 +416,24 @@ impl BedrockGuardrail {
         texts: &[String],
     ) -> SegmentsOutcome {
         let fail_open = self.fail_open_for(&source);
-        match self.send(source, texts).await {
-            Ok(resp) => match classify_response(&resp, &self.guardrail_id) {
-                BedrockOutcome::Allow => SegmentsOutcome::allow(),
-                BedrockOutcome::Block => SegmentsOutcome::from_verdict(GuardrailVerdict::block(
-                    format!("bedrock guardrail {} intervened", self.guardrail_id),
-                )),
-                BedrockOutcome::Mask(outputs) => {
-                    if outputs.len() == texts.len() {
-                        SegmentsOutcome {
-                            verdict: GuardrailVerdict::Allow,
-                            masked: Some(outputs),
-                            counts: anonymized_counts(&resp),
-                            monitor_hits: Vec::new(),
-                        }
-                    } else {
-                        tracing::warn!(
-                            row = %self.row_name,
-                            guardrail_id = %self.guardrail_id,
-                            expected = texts.len(),
-                            got = outputs.len(),
-                            "bedrock masked outputs don't align with input \
-                             blocks; skipping mask write-back",
-                        );
-                        SegmentsOutcome::allow()
-                    }
+        match self.apply_split(source, texts).await {
+            Ok(SplitOutcome::Block) => SegmentsOutcome::from_verdict(GuardrailVerdict::block(
+                format!("bedrock guardrail {} intervened", self.guardrail_id),
+            )),
+            Ok(outcome) => {
+                if !outcome.rewrote(texts) {
+                    return SegmentsOutcome::allow();
                 }
-            },
+                let SplitOutcome::Allow { masked, counts } = outcome else {
+                    unreachable!("Block handled above")
+                };
+                SegmentsOutcome {
+                    verdict: GuardrailVerdict::Allow,
+                    masked: Some(masked),
+                    counts,
+                    monitor_hits: Vec::new(),
+                }
+            }
             Err(failure) => SegmentsOutcome::from_verdict(self.handle_failure(failure, fail_open)),
         }
     }
@@ -303,6 +457,125 @@ impl BedrockGuardrail {
             GuardrailVerdict::block_unavailable(format!("bedrock unavailable ({reason})"), reason)
         }
     }
+}
+
+/// The result of one `apply_split` call, carrying enough to rebuild a
+/// mask vector aligned with the slots it covered.
+///
+/// `Allow.masked[i]` is always present and always corresponds to slot
+/// `i` — it holds AWS's replacement where one was returned and the
+/// original text where it was not. Keeping unchanged slots in the vector
+/// (rather than an `Option` per slot) is what lets batches concatenate:
+/// merging two batches is appending their vectors, with no index
+/// arithmetic to get wrong.
+#[derive(Debug, PartialEq, Eq)]
+enum SplitOutcome {
+    Block,
+    Allow {
+        masked: Vec<String>,
+        /// Entity-type counts AWS reported, summed across every call the
+        /// split took. Names only — never matched values (#932).
+        counts: std::collections::BTreeMap<String, u32>,
+    },
+}
+
+impl SplitOutcome {
+    fn from_response(
+        resp: &ApplyGuardrailOutput,
+        texts: &[String],
+        guardrail_id: &str,
+        row_name: &str,
+    ) -> Self {
+        match classify_response(resp, guardrail_id) {
+            BedrockOutcome::Allow => Self::Allow {
+                masked: texts.to_vec(),
+                counts: Default::default(),
+            },
+            BedrockOutcome::Block => Self::Block,
+            BedrockOutcome::Mask(outputs) => {
+                if outputs.len() == texts.len() {
+                    Self::Allow {
+                        masked: outputs,
+                        counts: anonymized_counts(resp),
+                    }
+                } else {
+                    // Same fallback the un-split path takes: an
+                    // unattributable rewrite is dropped rather than
+                    // applied to the wrong slot.
+                    tracing::warn!(
+                        row = %row_name,
+                        guardrail_id = %guardrail_id,
+                        expected = texts.len(),
+                        got = outputs.len(),
+                        "bedrock masked outputs don't align with input \
+                         blocks; skipping mask write-back",
+                    );
+                    Self::Allow {
+                        masked: texts.to_vec(),
+                        counts: Default::default(),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Append `other`'s slots after this one's. `None` means the merge
+    /// hit a block, which ends the whole scan.
+    fn merge(self, other: Self) -> Option<Self> {
+        match (self, other) {
+            (Self::Block, _) | (_, Self::Block) => None,
+            (
+                Self::Allow {
+                    mut masked,
+                    mut counts,
+                },
+                Self::Allow {
+                    masked: rest,
+                    counts: more,
+                },
+            ) => {
+                masked.extend(rest);
+                for (k, v) in more {
+                    *counts.entry(k).or_insert(0) += v;
+                }
+                Some(Self::Allow { masked, counts })
+            }
+        }
+    }
+
+    /// Whether any slot came back rewritten, i.e. whether the write-back
+    /// is worth doing at all.
+    fn rewrote(&self, texts: &[String]) -> bool {
+        match self {
+            Self::Block => false,
+            Self::Allow { masked, .. } => masked.len() == texts.len() && masked != texts,
+        }
+    }
+}
+
+/// Group `texts` into batches whose combined length stays within
+/// `budget` characters, keeping every slot whole and in order.
+///
+/// A slot longer than the budget on its own becomes its own batch — it
+/// cannot be made smaller by grouping, and `apply_split` divides its
+/// text instead.
+fn batch_by_chars(texts: &[String], budget: usize) -> Vec<Vec<String>> {
+    let mut batches: Vec<Vec<String>> = Vec::new();
+    let mut current: Vec<String> = Vec::new();
+    let mut used = 0usize;
+    for text in texts {
+        let len = text.chars().count();
+        if !current.is_empty() && used + len > budget {
+            batches.push(std::mem::take(&mut current));
+            used = 0;
+        }
+        used += len;
+        current.push(text.clone());
+    }
+    if !current.is_empty() {
+        batches.push(current);
+    }
+    batches
 }
 
 /// The masking-aware interpretation of an `ApplyGuardrail` response.
@@ -452,6 +725,14 @@ fn assessment_has_hard_block(a: &GuardrailAssessment) -> bool {
 enum BedrockFailure {
     Timeout,
     Throttled,
+    /// AWS refused the payload for its size. Its own detail is kept so
+    /// the log still names the exception; the variant exists separately
+    /// because it is the one failure the dispatcher can act on — the
+    /// content is re-sent in smaller pieces rather than the request
+    /// simply failing (AISIX-Cloud#1386).
+    TooLarge {
+        detail: String,
+    },
     Other {
         /// Human-readable detail for logs: the modeled service error
         /// (carries the exception code, e.g. AccessDeniedException) or
@@ -466,14 +747,23 @@ impl BedrockFailure {
     fn from_sdk(err: SdkError<ApplyGuardrailError, Response>) -> Self {
         // ThrottlingException is the SDK's named throttle variant.
         if let SdkError::ServiceError(svc) = &err {
-            if matches!(svc.err(), ApplyGuardrailError::ThrottlingException(_)) {
-                return Self::Throttled;
-            }
             // Surface the modeled service error — its Debug carries the
             // exception code (AccessDeniedException, ValidationException,
             // …) so the failure log is greppable.
+            let detail = format!("{:?}", svc.err());
+            // Size first, and by MESSAGE rather than by exception type:
+            // AWS's per-request ceiling is a service quota, so the
+            // refusal arrives as a ValidationException in the documented
+            // case and has been observed as a throttle in practice —
+            // the wording is the reliable signal, not the variant.
+            if crate::too_large::body_says_too_large(&detail) {
+                return Self::TooLarge { detail };
+            }
+            if matches!(svc.err(), ApplyGuardrailError::ThrottlingException(_)) {
+                return Self::Throttled;
+            }
             return Self::Other {
-                detail: format!("{:?}", svc.err()),
+                detail,
                 source: std::error::Error::source(&err).map(|s| s.to_string()),
             };
         }
@@ -490,6 +780,7 @@ impl BedrockFailure {
         match self {
             Self::Timeout => "bedrock_timeout",
             Self::Throttled => "bedrock_throttled",
+            Self::TooLarge { .. } => "bedrock_too_large",
             Self::Other { .. } => "bedrock_5xx",
         }
     }
@@ -501,6 +792,7 @@ impl BedrockFailure {
             Self::Other { detail, source } => {
                 (self.bypass_tag(), Some(detail.as_str()), source.as_deref())
             }
+            Self::TooLarge { detail } => (self.bypass_tag(), Some(detail.as_str()), None),
             _ => (self.bypass_tag(), None, None),
         }
     }
@@ -1021,6 +1313,256 @@ mod tests {
             fail_open,
             Some(endpoint),
         )
+    }
+
+    // --- reactive split on an over-limit refusal (AISIX-Cloud#1386) ------
+    //
+    // AWS's per-request ceiling is a service quota that varies by region,
+    // policy type and tier and is adjustable per account, so it cannot be
+    // known here and cannot be enforced ahead of the call. These mocks
+    // stand in for whatever ceiling the account has: they refuse a body
+    // over `LIMIT` the way AWS does — a ValidationException whose message
+    // names text units — and accept anything under it.
+
+    const MOCK_LIMIT: usize = 4_000;
+
+    fn clean_body() -> serde_json::Value {
+        json!({
+            "action": "NONE",
+            "outputs": [],
+            "assessments": [],
+            "usage": {
+                "topicPolicyUnits": 0, "contentPolicyUnits": 0, "wordPolicyUnits": 0,
+                "sensitiveInformationPolicyUnits": 0,
+                "sensitiveInformationPolicyFreeUnits": 0,
+                "contextualGroundingPolicyUnits": 0
+            }
+        })
+    }
+
+    /// Refuses any request body over `MOCK_LIMIT` bytes with AWS's
+    /// size wording; otherwise answers clean. Records every body it saw
+    /// so a test can prove the whole content was submitted.
+    struct SizeLimitedBedrock {
+        seen: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+        refused: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl wiremock::Respond for SizeLimitedBedrock {
+        fn respond(&self, request: &wiremock::Request) -> ResponseTemplate {
+            let body = String::from_utf8_lossy(&request.body).to_string();
+            if body.len() > MOCK_LIMIT {
+                self.refused
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                return ResponseTemplate::new(400)
+                    .append_header("x-amzn-errortype", "ValidationException")
+                    .set_body_json(json!({
+                        "message": "Input is too long: the request exceeds the maximum \
+                                    input size in text units for this guardrail"
+                    }));
+            }
+            self.seen.lock().unwrap().push(body);
+            ResponseTemplate::new(200).set_body_json(clean_body())
+        }
+    }
+
+    /// The whole point: content AWS refuses is re-sent in pieces until it
+    /// is all scanned, instead of the request simply failing. Every
+    /// segment must appear in something the mock accepted.
+    #[tokio::test]
+    async fn over_limit_payload_is_resent_in_batches_until_all_scanned() {
+        let server = MockServer::start().await;
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let refused = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/guardrail/.+/apply$"))
+            .respond_with(SizeLimitedBedrock {
+                seen: seen.clone(),
+                refused: refused.clone(),
+            })
+            .mount(&server)
+            .await;
+
+        // Four slots, each well under the ceiling alone but far over it
+        // together, plus a distinct marker per slot.
+        let texts: Vec<String> = (0..4)
+            .map(|i| format!("MARKER{i}{}", "x".repeat(1_500)))
+            .collect();
+
+        let g = build_with_endpoint(server.uri(), false);
+        let outcome = g
+            .apply_segments(GuardrailContentSource::Input, &texts)
+            .await;
+
+        assert_eq!(
+            outcome.verdict,
+            GuardrailVerdict::Allow,
+            "a clean split must not fail the request",
+        );
+        assert!(
+            refused.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "the payload was never refused — this test would pass without any split",
+        );
+        let accepted = seen.lock().unwrap().concat();
+        for i in 0..4 {
+            assert!(
+                accepted.contains(&format!("MARKER{i}")),
+                "slot {i} never reached the provider — it was dropped, not split",
+            );
+        }
+    }
+
+    /// A single slot bigger than the ceiling has no other slots to group
+    /// with, so its own text must be divided rather than the request
+    /// failing.
+    #[tokio::test]
+    async fn single_over_limit_slot_has_its_text_split() {
+        let server = MockServer::start().await;
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let refused = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/guardrail/.+/apply$"))
+            .respond_with(SizeLimitedBedrock {
+                seen: seen.clone(),
+                refused: refused.clone(),
+            })
+            .mount(&server)
+            .await;
+
+        // One slot, several times the ceiling, whitespace-separated so
+        // the split has boundaries to prefer. Sized well past MOCK_LIMIT
+        // so the refusal path is certain to fire — the assertion below
+        // pins that it did.
+        let text = (0..2_000)
+            .map(|i| format!("token{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let g = build_with_endpoint(server.uri(), false);
+        let v = g.apply(GuardrailContentSource::Input, text.clone()).await;
+
+        assert_eq!(v, GuardrailVerdict::Allow);
+        assert!(
+            refused.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "the slot was never refused — this test would pass without any split",
+        );
+        let accepted = seen.lock().unwrap().concat();
+        assert!(
+            accepted.contains("token0") && accepted.contains("token1999"),
+            "both ends of the oversized slot must be scanned",
+        );
+    }
+
+    /// A block found in any piece ends the scan — the split must not let
+    /// a later clean piece overwrite an earlier refusal.
+    #[tokio::test]
+    async fn a_block_in_any_piece_blocks_the_request() {
+        let server = MockServer::start().await;
+        struct BlockOnMarker;
+        impl wiremock::Respond for BlockOnMarker {
+            fn respond(&self, request: &wiremock::Request) -> ResponseTemplate {
+                let body = String::from_utf8_lossy(&request.body).to_string();
+                if body.len() > MOCK_LIMIT {
+                    return ResponseTemplate::new(400)
+                        .append_header("x-amzn-errortype", "ValidationException")
+                        .set_body_json(json!({ "message": "exceeds the maximum input size" }));
+                }
+                if body.contains("FORBIDDEN") {
+                    return ResponseTemplate::new(200).set_body_json(json!({
+                        "action": "GUARDRAIL_INTERVENED",
+                        "outputs": [{ "text": "blocked" }],
+                        "assessments": [{
+                            "topicPolicy": { "topics": [
+                                { "name": "t", "type": "DENY", "action": "BLOCKED" }
+                            ]}
+                        }],
+                        "usage": {
+                            "topicPolicyUnits": 1, "contentPolicyUnits": 0,
+                            "wordPolicyUnits": 0, "sensitiveInformationPolicyUnits": 0,
+                            "sensitiveInformationPolicyFreeUnits": 0,
+                            "contextualGroundingPolicyUnits": 0
+                        }
+                    }));
+                }
+                ResponseTemplate::new(200).set_body_json(clean_body())
+            }
+        }
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/guardrail/.+/apply$"))
+            .respond_with(BlockOnMarker)
+            .mount(&server)
+            .await;
+
+        // The offending content sits in the LAST slot, so a split that
+        // stopped early would miss it.
+        let mut texts: Vec<String> = (0..3)
+            .map(|i| format!("clean{i}{}", "x".repeat(1_500)))
+            .collect();
+        texts.push("FORBIDDEN".to_owned());
+
+        let g = build_with_endpoint(server.uri(), false);
+        let outcome = g
+            .apply_segments(GuardrailContentSource::Input, &texts)
+            .await;
+        assert!(
+            outcome.verdict.is_block(),
+            "a block in the final batch must still block the request",
+        );
+    }
+
+    /// A payload AWS accepts must still cost exactly one call — the
+    /// split is reactive, so it must not add round trips to traffic that
+    /// never had a size problem.
+    #[tokio::test]
+    async fn accepted_payload_is_still_a_single_call() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/guardrail/.+/apply$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(clean_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let g = build_with_endpoint(server.uri(), false);
+        let texts = vec!["a".to_owned(), "b".to_owned(), "c".to_owned()];
+        let outcome = g
+            .apply_segments(GuardrailContentSource::Input, &texts)
+            .await;
+        assert_eq!(outcome.verdict, GuardrailVerdict::Allow);
+    }
+
+    /// A refusal we cannot make smaller still fails — and fails as a size
+    /// problem, not as an outage or a throttle, so the operator is told
+    /// what actually to change.
+    #[tokio::test]
+    async fn unsplittable_refusal_reports_too_large() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/guardrail/.+/apply$"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .append_header("x-amzn-errortype", "ValidationException")
+                    .set_body_json(json!({ "message": "exceeds the maximum input size" })),
+            )
+            .mount(&server)
+            .await;
+        let g = build_with_endpoint(server.uri(), true);
+        // A single short slot: nothing to batch, nothing to divide.
+        let v = g.apply(GuardrailContentSource::Input, "hi".into()).await;
+        match v {
+            GuardrailVerdict::Bypass { reason } => assert_eq!(reason, "bedrock_too_large"),
+            other => panic!("expected a size-tagged bypass, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn batching_keeps_slots_whole_and_ordered() {
+        let texts: Vec<String> = vec!["a".repeat(60), "b".repeat(60), "c".repeat(10)];
+        let batches = batch_by_chars(&texts, 100);
+        assert_eq!(batches.len(), 2, "60+60 exceeds 100, so it must split");
+        assert_eq!(batches.concat(), texts, "no slot may be lost or reordered");
+        // A slot bigger than the budget becomes its own batch rather than
+        // being dropped — apply_split divides its text instead.
+        let huge = vec!["z".repeat(500)];
+        assert_eq!(batch_by_chars(&huge, 100).len(), 1);
     }
 
     /// Happy-path: Bedrock returns `action=NONE` → Allow. This is the

--- a/crates/aisix-guardrails/src/lakera.rs
+++ b/crates/aisix-guardrails/src/lakera.rs
@@ -47,6 +47,7 @@
 //! | timeout                         | true        | Bypass { "lakera_timeout" }      |
 //! | 429 Throttling                  | true        | Bypass { "lakera_throttled" }    |
 //! | 5xx / IO error                  | true        | Bypass { "lakera_5xx" }          |
+//! | 413, or size wording in the body | true       | Bypass { "lakera_too_large" }    |
 //! | 4xx (non-429, e.g. 401/400)     | true        | Bypass { "lakera_config_error" } |
 //! | any failure                     | false       | Block { "lakera unavailable …" } |
 
@@ -162,6 +163,9 @@ impl LakeraGuardrail {
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
             return Err(LakeraFailure::Throttled);
         }
+        if status == reqwest::StatusCode::PAYLOAD_TOO_LARGE {
+            return Err(LakeraFailure::TooLarge);
+        }
         if status.is_server_error() {
             return Err(LakeraFailure::ServerError);
         }
@@ -177,6 +181,9 @@ impl LakeraGuardrail {
                 response_body = %response_body,
                 "lakera guard returned 4xx — check endpoint, api_key, and project_id configuration",
             );
+            if crate::too_large::body_says_too_large(&response_body) {
+                return Err(LakeraFailure::TooLarge);
+            }
             return Err(LakeraFailure::ConfigError);
         }
 
@@ -304,6 +311,11 @@ enum LakeraFailure {
     IoError,
     ServerError,
     ConfigError,
+    /// The provider refused the payload for its size. Lakera publishes
+    /// neither a size limit nor an error shape, so this is reached only
+    /// through a standard `413` or generic size wording — see
+    /// `crate::too_large` (AISIX-Cloud#1386).
+    TooLarge,
 }
 
 impl LakeraFailure {
@@ -313,6 +325,7 @@ impl LakeraFailure {
             Self::Throttled => "lakera_throttled",
             Self::IoError | Self::ServerError => "lakera_5xx",
             Self::ConfigError => "lakera_config_error",
+            Self::TooLarge => "lakera_too_large",
         }
     }
 }

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -45,6 +45,7 @@ mod prompt_shield;
 mod semantic;
 #[cfg(feature = "azure-content-safety")]
 mod text_moderation;
+mod too_large;
 
 use aisix_core::models::GuardrailMonitorHit;
 use aisix_gateway::{ChatFormat, ChatMessage, ChatResponse};

--- a/crates/aisix-guardrails/src/openai_moderation.rs
+++ b/crates/aisix-guardrails/src/openai_moderation.rs
@@ -41,6 +41,7 @@
 //! | timeout                         | true        | Bypass { "openai_moderation_timeout" }      |
 //! | 429 Throttling                  | true        | Bypass { "openai_moderation_throttled" }    |
 //! | 5xx / IO error                  | true        | Bypass { "openai_moderation_5xx" }          |
+//! | 413, or size wording in the body | true       | Bypass { "openai_moderation_too_large" }    |
 //! | 4xx (non-429, e.g. 401/400)     | true        | Bypass { "openai_moderation_config_error" } |
 //! | any failure                     | false       | Block { "openai moderation unavailable …" } |
 
@@ -156,7 +157,25 @@ impl OpenaiModerationGuardrail {
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
             return Err(ModerationFailure::Throttled);
         }
+        if status == reqwest::StatusCode::PAYLOAD_TOO_LARGE {
+            return Err(ModerationFailure::TooLarge);
+        }
         if status.is_server_error() {
+            // A 5xx is normally an outage, but a Presidio-style analyzer
+            // surfaces its NLP pipeline's own length ceiling as an
+            // unhandled error here — read the body before deciding which
+            // it was, so the operator is not sent after an outage that
+            // is really a payload the deployment cannot take.
+            let response_body = crate::read_error_body_capped(resp).await;
+            if crate::too_large::body_says_too_large(&response_body) {
+                tracing::error!(
+                    row = %self.row_name,
+                    http_status = status.as_u16(),
+                    response_body = %response_body,
+                    "openai_moderation refused the payload for its size",
+                );
+                return Err(ModerationFailure::TooLarge);
+            }
             return Err(ModerationFailure::ServerError);
         }
         if !status.is_success() {
@@ -171,6 +190,9 @@ impl OpenaiModerationGuardrail {
                 response_body = %response_body,
                 "openai moderation returned 4xx — check endpoint, api_key, and model configuration",
             );
+            if crate::too_large::body_says_too_large(&response_body) {
+                return Err(ModerationFailure::TooLarge);
+            }
             return Err(ModerationFailure::ConfigError);
         }
 
@@ -254,6 +276,11 @@ enum ModerationFailure {
     IoError,
     ServerError,
     ConfigError,
+    /// The provider refused the payload for its size. Distinct from
+    /// `ConfigError` and `Throttled` because the operator's fix is
+    /// different: neither fixing credentials nor waiting helps — the
+    /// request has to get smaller (AISIX-Cloud#1386).
+    TooLarge,
 }
 
 impl ModerationFailure {
@@ -263,6 +290,7 @@ impl ModerationFailure {
             Self::Throttled => "openai_moderation_throttled",
             Self::IoError | Self::ServerError => "openai_moderation_5xx",
             Self::ConfigError => "openai_moderation_config_error",
+            Self::TooLarge => "openai_moderation_too_large",
         }
     }
 }

--- a/crates/aisix-guardrails/src/presidio.rs
+++ b/crates/aisix-guardrails/src/presidio.rs
@@ -41,6 +41,7 @@
 //! | timeout                         | true        | Bypass { "presidio_timeout" }      |
 //! | 429 Throttling                  | true        | Bypass { "presidio_throttled" }    |
 //! | 5xx / IO error                  | true        | Bypass { "presidio_5xx" }          |
+//! | 413, or spaCy's E088 in the body | true       | Bypass { "presidio_too_large" }    |
 //! | 4xx (non-429, e.g. 400/404)     | true        | Bypass { "presidio_config_error" } |
 //! | any failure                     | false       | Block { "presidio unavailable …" } |
 
@@ -213,7 +214,25 @@ impl PresidioGuardrail {
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
             return Err(PresidioFailure::Throttled);
         }
+        if status == reqwest::StatusCode::PAYLOAD_TOO_LARGE {
+            return Err(PresidioFailure::TooLarge);
+        }
         if status.is_server_error() {
+            // A 5xx is normally an outage, but a Presidio-style analyzer
+            // surfaces its NLP pipeline's own length ceiling as an
+            // unhandled error here — read the body before deciding which
+            // it was, so the operator is not sent after an outage that
+            // is really a payload the deployment cannot take.
+            let response_body = crate::read_error_body_capped(resp).await;
+            if crate::too_large::body_says_too_large(&response_body) {
+                tracing::error!(
+                    row = %self.row_name,
+                    http_status = status.as_u16(),
+                    response_body = %response_body,
+                    "presidio refused the payload for its size",
+                );
+                return Err(PresidioFailure::TooLarge);
+            }
             return Err(PresidioFailure::ServerError);
         }
         if !status.is_success() {
@@ -227,6 +246,9 @@ impl PresidioGuardrail {
                 response_body = %response_body,
                 "presidio returned 4xx — check analyzer_url/anonymizer_url, language, and entities configuration",
             );
+            if crate::too_large::body_says_too_large(&response_body) {
+                return Err(PresidioFailure::TooLarge);
+            }
             return Err(PresidioFailure::ConfigError);
         }
         resp.json().await.map_err(|_| PresidioFailure::ServerError)
@@ -373,6 +395,11 @@ enum PresidioFailure {
     IoError,
     ServerError,
     ConfigError,
+    /// The provider refused the payload for its size. Distinct from
+    /// `ConfigError` and `Throttled` because the operator's fix is
+    /// different: neither fixing credentials nor waiting helps — the
+    /// request has to get smaller (AISIX-Cloud#1386).
+    TooLarge,
 }
 
 impl PresidioFailure {
@@ -382,6 +409,7 @@ impl PresidioFailure {
             Self::Throttled => "presidio_throttled",
             Self::IoError | Self::ServerError => "presidio_5xx",
             Self::ConfigError => "presidio_config_error",
+            Self::TooLarge => "presidio_too_large",
         }
     }
 }

--- a/crates/aisix-guardrails/src/too_large.rs
+++ b/crates/aisix-guardrails/src/too_large.rs
@@ -1,0 +1,123 @@
+//! Recognising "the provider refused this payload for being too big".
+//!
+//! Every remote kind already classifies its failures, but none of them
+//! had a bucket for this one, so an over-limit refusal was filed as
+//! whatever its status code happened to look like — a throttle, or a
+//! misconfiguration. Both are actively misleading: an operator who reads
+//! `throttled` waits and retries, and the retry can never succeed
+//! because the cause is the size of the request, not its rate
+//! (AISIX-Cloud#1386).
+//!
+//! The bound itself is deliberately NOT hardcoded per kind. Of the four
+//! kinds with no local limit, not one publishes a figure we could hold:
+//!
+//! - **Bedrock** caps `ApplyGuardrail` at 25–1 000 text units of 1 000
+//!   characters each, varying by region, by policy type, by tier, and
+//!   adjustable per account — so between 25 000 and 1 000 000 characters,
+//!   knowable only to the account that owns the quota.
+//!   <https://docs.aws.amazon.com/general/latest/gr/bedrock.html>
+//! - **OpenAI** documents no input limit for `/moderations` at all; the
+//!   real constraint is the tokens-per-minute budget, which a single
+//!   large request exhausts — which is why the refusal arrives as a 429
+//!   whose message is about rate.
+//!   <https://developers.openai.com/api/docs/guides/moderation>
+//! - **Presidio** has no limit of its own — the ceiling is whichever
+//!   spaCy pipeline the operator deployed (`nlp.max_length`, 1 000 000
+//!   characters by default), i.e. their configuration, not ours.
+//!   <https://github.com/microsoft/presidio/discussions/916>
+//! - **Lakera** publishes nothing: neither a size limit nor an error
+//!   response other than `200`.
+//!   <https://docs.lakera.ai/api-reference/lakera-api/guard/screen-content>
+//!
+//! So detection is reactive by necessity, and the evidence for it is
+//! uneven. HTTP 413 is the standard answer and costs nothing to honour
+//! anywhere. Beyond that only Bedrock and Presidio have a documented
+//! message shape to match; for Lakera and OpenAI we match nothing
+//! extra rather than invent vendor strings we have never seen.
+
+/// Wording a provider uses when it refuses a payload for its size.
+///
+/// Sourced, not guessed: the first six are AWS's, the last two are
+/// spaCy's `E088` (which surfaces through Presidio's analyzer when the
+/// text exceeds the deployed pipeline's `nlp.max_length`). Matching is
+/// case-insensitive and substring-based because these arrive inside
+/// longer sentences that also carry the offending numbers.
+const TOO_LARGE_MARKERS: &[&str] = &[
+    "text unit",
+    "maximum input size",
+    "content size",
+    "too long",
+    "too large",
+    "exceeds the maximum",
+    "exceeds maximum of",
+    "e088",
+];
+
+/// Whether a provider's error text says the payload was too big.
+///
+/// Status is handled at the call sites, which match `413` directly:
+/// that is the only status meaning this unambiguously. `400` and `429`
+/// are deliberately NOT treated as size failures by status — both have
+/// overwhelmingly more common causes (a malformed request, a real
+/// throttle), so they reach this function and are judged on their
+/// message instead.
+///
+/// Callers pass the response body or the SDK error's own rendering; both
+/// are bounded upstream before reaching here.
+pub(crate) fn body_says_too_large(body: &str) -> bool {
+    let lowered = body.to_ascii_lowercase();
+    TOO_LARGE_MARKERS.iter().any(|m| lowered.contains(m))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// AWS's own wording, which is what makes the Bedrock reactive split
+    /// fire. Taken from the quota documentation's vocabulary.
+    #[test]
+    fn recognises_aws_size_wording() {
+        for body in [
+            "ValidationException: Input is too long for requested model",
+            "maximum input size in text units exceeded",
+            "The content size exceeds the maximum allowed",
+            "Guardrail input too large",
+            "input exceeds the maximum of 25 text units",
+        ] {
+            assert!(body_says_too_large(body), "missed: {body}");
+        }
+    }
+
+    /// spaCy's error, which is what a Presidio analyzer raises when the
+    /// text is longer than the deployed pipeline allows.
+    #[test]
+    fn recognises_spacy_max_length_error() {
+        let body = "ValueError: [E088] Text of length 2000000 exceeds maximum of 1000000. \
+                    The parser and NER models require roughly 1GB of temporary memory per \
+                    100,000 characters in the input.";
+        assert!(body_says_too_large(body));
+    }
+
+    #[test]
+    fn matching_is_case_insensitive() {
+        assert!(body_says_too_large("CONTENT SIZE EXCEEDS LIMIT"));
+        assert!(body_says_too_large("Text Unit quota exceeded"));
+    }
+
+    /// The failure texts that must keep their existing buckets — a
+    /// mis-hit here would relabel a real outage or misconfiguration as a
+    /// size problem and send the operator after the wrong fix.
+    #[test]
+    fn ordinary_failures_are_not_size_failures() {
+        for body in [
+            "AccessDeniedException: not authorized to perform bedrock:ApplyGuardrail",
+            "ThrottlingException: Rate exceeded",
+            "Rate limit reached for text-moderation-007 on tokens per min (TPM)",
+            "invalid_api_key: Incorrect API key provided",
+            "503 Service Unavailable",
+            "connection reset by peer",
+        ] {
+            assert!(!body_says_too_large(body), "false positive: {body}");
+        }
+    }
+}

--- a/tests/e2e/src/cases/bedrock-anonymize-mask-e2e.test.ts
+++ b/tests/e2e/src/cases/bedrock-anonymize-mask-e2e.test.ts
@@ -46,8 +46,14 @@ interface BedrockCall {
 interface MockBedrock {
   url: string;
   calls: BedrockCall[];
+  /** Body sizes the mock refused as too large, in arrival order. */
+  refusals: number[];
   close(): Promise<void>;
 }
+
+// Small enough that an ordinary multi-turn conversation trips it, so the
+// split path is exercised without megabyte fixtures.
+const SIZE_CEILING_BYTES = 6_000;
 
 // Content-driven ApplyGuardrail mock:
 // - any block containing "BLOCKME"   → INTERVENED, BLOCKED pii entity
@@ -58,6 +64,7 @@ interface MockBedrock {
 // - otherwise                        → NONE
 async function startMockBedrock(): Promise<MockBedrock> {
   const calls: BedrockCall[] = [];
+  const refusals: number[] = [];
   const server: Server = createServer((req, res) => {
     let raw = "";
     req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
@@ -73,6 +80,26 @@ async function startMockBedrock(): Promise<MockBedrock> {
         texts = (body.content ?? []).map((c) => c.text?.text ?? "");
       } catch {
         // fall through with empty texts — answered as NONE below
+      }
+      // AISIX-Cloud#1386: stand in for the account's real ApplyGuardrail
+      // ceiling, which is a per-region, per-policy, adjustable service
+      // quota the gateway cannot know. Refuse an oversized body the way
+      // AWS does — a ValidationException naming text units — so the
+      // dispatcher's reactive split is what has to get the content
+      // through. Refusals are NOT recorded as calls: `calls` is what the
+      // provider actually scanned.
+      if (raw.length > SIZE_CEILING_BYTES) {
+        refusals.push(raw.length);
+        res.statusCode = 400;
+        res.setHeader("content-type", "application/json");
+        res.setHeader("x-amzn-errortype", "ValidationException");
+        res.end(
+          JSON.stringify({
+            message:
+              "Input is too long: the request exceeds the maximum input size in text units",
+          }),
+        );
+        return;
       }
       calls.push({ source, texts });
 
@@ -125,6 +152,7 @@ async function startMockBedrock(): Promise<MockBedrock> {
   return {
     url: `http://127.0.0.1:${port}`,
     calls,
+    refusals,
     async close() {
       await new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()));
@@ -315,6 +343,56 @@ describe("bedrock guardrail ANONYMIZE write-back (#932 follow-up)", () => {
         bedrock!.calls.some((c) => c.source === "OUTPUT"),
         "output hook must have scanned the reply",
       ).toBe(true);
+    },
+    60_000,
+  );
+
+  // AISIX-Cloud#1386
+  test(
+    "a payload AWS refuses as too large is re-sent in pieces, not failed",
+    async (ctx) => {
+      if (!etcdReachable) {
+        ctx.skip();
+        return;
+      }
+      const refusalsBefore = bedrock!.refusals.length;
+      const callsBefore = bedrock!.calls.length;
+
+      // A conversation comfortably past the mock's ceiling, with a
+      // distinct marker per turn so the assertions can prove each one
+      // was actually scanned rather than dropped.
+      const turns = Array.from({ length: 6 }, (_, i) => ({
+        role: "user" as const,
+        content: `TURNMARK${i} ${"filler ".repeat(200)}`,
+      }));
+
+      const r = await chat(CALLER, "bmask-e2e", turns);
+      expect(r.status).toBe(200);
+
+      // The ceiling really was hit — without this the test would pass
+      // even if nothing was ever split.
+      expect(
+        bedrock!.refusals.length,
+        "the mock never refused; the payload was under the ceiling",
+      ).toBeGreaterThan(refusalsBefore);
+
+      // Every turn reached the provider inside some accepted call.
+      const scanned = bedrock!.calls
+        .slice(callsBefore)
+        .filter((c) => c.source === "INPUT")
+        .flatMap((c) => c.texts)
+        .join("\n");
+      for (let i = 0; i < turns.length; i += 1) {
+        expect(
+          scanned.includes(`TURNMARK${i}`),
+          `turn ${i} never reached the provider — it was dropped, not split`,
+        ).toBe(true);
+      }
+
+      // And every accepted call stayed inside the ceiling.
+      for (const c of bedrock!.calls.slice(callsBefore)) {
+        expect(c.texts.join("").length).toBeLessThan(SIZE_CEILING_BYTES);
+      }
     },
     60_000,
   );


### PR DESCRIPTION
Fixes api7/AISIX-Cloud#1386

Carries out the part of #1382 that api7/aisix#1040 left open, now that the vendor research it was waiting on is done.

## The research changed the plan

#1386 assumed each provider publishes a per-call limit we could chunk to ahead of the call, the way the Aliyun and Azure kinds already do. **None of the four does.** Primary sources:

| kind | documented per-call limit | |
|---|---|---|
| **bedrock** | 25–1 000 text units × 1 000 chars = **25 000 – 1 000 000 chars**, varying by region, policy type and tier, and **adjustable per account** | [service quotas](https://docs.aws.amazon.com/general/latest/gr/bedrock.html), [text unit = 1 000 chars](https://aws.amazon.com/bedrock/pricing/) |
| **lakera** | none — no size limit and no error response other than `200` | [API reference](https://docs.lakera.ai/api-reference/lakera-api/guard/screen-content) |
| **openai_moderation** | none documented; the real constraint is the tokens-per-minute budget | [moderation guide](https://developers.openai.com/api/docs/guides/moderation) |
| **presidio** | none in Presidio — the ceiling is the operator's own spaCy `nlp.max_length` (default 1 000 000) | [maintainer](https://github.com/microsoft/presidio/discussions/916) |

Worth noting for the reference-implementation rule: LiteLLM hardcodes a limit constant for **Azure only**. Its Bedrock value is a re-send batch size, with a comment saying the real quota "cannot be predicted ahead of time" — the same conclusion, reached independently.

So the bound stays reactive, and item 3 as written ("chunk proactively where a limit exists") is not actionable for any of the four.

## What was actually wrong: the diagnosis

An over-limit refusal was filed as whatever its status code resembled — a throttle, or a misconfiguration. Both send the operator after the wrong fix: neither waiting nor rotating credentials makes the request smaller.

Every remote kind now has a distinct size-failure class (`*_too_large`), reached through a standard `413` or through `crate::too_large`'s wording. That wording is **sourced, not guessed**: AWS's own vocabulary and spaCy's `E088`. For Lakera and OpenAI, where no message shape has ever been published, nothing beyond `413` is matched — inventing vendor strings we have never seen would be worse than not matching.

One honest non-finding: OpenAI's over-long input returns a **genuine** 429 about TPM, and splitting would not reduce the tokens it costs. It stays classified as a throttle because that is what it is.

## Bedrock re-sends instead of failing

The one provider that refuses recognisably now acts on it. The payload goes whole first, so a request AWS would have accepted still costs exactly one call — packing into fixed batches up front would split conversations AWS was happy to take whole and multiply billed text units on traffic that never had a size problem.

Only a refusal triggers a re-send in pieces. Batches of whole slots keep the mask write-back aligned by construction: each batch's `outputs[]` lines up with the slots it carried, so concatenating batches yields a vector aligned with `texts`. Entity counts are summed across every call.

**Progress is guaranteed at every step**, which is what makes the recursion terminate: batch → halve the slot list when batching cannot reduce it (the account's ceiling may be below our batch budget) → halve the slot's own text when one slot is left. The middle step is not theoretical — it is what the first version got wrong, and the test that caught it is in the suite.

## No config surface

The batch size is a constant, not a knob. It is not a limit to be tuned but a value to try after a refusal, and a batch still refused is split again — so it trades round trips against batch size and cannot fail a request on its own. No `cp-admin.yaml`, no dashboard, no schema change.

## Tests

- Both split paths and the block short-circuit, against a mock that refuses oversized bodies the way AWS does. Each asserts **the refusal actually fired** — a test that never trips the ceiling proves nothing, and one of these was silently doing exactly that until the assertion was added.
- Per-slot markers proving nothing was dropped rather than split; an accepted payload still costing one call; an unsplittable refusal surfacing as `bedrock_too_large`.
- Detector tests covering AWS and spaCy wording, and pinning that ordinary failures (`AccessDenied`, `ThrottlingException`, a real TPM message, `503`) are **not** reclassified.
- DP E2E over a real `aisix` binary: a six-turn conversation past a mock ceiling, asserting every turn reached the provider and every accepted call stayed inside it.

Full workspace `cargo test`, `clippy -D warnings`, `fmt --check`, and the complete DP E2E suite (218 files / 674 tests) green locally. No schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)