### PR TITLE
build(profile): cut dev debuginfo to line tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,10 +203,14 @@ tempfile = "3.13"
 # Measured on one worktree replaying four real commits off main, same
 # commands, only this setting varied:
 #
-#   debug = 2                 42.1 GiB target, 22.0 GiB of test bins, 243s
-#   debug = line-tables-only  19.8 GiB target,  8.3 GiB of test bins, 171s
+#   debug = 2                 42.1 GiB target, 22.0 GiB of test bins
+#   debug = line-tables-only  19.8 GiB target,  8.3 GiB of test bins
 #
-# So 53% off the tree and 30% off the wall clock -- emitting debuginfo
+# Timing was measured separately, since a single build run is noisy: a
+# clean `cargo test --workspace --no-run`, three runs per setting,
+# alternating so machine drift hits both equally, came out at a 92s
+# median (90-111s spread) against 70s (70s on every run). So 53% off the
+# tree and about a quarter off the wall clock -- emitting debuginfo
 # costs both, which is why the two move together rather than trading off.
 #
 # Panic backtraces keep file and line. On rustc 1.97.1 the frames came

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,27 @@ wiremock = "0.6"
 testcontainers = "0.28"
 tempfile = "3.13"
 
+# Full DWARF is the largest single thing in `target/` here: it is 83% of
+# every test binary, and `cargo test --workspace` links 44 of them. Line
+# tables keep exactly what a failing test needs — panic backtraces stay
+# byte-for-byte identical, file:line:col included — and cost less to
+# emit, so the tree and the wall clock both halve. Measured on one
+# worktree replaying four real commits off main, same commands, only
+# this setting varied:
+#
+#   debug = 2                 42.1 GiB target, 22.0 GiB of test bins, 243s
+#   debug = line-tables-only  19.8 GiB target,  8.3 GiB of test bins, 171s
+#
+# What line tables drop is variable inspection under gdb/lldb. Recover it
+# for one build with the same escape hatch [profile.release] documents
+# below:
+#   CARGO_PROFILE_DEV_DEBUG=2 cargo test -p aisix-proxy
+#
+# [profile.coverage] sets `debug = 2` explicitly, so llvm-cov is
+# unaffected.
+[profile.dev]
+debug = "line-tables-only"
+
 # Shipped binaries must stay profileable in the field (perf / cargo
 # flamegraph against the very build a user runs), so keep the symbol
 # table: function-level flame graphs cost ~10 MiB over stripped. DWARF

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,22 +199,32 @@ tempfile = "3.13"
 
 # Full DWARF is the largest single thing in `target/` here: it is 83% of
 # every test binary, and `cargo test --workspace` links 44 of them. Line
-# tables keep exactly what a failing test needs — panic backtraces stay
-# byte-for-byte identical, file:line:col included — and cost less to
-# emit, so the tree and the wall clock both halve. Measured on one
-# worktree replaying four real commits off main, same commands, only
-# this setting varied:
+# tables keep what a failing test needs while costing much less to emit.
+# Measured on one worktree replaying four real commits off main, same
+# commands, only this setting varied:
 #
 #   debug = 2                 42.1 GiB target, 22.0 GiB of test bins, 243s
 #   debug = line-tables-only  19.8 GiB target,  8.3 GiB of test bins, 171s
 #
-# What line tables drop is variable inspection under gdb/lldb. Recover it
-# for one build with the same escape hatch [profile.release] documents
-# below:
+# So 53% off the tree and 30% off the wall clock -- emitting debuginfo
+# costs both, which is why the two move together rather than trading off.
+#
+# Panic backtraces keep file and line. On rustc 1.97.1 the frames came
+# out identical to `debug = 2`, column included, but treat only file and
+# line as durable -- the column is not something to rely on across a
+# toolchain bump.
+#
+# What line tables drop is variable inspection under gdb/lldb: a
+# breakpoint still stops and still reports its line, but `print x` finds
+# no symbol. Recover it for one build with the same escape hatch
+# [profile.release] documents below:
 #   CARGO_PROFILE_DEV_DEBUG=2 cargo test -p aisix-proxy
 #
-# [profile.coverage] sets `debug = 2` explicitly, so llvm-cov is
-# unaffected.
+# Coverage survives this, but not for the reason [profile.coverage]
+# suggests: nothing passes `--profile coverage`, so `cargo llvm-cov`
+# builds under this profile too. It reads the `__llvm_covmap` section
+# that `-C instrument-coverage` emits, not DWARF, so line-level coverage
+# is unaffected -- the coverage gate passes on this commit.
 [profile.dev]
 debug = "line-tables-only"
 


### PR DESCRIPTION
## What

One setting in the root `Cargo.toml`:

```toml
[profile.dev]
debug = "line-tables-only"
```

## Why

A worktree running the normal local regression loop reaches 40–50 GiB of `target/`, and has repeatedly failed mid-compile with `No space left on device` (`aisix-proxy`, `aisix-core`). Full DWARF is not the root cause, but it is the multiplier on top of it.

## Root cause, for context

`target/` only ever grows. Cargo's fingerprint encodes the dependency graph, the feature set and the rustc flags; change any of them and the whole tree is rebuilt under a new hash, while the previous set stays on disk forever — cargo has no GC for build artifacts.

