### PR TITLE
docs(proxy): record why h2 gets no retirement signal during the drain

### DIFF
--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -597,10 +597,6 @@ fn hold_until_body_done(response: Response, drain: DrainGuard) -> Response {
 /// still surfaces as a 502/503 upstream-reset at the caller. Retiring them
 /// as they are used means there is nothing idle left to lose.
 ///
-/// HTTP/2 has no such header (it is a connection-specific field, forbidden
-/// by RFC 9113 §8.2.2); its drain signal is the GOAWAY that hyper emits
-/// when the listener does shut down.
-///
 /// It cannot retire a stream that was ALREADY RUNNING when the signal
 /// landed, and no change to this function can. This mutates a response
 /// the middleware still holds, so a streamed response whose handler
@@ -611,6 +607,15 @@ fn hold_until_body_done(response: Response, drain: DrainGuard) -> Response {
 /// the next request and is retired on that one (AISIX-Cloud#1394).
 /// Retiring the still-running ones is the listener's shutdown to do, not
 /// this header's.
+///
+/// HTTP/2 forbids this header (RFC 9113 §8.2.2 — it is connection-specific)
+/// and has no header in its place: the h2 retirement signal is GOAWAY, a
+/// connection-level frame. hyper emits one when the listener shuts down,
+/// which is after the drain, so an h2 downstream goes the whole window
+/// unsignalled. Emitting it at SIGTERM instead needs the hyper connection
+/// future, which `axum_server` owns internally and only retires together
+/// with the listener (AISIX-Cloud#1395) — nothing added to the response
+/// here can reach an h2 peer.
 fn retire_connection(version: &axum::http::Version, response: &mut Response) {
     if *version == axum::http::Version::HTTP_2 || *version == axum::http::Version::HTTP_3 {
         return;


### PR DESCRIPTION
Comment only, no behavior change.

## Why

`retire_connection` skips HTTP/2 because `Connection` is a connection-specific field that RFC 9113 §8.2.2 forbids, and the comment pointed at "the GOAWAY that hyper emits when the listener does shut down" as the h2 equivalent. That is true but stops one step short of the state a reader needs: the listener shuts down only *after* the drain has finished (`min_drain_secs` elapsed **and** in-flight at zero), so an HTTP/2 downstream goes the entire grace period with no retirement signal — and nothing added to a response in this function can reach an h2 peer.

GOAWAY at `SIGTERM` is the right mechanism and hyper supports it: `hyper::server::conn::http2::Connection::graceful_shutdown()` performs the two-stage GOAWAY of RFC 9113 §6.8 (`GOAWAY(2^31-1, NO_ERROR)`, a PING, then a second GOAWAY carrying the real last-processed stream id) and does not close the connection — active streams run to completion first. Unlike a server-initiated close it therefore carries no race with a client dispatching onto the connection.

What is missing is reach, not API: `axum_server` builds the hyper connection future inside a private task, and its one external trigger retires connections and stops the accept loop as a single event — while the drain requires the listener to stay open. AISIX-Cloud#1395 records the source-level analysis and the options.

## What

Expands the HTTP/2 paragraph on `retire_connection` with where the gap is and why a header cannot close it, and moves it below the streaming paragraph added in #1045 so that paragraph's "It" still refers to the `Connection: close` mechanism it qualifies.