### PR TITLE
feat(obs): log the downstream connection identity a rollout needs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -364,8 +364,19 @@ downstream:
 # is left in flight. In-flight requests then drain with no deadline — an
 # inference call or an SSE stream may run for minutes — so the platform
 # (Kubernetes terminationGracePeriodSeconds, systemd TimeoutStopSec) is
-# the only hard bound. Make sure that bound is generous enough for your
-# longest request.
+# the only hard bound.
+#
+# Size that bound for TWO requests back to back, not one. The gateway
+# retires a client's connection by answering `Connection: close`, which
+# rides on the response head — and a streamed response commits its head
+# at the first token, so a stream already running at SIGTERM can never
+# carry it, however long it runs. That connection returns to the client's
+# pool unmarked and gets used once more; only THAT request's head is
+# generated during the drain, carries the header, and ends the chain. So
+# the tail is the stream still running at the signal plus the one request
+# its connection is reused for, each able to run to its own client
+# timeout. The aisix Helm chart's "Termination and draining" section
+# works a default out from that.
 shutdown:
   # Minimum seconds to keep accepting new connections after the signal,
   # while /readyz already reports 503.

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -165,6 +165,11 @@ downstream:
 # in front has time to withdraw it, then waits for in-flight requests to
 # finish before closing the listener. Raise it above the detection latency
 # of your balancer's health check. In-flight drain itself is unbounded, so
-# terminationGracePeriodSeconds must cover your longest request.
+# terminationGracePeriodSeconds must cover two requests back to back: a
+# streamed response commits its head at the first token, so a stream
+# already running at SIGTERM never gets the `Connection: close` that
+# retires its connection, and the client reuses that connection once more
+# before the successor's head — generated during the drain — ends the
+# chain. See the aisix Helm chart's "Termination and draining" section.
 shutdown:
   min_drain_secs: 30

--- a/crates/aisix-obs/src/access_log.rs
+++ b/crates/aisix-obs/src/access_log.rs
@@ -15,6 +15,12 @@
 //!   produced nothing yet, so the token counts and `provider_request_id` are
 //!   necessarily absent, and `status` is the response-OPEN status: a stream
 //!   that later aborts, or whose consumer walks away, still logged `200`.
+//!   `latency` is time-to-first-token for the same reason, NOT how long the
+//!   stream ran — the two differ by the whole length of the stream, which
+//!   for an LLM is routinely minutes. A stream's real end is only on its
+//!   `UsageEvent`; reading this line as the end of the request is how a
+//!   long-running stream gets mistaken for a connection sitting idle
+//!   (AISIX-Cloud#1394).
 //! - **`/v1/realtime`** — the opposite extreme. The handler returns the
 //!   WebSocket upgrade immediately; the line is written by `run_session` on
 //!   a detached task once the session closes, so it carries the close status

--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -1221,6 +1221,28 @@ mod tests {
         assert!(text.contains("livez check failed"));
     }
 