Replaying 13 real commits off `main` through one worktree, running the same command each round, separates the two cases cleanly:

| round | change | target | test binaries | rlib / unique names |
|---|---|---|---|---|
| 0 | clean build | 17.8G | 41 | 478 / **414** |
| 1–9 | 9 rounds of real code churn (up to 976 lines) | **~21G, flat** | 41 | 478 / **414** |
| 10 | removes the bundled ML guardrail (596 → 558 lock packages) | 27.2G | 53 | 493 / **414** |
| 11 | swaps the HTTP stack in `[workspace.dependencies]`, changes `hyper-util` features | 42.2G | **94** | 541 / **414** |
| 12 | plain code change | 44.2G | 94 | 541 / **414** |

The unique-crate count never moves off 414, while copies climb to 541 and test binaries more than double. Rounds 1–9 prove editing `.rs` files costs nothing. Round 11 is the pattern that hurts: touching `[workspace.dependencies]` and a feature list re-runs feature unification across the whole graph, so every fingerprint upstream of it changes and a **complete second set** of all 41 binaries is emitted next to the first.

That accumulation is inherent to cargo. What this PR removes is the factor of two sitting on top of it: debuginfo is **83%** of every test binary (sampled over the 8 largest, 3.9 GiB of which 3.3 GiB is `.debug_*`), and `cargo test --workspace` links 44 of them.

## Measurement

One worktree, `cargo clean` between variants, replaying the four commits that take `target` from 20.5G to 44.2G. Same commands throughout; only the debuginfo setting varied.

| variant | target | test binaries | incremental | build time |
|---|---|---|---|---|
| `debug = 2` (today) | 42.1G | 22.0G | 14.3G | 243s |
| **`debug = "line-tables-only"`** | **19.8G** | **8.3G** | **8.1G** | **171s** |
| `debug = 0` | 13.5G | 3.7G | 7.2G | 156s |
| deps-only reduction | 32.2G | 13.1G | 14.3G | 215s |

The `build time` column above is one run of each sequence and is only indicative — a single build turned out to be too noisy to carry a precise claim. Timing was re-measured on its own: a clean `cargo test --workspace --no-run`, three runs per setting, alternating between them so any drift in machine state lands on both equally.

| setting | median | spread |
|---|---|---|
| `debug = 2` | 92s | 90–111s |
| `line-tables-only` | **70s** | 70s on every run |

So **−53% disk and about a quarter off the wall clock**, in the same direction: emitting debuginfo costs both space and CPU, so there is no trade-off between them here. The spread is worth noting on its own — `debug = 2` swings 20% run to run, while line tables reproduced exactly; a lighter build has less to be perturbed by. Size figures were byte-identical across all three repetitions.

## What it costs

Panic backtraces are unchanged. Verified directly:

```
debug = 2                        debug = "line-tables-only"       debug = 0
  2: bt::inner                     2: bt::inner                     2: bt::inner
     at ./src/main.rs:1:14            at ./src/main.rs:1:14         3: bt::main
```

File, line and column all survive — byte-for-byte identical to today. Unaffected: test failure locations, single-stepping, breakpoints, call stacks, `perf`/flamegraphs (they need symbols and line tables, not type info).

The one thing dropped is **variable inspection under gdb/lldb** — breakpoints still stop and still report the line, but `print x` finds no symbol and IDE variable panes are empty. Recover it for a single build:

```bash
CARGO_PROFILE_DEV_DEBUG=2 cargo test -p aisix-proxy
```

This is the same escape hatch `[profile.release]` already documents a few lines below for its own stripped default, so the pattern is not new to this manifest.

`[profile.coverage]` sets `debug = 2` explicitly and therefore keeps full debuginfo — llvm-cov and the coverage gate are unaffected.

## Alternatives measured and rejected

- **`debug = 0`** — saves a further 6.3 GiB, but drops backtrace line numbers: a failing test reports only a function name. Not worth it.
- **Reduce dependencies only** (`[profile.dev.package."*"]`) — keeps full debuginfo for our own crates and would be strictly better if it were close. It is not: 32.2G, less than half the saving. Our 18 crates carry as much debuginfo as all 556 dependencies combined, and cargo enables incremental compilation only for workspace members, so this variant leaves the 14.3 GiB incremental cache exactly where it was.
- **`[profile.dev.build-override] debug = false`** — build scripts and proc macros. Measured at 153 MiB, under 1.5% of the result, and `line-tables-only` already covers them. Not worth the extra knob.
- **`cargo-sweep`** — its heuristics do not apply. A no-op build touches **0 of 735** `invoked.timestamp` files, so cargo only stamps units it actually recompiles; `--stamp/--file` would classify every live unit as stale, and `--time N` cannot separate anything inside a single day's session.

## CI

Same setting applies, so `Swatinem/rust-cache` entries get roughly half as large and both save and restore get faster. CI has no interactive debugger to lose.

## Risk

Config-only, no code change. Reverting is a one-line revert with no migration. The failure mode if someone needs variable inspection is discoverable and documented inline next to the setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced debug build artifact sizes and improved build times by using streamlined debug information.
  * Added an environment-variable override for generating full debug information when detailed debugging is needed.
  * Preserved full debug information for coverage builds.
  * Documented expected size, build-time, backtrace, debugger, override, and coverage behavior, including updated multi-run timing measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
