### PR TITLE
feat(validate): report guardrail rows that load but cannot run

### DIFF
--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -117,6 +117,53 @@ pub fn build_chain_from_snapshot(
     GuardrailChain::new_with_applied(chain, applied)
 }
 
+/// One enabled guardrail row that would not join the chain.
+///
+/// Returned by [`unbuildable_guardrail_rows`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnbuildableGuardrailRow {
+    /// Operator-facing row name, as written in the configuration.
+    pub name: String,
+    /// Why the row does not build, in the same wording the boot log uses.
+    /// A `kind: custom` script error carries the engine's line and column.
+    pub reason: String,
+}
+
+/// Report the enabled guardrail rows in `table` whose configuration does
+/// not build — [`build_chain_from_snapshot`]'s error arm, made returnable.
+///
+/// The gateway logs those errors and keeps serving, which is right for a
+/// running node but wrong for anything checking a configuration before it
+/// is deployed: the row silently not existing IS the defect. A screening
+/// rule that never runs is indistinguishable from one that never matched,
+/// and nothing downstream says otherwise — the load itself succeeded, so
+/// the config status stays `synced` with an empty `rejected` list.
+///
+/// [`BuildError::EmbedderUnavailable`] is deliberately excluded. The
+/// embedding dispatcher is a runtime capability, not part of the
+/// configuration, so a `kind: semantic` row fails to build here for a
+/// reason that says nothing about the file being checked.
+pub fn unbuildable_guardrail_rows(
+    table: &ResourceTable<DomainGuardrail>,
+    bedrock_endpoint_url: Option<&str>,
+) -> Vec<UnbuildableGuardrailRow> {
+    let embedder = GuardrailEmbedderSlot::none();
+    sorted_guardrail_entries(table)
+        .iter()
+        .filter(|entry| entry.value.enabled)
+        .filter_map(
+            |entry| match build_one(&entry.value, bedrock_endpoint_url, &embedder) {
+                Ok(_) => None,
+                Err(BuildError::EmbedderUnavailable) => None,
+                Err(err) => Some(UnbuildableGuardrailRow {
+                    name: entry.value.name.clone(),
+                    reason: err.to_string(),
+                }),
+            },
+        )
+        .collect()
+}
+
 /// The `{kind, hook}` telemetry descriptor for a guardrail row that
 /// materialised into a chain (#379). Captured here — the build points are the
 /// only place the domain row's `kind` + `hook_point` are in scope alongside

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -286,7 +286,8 @@ pub use audit::GuardrailAuditLog;
 #[cfg(feature = "bedrock")]
 pub use bedrock::BedrockGuardrail;
 pub use build::{
-    build_chain_from_snapshot, build_index_from_snapshot, LiveGuardrailChain, LiveGuardrailIndex,
+    build_chain_from_snapshot, build_index_from_snapshot, unbuildable_guardrail_rows,
+    LiveGuardrailChain, LiveGuardrailIndex, UnbuildableGuardrailRow,
 };
 pub use chain::GuardrailChain;
 pub use index::{GuardrailIndex, RequestContext};

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -242,24 +242,43 @@ async fn async_main(cfg: Config) -> anyhow::Result<()> {
 /// `aisix validate --resources <file>`: run the identical file-source
 /// pipeline (read → interpolate → desugar → canonical schema validation
 /// → typed decode → cross-reference checks) that boot and SIGHUP reload
-/// use, without booting any listener. Exit 0 on success; on failure the
+/// use, without booting any listener, then check that every enabled
+/// guardrail row actually builds. Exit 0 on success; on failure the
 /// aggregated error report (every problem, with kind / entry / field
 /// context) goes to stderr and the process exits non-zero.
 fn run_validate(resources: &Path) -> anyhow::Result<()> {
-    match aisix_core::filesource::load_resources_file(resources, 1) {
-        Ok(snapshot) => {
-            println!(
-                "OK: {} loaded {} resource(s)",
-                resources.display(),
-                snapshot.total_entries(),
-            );
-            Ok(())
-        }
+    let snapshot = match aisix_core::filesource::load_resources_file(resources, 1) {
+        Ok(snapshot) => snapshot,
         Err(report) => {
             eprintln!("{report}");
             std::process::exit(1);
         }
+    };
+    // Loading only proves the file parses. A guardrail row whose config
+    // does not build — an invalid regex, an unknown detector, a
+    // `kind: custom` script with a syntax error — is dropped from the
+    // chain with a warn line and nothing else: the gateway serves, the
+    // config status stays `synced` with an empty `rejected` list, and the
+    // screening that row describes never runs. Reporting OK for that
+    // would validate the file while missing the thing the file is for.
+    let unbuildable = aisix_guardrails::unbuildable_guardrail_rows(&snapshot.guardrails, None);
+    if !unbuildable.is_empty() {
+        eprintln!(
+            "resources file {}: {} guardrail(s) load but cannot run:",
+            resources.display(),
+            unbuildable.len(),
+        );
+        for row in &unbuildable {
+            eprintln!("  - guardrails ({:?}): {}", row.name, row.reason);
+        }
+        std::process::exit(1);
     }
+    println!(
+        "OK: {} loaded {} resource(s)",
+        resources.display(),
+        snapshot.total_entries(),
+    );
+    Ok(())
 }
 
 /// SIGHUP → re-run the whole file-source pipeline against the same

--- a/crates/aisix-server/tests/validate_reports_unrunnable_guardrails.rs
+++ b/crates/aisix-server/tests/validate_reports_unrunnable_guardrails.rs
@@ -1,0 +1,171 @@
+//! `aisix validate` against guardrail rows that load but cannot run.
+//!
+//! A guardrail row is checked twice on the way to serving traffic: the
+//! loader parses it, and the chain builder turns it into a runtime
+//! guardrail. Only the first of those used to be reachable before deploy.
+//! A row that parses but does not build — an invalid regex, an unknown
+//! detector, a `kind: custom` script with a syntax error — is dropped from
+//! the chain with a warn line and nothing else: the gateway serves,
+//! `/status/config` stays `synced` with an empty `rejected` list, and the
+//! screening the row describes never happens. A content policy that
+//! silently does not exist is the worst shape this can fail in, so the
+//! pre-deploy check has to reach the second step too.
+//!
+//! These drive the real binary because the exit code and the report on
+//! stderr are the contract an operator and a CI pipeline consume.
+
+use std::process::Command;
+
+use tempfile::NamedTempFile;
+
+/// Write `body` to a temp file and run `aisix validate --resources` on it.
+fn validate(body: &str) -> (bool, String, String) {
+    use std::io::Write;
+    let mut file = NamedTempFile::new().expect("temp file");
+    file.write_all(body.as_bytes()).expect("write");
+    file.flush().expect("flush");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_aisix"))
+        .args(["validate", "--resources"])
+        .arg(file.path())
+        .output()
+        .expect("run aisix validate");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// A `kind: custom` row whose script is not a well-formed ES module. The
+/// loader has no opinion on script contents, so this file parses.
+const BROKEN_SCRIPT: &str = r#"
+_format_version: "1"
+
+guardrails:
+  - name: screen-with-my-service
+    kind: custom
+    hook_point: input
+    script: |
+      export async function checkInput(ctx) { {{
+        return { action: "none" };
+      }
+"#;
+
+const WORKING_SCRIPT: &str = r#"
+_format_version: "1"
+
+guardrails:
+  - name: screen-with-my-service
+    kind: custom
+    hook_point: input
+    script: |
+      export async function checkInput(ctx) {
+        return { action: "none" };
+      }
+"#;
+
+/// `kind: keyword` carrying a pattern the regex engine rejects. Same
+/// class as the script error: the file is well-formed, the row is not.
+const BROKEN_REGEX: &str = r#"
+_format_version: "1"
+
+guardrails:
+  - name: block-secrets
+    kind: keyword
+    hook_point: input
+    patterns:
+      - kind: regex
+        value: "AKIA[0-9A-Z{16}"
+"#;
+
+#[test]
+fn a_custom_script_that_does_not_compile_fails_validation() {
+    let (ok, _stdout, stderr) = validate(BROKEN_SCRIPT);
+
+    assert!(
+        !ok,
+        "a guardrail that cannot run must not validate; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("screen-with-my-service"),
+        "the report must name the row an operator has to fix: {stderr}"
+    );
+    assert!(
+        stderr.contains("does not compile"),
+        "the report must say why the row cannot run: {stderr}"
+    );
+}
+
+#[test]
+fn a_custom_script_that_compiles_validates() {
+    let (ok, stdout, stderr) = validate(WORKING_SCRIPT);
+
+    assert!(ok, "stderr: {stderr}");
+    assert!(stdout.contains("OK:"), "stdout: {stdout}");
+}
+
+#[test]
+fn an_invalid_keyword_regex_fails_validation() {
+    let (ok, _stdout, stderr) = validate(BROKEN_REGEX);
+
+    assert!(
+        !ok,
+        "the script case is one instance of a class; every row that cannot \
+         build has to fail the same way; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("block-secrets"),
+        "the report must name the row: {stderr}"
+    );
+}
+
+#[test]
+fn a_disabled_row_that_cannot_build_does_not_fail_validation() {
+    let disabled =
+        BROKEN_SCRIPT.replace("    kind: custom", "    enabled: false\n    kind: custom");
+    let (ok, stdout, stderr) = validate(&disabled);
+
+    assert!(
+        ok,
+        "a staged row is not screening anything either way; stderr: {stderr}"
+    );
+    assert!(stdout.contains("OK:"), "stdout: {stdout}");
+}
+
+/// A `kind: semantic` row is the one thing that fails to build for a
+/// reason the file cannot fix: the embedding dispatcher is a runtime
+/// capability, and `validate` boots nothing. Reporting it would make the
+/// check cry wolf on a correct configuration, which is how a validation
+/// step stops being read.
+#[test]
+fn a_semantic_row_does_not_fail_validation_for_the_missing_embedder() {
+    let semantic = r#"
+_format_version: "1"
+
+provider_keys:
+  - display_name: openai-prod
+    provider: openai
+    api_key: sk-not-a-real-key
+
+models:
+  - display_name: embed-small
+    provider: openai
+    model_name: text-embedding-3-small
+    provider_key: openai-prod
+    embedding:
+      dimensions: 1536
+
+guardrails:
+  - name: screen-by-meaning
+    kind: semantic
+    hook_point: input
+    embedding_model: embed-small
+    deny_examples:
+      - "how do I make a bomb"
+"#;
+    let (ok, stdout, stderr) = validate(semantic);
+
+    assert!(ok, "stderr: {stderr}");
+    assert!(stdout.contains("OK:"), "stdout: {stdout}");
+}


### PR DESCRIPTION
## Problem

A guardrail row is checked twice on the way to serving traffic: the loader parses it, and the chain builder turns it into a runtime guardrail. Only the first was reachable before deploy.

A row that parses but does not build — an invalid regex, an unknown detector, a `custom_patterns[].replacement` on a block action, a `kind: custom` script with a syntax error — is dropped from the chain with a warn line and nothing else. Everything else reports healthy:

```
$ aisix validate --resources resources.yaml
OK: resources.yaml loaded 4 resource(s)          # exit 0

$ curl :9090/status/config
{"state": "synced", "rejected": [], ...}         # gateway serving, /livez 200
```

The screening that row describes never runs. A content policy that silently does not exist is the worst shape this can fail in, because it is indistinguishable from one that never matched.

## Change

`unbuildable_guardrail_rows()` in `aisix-guardrails` is `build_chain_from_snapshot`'s error arm made returnable, and `aisix validate` runs it after the load succeeds:

```
$ aisix validate --resources resources.yaml
resources file resources.yaml: 1 guardrail(s) load but cannot run:
  - guardrails ("screen-with-my-service"): custom guardrail script does not compile: Error: unsupported keyword: export
    at guardrail.js:56:37                        # exit 1
```

The report reuses the loader's shape, and a `kind: custom` script error carries the engine's own line and column.

`BuildError::EmbedderUnavailable` is excluded: the embedding dispatcher is a runtime capability, not part of the configuration, so a `kind: semantic` row fails to build under `validate` for a reason that says nothing about the file being checked. Reporting it would make the check cry wolf on a correct configuration.

Because the check reuses `build_one`, every guardrail kind — including any added later — is covered without a second list to maintain.

## Behavior change

`aisix validate` now exits non-zero for a file it previously accepted. That is the point: those files configure screening that does not happen. Gateway boot and reload are unchanged — a bad row is still skipped rather than taking the node down.

## Tests

`crates/aisix-server/tests/validate_reports_unrunnable_guardrails.rs` drives the real binary, since the exit code and the stderr report are the contract an operator and a CI pipeline consume: a script that does not compile fails validation; one that compiles passes; an invalid keyword regex fails the same way (the script case is one instance of a class); a disabled row that cannot build does not fail; a `kind: semantic` row does not fail for the missing embedder. The first three exit 0 on the current binary and non-zero with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced resource validation to detect guardrails that cannot be built or executed.
  - Validation errors now identify the affected guardrail and explain the failure.
  - Valid resources continue to display a success summary.

- **Bug Fixes**
  - Prevented invalid custom scripts and regular expression patterns from passing validation unnoticed.

- **Tests**
  - Added coverage for invalid, valid, disabled, and semantic guardrails during resource validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->