+    /// The count has to survive an unpaired decrement: it is reported on
+    /// the drain heartbeat, and a wrapped counter would report billions of
+    /// open connections at exactly the moment an operator is reading the
+    /// line to decide whether traffic is still arriving.
+    #[test]
+    fn open_connections_saturates_at_zero() {
+        let state = LivezState::new();
+        assert_eq!(state.open_connections(), 0);
+
+        state.connection_closed();
+        assert_eq!(state.open_connections(), 0);
+
+        state.connection_opened();
+        state.connection_opened();
+        assert_eq!(state.open_connections(), 2);
+
+        state.connection_closed();
+        state.connection_closed();
+        state.connection_closed();
+        assert_eq!(state.open_connections(), 0);
+    }
+
     #[test]
     fn config_readiness_block_logic() {
         // No apply yet → not ready (startup).

--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -34,11 +34,18 @@ static TEXT_PLAIN_UTF8: HeaderValue = HeaderValue::from_static("text/plain; char
 pub struct LivezState {
     shutting_down: AtomicBool,
     /// Requests currently being served on the proxy listener, raised and
-    /// lowered by the telemetry middleware's RAII guard. Read by the
-    /// shutdown coordinator to decide when closing the listener can no
-    /// longer interrupt anything; a streaming response keeps its slot for
-    /// as long as bytes may still flow.
+    /// lowered by the telemetry middleware's RAII guard. Reported on the
+    /// drain heartbeat so an operator can watch the tail empty; a
+    /// streaming response keeps its slot for as long as bytes may still
+    /// flow.
     in_flight: AtomicUsize,
+    /// Downstream connections currently open on the proxy listener,
+    /// raised and lowered by the acceptor's RAII guard. Distinct from
+    /// `in_flight` and not derivable from it: a pooled connection sitting
+    /// idle carries no request, and during a drain a count that stays up
+    /// while `in_flight` falls is what tells an operator the load
+    /// balancer has not stopped routing here yet (AISIX-Cloud#1394).
+    connections: AtomicUsize,
 }
 
 impl LivezState {
@@ -70,6 +77,28 @@ impl LivezState {
     /// Requests in flight right now.
     pub fn in_flight(&self) -> usize {
         self.in_flight.load(Ordering::Relaxed)
+    }
+
+    /// Raise the open-connection count. Pair with
+    /// [`Self::connection_closed`]; the acceptor does that through a
+    /// `Drop` guard carried by the accepted stream.
+    pub fn connection_opened(&self) {
+        self.connections.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Lower the open-connection count, saturating at zero for the same
+    /// reason [`Self::leave`] does.
+    pub fn connection_closed(&self) {
+        let _ = self
+            .connections
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                Some(v.saturating_sub(1))
+            });
+    }
+
+    /// Downstream connections open right now.
+    pub fn open_connections(&self) -> usize {
+        self.connections.load(Ordering::Relaxed)
     }
 
     fn shutdown_check(&self) -> Result<(), &'static str> {

--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -34,10 +34,11 @@ static TEXT_PLAIN_UTF8: HeaderValue = HeaderValue::from_static("text/plain; char
 pub struct LivezState {
     shutting_down: AtomicBool,
     /// Requests currently being served on the proxy listener, raised and
-    /// lowered by the telemetry middleware's RAII guard. Reported on the
-    /// drain heartbeat so an operator can watch the tail empty; a
-    /// streaming response keeps its slot for as long as bytes may still
-    /// flow.
+    /// lowered by the telemetry middleware's RAII guard. Read by the
+    /// shutdown coordinator to decide when closing the listener can no
+    /// longer interrupt anything, and reported on the drain heartbeat so
+    /// an operator can watch the tail empty; a streaming response keeps
+    /// its slot for as long as bytes may still flow.
     in_flight: AtomicUsize,
     /// Downstream connections currently open on the proxy listener,
     /// raised and lowered by the acceptor's RAII guard. Distinct from

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -537,6 +537,21 @@ async fn record_request_telemetry(
         inbound_protocol_for_endpoint(endpoint),
     );
     let drain = DrainGuard::new(state.livez.clone());
+    // Arrival is only logged while draining, where it is the one window in
+    // which a request can leave no trace at all: everything else this
+    // gateway writes about a request is written when the request ENDS, and
+    // a request still running when the platform's grace period expires
+    // never gets there. Its `peer` and ids come from the request span
+    // (see request_id.rs), which is what makes the line joinable to the
+    // fronting proxy's record of the same request. Steady-state logging
+    // volume is unchanged.
+    if state.livez.is_shutting_down() {
+        tracing::info!(
+            method = %request.method(),
+            path = %request.uri().path(),
+            "request arrived while draining"
+        );
+    }
     let mut response = attribution::scope(attribution, next.run(request)).await;
     guard.armed = false;
     // Sampled AFTER the handler, not before: a request that arrived just
@@ -574,6 +589,15 @@ fn hold_until_body_done(response: Response, drain: DrainGuard) -> Response {
 /// HTTP/2 has no such header (it is a connection-specific field, forbidden
 /// by RFC 9113 §8.2.2); its drain signal is the GOAWAY that hyper emits
 /// when the listener does shut down.
+///
+/// It cannot retire a **streaming** connection at all, and no change to
+/// this function can. A streamed response returns from the handler at the
+/// first token, so its head — this header included — is already committed
+/// and on the wire; a stream whose head went out before the signal will
+/// therefore never carry `Connection: close` however long it runs
+/// afterwards, and an LLM stream routinely runs for minutes
+/// (AISIX-Cloud#1394). Retiring those connections is the listener's
+/// shutdown to do, not this header's.
 fn retire_connection(version: &axum::http::Version, response: &mut Response) {
     if *version == axum::http::Version::HTTP_2 || *version == axum::http::Version::HTTP_3 {
         return;

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -543,12 +543,23 @@ async fn record_request_telemetry(
     // a request still running when the platform's grace period expires
     // never gets there. Its `peer` and ids come from the request span
     // (see request_id.rs), which is what makes the line joinable to the
-    // fronting proxy's record of the same request. Steady-state logging
-    // volume is unchanged.
-    if state.livez.is_shutting_down() {
+    // fronting proxy's record of the same request. No line is added to
+    // steady-state logging.
+    //
+    // The health endpoints are excluded because they are served on THIS
+    // listener and the platform keeps probing them right through the
+    // drain — the shipped chart every 3s and 10s — so including them would
+    // bury the handful of real arrivals under a probe every few seconds.
+    // A probe always reaches its completion line anyway, which is the
+    // reason this line exists for anything else.
+    //
+    // `path` is caller-controlled, so it is recorded as a string: that
+    // renders it quoted and escaped, the same way the access log writes
+    // it, rather than raw into a space-delimited line.
+    if state.livez.is_shutting_down() && !matches!(endpoint, "/livez" | "/readyz") {
         tracing::info!(
             method = %request.method(),
-            path = %request.uri().path(),
+            path = request.uri().path(),
             "request arrived while draining"
         );
     }
@@ -590,14 +601,16 @@ fn hold_until_body_done(response: Response, drain: DrainGuard) -> Response {
 /// by RFC 9113 §8.2.2); its drain signal is the GOAWAY that hyper emits
 /// when the listener does shut down.
 ///
-/// It cannot retire a **streaming** connection at all, and no change to
-/// this function can. A streamed response returns from the handler at the
-/// first token, so its head — this header included — is already committed
-/// and on the wire; a stream whose head went out before the signal will
-/// therefore never carry `Connection: close` however long it runs
-/// afterwards, and an LLM stream routinely runs for minutes
-/// (AISIX-Cloud#1394). Retiring those connections is the listener's
-/// shutdown to do, not this header's.
+/// It cannot retire a stream that was ALREADY RUNNING when the signal
+/// landed, and no change to this function can. This mutates a response
+/// the middleware still holds, so a streamed response whose handler
+/// returns DURING the drain does get the header like any other; what it
+/// cannot reach is a head that already went out. A stream is where that
+/// matters, because its connection then stays busy for minutes while the
+/// drain runs, whereas a buffered response's connection comes back for
+/// the next request and is retired on that one (AISIX-Cloud#1394).
+/// Retiring the still-running ones is the listener's shutdown to do, not
+/// this header's.
 fn retire_connection(version: &axum::http::Version, response: &mut Response) {
     if *version == axum::http::Version::HTTP_2 || *version == axum::http::Version::HTTP_3 {
         return;

--- a/crates/aisix-proxy/src/request_id.rs
+++ b/crates/aisix-proxy/src/request_id.rs
@@ -201,7 +201,7 @@ pub(crate) async fn ensure_request_id(
         span.record("peer", tracing::field::display(peer.0));
     }
     if let Some(downstream) = downstream_request_id(request.headers()) {
-        span.record("downstream_request_id", downstream);
+        span.record("downstream_request_id", tracing::field::display(downstream));
     }
     let mut response = next.run(request).instrument(span).await;
 

--- a/crates/aisix-proxy/src/request_id.rs
+++ b/crates/aisix-proxy/src/request_id.rs
@@ -1,4 +1,4 @@
-use axum::extract::{Request, State};
+use axum::extract::{ConnectInfo, Request, State};
 use axum::http::{HeaderName, HeaderValue};
 use axum::middleware::Next;
 use axum::response::Response;
@@ -17,6 +17,21 @@ pub(crate) const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-aisi
 pub(crate) fn new_request_id() -> String {
     Uuid::new_v4().to_string()
 }
+
+/// The correlation id a fronting proxy stamps on the requests it
+/// forwards. `x-request-id` is what Envoy, nginx and the ingresses built
+/// on them all emit by default, which is why it is fixed here rather than
+/// configurable.
+///
+/// It is **recorded, never adopted**: whether a caller-supplied id becomes
+/// this gateway's own `request_id` stays governed by
+/// `proxy.request_id.accept_headers`, which by default takes only
+/// `x-aisix-request-id`. So a deployment behind an ingress logs two ids
+/// that mean different things — the ingress's `downstream_request_id` and
+/// the gateway's `request_id` — and neither can be mistaken for the other.
+/// When an operator does list this header in `accept_headers`, the two
+/// carry the same value, which is the honest report of what happened.
+const DOWNSTREAM_REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
 
 /// Longest caller-supplied request id accepted. Matches cp-api's
 /// `maxRequestIDLen`.
@@ -70,6 +85,18 @@ fn client_request_id(headers: &axum::http::HeaderMap, accept: &[HeaderName]) -> 
     None
 }
 
+/// The fronting proxy's own request id, when it sent an acceptable one.
+///
+/// Screened by the same [`is_acceptable`] rule as an adopted id: this
+/// value is written into logs verbatim, so it has to be visible ASCII of
+/// bounded length whether or not the gateway ever hands it back.
+fn downstream_request_id(headers: &axum::http::HeaderMap) -> Option<&str> {
+    headers
+        .get(&DOWNSTREAM_REQUEST_ID_HEADER)
+        .and_then(|raw| raw.to_str().ok())
+        .filter(|id| is_acceptable(id))
+}
+
 /// The per-request correlation id, stashed in the request extensions by
 /// [`ensure_request_id`] so every handler resolves the SAME id for both
 /// its usage event and the response header. Handlers with a
@@ -113,6 +140,25 @@ pub(crate) struct RequestId(pub String);
 /// across an await would leak the span onto whatever else the executor
 /// runs on this thread.
 ///
+/// Two connection-level identities ride the same span, for the same
+/// reason and with the same reach — the access log, the per-attempt
+/// `provider call completed` line, and every diagnostic in between:
+///
+/// - `peer`, the accepted socket's remote address INCLUDING its port. It
+///   is deliberately not the resolved client IP that
+///   [`ClientContext::source_ip`](crate::client_ip::ClientContext) already
+///   carries: that one answers "who is the caller", follows
+///   `proxy.real_ip`, and has no port. This one answers "which TCP
+///   connection", and the port is the whole of its value — behind a
+///   layer-4 load balancer with the gateway on the host network it is the
+///   only field that joins a gateway log line to the fronting proxy's
+///   record of the same connection.
+/// - `downstream_request_id`, from [`DOWNSTREAM_REQUEST_ID_HEADER`], so a
+///   trace id minted before the gateway can be searched for here.
+///
+/// Both are recorded rather than declared, so a request that carried
+/// neither logs neither field instead of an empty one.
+///
 /// Response-body streams (SSE) are polled after this middleware returns,
 /// so they fall outside the span. Generators that moderate streamed
 /// output re-attach it explicitly — see `chat::build_sse_stream`.
@@ -142,7 +188,21 @@ pub(crate) async fn ensure_request_id(
             remote,
         )));
 
-    let span = tracing::info_span!("request", request_id = %id);
+    let span = tracing::info_span!(
+        "request",
+        request_id = %id,
+        peer = tracing::field::Empty,
+        downstream_request_id = tracing::field::Empty,
+    );
+    if let Some(peer) = request
+        .extensions()
+        .get::<ConnectInfo<std::net::SocketAddr>>()
+    {
+        span.record("peer", tracing::field::display(peer.0));
+    }
+    if let Some(downstream) = downstream_request_id(request.headers()) {
+        span.record("downstream_request_id", downstream);
+    }
     let mut response = next.run(request).instrument(span).await;
 
     // If the handler already stamped the header (from the same id), keep

--- a/crates/aisix-proxy/src/request_id.rs
+++ b/crates/aisix-proxy/src/request_id.rs
@@ -201,7 +201,11 @@ pub(crate) async fn ensure_request_id(
         span.record("peer", tracing::field::display(peer.0));
     }
     if let Some(downstream) = downstream_request_id(request.headers()) {
-        span.record("downstream_request_id", tracing::field::display(downstream));
+        // Recorded as a string, not `display`: the value is caller-supplied
+        // and `is_acceptable` permits `{`, `}` and `:` — the characters the
+        // fmt subscriber delimits a span's field list with. As a string it
+        // is rendered quoted and escaped, so it cannot forge one.
+        span.record("downstream_request_id", downstream);
     }
     let mut response = next.run(request).instrument(span).await;
 

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -1669,14 +1669,19 @@ const DOWNSTREAM_NODELAY: axum_server::accept::NoDelayAcceptor =
 /// signal.
 ///
 /// Accepting is the only place either fact is observable, and during a
-/// drain the two together answer a question the logs otherwise cannot:
-/// whether what is keeping the process busy is work it had already taken
-/// on, or traffic a load balancer is still routing here
-/// (AISIX-Cloud#1394).
+/// drain they are what separates work the gateway had already taken on
+/// from traffic still being routed at it (AISIX-Cloud#1394).
+///
+/// Neither can tell a client apart from the platform, though: `/livez`
+/// and `/readyz` are served on the proxy listener too, and the probes
+/// keep arriving throughout the drain, each on its own connection. So the
+/// count includes them and the accept line does not claim to know who
+/// connected — the arrival line in `record_request_telemetry` knows the
+/// path and is where that judgement is made. This line covers what the
+/// arrival line cannot: a connection opened and never used.
 ///
 /// `drain` is `None` for the admin and metrics listeners, which are
-/// control surfaces: their probes would otherwise be counted as client
-/// connections a drain is waiting on.
+/// control surfaces nothing routes client traffic to.
 #[derive(Clone)]
 struct CountedAcceptor {
     nodelay: axum_server::accept::NoDelayAcceptor,
@@ -1775,8 +1780,7 @@ impl<S> axum_server::accept::Accept<tokio::net::TcpStream, S> for CountedAccepto
                     tracing::info!(
                         peer = stream.peer_addr().ok().map(tracing::field::display),
                         open_connections = drain.open_connections(),
-                        "accepted a new connection while draining — the load \
-                         balancer is still routing here"
+                        "accepted a new downstream connection while draining"
                     );
                 }
                 ConnectionGuard(drain.clone())
@@ -2706,6 +2710,55 @@ models:
             .await
             .expect("accept");
         assert!(accepted.nodelay().expect("read nodelay"));
+    }
+
+    /// The slot has to be released with the stream. Nothing else checks
+    /// it: every drain assertion is "at least one", so a guard that
+    /// outlived its connection would keep them all green while the count
+    /// climbed for the life of the process.
+    #[tokio::test]
+    async fn the_counted_acceptor_releases_the_slot_when_the_stream_drops() {
+        use axum_server::accept::Accept;
+
+        let livez = std::sync::Arc::new(aisix_proxy::LivezState::new());
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let client = tokio::net::TcpStream::connect(addr).await.expect("connect");
+        let (accepted, _peer) = listener.accept().await.expect("accept");
+
+        let acceptor = CountedAcceptor::new(DOWNSTREAM_NODELAY, Some(livez.clone()));
+        let (stream, ()) = acceptor.accept(accepted, ()).await.expect("accept");
+        assert_eq!(livez.open_connections(), 1);
+
+        drop(stream);
+        assert_eq!(
+            livez.open_connections(),
+            0,
+            "the slot must go back when the connection task drops the stream",
+        );
+        drop(client);
+    }
+
+    /// A listener that counts nothing must still accept: the admin and
+    /// metrics surfaces pass `None`, and a panic or a miscount there would
+    /// take down control traffic for a number nobody reads.
+    #[tokio::test]
+    async fn the_counted_acceptor_is_a_passthrough_without_a_drain_state() {
+        use axum_server::accept::Accept;
+
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let _client = tokio::net::TcpStream::connect(addr).await.expect("connect");
+        let (accepted, _peer) = listener.accept().await.expect("accept");
+
+        let acceptor = CountedAcceptor::new(DOWNSTREAM_NODELAY, None);
+        let (stream, ()) = acceptor.accept(accepted, ()).await.expect("accept");
+        // The acceptor still has to do the job it wraps.
+        assert!(stream.inner.nodelay().expect("read nodelay"));
     }
 
     /// Four listeners are served — HTTP and HTTPS, on the shared runtime

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -1188,6 +1188,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             cancel_rx.clone(),
             "admin",
             None,
+            None,
         )))
     } else {
         // Drop unused shared components so the compiler can see they
@@ -1234,6 +1235,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 cancel_rx.clone(),
                 "metrics",
                 None,
+                None,
             )))
         } else {
             None
@@ -1255,6 +1257,10 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         cancel_rx.clone(),
         "proxy",
         proxy_workers,
+        // Only the proxy listener's connections are counted: the drain is
+        // about client traffic, and folding the platform's probes into the
+        // number would report a connection nobody is waiting on.
+        Some(livez_state.clone()),
     );
 
     // Step 10: shutdown coordinator. Whichever of (signal, proxy, admin)
@@ -1658,6 +1664,134 @@ fn background_check_interval(snapshot: &aisix_core::AisixSnapshot) -> std::time:
 const DOWNSTREAM_NODELAY: axum_server::accept::NoDelayAcceptor =
     axum_server::accept::NoDelayAcceptor;
 
+/// Wraps [`DOWNSTREAM_NODELAY`] to keep [`LivezState::open_connections`]
+/// current, and to say so when a connection arrives after the shutdown
+/// signal.
+///
+/// Accepting is the only place either fact is observable, and during a
+/// drain the two together answer a question the logs otherwise cannot:
+/// whether what is keeping the process busy is work it had already taken
+/// on, or traffic a load balancer is still routing here
+/// (AISIX-Cloud#1394).
+///
+/// `drain` is `None` for the admin and metrics listeners, which are
+/// control surfaces: their probes would otherwise be counted as client
+/// connections a drain is waiting on.
+#[derive(Clone)]
+struct CountedAcceptor {
+    nodelay: axum_server::accept::NoDelayAcceptor,
+    drain: Option<std::sync::Arc<aisix_proxy::LivezState>>,
+}
+
+impl CountedAcceptor {
+    fn new(
+        nodelay: axum_server::accept::NoDelayAcceptor,
+        drain: Option<std::sync::Arc<aisix_proxy::LivezState>>,
+    ) -> Self {
+        Self { nodelay, drain }
+    }
+}
+
+/// Holds a connection's slot in the open-connection count for as long as
+/// the accepted stream lives.
+struct ConnectionGuard(std::sync::Arc<aisix_proxy::LivezState>);
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        self.0.connection_closed();
+    }
+}
+
+/// An accepted stream that lowers the open-connection count when the
+/// connection task drops it. `TcpStream` is `Unpin`, so the delegation
+/// needs no pin projection.
+struct CountedStream {
+    inner: tokio::net::TcpStream,
+    _guard: Option<ConnectionGuard>,
+}
+
+impl tokio::io::AsyncRead for CountedStream {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl tokio::io::AsyncWrite for CountedStream {
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        std::pin::Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        std::pin::Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+}
+
+impl<S> axum_server::accept::Accept<tokio::net::TcpStream, S> for CountedAcceptor {
+    type Stream = CountedStream;
+    type Service = S;
+    type Future = std::future::Ready<std::io::Result<(Self::Stream, Self::Service)>>;
+
+    fn accept(&self, stream: tokio::net::TcpStream, service: S) -> Self::Future {
+        let accepted = axum_server::accept::Accept::<tokio::net::TcpStream, S>::accept(
+            &self.nodelay,
+            stream,
+            service,
+        )
+        .into_inner();
+        std::future::ready(accepted.map(|(stream, service)| {
+            let guard = self.drain.as_ref().map(|drain| {
+                drain.connection_opened();
+                if drain.is_shutting_down() {
+                    tracing::info!(
+                        peer = stream.peer_addr().ok().map(tracing::field::display),
+                        open_connections = drain.open_connections(),
+                        "accepted a new connection while draining — the load \
+                         balancer is still routing here"
+                    );
+                }
+                ConnectionGuard(drain.clone())
+            });
+            (
+                CountedStream {
+                    inner: stream,
+                    _guard: guard,
+                },
+                service,
+            )
+        }))
+    }
+}
+
 /// Completes when the process receives SIGINT or SIGTERM (best-effort on
 /// Windows — Ctrl+C only) OR when another part of the system has already
 /// flipped the cancel channel.
@@ -1671,6 +1805,7 @@ const DOWNSTREAM_NODELAY: axum_server::accept::NoDelayAcceptor =
 /// Both variants run on `axum_server` rather than `axum::serve` because
 /// only the former exposes the hyper connection builder, which is where
 /// `downstream.idle_timeout_secs` has to be applied (AISIX-Cloud#1126).
+#[allow(clippy::too_many_arguments)]
 async fn serve_http(
     addr: std::net::SocketAddr,
     router: axum::Router,
@@ -1679,6 +1814,7 @@ async fn serve_http(
     cancel: watch::Receiver<bool>,
     label: &'static str,
     workers: Option<usize>,
+    drain: Option<std::sync::Arc<aisix_proxy::LivezState>>,
 ) -> anyhow::Result<()> {
     // Resolved before binding so a bad cert path still fails with the
     // same error it always did, before a port is taken.
@@ -1708,6 +1844,7 @@ async fn serve_http(
             cancel,
             label,
             workers,
+            drain,
         )
         .await;
     }
@@ -1738,7 +1875,7 @@ async fn serve_http(
         None => {
             tracing::info!(%addr, label, "aisix listening (http)");
             let mut server = axum_server::from_tcp(listener)
-                .acceptor(DOWNSTREAM_NODELAY)
+                .acceptor(CountedAcceptor::new(DOWNSTREAM_NODELAY, drain))
                 .handle(handle);
             apply_idle_timeout(server.http_builder(), idle_timeout);
             server.serve(make_service).await?;
@@ -1746,7 +1883,7 @@ async fn serve_http(
         Some(tls_config) => {
             tracing::info!(%addr, label, "aisix listening (https)");
             let mut server = axum_server::from_tcp_rustls(listener, tls_config)
-                .map(|tls| tls.acceptor(DOWNSTREAM_NODELAY))
+                .map(|tls| tls.acceptor(CountedAcceptor::new(DOWNSTREAM_NODELAY, drain)))
                 .handle(handle);
             apply_idle_timeout(server.http_builder(), idle_timeout);
             server.serve(make_service).await?;
@@ -1771,6 +1908,7 @@ async fn serve_http(
 /// 4-tuple. That spreads evenly across many client connections and
 /// unevenly across few, which is why the mode is documented as a
 /// throughput setting rather than a latency one.
+#[allow(clippy::too_many_arguments)]
 async fn serve_http_tpc(
     addr: std::net::SocketAddr,
     router: axum::Router,
@@ -1779,6 +1917,7 @@ async fn serve_http_tpc(
     cancel: watch::Receiver<bool>,
     label: &'static str,
     workers: usize,
+    drain: Option<std::sync::Arc<aisix_proxy::LivezState>>,
 ) -> anyhow::Result<()> {
     // An address someone else already holds has to stay a loud boot
     // failure. Every socket on a `SO_REUSEPORT` address has to set the
@@ -1811,6 +1950,10 @@ async fn serve_http_tpc(
         let cancel = cancel.clone();
         let tls_config = tls_config.clone();
         let exit_tx = exit_tx.clone();
+        // Every worker raises and lowers the same process-wide count, so
+        // the drain heartbeat reports the listener as a whole rather than
+        // whichever worker happened to accept.
+        let drain = drain.clone();
         std::thread::Builder::new()
             // Names the mode in `ps -T` / `top -H`: `tpc-N` here,
             // tokio's own `tokio-rt-worker` on the shared runtime.
@@ -1830,6 +1973,7 @@ async fn serve_http_tpc(
                     cancel,
                     label,
                     worker,
+                    drain,
                 ));
             })?;
     }
@@ -1898,6 +2042,7 @@ fn run_tpc_worker(
     cancel: watch::Receiver<bool>,
     label: &'static str,
     worker: usize,
+    drain: Option<std::sync::Arc<aisix_proxy::LivezState>>,
 ) -> anyhow::Result<()> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -1923,7 +2068,7 @@ fn run_tpc_worker(
             None => {
                 tracing::info!(%addr, label, worker, "aisix listening (http, thread-per-core)");
                 let mut server = axum_server::from_tcp(listener)
-                    .acceptor(DOWNSTREAM_NODELAY)
+                    .acceptor(CountedAcceptor::new(DOWNSTREAM_NODELAY, drain))
                     .handle(handle);
                 apply_idle_timeout(server.http_builder(), idle_timeout);
                 server.serve(make_service).await?;
@@ -1931,7 +2076,7 @@ fn run_tpc_worker(
             Some(tls_config) => {
                 tracing::info!(%addr, label, worker, "aisix listening (https, thread-per-core)");
                 let mut server = axum_server::from_tcp_rustls(listener, tls_config)
-                    .map(|tls| tls.acceptor(DOWNSTREAM_NODELAY))
+                    .map(|tls| tls.acceptor(CountedAcceptor::new(DOWNSTREAM_NODELAY, drain)))
                     .handle(handle);
                 apply_idle_timeout(server.http_builder(), idle_timeout);
                 server.serve(make_service).await?;
@@ -2057,6 +2202,7 @@ async fn wait_for_signal(
     tracing::info!(
         min_drain_secs = min_drain.as_secs(),
         in_flight = livez_state.in_flight(),
+        open_connections = livez_state.open_connections(),
         "draining — /readyz now reports 503, still accepting new connections"
     );
 
@@ -2079,7 +2225,16 @@ async fn wait_for_signal(
             break;
         }
         if last_log.elapsed() >= DRAIN_LOG_INTERVAL {
-            tracing::info!(in_flight, "still draining in-flight requests");
+            // The open-connection count next to it separates the two
+            // reasons a drain does not end: requests this gateway already
+            // took on, versus a load balancer still routing here — only
+            // the second of which is a balancer problem
+            // (AISIX-Cloud#1394).
+            tracing::info!(
+                in_flight,
+                open_connections = livez_state.open_connections(),
+                "still draining in-flight requests"
+            );
             last_log = std::time::Instant::now();
         }
         tokio::time::sleep(DRAIN_POLL_INTERVAL).await;

--- a/tests/e2e/src/cases/drain-observability-e2e.test.ts
+++ b/tests/e2e/src/cases/drain-observability-e2e.test.ts
@@ -21,9 +21,13 @@ import {
 const CALLER_PLAINTEXT = "sk-drain-obs-caller";
 const CALLER_KEY_ENV = "DRAIN_OBS_CALLER_KEY";
 
-/** Long enough that the drain heartbeat (5s) fires at least once. */
+/** Short, so the in-flight wait is reached while the requests still run. */
 const DRAIN_WINDOW_SECS = 2;
-/** Outlives the window several times over, so requests span the drain. */
+/**
+ * Long enough that requests are still in flight for more than the 5s
+ * heartbeat interval after the window elapses — which is what makes the
+ * heartbeat fire, not the window length.
+ */
 const SLOW_UPSTREAM_MS = 14_000;
 
 function resources(upstreamBase: string): string {
@@ -144,7 +148,9 @@ describe("access log carries the downstream connection identity", () => {
       () => accessLogFor(app!.output(), requestId),
       "the access-log line for the request",
     );
-    expect(line).toContain(`downstream_request_id=${downstreamId}`);
+    // Quoted, because the value is caller-supplied: rendered raw it could
+    // carry the characters the span prefix is delimited with.
+    expect(line).toContain(`downstream_request_id="${downstreamId}"`);
   });
 
   test("omits the field for a request that carried no downstream id", async () => {
@@ -236,6 +242,17 @@ describe("the drain reports what is still arriving and what is still open", () =
       expect(startLine).toMatch(/\bin_flight=\d+\b/);
       expect(startLine).toMatch(/\bopen_connections=[1-9]\d*\b/);
 
+      // The platform keeps probing the health endpoints on this same
+      // listener for the whole grace period — the shipped chart every 3s
+      // and 10s. Drive a few by hand now; the absence of an arrival line
+      // for them is asserted at the end of the test, by which point plenty
+      // of later output has been read.
+      for (let i = 0; i < 3; i++) {
+        const probe = await fetch(`${proxyUrl}/readyz`);
+        expect(probe.status).toBe(503);
+        await probe.text();
+      }
+
       // A second request, on a new connection, inside the window — the
       // shape that says the balancer has not withdrawn this instance yet.
       const duringDrain = chat(proxyUrl, { "x-request-id": "ingress-during" });
@@ -245,7 +262,9 @@ describe("the drain reports what is still arriving and what is still open", () =
           app!
             .output()
             .split("\n")
-            .find((l) => l.includes("accepted a new connection while draining")),
+            .find((l) =>
+              l.includes("accepted a new downstream connection while draining"),
+            ),
         "the accept-during-drain line",
       );
       expect(acceptLine).toMatch(/\bpeer=\d{1,3}(?:\.\d{1,3}){3}:\d+\b/);
@@ -260,12 +279,12 @@ describe("the drain reports what is still arriving and what is still open", () =
         "the arrival-during-drain line",
       );
       expect(arrivalLine).toContain("method=POST");
-      expect(arrivalLine).toContain("path=/v1/chat/completions");
+      expect(arrivalLine).toContain('path="/v1/chat/completions"');
       // Arrival is written before anything about the request is known, so
       // its only identity is the connection's — which is exactly what a
       // request killed before it could complete leaves behind.
       expect(arrivalLine).toMatch(/\bpeer=\d{1,3}(?:\.\d{1,3}){3}:\d+\b/);
-      expect(arrivalLine).toContain("downstream_request_id=ingress-during");
+      expect(arrivalLine).toContain('downstream_request_id="ingress-during"');
 
       // Past the window, with both requests still running: the heartbeat
       // separates work already taken on from connections still held.
@@ -279,6 +298,18 @@ describe("the drain reports what is still arriving and what is still open", () =
       );
       expect(heartbeat).toMatch(/\bin_flight=[1-9]\d*\b/);
       expect(heartbeat).toMatch(/\bopen_connections=[1-9]\d*\b/);
+
+      // Health probes must not produce arrival lines. They are served on
+      // this listener and keep coming for the whole grace period, so
+      // logging them would bury the real arrivals this line exists for —
+      // and a probe reaches its completion line regardless.
+      const probeArrivals = app
+        .output()
+        .split("\n")
+        .filter(
+          (l) => l.includes("request arrived while draining") && l.includes("readyz"),
+        );
+      expect(probeArrivals, `probe arrivals were logged: ${probeArrivals}`).toEqual([]);
 
       for (const pending of [beforeSignal, duringDrain]) {
         const res = await pending;

--- a/tests/e2e/src/cases/drain-observability-e2e.test.ts
+++ b/tests/e2e/src/cases/drain-observability-e2e.test.ts
@@ -1,0 +1,287 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  spawnApp,
+  startOpenAiUpstream,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the connection-level identity a rolling update has to be traced by.
+//
+// Reconstructing what happened to a request during a rollout means joining
+// three records that no shared field used to connect: the fronting proxy's
+// log of the connection it dispatched on, the gateway's log of the request,
+// and the fact that a request was ever received at all. The fields below
+// close that gap, and each is asserted through the binary's real stderr —
+// the only place an operator would look for them.
+//
+// The proxy's own `request_id` is deliberately NOT the join key: it is
+// minted here, so nothing upstream of the gateway knows it.
+
+const CALLER_PLAINTEXT = "sk-drain-obs-caller";
+const CALLER_KEY_ENV = "DRAIN_OBS_CALLER_KEY";
+
+/** Long enough that the drain heartbeat (5s) fires at least once. */
+const DRAIN_WINDOW_SECS = 2;
+/** Outlives the window several times over, so requests span the drain. */
+const SLOW_UPSTREAM_MS = 14_000;
+
+function resources(upstreamBase: string): string {
+  return `
+_format_version: "1"
+provider_keys:
+  - display_name: drain-obs-pk
+    provider: openai
+    api_key: sk-mock
+    api_base: ${upstreamBase}/v1
+models:
+  - display_name: drain-obs
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: drain-obs-pk
+api_keys:
+  - display_name: drain-obs-caller
+    key_env: ${CALLER_KEY_ENV}
+    allowed_models: ["drain-obs"]
+`;
+}
+
+function chat(proxyUrl: string, headers: Record<string, string> = {}): Promise<Response> {
+  return fetch(`${proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({
+      model: "drain-obs",
+      messages: [{ role: "user", content: "hi" }],
+    }),
+  });
+}
+
+/** The access-log line for `requestId`, or undefined while it is absent. */
+function accessLogFor(output: string, requestId: string): string | undefined {
+  return output
+    .split("\n")
+    .find(
+      (line) =>
+        line.includes("proxy request completed") &&
+        line.includes(`request_id="${requestId}"`),
+    );
+}
+
+/** Poll until `read` yields a value, or fail with `what`. */
+async function waitFor<T>(
+  read: () => T | undefined,
+  what: string,
+  timeoutMs = 20_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = read();
+    if (value !== undefined) return value;
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+describe("access log carries the downstream connection identity", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp({
+      // The fields under test are reported at INFO; the suite default is WARN.
+      logLevel: "info",
+      resourcesFile: resources(upstream.baseUrl),
+      extraEnv: { [CALLER_KEY_ENV]: CALLER_PLAINTEXT },
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("logs the peer socket address, with its port", async () => {
+    if (!app) throw new Error("setup failed");
+
+    const res = await chat(app.proxyUrl);
+    expect(res.status).toBe(200);
+    await res.text();
+    const requestId = res.headers.get("x-aisix-request-id")!;
+    expect(requestId).toBeTruthy();
+
+    const line = await waitFor(
+      () => accessLogFor(app!.output(), requestId),
+      "the access-log line for the request",
+    );
+    // The port is the point: an address without one names a host, not a
+    // connection, and a host-network deployment behind a layer-4 balancer
+    // has every request arriving from the same handful of hosts.
+    const peer = /\bpeer=(\d{1,3}(?:\.\d{1,3}){3}):(\d+)\b/.exec(line);
+    expect(peer, `no peer=<ip>:<port> on: ${line}`).not.toBeNull();
+    expect(Number(peer![2])).toBeGreaterThan(0);
+  });
+
+  test("records the fronting proxy's request id as its own field", async () => {
+    if (!app) throw new Error("setup failed");
+
+    const downstreamId = `ingress-${Date.now()}`;
+    const res = await chat(app.proxyUrl, { "x-request-id": downstreamId });
+    expect(res.status).toBe(200);
+    await res.text();
+    const requestId = res.headers.get("x-aisix-request-id")!;
+
+    // Two ids, two fields. The gateway must not adopt the ingress's id by
+    // default, and must not report its own under the ingress's name.
+    expect(requestId).not.toBe(downstreamId);
+
+    const line = await waitFor(
+      () => accessLogFor(app!.output(), requestId),
+      "the access-log line for the request",
+    );
+    expect(line).toContain(`downstream_request_id=${downstreamId}`);
+  });
+
+  test("omits the field for a request that carried no downstream id", async () => {
+    if (!app) throw new Error("setup failed");
+
+    const res = await chat(app.proxyUrl);
+    expect(res.status).toBe(200);
+    await res.text();
+    const requestId = res.headers.get("x-aisix-request-id")!;
+
+    const line = await waitFor(
+      () => accessLogFor(app!.output(), requestId),
+      "the access-log line for the request",
+    );
+    // An always-present empty field would defeat filtering on it — the
+    // same rule the failure fields on this line already follow.
+    expect(line).not.toContain("downstream_request_id");
+  });
+
+  test("ignores a downstream id that is not safe to log verbatim", async () => {
+    if (!app) throw new Error("setup failed");
+
+    // A value with a space cannot be a correlation id and must not be
+    // written into a whitespace-delimited log line as one.
+    const res = await chat(app.proxyUrl, { "x-request-id": "not an id" });
+    expect(res.status).toBe(200);
+    await res.text();
+    const requestId = res.headers.get("x-aisix-request-id")!;
+
+    const line = await waitFor(
+      () => accessLogFor(app!.output(), requestId),
+      "the access-log line for the request",
+    );
+    expect(line).not.toContain("downstream_request_id");
+  });
+});
+
+describe("the drain reports what is still arriving and what is still open", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    upstream = await startOpenAiUpstream({ responseDelayMs: SLOW_UPSTREAM_MS });
+    app = await spawnApp({
+      logLevel: "info",
+      resourcesFile: resources(upstream.baseUrl),
+      extraEnv: { [CALLER_KEY_ENV]: CALLER_PLAINTEXT },
+      extra: { shutdown: { min_drain_secs: DRAIN_WINDOW_SECS } },
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test(
+    "logs arrival, the accept, and the open-connection count",
+    async () => {
+      if (!app || !upstream) throw new Error("setup failed");
+      const proxyUrl = app.proxyUrl;
+
+      // A request that arrives BEFORE the signal, and is still running
+      // when it lands. Its completion line is the control: arrival is a
+      // drain-only line, so a request received in steady state must not
+      // produce one.
+      const beforeSignal = chat(proxyUrl, { "x-request-id": "ingress-before" });
+      await waitFor(
+        () => (upstream!.receivedRequests.length > 0 ? true : undefined),
+        "the first request to reach the upstream",
+      );
+      expect(app.output()).not.toContain("request arrived while draining");
+
+      app.signal("SIGTERM");
+      await waitFor(
+        () => (app!.output().includes("draining — /readyz") ? true : undefined),
+        "the drain to start",
+      );
+      // The signal-time line already reports both counts, so an operator
+      // knows what the drain inherited.
+      const startLine = app
+        .output()
+        .split("\n")
+        .find((l) => l.includes("draining — /readyz"))!;
+      expect(startLine).toMatch(/\bin_flight=\d+\b/);
+      expect(startLine).toMatch(/\bopen_connections=[1-9]\d*\b/);
+
+      // A second request, on a new connection, inside the window — the
+      // shape that says the balancer has not withdrawn this instance yet.
+      const duringDrain = chat(proxyUrl, { "x-request-id": "ingress-during" });
+
+      const acceptLine = await waitFor(
+        () =>
+          app!
+            .output()
+            .split("\n")
+            .find((l) => l.includes("accepted a new connection while draining")),
+        "the accept-during-drain line",
+      );
+      expect(acceptLine).toMatch(/\bpeer=\d{1,3}(?:\.\d{1,3}){3}:\d+\b/);
+      expect(acceptLine).toMatch(/\bopen_connections=[1-9]\d*\b/);
+
+      const arrivalLine = await waitFor(
+        () =>
+          app!
+            .output()
+            .split("\n")
+            .find((l) => l.includes("request arrived while draining")),
+        "the arrival-during-drain line",
+      );
+      expect(arrivalLine).toContain("method=POST");
+      expect(arrivalLine).toContain("path=/v1/chat/completions");
+      // Arrival is written before anything about the request is known, so
+      // its only identity is the connection's — which is exactly what a
+      // request killed before it could complete leaves behind.
+      expect(arrivalLine).toMatch(/\bpeer=\d{1,3}(?:\.\d{1,3}){3}:\d+\b/);
+      expect(arrivalLine).toContain("downstream_request_id=ingress-during");
+
+      // Past the window, with both requests still running: the heartbeat
+      // separates work already taken on from connections still held.
+      const heartbeat = await waitFor(
+        () =>
+          app!
+            .output()
+            .split("\n")
+            .find((l) => l.includes("still draining in-flight requests")),
+        "a drain heartbeat",
+      );
+      expect(heartbeat).toMatch(/\bin_flight=[1-9]\d*\b/);
+      expect(heartbeat).toMatch(/\bopen_connections=[1-9]\d*\b/);
+
+      for (const pending of [beforeSignal, duringDrain]) {
+        const res = await pending;
+        expect(res.status).toBe(200);
+        await res.text();
+      }
+    },
+    90_000,
+  );
+});

--- a/tests/e2e/src/cases/drain-observability-e2e.test.ts
+++ b/tests/e2e/src/cases/drain-observability-e2e.test.ts
@@ -160,7 +160,10 @@ describe("access log carries the downstream connection identity", () => {
       "the access-log line for the request",
     );
     // An always-present empty field would defeat filtering on it — the
-    // same rule the failure fields on this line already follow.
+    // same rule the failure fields on this line already follow. Pinned
+    // against `peer`, which the same request DOES carry, so the assertion
+    // cannot pass merely because neither field is reported at all.
+    expect(line).toMatch(/\bpeer=\d{1,3}(?:\.\d{1,3}){3}:\d+\b/);
     expect(line).not.toContain("downstream_request_id");
   });
 
@@ -178,6 +181,7 @@ describe("access log carries the downstream connection identity", () => {
       () => accessLogFor(app!.output(), requestId),
       "the access-log line for the request",
     );
+    expect(line).toMatch(/\bpeer=\d{1,3}(?:\.\d{1,3}){3}:\d+\b/);
     expect(line).not.toContain("downstream_request_id");
   });
 });


### PR DESCRIPTION
Four log fields that a rolling-update investigation needed and could not get. Observability only — no behaviour changes, no new config, no wire or schema change.

## The gaps

Reconstructing what happened to a request during a rolling update means joining three records, and nothing connected them:

- **No downstream peer address.** The gateway's own `request_id` is minted here, so nothing in front of it knows that value. Behind a layer-4 load balancer with the gateway on the host network, the accepted socket's remote address *with its port* is the only field that lines a gateway log line up with the fronting proxy's record of the same connection — every request otherwise arrives from the same handful of hosts.
- **No arrival line.** Everything the gateway writes about a request is written when the request *ends*. A request still running when the platform's grace period expires never gets there, so it leaves no trace at all — which is exactly the request an investigation is looking for.
- **No connection count on the drain, and no line when one is accepted during it.** Without them the in-flight count alone cannot distinguish work the gateway had already taken on from traffic a balancer is still routing at it.
- **The fronting proxy's `X-Request-Id` was discarded.** It is not adopted as the gateway's id by default, and it was not recorded either, so a search by an id from the ingress's logs returned nothing.

## What is added

**`peer` on the request span** — the accepted socket's remote address including its port. Deliberately not the resolved `source_ip` that `ClientContext` already carries: that answers "who is the caller", follows `proxy.real_ip`, and has no port. This one answers "which TCP connection".

**`downstream_request_id` on the request span**, read from `x-request-id` and screened by the same rule an adopted id passes, so nothing unsafe is written into a log line verbatim. Recorded, never adopted: which header may *become* this gateway's id stays governed by `proxy.request_id.accept_headers`. The ingress's id and the gateway's id are two fields that cannot be confused for one another.

Both ride the existing request span, so they reach the access log, the per-attempt `provider call completed` line, and every diagnostic in between — the same mechanism `request_id` already uses, rather than a second one threaded through the emit sites.

**A drain-time arrival line** (`request arrived while draining`, with method and path; identity comes from the span). Gated on the shutdown flag, so no line is added to steady-state logging. It skips `/livez` and `/readyz`: those are served on this same listener and the platform probes them every few seconds for the whole grace period, so including them would bury the handful of real arrivals — and a probe reaches its completion line regardless, which is the reason the arrival line exists for anything else.

**`open_connections`** on the signal-time line and on the drain heartbeat, plus an INFO when a connection is accepted after the signal. The count is raised and lowered by an RAII guard on the accepted stream and saturates at zero, so an unpaired decrement cannot wrap it. Only the proxy listener is counted; the admin and metrics listeners pass no drain state. At accept time there is no path to tell a probe from a client, so the count includes health probes and the accept line does not claim to know who connected — that judgement belongs to the arrival line, which has the path. The accept line covers what the arrival line cannot: a connection opened and never used.

Both new span fields carry caller-controlled or caller-influenced text and are recorded as strings, so they render quoted and escaped rather than raw into a space-delimited line.

Two things deliberately not done: `open_connections` is log-only and gets no Prometheus gauge (this repo only ships a metric family together with an e2e that asserts it in a real scrape, which is more than this needs); and no `max_drain_secs` knob — the platform stays the only hard bound.

Also documents, on `retire_connection`, why it is structurally unable to retire a **streaming** connection: a streamed response returns from the handler at the first token, so its head is already on the wire and a stream whose head went out before the signal can never carry `Connection: close`, however long it runs afterwards. No change to that function — the note exists so the next reader does not conclude a header fix would cover it.

## Also: the grace-period guidance was wrong

`config.example.yaml` and `config.managed.yaml` both told operators to size `terminationGracePeriodSeconds` to cover their *longest request*. That underestimates the real bound, and a deployment sized by it gets pods killed mid-request.

The gateway does not close a client's connection itself — it answers `Connection: close` and lets the client retire it, which is deliberate: a server-side close races the client dispatching onto the same connection. But that header rides the response head, and a streamed response commits its head at the first token, so a stream already running at SIGTERM can never carry it, and HTTP/1.1 offers no other way to retire the connection once the head is on the wire. It returns to the client's pool unmarked and is reused exactly once more; that successor's head IS generated during the drain, carries the header, and ends the chain.

The bound is therefore **two requests back to back**, each able to run to its own client timeout. Both files now say so and point at the Helm chart's "Termination and draining" section for the arithmetic, rather than duplicating a default here.

The same trap is now named on the access log itself: a streamed line's `latency_ms` is time-to-first-token, not how long the stream ran — the two differ by the length of the stream, and reading it as the end of the request is how a long-running stream gets mistaken for an idle connection.

## Tests

`tests/e2e/src/cases/drain-observability-e2e.test.ts` drives the real binary and asserts on its stderr, which is the only place these fields are consumed from. All five cases fail on `main` and pass here.

The assertions are built so none of them can pass for the wrong reason: the two negative cases (no downstream id sent; an unusable one sent) also assert `peer` is present on the same line, so neither passes merely because no connection fields are reported at all; and the drain case drives real health probes during the drain and fails if they produce arrival lines. Unit tests pin the counter's saturation and that the acceptor releases a connection's slot when the stream drops — every drain assertion is "at least one", so a leaked guard would otherwise keep them all green while the count climbed.

Note on volume: line *count* in steady state is unchanged, but `peer` rides the request span, so every line inside a request span grows by roughly the length of an `ip:port`.

The existing drain and request-id e2e suites pass unchanged, which is the check that behaviour did not move.

Ref api7/AISIX-Cloud#1394
