### PR TITLE
test(ratelimit): stop the shared rps test racing the second boundary

### DIFF
--- a/crates/aisix-ratelimit/tests/redis_integration.rs
+++ b/crates/aisix-ratelimit/tests/redis_integration.rs
@@ -104,6 +104,29 @@ async fn rpm_counter_is_shared_across_replicas() {
     );
 }
 
+/// Sleep until the next whole second starts.
+///
+/// The rps counter buckets server-side: the Lua script reads `now` from
+/// `redis.call('TIME')` and derives `ws = now - (now % window)`. So the
+/// boundary that matters is Redis's clock at script-execution time, and
+/// a test that starts at an arbitrary offset into a second is racing
+/// whatever is left of it. Aligning first puts a full second between the
+/// pair and the next boundary, so only a Redis stalled for more than a
+/// second could still split them — which is a real failure, not a race.
+///
+/// This uses the client clock to align against a server-side bucket,
+/// which holds because CI runs Redis as a service container on the same
+/// host. A remote Redis with clock skew would need the alignment read
+/// from `TIME` instead.
+async fn wait_for_second_boundary() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is after the epoch");
+    let remainder = Duration::from_nanos(u64::from(now.subsec_nanos()));
+    tokio::time::sleep(Duration::from_secs(1) - remainder).await;
+}
+
 #[tokio::test]
 async fn rps_window_rolls_over_on_the_shared_counter() {
     let Some(url) = redis_url() else {
@@ -117,6 +140,15 @@ async fn rps_window_rolls_over_on_the_shared_counter() {
         rps: Some(1),
         ..rl()
     };
+
+    // The rps counter buckets by whole wall-clock second, so both
+    // acquires have to land inside the SAME bucket for the second one to
+    // be rejected. Starting mid-second, two Redis round-trips can
+    // straddle the boundary and the second call is legitimately allowed
+    // — the assertion below then fails with nothing wrong in the code.
+    // Wait out whatever is left of the current second first, so the pair
+    // begins with a full one ahead of it.
+    wait_for_second_boundary().await;
 
     a.acquire(&key, &limits, "a-1")
         .await


### PR DESCRIPTION
`rps_window_rolls_over_on_the_shared_counter` fails intermittently on CI — it took down `rust unit + coverage` on an unrelated PR (#1042), which is how it surfaced. Split out per the rule that a CI fix unrelated to a PR's purpose ships on its own.

## What is wrong

The test asserts that two acquires against one Redis land in the same one-second bucket, so the second is rejected. Nothing made them do so. It began wherever in the second the previous test left it, and when the boundary fell between the two calls the second one was legitimately allowed — failing with `same second is shared-rejected` while the code under test was behaving correctly.

The bucket is computed **server-side**: the Lua script reads `now` from `redis.call('TIME')` and takes `now - (now % window)`. So the race window is exactly the gap between the two script executions.

The fix waits out the current second before the pair, putting a full second between them and the next boundary. Only a Redis stalled for over a second could then split them — which is a real failure, not a race.

## What I could not verify

**This was not reproduced locally**, and I would rather say so than imply otherwise. The gap between two round-trips to a local Redis is sub-millisecond, so the boundary almost never lands inside it: sweeping deliberate start offsets from 100µs to 1.2ms before a boundary gave **0 failures in 42 runs**. The mechanism is established by reading the script, not by reproduction — which is consistent with it appearing on CI (containerised Redis, loaded runner, wider gap) and not on a developer's machine.

The fix removes the dependence on where in the second the test starts, so it holds however wide that gap gets. Ten consecutive runs of the full `redis_integration` suite against a real Redis pass.

## One caveat worth knowing

The alignment reads the **client** clock against a **server-side** bucket. That holds only because CI runs Redis as a service container on the same host. A remote Redis with clock skew would have to align from `TIME` instead — recorded at the helper so the next person hitting this does not have to rediscover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)