### PR TITLE
fix(chat): accept developer messages in /v1/chat/completions

### DIFF
--- a/crates/aisix-cache/src/key.rs
+++ b/crates/aisix-cache/src/key.rs
@@ -277,6 +277,7 @@ fn message_pair(m: &ChatMessage) -> (String, String) {
 fn role_str(role: Role) -> &'static str {
     match role {
         Role::System => "system",
+        Role::Developer => "developer",
         Role::User => "user",
         Role::Assistant => "assistant",
         Role::Tool => "tool",
@@ -325,6 +326,16 @@ mod tests {
         assert_ne!(
             CacheKey::from_request(&a).fingerprint(),
             CacheKey::from_request(&b).fingerprint(),
+        );
+    }
+
+    #[test]
+    fn developer_and_system_roles_have_distinct_fingerprints() {
+        let system = req("m", vec![ChatMessage::system("same")], None);
+        let developer = req("m", vec![ChatMessage::developer("same")], None);
+        assert_ne!(
+            CacheKey::from_request(&system).fingerprint(),
+            CacheKey::from_request(&developer).fingerprint(),
         );
     }
 

--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -15,13 +15,13 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// Role of a chat message. Providers that only
-/// support system/user/assistant are expected to reject `Tool` at their
-/// own boundary rather than silently collapsing roles.
+/// Role of a chat message. Provider bridges are responsible for preserving
+/// roles that their upstream accepts and translating the others.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
     System,
+    Developer,
     User,
     Assistant,
     Tool,
@@ -183,6 +183,17 @@ impl ChatMessage {
     pub fn system(content: impl Into<String>) -> Self {
         Self {
             role: Role::System,
+            content: Some(content.into()),
+            content_blocks: None,
+            name: None,
+            tool_call_id: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    pub fn developer(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Developer,
             content: Some(content.into()),
             content_blocks: None,
             name: None,
@@ -630,6 +641,29 @@ mod tests {
     }
 
     #[test]
+    fn chat_message_accepts_and_round_trips_developer_role() {
+        let m: ChatMessage = serde_json::from_str(
+            r#"{"role": "developer", "content": "Follow application instructions"}"#,
+        )
+        .expect("developer is a documented Chat Completions message role");
+
+        let value = serde_json::to_value(m).unwrap();
+        assert_eq!(value["role"], "developer");
+        assert_eq!(value["content"], "Follow application instructions");
+    }
+
+    #[test]
+    fn chat_message_rejects_unknown_and_mis_cased_roles() {
+        for role in ["Developer", "tool_result"] {
+            let raw = format!(r#"{{"role":"{role}","content":"x"}}"#);
+            assert!(
+                serde_json::from_str::<ChatMessage>(&raw).is_err(),
+                "role {role:?} must remain invalid"
+            );
+        }
+    }
+
+    #[test]
     fn content_null_preserved_as_none() {
         // #395: `content: null` (OpenAI's assistant-with-tool_calls shape)
         // is preserved as `None` so it round-trips back to JSON `null`,
@@ -835,6 +869,7 @@ mod tests {
     #[test]
     fn message_constructors_set_role() {
         assert_eq!(ChatMessage::system("x").role, Role::System);
+        assert_eq!(ChatMessage::developer("x").role, Role::Developer);
         assert_eq!(ChatMessage::user("x").role, Role::User);
         assert_eq!(ChatMessage::assistant("x").role, Role::Assistant);
     }

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -315,7 +315,9 @@ pub enum TranslateError {
 }
 
 /// Split the gateway's flat ChatFormat into Anthropic's (system, messages)
-/// shape. Consecutive plain-text system messages at the head are
+/// shape. Developer messages always join Anthropic's top-level system
+/// field, including when interleaved with conversation turns. Consecutive
+/// plain-text system messages at the head are
 /// concatenated with a blank line into the string form, matching how
 /// users typically compose multi-paragraph system prompts in the OpenAI
 /// format; when any head system message carried typed content blocks,
@@ -345,6 +347,13 @@ pub fn split_system<'a>(
                 } else {
                     system_msgs.push(m);
                 }
+            }
+            Role::Developer => {
+                // Anthropic has no positional developer role. Keep the
+                // instruction at system authority instead of rewriting it as
+                // a user turn, even when that requires lifting it out of the
+                // conversational sequence.
+                system_msgs.push(m);
             }
             Role::User => {
                 seen_non_system = true;
@@ -2080,6 +2089,27 @@ mod tests {
     }
 
     #[test]
+    fn split_system_merges_leading_developer_messages() {
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::system("system instruction"),
+                ChatMessage::developer("developer instruction"),
+                ChatMessage::user("hi"),
+            ],
+        );
+        let (system, msgs) = split_system(&req).unwrap();
+        assert_eq!(
+            system,
+            Some(AnthropicSystem::Text(
+                "system instruction\n\ndeveloper instruction".into()
+            ))
+        );
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "user");
+    }
+
+    #[test]
     fn split_system_mid_conversation_becomes_user_turn() {
         let req = ChatFormat::new(
             "claude",
@@ -2100,6 +2130,53 @@ mod tests {
         assert_eq!(msgs[0].content[0]["text"], "hi");
         assert_eq!(msgs[0].content[1]["text"], "forget everything");
         assert_eq!(msgs[1].role, "assistant");
+    }
+
+    #[test]
+    fn split_system_mid_conversation_developer_stays_system() {
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::user("hi"),
+                ChatMessage::developer("follow application instructions"),
+                ChatMessage::assistant("hello"),
+            ],
+        );
+        let (system, msgs) = split_system(&req).unwrap();
+        assert_eq!(
+            system,
+            Some(AnthropicSystem::Text(
+                "follow application instructions".into()
+            ))
+        );
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[1].role, "assistant");
+    }
+
+    #[test]
+    fn split_system_hoists_interleaved_developer_and_merges_surrounding_users() {
+        let req = ChatFormat::new(
+            "claude",
+            vec![
+                ChatMessage::system("system instruction"),
+                ChatMessage::user("first user turn"),
+                ChatMessage::developer("developer instruction"),
+                ChatMessage::user("second user turn"),
+            ],
+        );
+        let (system, msgs) = split_system(&req).unwrap();
+        assert_eq!(
+            system,
+            Some(AnthropicSystem::Text(
+                "system instruction\n\ndeveloper instruction".into()
+            ))
+        );
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[0].content.len(), 2);
+        assert_eq!(msgs[0].content[0]["text"], "first user turn");
+        assert_eq!(msgs[0].content[1]["text"], "second user turn");
     }
 
     #[test]

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -36,13 +36,19 @@ use aisix_provider_openai::overrides::{
 };
 use aisix_provider_openai::wire::{
     build_request, messages_from, response_into_chat_response, stream_chunk_into_chat_chunk,
-    OpenAiResponse, OpenAiStreamChunk,
+    DeveloperRoleMode, OpenAiResponse, OpenAiStreamChunk,
 };
 
 use crate::aad_token_mint::TokenMinter;
 use crate::wire;
 
 use std::sync::Arc;
+
+/// The bridge pins Azure API version `2024-10-21`, whose request-message
+/// union does not define `developer`. Azure documents developer instructions
+/// as functionally equivalent to system instructions, so both chat paths map
+/// them to the supported `system` wire role.
+const AZURE_DEVELOPER_ROLE_MODE: DeveloperRoleMode = DeveloperRoleMode::MapToSystem;
 
 /// Family Bridge for Azure OpenAI Service.
 pub struct AzureOpenAiBridge {
@@ -710,7 +716,7 @@ impl Bridge for AzureOpenAiBridge {
         // body's `model` field is ignored by Azure (or echoed back).
         // We still set it to the deployment name for log-trace clarity
         // and to mirror the upstream OpenAI SDK convention.
-        let messages = messages_from(req);
+        let messages = messages_from(req, AZURE_DEVELOPER_ROLE_MODE);
         let typed = build_request(req, deployment, &messages, false);
         let body = prepare_outbound_body(
             &typed,
@@ -762,7 +768,7 @@ impl Bridge for AzureOpenAiBridge {
 
         // See chat() — resolve auth before the request future.
         let auth = self.resolve_auth(ctx).await?;
-        let messages = messages_from(req);
+        let messages = messages_from(req, AZURE_DEVELOPER_ROLE_MODE);
         let typed = build_request(req, deployment, &messages, true);
         let body = prepare_outbound_body(
             &typed,
@@ -1667,7 +1673,13 @@ mod tests {
         let bridge =
             AzureOpenAiBridge::new().with_url_override(mock_chat_url(&server.uri(), "gpt4o-prod"));
         let ctx = canonical_test_ctx();
-        let req = ChatFormat::new("my-azure-gpt4", vec![ChatMessage::user("hi")]);
+        let req = ChatFormat::new(
+            "my-azure-gpt4",
+            vec![
+                ChatMessage::developer("follow application instructions"),
+                ChatMessage::user("hi"),
+            ],
+        );
         bridge.chat(&req, &ctx).await.unwrap();
 
         let body = responder.captured_body.lock().unwrap().clone().unwrap();
@@ -1677,13 +1689,22 @@ mod tests {
             "body.model must = deployment name; got body={body}"
         );
         let messages = body.get("messages").and_then(|v| v.as_array()).unwrap();
-        assert_eq!(messages.len(), 1, "exactly one message; got body={body}");
+        assert_eq!(messages.len(), 2, "exactly two messages; got body={body}");
         assert_eq!(
             messages[0].get("role").and_then(|v| v.as_str()),
-            Some("user")
+            Some("system"),
+            "Azure API version 2024-10-21 receives developer instructions as system"
         );
         assert_eq!(
             messages[0].get("content").and_then(|v| v.as_str()),
+            Some("follow application instructions")
+        );
+        assert_eq!(
+            messages[1].get("role").and_then(|v| v.as_str()),
+            Some("user")
+        );
+        assert_eq!(
+            messages[1].get("content").and_then(|v| v.as_str()),
             Some("hi")
         );
         assert_eq!(
@@ -2088,14 +2109,15 @@ mod tests {
             "data: {\"id\":\"x\",\"model\":\"gpt4o-prod\",\"choices\":[{\"delta\":{\"content\":\" world\"},\"finish_reason\":\"stop\"}]}\n\n",
             "data: [DONE]\n\n",
         );
+        let responder = CapturingResponder::default().with_response(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse_body),
+        );
         Mock::given(method("POST"))
             .and(path("/openai/deployments/gpt4o-prod/chat/completions"))
             .and(header("accept", "text/event-stream"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("content-type", "text/event-stream")
-                    .set_body_string(sse_body),
-            )
+            .respond_with(responder.clone())
             .expect(1)
             .mount(&server)
             .await;
@@ -2103,7 +2125,13 @@ mod tests {
         let bridge =
             AzureOpenAiBridge::new().with_url_override(mock_chat_url(&server.uri(), "gpt4o-prod"));
         let ctx = canonical_test_ctx();
-        let req = ChatFormat::new("my-azure-gpt4", vec![ChatMessage::user("hi")]);
+        let req = ChatFormat::new(
+            "my-azure-gpt4",
+            vec![
+                ChatMessage::developer("follow application instructions"),
+                ChatMessage::user("hi"),
+            ],
+        );
         let mut stream = bridge.chat_stream(&req, &ctx).await.unwrap();
         let mut chunks = Vec::new();
         while let Some(item) = stream.next().await {
@@ -2128,6 +2156,15 @@ mod tests {
         assert!(
             last.finish_reason.is_some(),
             "last chunk must carry finish_reason"
+        );
+        let body = responder.captured_body.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            body.get("messages"),
+            Some(&serde_json::json!([
+                {"role": "system", "content": "follow application instructions"},
+                {"role": "user", "content": "hi"}
+            ])),
+            "streaming Azure requests map developer instructions to system: {body}"
         );
     }
 

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -1062,8 +1062,8 @@ impl BedrockBridge {
 /// Translate the gateway [`ChatFormat`] into the SDK's typed
 /// `(Vec<SystemContentBlock>, Vec<Message>)` Converse inputs.
 ///
-/// System messages → top-level `system[]` blocks (Converse splits
-/// them out of `messages[]` per AWS spec).
+/// System and developer messages → top-level `system[]` blocks
+/// (Converse splits instructions out of `messages[]` per AWS spec).
 /// User messages → `messages[]` with a text content block.
 /// Assistant messages → a text block plus a `toolUse` block per OpenAI
 /// `tool_calls` entry (#560, multi-turn history).
@@ -1092,7 +1092,7 @@ fn build_converse_inputs(
             )?);
         }
         match msg.role {
-            Role::System => {
+            Role::System | Role::Developer => {
                 let content = msg.content_str();
                 if !content.is_empty() {
                     systems.push(SystemContentBlock::Text(content.to_string()));
@@ -3576,6 +3576,26 @@ mod tests {
             chat.message.content.is_none(),
             "content must be null alongside tool_calls when there is no prose"
         );
+    }
+
+    #[test]
+    fn build_converse_inputs_lifts_developer_to_system_blocks() {
+        let req = ChatFormat::new(
+            "m",
+            vec![
+                ChatMessage::developer("follow application instructions"),
+                ChatMessage::user("hello"),
+            ],
+        );
+
+        let (systems, messages) = build_converse_inputs(&req).unwrap();
+        assert_eq!(systems.len(), 1);
+        assert_eq!(
+            systems[0],
+            SystemContentBlock::Text("follow application instructions".into())
+        );
+        assert_eq!(messages.len(), 1);
+        assert_eq!(*messages[0].role(), ConversationRole::User);
     }
 
     #[test]

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -43,9 +43,27 @@ use crate::overrides::{
 };
 use crate::wire::{
     build_request, embed_request_body, embed_response_into, messages_from,
-    response_into_chat_response, stream_chunk_into_chat_chunk, OpenAiEmbedResponse, OpenAiResponse,
-    OpenAiStreamChunk,
+    response_into_chat_response, stream_chunk_into_chat_chunk, DeveloperRoleMode,
+    OpenAiEmbedResponse, OpenAiResponse, OpenAiStreamChunk,
 };
+
+fn developer_role_mode(ctx: &BridgeContext) -> DeveloperRoleMode {
+    let provider = ctx.provider_key.provider.trim();
+    // Mirror `resolve_base`: a legacy empty-provider key with no explicit
+    // base still reaches `OPENAI_DEFAULT_BASE`, so it must preserve the
+    // canonical OpenAI wire role too.
+    let uses_default_openai_base = provider.is_empty()
+        && ctx
+            .provider_key
+            .api_base
+            .as_deref()
+            .is_none_or(|base| base.trim().is_empty());
+    if provider.eq_ignore_ascii_case("openai") || uses_default_openai_base {
+        DeveloperRoleMode::Preserve
+    } else {
+        DeveloperRoleMode::MapToSystem
+    }
+}
 
 /// Default OpenAI upstream host. Used only when `ProviderKey.api_base`
 /// is empty AND the dispatching PK identifies the openai vendor — the
@@ -391,7 +409,7 @@ impl Bridge for OpenAiBridge {
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
-        let messages = messages_from(req);
+        let messages = messages_from(req, developer_role_mode(ctx));
         let typed = build_request(req, upstream, &messages, false);
         let body = prepare_outbound_body(
             &typed,
@@ -608,7 +626,7 @@ impl Bridge for OpenAiBridge {
         let key = api_key(ctx)?;
         let upstream = upstream_model(ctx)?;
 
-        let messages = messages_from(req);
+        let messages = messages_from(req, developer_role_mode(ctx));
         let typed = build_request(req, upstream, &messages, true);
         let body = prepare_outbound_body(
             &typed,
@@ -1327,6 +1345,50 @@ data: {\"error\":{\"message\":\"The server had an error processing your request\
     fn pk_with_base(api_base: &str) -> ProviderKey {
         let cfg = format!(r#"{{"display_name":"x","secret":"k","api_base":"{api_base}"}}"#);
         serde_json::from_str(&cfg).unwrap()
+    }
+
+    #[test]
+    fn developer_role_mode_matches_provider_endpoint_identity() {
+        let legacy_pk: ProviderKey =
+            serde_json::from_str(r#"{"display_name":"x","secret":"k"}"#).unwrap();
+        let legacy_ctx = BridgeContext::new("rid", sample_model(), Arc::new(legacy_pk));
+        assert_eq!(
+            developer_role_mode(&legacy_ctx),
+            DeveloperRoleMode::Preserve,
+            "legacy empty-provider keys without api_base resolve to canonical OpenAI"
+        );
+
+        let custom_ctx = BridgeContext::new(
+            "rid",
+            sample_model(),
+            Arc::new(pk_with_base("https://compatible.example/v1")),
+        );
+        assert_eq!(
+            developer_role_mode(&custom_ctx),
+            DeveloperRoleMode::MapToSystem,
+            "an empty provider with a custom endpoint is not canonical OpenAI"
+        );
+
+        let deepseek_pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"ds","secret":"k","provider":"deepseek","adapter":"openai","api_base":"https://api.deepseek.com"}"#,
+        )
+        .unwrap();
+        let deepseek_ctx = BridgeContext::new("rid", sample_model(), Arc::new(deepseek_pk));
+        assert_eq!(
+            developer_role_mode(&deepseek_ctx),
+            DeveloperRoleMode::MapToSystem
+        );
+
+        let openai_pk: ProviderKey = serde_json::from_str(
+            r#"{"display_name":"oai","secret":"k","provider":" OpenAI ","adapter":"openai","api_base":"https://proxy.example/v1"}"#,
+        )
+        .unwrap();
+        let openai_ctx = BridgeContext::new("rid", sample_model(), Arc::new(openai_pk));
+        assert_eq!(
+            developer_role_mode(&openai_ctx),
+            DeveloperRoleMode::Preserve,
+            "an explicitly declared OpenAI key preserves the canonical role through a proxy"
+        );
     }
 
     /// `OpenAiBridge::new()` is the `Adapter::Openai` family bridge.

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -114,11 +114,24 @@ pub fn build_request<'a>(
     }
 }
 
-pub fn messages_from(req: &ChatFormat) -> Vec<OpenAiMessage<'_>> {
+/// How an upstream Chat Completions endpoint represents developer
+/// instructions. Canonical OpenAI receives the distinct `developer` role;
+/// providers whose selected API contract does not define it are given the
+/// broadly supported `system` role instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeveloperRoleMode {
+    Preserve,
+    MapToSystem,
+}
+
+pub fn messages_from(
+    req: &ChatFormat,
+    developer_role_mode: DeveloperRoleMode,
+) -> Vec<OpenAiMessage<'_>> {
     req.messages
         .iter()
         .map(|m| OpenAiMessage {
-            role: role_str(m.role),
+            role: role_str(m.role, developer_role_mode),
             // Vision / multimodal callers send `content` as an array
             // of typed blocks; OpenAI accepts the array form natively
             // (no translation needed for OpenAI / Gemini-OpenAI-compat /
@@ -136,9 +149,11 @@ pub fn messages_from(req: &ChatFormat) -> Vec<OpenAiMessage<'_>> {
         .collect()
 }
 
-fn role_str(role: Role) -> &'static str {
+fn role_str(role: Role, developer_role_mode: DeveloperRoleMode) -> &'static str {
     match role {
         Role::System => "system",
+        Role::Developer if developer_role_mode == DeveloperRoleMode::Preserve => "developer",
+        Role::Developer => "system",
         Role::User => "user",
         Role::Assistant => "assistant",
         Role::Tool => "tool",
@@ -592,6 +607,44 @@ pub(crate) fn embed_response_into(raw: OpenAiEmbedResponse) -> EmbeddingResponse
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn messages_from_preserves_developer_role() {
+        let req = ChatFormat::new(
+            "gpt-4o",
+            vec![
+                ChatMessage::developer("Follow application instructions"),
+                ChatMessage::user("hello"),
+            ],
+        );
+
+        let messages = messages_from(&req, DeveloperRoleMode::Preserve);
+        assert_eq!(messages[0].role, "developer");
+        assert!(matches!(
+            messages[0].content,
+            OpenAiContent::Text("Follow application instructions")
+        ));
+        assert_eq!(messages[1].role, "user");
+    }
+
+    #[test]
+    fn messages_from_maps_developer_to_system_for_compatible_upstreams() {
+        let req = ChatFormat::new(
+            "deepseek-chat",
+            vec![
+                ChatMessage::developer("Follow application instructions"),
+                ChatMessage::user("hello"),
+            ],
+        );
+
+        let messages = messages_from(&req, DeveloperRoleMode::MapToSystem);
+        assert_eq!(messages[0].role, "system");
+        assert!(matches!(
+            messages[0].content,
+            OpenAiContent::Text("Follow application instructions")
+        ));
+        assert_eq!(messages[1].role, "user");
+    }
 
     #[test]
     fn non_streaming_response_parses_into_chat_response() {
@@ -1275,7 +1328,7 @@ mod tests {
             stream: None,
             extra: serde_json::Map::new(),
         };
-        let msgs = messages_from(&req);
+        let msgs = messages_from(&req, DeveloperRoleMode::Preserve);
         let built = build_request(&req, "gpt-4o", &msgs, true);
         let json = serde_json::to_value(&built).unwrap();
         assert_eq!(json["model"], "gpt-4o");
@@ -1304,7 +1357,7 @@ mod tests {
             stream: Some(true),
             extra: serde_json::Map::new(),
         };
-        let msgs = messages_from(&req);
+        let msgs = messages_from(&req, DeveloperRoleMode::Preserve);
         let json = serde_json::to_value(build_request(&req, "gpt-4o", &msgs, true)).unwrap();
         assert_eq!(
             json["stream_options"],
@@ -1330,7 +1383,7 @@ mod tests {
             stream: Some(true),
             extra,
         };
-        let msgs = messages_from(&req);
+        let msgs = messages_from(&req, DeveloperRoleMode::Preserve);
         let raw = serde_json::to_string(&build_request(&req, "gpt-4o", &msgs, true)).unwrap();
         // Exactly one stream_options key on the wire (flatten + typed
         // field would double-emit if both were set).
@@ -1355,7 +1408,7 @@ mod tests {
             stream: None,
             extra: serde_json::Map::new(),
         };
-        let msgs = messages_from(&req);
+        let msgs = messages_from(&req, DeveloperRoleMode::Preserve);
         let json = serde_json::to_value(build_request(&req, "gpt-4o", &msgs, false)).unwrap();
         assert!(json.get("stream_options").is_none());
     }
@@ -1374,7 +1427,7 @@ mod tests {
             stream: None,
             extra,
         };
-        let msgs = messages_from(&req);
+        let msgs = messages_from(&req, DeveloperRoleMode::Preserve);
         let built = build_request(&req, "gpt-4o", &msgs, false);
         let json = serde_json::to_value(&built).unwrap();
         assert_eq!(json["seed"], 42);
@@ -1406,7 +1459,7 @@ mod tests {
             stream: None,
             extra: serde_json::Map::new(),
         };
-        let msgs = messages_from(&req);
+        let msgs = messages_from(&req, DeveloperRoleMode::Preserve);
         let built = build_request(&req, "gpt-4o", &msgs, false);
         let json = serde_json::to_value(&built).unwrap();
         let assistant = &json["messages"][1];

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -61,8 +61,8 @@ use aisix_provider_anthropic::wire::{
 use aisix_provider_openai::wire::{
     build_request as build_openai_request, messages_from as openai_messages_from,
     response_into_chat_response as openai_response_into_chat_response,
-    stream_chunk_into_chat_chunk as openai_stream_chunk_into_chat_chunk, OpenAiResponse,
-    OpenAiStreamChunk,
+    stream_chunk_into_chat_chunk as openai_stream_chunk_into_chat_chunk, DeveloperRoleMode,
+    OpenAiResponse, OpenAiStreamChunk,
 };
 
 // Per-`ProviderKey` request/response override pipeline (#302 §5 / #339).
@@ -1212,7 +1212,7 @@ impl VertexBridge {
             || self.openai_shim_url(&creds, ctx.provider_key.api_base.as_deref()),
         )?;
 
-        let messages = openai_messages_from(req);
+        let messages = openai_messages_from(req, DeveloperRoleMode::MapToSystem);
         let typed = build_openai_request(req, upstream_id, &messages, false);
         let mut body = serde_json::to_value(&typed)
             .map_err(|e| BridgeError::Config(format!("serialize OpenAI shim request body: {e}")))?;
@@ -1273,7 +1273,7 @@ impl VertexBridge {
             || self.openai_shim_url(&creds, ctx.provider_key.api_base.as_deref()),
         )?;
 
-        let messages = openai_messages_from(req);
+        let messages = openai_messages_from(req, DeveloperRoleMode::MapToSystem);
         let typed = build_openai_request(req, upstream_id, &messages, true);
         let mut body = serde_json::to_value(&typed)
             .map_err(|e| BridgeError::Config(format!("serialize OpenAI shim request body: {e}")))?;
@@ -1417,7 +1417,7 @@ impl VertexBridge {
         // OpenAI chat-completions body — same serializer the OpenAI-shim
         // (Llama/MaaS) rail uses. The model is KEPT in the body (Mistral /
         // AI21 on Vertex expect it in both the URL and the body).
-        let messages = openai_messages_from(req);
+        let messages = openai_messages_from(req, DeveloperRoleMode::MapToSystem);
         let typed = build_openai_request(req, upstream_id, &messages, false);
         let mut body = serde_json::to_value(&typed)
             .map_err(|e| BridgeError::Config(format!("serialize OpenAI request body: {e}")))?;
@@ -1494,7 +1494,7 @@ impl VertexBridge {
             },
         )?;
 
-        let messages = openai_messages_from(req);
+        let messages = openai_messages_from(req, DeveloperRoleMode::MapToSystem);
         let typed = build_openai_request(req, upstream_id, &messages, true);
         let mut body = serde_json::to_value(&typed)
             .map_err(|e| BridgeError::Config(format!("serialize OpenAI request body: {e}")))?;
@@ -1910,8 +1910,9 @@ struct GeminiGenerationConfig {
 /// `generateContent` body.
 ///
 /// Translation rules:
-/// - System messages → top-level `systemInstruction` (concatenated
-///   with `\n\n` if multiple). They do NOT appear in `contents`.
+/// - System and developer messages → top-level `systemInstruction`
+///   (concatenated with `\n\n` if multiple). They do NOT appear in
+///   `contents`.
 /// - User messages → `{"role":"user","parts":[{"text":...}]}`
 /// - Assistant messages → `{"role":"model","parts":[{"text":...}]}`
 ///   (Gemini uses `"model"` not `"assistant"`)
@@ -1923,7 +1924,7 @@ fn build_gemini_request(req: &ChatFormat) -> GeminiGenerateContentRequest {
     let mut contents: Vec<GeminiContent> = Vec::new();
     for m in &req.messages {
         match m.role {
-            Role::System => system_parts.push(m.content_str().to_string()),
+            Role::System | Role::Developer => system_parts.push(m.content_str().to_string()),
             Role::User | Role::Tool => contents.push(GeminiContent {
                 role: "user",
                 parts: vec![GeminiPart {
@@ -2666,6 +2667,21 @@ mod tests {
     }
 
     #[test]
+    fn build_gemini_request_lifts_developer_to_system_instruction() {
+        let req = ChatFormat::new(
+            "my-gemini",
+            vec![
+                ChatMessage::developer("follow application instructions"),
+                ChatMessage::user("hi"),
+            ],
+        );
+        let body = build_gemini_request(&req);
+        assert_eq!(body.contents.len(), 1);
+        let sys = body.system_instruction.as_ref().unwrap();
+        assert_eq!(sys.parts[0].text, "follow application instructions");
+    }
+
+    #[test]
     fn build_gemini_request_concatenates_multiple_system_messages() {
         let req = ChatFormat::new(
             "my-gemini",
@@ -3249,7 +3265,13 @@ mod tests {
             sample_model_with("meta/llama-3.3-70b-instruct-maas"),
             sample_pk_with_secret(valid_secret_json()),
         );
-        let req = ChatFormat::new("my-llama", vec![ChatMessage::user("hi")]);
+        let req = ChatFormat::new(
+            "my-llama",
+            vec![
+                ChatMessage::developer("Follow application instructions"),
+                ChatMessage::user("hi"),
+            ],
+        );
         let chat = bridge.chat(&req, &ctx).await.unwrap();
 
         // Customer-visible response decoded from the OpenAI envelope.
@@ -3271,11 +3293,13 @@ mod tests {
             Some("meta/llama-3.3-70b-instruct-maas"),
             "openapi shim keys off the body `model` field (kept, not stripped): {body}"
         );
-        assert!(
-            obj.get("messages")
-                .and_then(|v| v.as_array())
-                .is_some_and(|m| !m.is_empty()),
-            "messages array must carry the user turn: {body}"
+        assert_eq!(
+            obj.get("messages"),
+            Some(&serde_json::json!([
+                {"role": "system", "content": "Follow application instructions"},
+                {"role": "user", "content": "hi"}
+            ])),
+            "the compatible shim must receive developer instructions as system: {body}"
         );
     }
 
@@ -3356,7 +3380,13 @@ mod tests {
             sample_model_with("meta/llama-3.3-70b-instruct-maas"),
             sample_pk_with_secret(valid_secret_json()),
         );
-        let req = ChatFormat::new("my-llama", vec![ChatMessage::user("hi")]);
+        let req = ChatFormat::new(
+            "my-llama",
+            vec![
+                ChatMessage::developer("Follow application instructions"),
+                ChatMessage::user("hi"),
+            ],
+        );
         let mut stream = bridge.chat_stream(&req, &ctx).await.unwrap();
 
         let mut content = String::new();
@@ -3395,6 +3425,14 @@ mod tests {
             obj.get("model").and_then(|v| v.as_str()),
             Some("meta/llama-3.3-70b-instruct-maas"),
             "model id stays in the body (never the URL) on the stream path: {body}"
+        );
+        assert_eq!(
+            obj.get("messages"),
+            Some(&serde_json::json!([
+                {"role": "system", "content": "Follow application instructions"},
+                {"role": "user", "content": "hi"}
+            ])),
+            "the streaming compatible shim maps developer instructions to system: {body}"
         );
     }
 

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -434,6 +434,7 @@ fn label_candidates(candidates: &[ChatResponse]) -> String {
 fn role_label(role: Role) -> &'static str {
     match role {
         Role::System => "System",
+        Role::Developer => "Developer",
         Role::User => "User",
         Role::Assistant => "Assistant",
         Role::Tool => "Tool",

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -8273,9 +8273,11 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
     /// DeepSeek PK with `adapter: "openai"` and `api_base` pointing
     /// at `https://api.deepseek.com`. The integration test pins
     /// that an inbound OpenAI request resolves through the family
-    /// bridge and round-trips DeepSeek's OpenAI-shape response.
+    /// bridge, maps the unsupported `developer` role to `system`,
+    /// and round-trips DeepSeek's OpenAI-shape response. DeepSeek's
+    /// Chat Completions schema documents system/user/assistant/tool.
     #[tokio::test]
-    async fn matrix_openai_in_deepseek_upstream_non_streaming() {
+    async fn matrix_openai_in_deepseek_upstream_maps_developer_to_system() {
         use aisix_core::Adapter;
         use aisix_provider_openai::OpenAiBridge;
 
@@ -8283,6 +8285,12 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
             .and(header("authorization", "Bearer sk-deepseek"))
+            .and(wiremock::matchers::body_partial_json(serde_json::json!({
+                "messages": [
+                    {"role": "system", "content": "Follow application instructions"},
+                    {"role": "user", "content": "hi"}
+                ]
+            })))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "id": "cmpl-deepseek",
                 "model": "deepseek-chat",
@@ -8308,7 +8316,10 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
 
         let body = serde_json::json!({
             "model": "my-deepseek",
-            "messages": [{"role": "user", "content": "hi"}]
+            "messages": [
+                {"role": "developer", "content": "Follow application instructions"},
+                {"role": "user", "content": "hi"}
+            ]
         });
         let req = Request::builder()
             .method("POST")

--- a/crates/aisix-proxy/src/render.rs
+++ b/crates/aisix-proxy/src/render.rs
@@ -298,6 +298,7 @@ pub fn inject_ratelimit_headers(
 fn role_to_str(role: Role) -> &'static str {
     match role {
         Role::System => "system",
+        Role::Developer => "developer",
         Role::User => "user",
         Role::Assistant => "assistant",
         Role::Tool => "tool",

--- a/crates/aisix-proxy/src/token_estimate.rs
+++ b/crates/aisix-proxy/src/token_estimate.rs
@@ -233,7 +233,10 @@ fn count_chat_prompt(bpe: &CoreBPE, req: &aisix_gateway::chat::ChatFormat) -> u3
     let mut has_system = false;
     for m in &req.messages {
         let role = role_label(&m.role);
-        if role == "system" {
+        if matches!(
+            m.role,
+            aisix_gateway::chat::Role::System | aisix_gateway::chat::Role::Developer
+        ) {
             has_system = true;
         }
         n = n.saturating_add(TOKENS_PER_MESSAGE);
@@ -275,6 +278,7 @@ fn count_chat_prompt(bpe: &CoreBPE, req: &aisix_gateway::chat::ChatFormat) -> u3
 fn role_label(role: &aisix_gateway::chat::Role) -> &'static str {
     match role {
         aisix_gateway::chat::Role::System => "system",
+        aisix_gateway::chat::Role::Developer => "developer",
         aisix_gateway::chat::Role::User => "user",
         aisix_gateway::chat::Role::Assistant => "assistant",
         aisix_gateway::chat::Role::Tool => "tool",
@@ -847,6 +851,25 @@ mod tests {
         assert_eq!(
             chat_est("gpt-4", with_system).count_prompt(),
             chat_est("gpt-4", without_system).count_prompt() + sys_msg_cost
+                - TOOLS_WITH_SYSTEM_DISCOUNT
+        );
+    }
+
+    #[test]
+    fn tools_with_developer_message_discount() {
+        let tools = json!([{"type": "function", "function": {"name": "f"}}]);
+        let mut with_developer = ChatFormat::new(
+            "gpt-4",
+            vec![msg(Role::Developer, "Be brief"), msg(Role::User, "Hi")],
+        );
+        with_developer.extra.insert("tools".into(), tools.clone());
+        let mut without_developer = ChatFormat::new("gpt-4", vec![msg(Role::User, "Hi")]);
+        without_developer.extra.insert("tools".into(), tools);
+        let developer_msg_cost =
+            TOKENS_PER_MESSAGE + count_text("gpt-4", "developer") + count_text("gpt-4", "Be brief");
+        assert_eq!(
+            chat_est("gpt-4", with_developer).count_prompt(),
+            chat_est("gpt-4", without_developer).count_prompt() + developer_msg_cost
                 - TOOLS_WITH_SYSTEM_DISCOUNT
         );
     }

--- a/tests/e2e/src/cases/openai-sdk-compat.test.ts
+++ b/tests/e2e/src/cases/openai-sdk-compat.test.ts
@@ -142,6 +142,71 @@ describe("openai SDK compat: drive gateway through real client", () => {
     );
   });
 
+  test("openai.chat.completions.create() — developer role", async (ctx) => {
+    if (!etcdReachable || !app || !nonStreamUpstream) {
+      ctx.skip();
+      return;
+    }
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+    });
+
+    await waitConfigPropagation(seedsPropagated);
+    const baseline = nonStreamUpstream.receivedRequests.length;
+
+    const completion = await client.chat.completions.create({
+      model: "sdk-compat-sync",
+      messages: [
+        // The harness pins openai 4.65.0, whose message union predates
+        // this role; the runtime request path forwards the JSON unchanged.
+        { role: "developer", content: "Follow application instructions" },
+        { role: "user", content: "hello" },
+      ] as unknown as OpenAI.Chat.Completions.ChatCompletionMessageParam[],
+    });
+
+    expect(completion.object).toBe("chat.completion");
+    expect(nonStreamUpstream.receivedRequests.length - baseline).toBe(1);
+    const request = nonStreamUpstream.receivedRequests[baseline];
+    expect(request?.path).toBe("/v1/chat/completions");
+    const body = JSON.parse(request!.body) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(body.messages).toEqual([
+      { role: "developer", content: "Follow application instructions" },
+      { role: "user", content: "hello" },
+    ]);
+  });
+
+  test("mis-cased developer role is rejected before upstream", async (ctx) => {
+    if (!etcdReachable || !app || !nonStreamUpstream) {
+      ctx.skip();
+      return;
+    }
+
+    await waitConfigPropagation(seedsPropagated);
+    const baseline = nonStreamUpstream.receivedRequests.length;
+    const response = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "sdk-compat-sync",
+        messages: [
+          { role: "Developer", content: "Follow application instructions" },
+          { role: "user", content: "hello" },
+        ],
+      }),
+    });
+    await response.text();
+
+    expect(response.status).toBe(400);
+    expect(nonStreamUpstream.receivedRequests.length - baseline).toBe(0);
+  });
+
   test("openai.chat.completions.create({stream:true}) — streaming", async (ctx) => {
     if (!etcdReachable || !app || !streamUpstream) {
       ctx.skip();
@@ -160,7 +225,10 @@ describe("openai SDK compat: drive gateway through real client", () => {
     const baseline = streamUpstream.receivedRequests.length;
     const stream = await client.chat.completions.create({
       model: "sdk-compat-stream",
-      messages: [{ role: "user", content: "say hello" }],
+      messages: [
+        { role: "developer", content: "Follow application instructions" },
+        { role: "user", content: "say hello" },
+      ] as unknown as OpenAI.Chat.Completions.ChatCompletionMessageParam[],
       stream: true,
     });
 
@@ -190,6 +258,12 @@ describe("openai SDK compat: drive gateway through real client", () => {
       .filter((r) => r.path === "/v1/chat/completions");
     expect(testCalls).toHaveLength(1);
     expect(testCalls[0]?.method).toBe("POST");
+    const requestBody = JSON.parse(testCalls[0]!.body) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(requestBody.messages).toEqual([
+      { role: "developer", content: "Follow application instructions" },
+      { role: "user", content: "say hello" },
+    ]);
   });
-
 });


### PR DESCRIPTION
## Problem

OpenAI defines `developer` messages as application-provided instructions that are prioritized ahead of user messages and carry the application's rules and business logic ([OpenAI message-role guidance](https://developers.openai.com/api/docs/guides/text-generation#message-roles-and-instruction-following)). OpenAI's reasoning-model guidance states that, beginning with `o1-2024-12-17`, reasoning models use developer messages in place of system messages ([OpenAI reasoning guidance](https://developers.openai.com/api/docs/guides/reasoning-best-practices#how-to-prompt-reasoning-models-effectively)).

Clients therefore emit this role when sending application-level instructions to reasoning-capable models. Pi v0.84.3, for example, documents that it uses `developer` for reasoning-capable models and sends the system prompt as `system` only when `compat.supportsDeveloperRole` is disabled ([Pi model configuration](https://github.com/earendil-works/pi/blob/4e58f324fae8ebfa98a3d45181fb248072a2afac/packages/coding-agent/docs/models.md#L37-L41)).

AISIX currently rejects such requests during deserialization. A Pi request containing a developer message produces:

```text
HTTP 400
{"message":"request payload is invalid: invalid JSON request body","type":"invalid_request_error"}
```

Supporting the role at the normalized request boundary is required for compatibility with these clients. Provider bridges can then preserve or translate it according to the upstream provider's message contract.

## Change

- Add `developer` to the normalized chat-message roles.
- Preserve `developer` for canonical OpenAI chat-completion requests.
- Translate it to `system` for OpenAI-compatible providers whose contracts do not support it directly.
- Map developer instructions to the native instruction mechanism for Anthropic, Gemini, and Bedrock.
- Include developer messages in prompt rendering, token accounting, caching, and ensemble handling.
- Continue rejecting unknown or incorrectly cased roles.
- Add unit and SDK compatibility coverage.

Provider-specific translations follow the documented request contracts for [DeepSeek](https://api-docs.deepseek.com/api/create-chat-completion), [Azure OpenAI](https://github.com/Azure/azure-rest-api-specs/blob/69fd7074df3358b7e2880a354c540f036fc4d863/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2024-10-21/inference.json#L1502-L1519), [Anthropic](https://docs.anthropic.com/en/api/messages), [Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects.locations.publishers.models/generateContent), and [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html).

For Anthropic, developer messages are combined into the top-level `system` instruction because its Messages API does not define message-level system or developer roles.

## Gateway comparison

- Envoy AI Gateway represents `developer` as an OpenAI chat-message role ([source](https://github.com/envoyproxy/ai-gateway/blob/b980aa8075594bdbbf94055f200750d7521d4dde/internal/apischema/openai/openai.go#L29-L36)).
- LiteLLM translates `developer` to `system` when the destination model does not support the role ([source](https://github.com/BerriAI/litellm/blob/f818a48ae57f7b7b484df6431b24ba0c89857323/litellm/llms/base_llm/base_utils.py#L207-L222)).
- Kong preserves the request message table while applying provider-specific request transformations ([source](https://github.com/Kong/kong/blob/fa9c3b695af72668f135cb17bbb84a8b4dc511d2/kong/llm/drivers/openai.lua#L20-L27)).

## Verification

- `cargo fmt --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace -- -D warnings`
- `env -u AISIX_API_KEY cargo test --workspace`
- `npx --yes pnpm@11 exec vitest run src/cases/openai-sdk-compat.test.ts`

Prepared with AI assistance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `developer` chat message role.
  * Developer instructions are preserved or converted to system instructions as required by each provider.
  * Added support across standard and streaming requests, including compatible provider integrations.
  * Developer messages are recognized in rendering, prompt estimation, caching, and proxy workflows.

* **Bug Fixes**
  * Cache fingerprints now distinguish system and developer messages.
  * Invalid role casing is rejected consistently.

* **Tests**
  * Expanded coverage for serialization, streaming, provider translation, caching, and cross-provider compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->