### PR TITLE
fix(messages): keep an OpenAI upstream's prompt-cache hit on /v1/messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,17 @@ This repo is developed end-to-end by agents — no human reviewer needs small re
 
 (Two recurrences of the same lesson: #471 — a Model-Group dispatch fix landed only on `/v1/messages` while `/v1/responses` and `count_tokens` had the identical gap; then #715 — `least_busy`'s in-flight counter shipped fed by chat.rs only (#684 left messages/responses as an un-filed "follow-up"), so the strategy silently degraded to declaration order for Claude Code / Codex traffic until #716. The EWMA for `least_latency` (#682) wired all three endpoints at once and never had this problem — that's the standard.)
 
+## Usage Converts at the Client Boundary, Never at the Telemetry One
+
+**`UsageStats` carries two *disjoint* cache representations with opposite arithmetic, and a cross-protocol handler must convert one for the client while leaving the UsageEvent in the upstream's own shape.**
+
+- OpenAI-shape upstreams report the prompt-cache hit as `cached_prompt_tokens`, a **subset already inside** `prompt_tokens`. Anthropic-shape upstreams report `cache_creation_tokens` / `cache_read_tokens` as counters **on top of** `prompt_tokens`. Each provider's wire fills one family and zeroes the other; never map between them inside `UsageStats`, and never add `cached_prompt_tokens` into a total (`total_tokens_with_cache` deliberately takes only the additive pair).
+- **The client-facing renderer converts** — an Anthropic client's `input_tokens` means non-cached input, so an OpenAI upstream's hit has to move out into `cache_read_input_tokens`, and the reverse renderer faces the mirror problem. Emit a cache counter only when non-zero: a fabricated `0` reads as "the provider reported no hit" rather than "the provider doesn't report this".
+- **The UsageEvent does NOT convert.** It carries the upstream's own shape, so one upstream call bills identically whichever inbound protocol addressed it — and because cp-api prices it that way: it charges `prompt_tokens - cached_prompt_tokens` at the prompt rate plus `cached_prompt_tokens` at the cache-read rate, and **rejects an event whose `cached_prompt_tokens` exceeds its `prompt_tokens`**. Converting on this side is a silent cost error, not a display choice.
+- A dropped counter here is invisible from the dashboard: no cache detail is indistinguishable from a provider that never cached, so nothing looks wrong while the whole prompt bills uncached.
+
+(Lesson from AISIX-Cloud#1405: the `/v1/messages` → OpenAI-compatible bridge parsed `prompt_tokens_details.cached_tokens` correctly into `UsageStats` and then dropped it at **both** exits — `AnthropicUsageMetrics` had no field for it and the Anthropic renderer emitted `input_tokens` / `output_tokens` only. `/v1/chat/completions` had carried it since #542.)
+
 ## A Config Knob Isn't Shipped Until the Control Plane Exposes It
 
 **A user-configurable data-plane feature is NOT delivered when the Rust side works — it's delivered when a user can reach it through the control plane. DP-only is a half-feature nobody can turn on.**

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -1618,6 +1618,68 @@ fn translate_assistant_blocks(blocks: &[serde_json::Value]) -> ChatMessage {
 // ─────────────────────────────────────────────────────────────────────
 // Outbound translation — internal ChatResponse  →  Anthropic JSON.
 
+/// The Anthropic-shape `usage` view of the gateway's canonical
+/// [`UsageStats`], for a response rendered back to a `/v1/messages`
+/// client (AISIX-Cloud#1405).
+///
+/// `UsageStats` carries two *disjoint* cache representations and they
+/// fold in opposite directions:
+///
+/// - An OpenAI-shape upstream reports its cache hit as
+///   `cached_prompt_tokens`, a SUBSET already counted inside
+///   `prompt_tokens`. Anthropic's `input_tokens` means NON-cached
+///   input, so the subset is subtracted back out.
+/// - An Anthropic-shape upstream reports `cache_creation_tokens` /
+///   `cache_read_tokens` as counters ON TOP of `prompt_tokens`, which
+///   is already Anthropic's `input_tokens` — nothing to subtract.
+///
+/// Because the two never co-occur (`wire.rs` in each provider fills one
+/// family and zeroes the other), summing them is the same as picking
+/// whichever the upstream actually reported. Either way the client sees
+/// the identity Anthropic guarantees: `input_tokens + cache_creation +
+/// cache_read` is the total input the model processed.
+///
+/// LiteLLM's `/v1/messages` adapter derives the same three numbers the
+/// same way; it subtracts BOTH cache counters from `prompt_tokens`
+/// because its single `Usage` object has already folded the
+/// Anthropic-shape counters in, which ours deliberately has not.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct AnthropicInputUsage {
+    /// `usage.input_tokens` — non-cached input.
+    input_tokens: u32,
+    cache_creation_input_tokens: u32,
+    cache_read_input_tokens: u32,
+}
+
+impl AnthropicInputUsage {
+    fn from_usage(u: &UsageStats) -> Self {
+        Self {
+            input_tokens: u.prompt_tokens.saturating_sub(u.cached_prompt_tokens),
+            cache_creation_input_tokens: u.cache_creation_tokens,
+            cache_read_input_tokens: u.cache_read_tokens.saturating_add(u.cached_prompt_tokens),
+        }
+    }
+
+    /// Add the cache counters to an Anthropic `usage` object, omitting
+    /// each when zero: an upstream that reports no prompt cache at all
+    /// must not be handed a fabricated `0` the client would read as
+    /// "cache reported, nothing hit".
+    fn insert_cache_fields(&self, usage: &mut serde_json::Map<String, serde_json::Value>) {
+        if self.cache_creation_input_tokens > 0 {
+            usage.insert(
+                "cache_creation_input_tokens".into(),
+                self.cache_creation_input_tokens.into(),
+            );
+        }
+        if self.cache_read_input_tokens > 0 {
+            usage.insert(
+                "cache_read_input_tokens".into(),
+                self.cache_read_input_tokens.into(),
+            );
+        }
+    }
+}
+
 /// Render an internal [`ChatResponse`] as the JSON an Anthropic
 /// `/v1/messages` client expects. The reverse of
 /// `response_into_chat_response`. `model_display_name` is the
@@ -1658,6 +1720,12 @@ pub fn chat_response_into_anthropic_json(
         content.push(serde_json::json!({"type": "text", "text": ""}));
     }
 
+    let input = AnthropicInputUsage::from_usage(&resp.usage);
+    let mut usage = serde_json::Map::new();
+    usage.insert("input_tokens".into(), input.input_tokens.into());
+    usage.insert("output_tokens".into(), resp.usage.completion_tokens.into());
+    input.insert_cache_fields(&mut usage);
+
     serde_json::json!({
         "id": resp.id,
         "type": "message",
@@ -1666,10 +1734,7 @@ pub fn chat_response_into_anthropic_json(
         "content": content,
         "stop_reason": stop_reason,
         "stop_sequence": serde_json::Value::Null,
-        "usage": {
-            "input_tokens": resp.usage.prompt_tokens,
-            "output_tokens": resp.usage.completion_tokens,
-        },
+        "usage": serde_json::Value::Object(usage),
     })
 }
 
@@ -1743,6 +1808,13 @@ pub struct AnthropicSseEncoder {
     /// robust to providers that double-emit usage.
     seen_input_tokens: u32,
     seen_output_tokens: u32,
+    /// Cache counters seen on the stream, in both of `UsageStats`'
+    /// representations — folded into the Anthropic shape by
+    /// [`AnthropicInputUsage`] when the closing pair is built
+    /// (AISIX-Cloud#1405).
+    seen_cached_prompt_tokens: u32,
+    seen_cache_creation_tokens: u32,
+    seen_cache_read_tokens: u32,
     usage_seen: bool,
 }
 
@@ -1769,6 +1841,9 @@ impl AnthropicSseEncoder {
             pending_stop_reason: None,
             seen_input_tokens: 0,
             seen_output_tokens: 0,
+            seen_cached_prompt_tokens: 0,
+            seen_cache_creation_tokens: 0,
+            seen_cache_read_tokens: 0,
             usage_seen: false,
         }
     }
@@ -1784,6 +1859,11 @@ impl AnthropicSseEncoder {
             self.usage_seen = true;
             self.seen_input_tokens = self.seen_input_tokens.max(u.prompt_tokens);
             self.seen_output_tokens = self.seen_output_tokens.max(u.completion_tokens);
+            self.seen_cached_prompt_tokens =
+                self.seen_cached_prompt_tokens.max(u.cached_prompt_tokens);
+            self.seen_cache_creation_tokens =
+                self.seen_cache_creation_tokens.max(u.cache_creation_tokens);
+            self.seen_cache_read_tokens = self.seen_cache_read_tokens.max(u.cache_read_tokens);
         }
 
         // Closing pair withheld at the stop chunk: only the trailing
@@ -1948,13 +2028,25 @@ impl AnthropicSseEncoder {
     /// best-known cumulative usage. `input_tokens` is included when
     /// known — on a translated stream `message_start` fires before any
     /// usage frame exists and always reports 0, so this is the only
-    /// place the client can learn the prompt token count.
+    /// place the client can learn the prompt token count. The same goes
+    /// for the cache counters (AISIX-Cloud#1405).
     fn closing_pair(&mut self, stop_reason: &'static str) -> Vec<AnthropicSseEvent> {
+        let input = AnthropicInputUsage::from_usage(&UsageStats {
+            prompt_tokens: self.seen_input_tokens,
+            cached_prompt_tokens: self.seen_cached_prompt_tokens,
+            cache_creation_tokens: self.seen_cache_creation_tokens,
+            cache_read_tokens: self.seen_cache_read_tokens,
+            ..UsageStats::default()
+        });
         let mut usage = serde_json::Map::new();
+        // Gate on the RAW prompt count, not the cache-adjusted one: a
+        // fully-cached prompt is a real `input_tokens: 0`, distinct from
+        // an upstream that reported no input count at all.
         if self.seen_input_tokens > 0 {
-            usage.insert("input_tokens".into(), self.seen_input_tokens.into());
+            usage.insert("input_tokens".into(), input.input_tokens.into());
         }
         usage.insert("output_tokens".into(), self.seen_output_tokens.into());
+        input.insert_cache_fields(&mut usage);
         self.finished = true;
         vec![
             AnthropicSseEvent {
@@ -3552,6 +3644,97 @@ mod tests {
         assert_eq!(mk(FinishReason::Other("vendor".into())), "end_turn");
     }
 
+    #[test]
+    fn render_anthropic_response_maps_openai_cache_hit_to_cache_read() {
+        // AISIX-Cloud#1405: an OpenAI-compatible upstream reports its
+        // prompt-cache hit as `prompt_tokens_details.cached_tokens`, a
+        // subset of `prompt_tokens`. Anthropic's `input_tokens` means
+        // NON-cached input, so the hit moves out into
+        // `cache_read_input_tokens` — pre-fix it vanished entirely and
+        // an Anthropic client billed the whole prompt at full rate.
+        let resp = ChatResponse {
+            id: "chatcmpl-cache-test".into(),
+            model: "MiniMax-M3".into(),
+            message: ChatMessage::assistant("ok"),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats {
+                prompt_tokens: 68_274,
+                completion_tokens: 497,
+                total_tokens: 68_771,
+                cached_prompt_tokens: 60_000,
+                ..UsageStats::default()
+            },
+        };
+        let usage = &chat_response_into_anthropic_json(&resp, "tencent-minimax-m3")["usage"];
+        assert_eq!(usage["input_tokens"], 8_274);
+        assert_eq!(usage["cache_read_input_tokens"], 60_000);
+        assert_eq!(usage["output_tokens"], 497);
+        // Not reported by an OpenAI upstream — never fabricated as 0.
+        assert!(usage.get("cache_creation_input_tokens").is_none());
+        // The Anthropic identity holds: input + cache = the prompt the
+        // model processed, so the client's own total stays P + O.
+        assert_eq!(
+            usage["input_tokens"].as_u64().unwrap()
+                + usage["cache_read_input_tokens"].as_u64().unwrap()
+                + usage["output_tokens"].as_u64().unwrap(),
+            68_771
+        );
+    }
+
+    #[test]
+    fn render_anthropic_response_keeps_anthropic_shape_counters_additive() {
+        // The other representation: an Anthropic-shape bridged upstream
+        // (bedrock/vertex Claude without the anthropic adapter) already
+        // reports `prompt_tokens` EXCLUDING cache, so the counters ride
+        // on top and nothing is subtracted.
+        let resp = ChatResponse {
+            id: "x".into(),
+            model: "u".into(),
+            message: ChatMessage::assistant("ok"),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::with_cache(10, 4, 200, 800),
+        };
+        let usage = &chat_response_into_anthropic_json(&resp, "m")["usage"];
+        assert_eq!(usage["input_tokens"], 10);
+        assert_eq!(usage["cache_creation_input_tokens"], 200);
+        assert_eq!(usage["cache_read_input_tokens"], 800);
+    }
+
+    #[test]
+    fn render_anthropic_response_omits_cache_fields_when_upstream_reports_none() {
+        let resp = ChatResponse {
+            id: "x".into(),
+            model: "u".into(),
+            message: ChatMessage::assistant("ok"),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats::new(7, 3),
+        };
+        let usage = &chat_response_into_anthropic_json(&resp, "m")["usage"];
+        assert_eq!(usage["input_tokens"], 7);
+        assert!(usage.get("cache_read_input_tokens").is_none());
+        assert!(usage.get("cache_creation_input_tokens").is_none());
+    }
+
+    #[test]
+    fn render_anthropic_response_fully_cached_prompt_reports_zero_input() {
+        let resp = ChatResponse {
+            id: "x".into(),
+            model: "u".into(),
+            message: ChatMessage::assistant("ok"),
+            finish_reason: FinishReason::Stop,
+            usage: UsageStats {
+                prompt_tokens: 900,
+                completion_tokens: 5,
+                total_tokens: 905,
+                cached_prompt_tokens: 900,
+                ..UsageStats::default()
+            },
+        };
+        let usage = &chat_response_into_anthropic_json(&resp, "m")["usage"];
+        assert_eq!(usage["input_tokens"], 0);
+        assert_eq!(usage["cache_read_input_tokens"], 900);
+    }
+
     // ─── AnthropicSseEncoder ──────────────────────────────────────
 
     #[test]
@@ -3696,6 +3879,89 @@ mod tests {
         assert_eq!(events[0].data["usage"]["input_tokens"], 17);
         assert_eq!(events[0].data["usage"]["output_tokens"], 23);
         assert!(enc.is_finished());
+    }
+
+    /// AISIX-Cloud#1405, streaming half: an OpenAI-compatible upstream
+    /// attaches `prompt_tokens_details.cached_tokens` to its trailing
+    /// `include_usage` frame. The closing `message_delta` is the only
+    /// place a translated stream can carry it — pre-fix the encoder
+    /// tracked input/output only and the cache hit never reached the
+    /// client.
+    #[test]
+    fn sse_encoder_closing_pair_carries_openai_cache_hit_as_cache_read() {
+        let mut enc = AnthropicSseEncoder::new("msg_01", "tencent-minimax-m3", 0);
+        let _ = enc.next_events(&delta_chunk("ok"));
+        let stop_no_usage = ChatChunk {
+            id: "chatcmpl-cache-test".into(),
+            model: "MiniMax-M3".into(),
+            delta: ChatDelta::default(),
+            finish_reason: Some(FinishReason::Stop),
+            usage: None,
+        };
+        let _ = enc.next_events(&stop_no_usage);
+
+        let usage_only = ChatChunk {
+            id: "chatcmpl-cache-test".into(),
+            model: "MiniMax-M3".into(),
+            delta: ChatDelta::default(),
+            finish_reason: None,
+            usage: Some(UsageStats {
+                prompt_tokens: 68_274,
+                completion_tokens: 497,
+                total_tokens: 68_771,
+                cached_prompt_tokens: 60_000,
+                ..UsageStats::default()
+            }),
+        };
+        let events = enc.next_events(&usage_only);
+        let usage = &events[0].data["usage"];
+        assert_eq!(usage["input_tokens"], 8_274);
+        assert_eq!(usage["cache_read_input_tokens"], 60_000);
+        assert_eq!(usage["output_tokens"], 497);
+        assert!(usage.get("cache_creation_input_tokens").is_none());
+    }
+
+    #[test]
+    fn sse_encoder_closing_pair_keeps_anthropic_shape_counters_additive() {
+        let mut enc = AnthropicSseEncoder::new("msg_01", "m", 0);
+        let _ = enc.next_events(&delta_chunk("ok"));
+        let stop_with_usage = ChatChunk {
+            id: "c".into(),
+            model: "u".into(),
+            delta: ChatDelta::default(),
+            finish_reason: Some(FinishReason::Stop),
+            usage: Some(UsageStats::with_cache(10, 4, 200, 800)),
+        };
+        let events = enc.next_events(&stop_with_usage);
+        let delta = events
+            .iter()
+            .find(|e| e.event == "message_delta")
+            .expect("closing pair emitted");
+        assert_eq!(delta.data["usage"]["input_tokens"], 10);
+        assert_eq!(delta.data["usage"]["cache_creation_input_tokens"], 200);
+        assert_eq!(delta.data["usage"]["cache_read_input_tokens"], 800);
+    }
+
+    #[test]
+    fn sse_encoder_closing_pair_omits_cache_fields_without_upstream_cache() {
+        let mut enc = AnthropicSseEncoder::new("msg_01", "m", 0);
+        let _ = enc.next_events(&delta_chunk("ok"));
+        let events = enc.next_events(&ChatChunk {
+            id: "c".into(),
+            model: "u".into(),
+            delta: ChatDelta::default(),
+            finish_reason: Some(FinishReason::Stop),
+            usage: Some(UsageStats::new(17, 23)),
+        });
+        let delta = events
+            .iter()
+            .find(|e| e.event == "message_delta")
+            .expect("closing pair emitted");
+        assert_eq!(delta.data["usage"]["input_tokens"], 17);
+        assert!(delta.data["usage"].get("cache_read_input_tokens").is_none());
+        assert!(delta.data["usage"]
+            .get("cache_creation_input_tokens")
+            .is_none());
     }
 
     /// An upstream that ignores `stream_options` never sends the usage

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1418,6 +1418,9 @@ async fn anthropic_passthrough_dispatch(
                 let metrics = AnthropicUsageMetrics {
                     prompt_tokens: usage.prompt_tokens,
                     completion_tokens: usage.completion_tokens,
+                    // Anthropic upstream: the cache hit arrives as
+                    // `cache_read_input_tokens`, never the OpenAI-shape subset.
+                    cached_prompt_tokens: 0,
                     cache_creation_tokens: usage.cache_creation_tokens,
                     cache_read_tokens: usage.cache_read_tokens,
                     usage_estimated: usage.usage_estimated,
@@ -1780,6 +1783,8 @@ fn anthropic_metrics_from_response_json(body: &Value) -> AnthropicUsageMetrics {
     let usage = body.get("usage");
     AnthropicUsageMetrics {
         usage_estimated: false,
+        // Anthropic upstream: see the streaming sibling — no OpenAI-shape subset.
+        cached_prompt_tokens: 0,
         prompt_tokens: usage
             .and_then(|u| u.get("input_tokens"))
             .and_then(Value::as_u64)
@@ -2074,6 +2079,7 @@ async fn cross_provider_dispatch(
                 let metrics = AnthropicUsageMetrics {
                     prompt_tokens: comp.prompt_tokens,
                     completion_tokens: comp.completion_tokens,
+                    cached_prompt_tokens: comp.cached_prompt_tokens,
                     cache_creation_tokens: comp.cache_creation_tokens,
                     cache_read_tokens: comp.cache_read_tokens,
                     usage_estimated: comp.usage_estimated,
@@ -2243,6 +2249,7 @@ async fn cross_provider_dispatch(
     let mut metrics = AnthropicUsageMetrics {
         prompt_tokens: resp.usage.prompt_tokens,
         completion_tokens: resp.usage.completion_tokens,
+        cached_prompt_tokens: resp.usage.cached_prompt_tokens,
         cache_creation_tokens: resp.usage.cache_creation_tokens,
         cache_read_tokens: resp.usage.cache_read_tokens,
         usage_estimated: false,
@@ -2394,6 +2401,8 @@ fn build_anthropic_sse_stream(
                     if let Some(u) = chunk.usage.as_ref() {
                         comp.prompt_tokens = comp.prompt_tokens.max(u.prompt_tokens);
                         comp.completion_tokens = comp.completion_tokens.max(u.completion_tokens);
+                        comp.cached_prompt_tokens =
+                            comp.cached_prompt_tokens.max(u.cached_prompt_tokens);
                         comp.cache_creation_tokens =
                             comp.cache_creation_tokens.max(u.cache_creation_tokens);
                         comp.cache_read_tokens = comp.cache_read_tokens.max(u.cache_read_tokens);
@@ -2648,6 +2657,8 @@ struct AnthropicStreamCompletion {
     reached_end: bool,
     prompt_tokens: u32,
     completion_tokens: u32,
+    /// See [`AnthropicUsageMetrics::cached_prompt_tokens`].
+    cached_prompt_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
     /// True when the Drop guard filled any token counter from the local
@@ -2786,6 +2797,16 @@ impl From<ProxyError> for MessagesDispatchError {
 struct AnthropicUsageMetrics {
     prompt_tokens: u32,
     completion_tokens: u32,
+    /// OpenAI-shape prompt-cache hit — a SUBSET of `prompt_tokens`,
+    /// non-zero only on the bridged path where the upstream speaks
+    /// OpenAI (AISIX-Cloud#1405). Kept in the upstream's own shape so a
+    /// given upstream call produces the same UsageEvent whichever
+    /// inbound protocol addressed it, and so cp-api's pricing split
+    /// (`prompt - cached` at the prompt rate, `cached` at the cache-read
+    /// rate) stays correct. Never summed into a total — that would
+    /// double-count it, unlike the two Anthropic-shape counters below,
+    /// which sit ON TOP of `prompt_tokens`.
+    cached_prompt_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
     /// True when any token counter was filled by the local estimator
@@ -2870,6 +2891,7 @@ fn emit_anthropic_usage_event(
         requested_model: model.to_string(),
         prompt_tokens: metrics.prompt_tokens,
         completion_tokens: metrics.completion_tokens,
+        cached_prompt_tokens: metrics.cached_prompt_tokens,
         cache_creation_tokens: metrics.cache_creation_tokens,
         cache_read_tokens: metrics.cache_read_tokens,
         usage_estimated: metrics.usage_estimated,
@@ -4751,6 +4773,177 @@ data: [DONE]\n\n";
         assert_eq!(v["stop_reason"], "end_turn");
         assert_eq!(v["usage"]["input_tokens"], 8);
         assert_eq!(v["usage"]["output_tokens"], 4);
+    }
+
+    /// AISIX-Cloud#1405: `/v1/messages` in front of an OpenAI-compatible
+    /// upstream that reports a prompt-cache hit. Pre-fix the hit was
+    /// dropped on BOTH exits — the client's Anthropic `usage` and the
+    /// UsageEvent that drives Logs/billing — so the whole 68k prompt
+    /// billed at the uncached rate and no cache detail existed to
+    /// reconcile against the provider's own bill.
+    ///
+    /// The numbers are the reporter's: MiniMax M3 behind an
+    /// OpenAI-compatible provider, addressed by the Claude CLI.
+    #[tokio::test]
+    async fn messages_openai_upstream_cache_hit_reaches_client_and_usage_event() {
+        use aisix_obs::UsageSink;
+        use aisix_provider_openai::OpenAiBridge;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "chatcmpl-cache-test",
+                "model": "MiniMax-M3",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {
+                    "prompt_tokens": 68_274,
+                    "completion_tokens": 497,
+                    "total_tokens": 68_771,
+                    "prompt_tokens_details": {"cached_tokens": 60_000}
+                }
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("tencent-minimax-m3"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_family(
+            aisix_core::Adapter::Anthropic,
+            Arc::new(AnthropicBridge::new()),
+        );
+        hub.register_family(aisix_core::Adapter::Openai, Arc::new(OpenAiBridge::new()));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = crate::build_router(
+            crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+                .without_cache()
+                .with_usage_sink(UsageSink::new(tx)),
+        );
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "tencent-minimax-m3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v: serde_json::Value =
+            serde_json::from_slice(&to_bytes(resp.into_body(), 65536).await.unwrap()).unwrap();
+
+        // Client side: Anthropic semantics — input_tokens excludes the
+        // cache read, which gets its own counter.
+        assert_eq!(v["usage"]["input_tokens"], 8_274);
+        assert_eq!(v["usage"]["cache_read_input_tokens"], 60_000);
+        assert_eq!(v["usage"]["output_tokens"], 497);
+        assert!(
+            v["usage"].get("cache_creation_input_tokens").is_none(),
+            "an OpenAI upstream reports no cache write — never fabricate one"
+        );
+
+        // Telemetry side: the upstream's OWN shape, so this call bills
+        // identically whether OpenAI or Anthropic protocol addressed it,
+        // and cp-api's `prompt - cached` split stays correct.
+        let event = rx.recv().await.expect("usage event was never emitted");
+        assert_eq!(event.prompt_tokens, 68_274);
+        assert_eq!(event.cached_prompt_tokens, 60_000);
+        assert_eq!(event.completion_tokens, 497);
+        // The cache hit is a SUBSET of prompt_tokens, so the Anthropic-shape
+        // additive counters stay 0 and the total is not double-counted.
+        assert_eq!(event.cache_read_tokens, 0);
+        assert_eq!(event.cache_creation_tokens, 0);
+        assert_eq!(
+            crate::usage_attr::total_tokens_with_cache(
+                event.prompt_tokens,
+                event.completion_tokens,
+                event.cache_creation_tokens,
+                event.cache_read_tokens,
+            ),
+            68_771
+        );
+    }
+
+    /// Streaming half of the above: the cache hit rides the trailing
+    /// `include_usage` frame, so the closing `message_delta` is the only
+    /// place the client can learn it.
+    #[tokio::test]
+    async fn messages_openai_upstream_cache_hit_streams_and_reaches_usage_event() {
+        use aisix_obs::UsageSink;
+        use aisix_provider_openai::OpenAiBridge;
+        use futures::StreamExt;
+
+        let upstream = MockServer::start().await;
+        let sse = "\
+data: {\"id\":\"chatcmpl-cache-test\",\"model\":\"MiniMax-M3\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"chatcmpl-cache-test\",\"model\":\"MiniMax-M3\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: {\"id\":\"chatcmpl-cache-test\",\"model\":\"MiniMax-M3\",\"choices\":[],\"usage\":{\"prompt_tokens\":68274,\"completion_tokens\":497,\"total_tokens\":68771,\"prompt_tokens_details\":{\"cached_tokens\":60000}}}\n\n\
+data: [DONE]\n\n";
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("tencent-minimax-m3"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_family(
+            aisix_core::Adapter::Anthropic,
+            Arc::new(AnthropicBridge::new()),
+        );
+        hub.register_family(aisix_core::Adapter::Openai, Arc::new(OpenAiBridge::new()));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = crate::build_router(
+            crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+                .without_cache()
+                .with_usage_sink(UsageSink::new(tx)),
+        );
+
+        let resp = app
+            .oneshot(make_req(serde_json::json!({
+                "model": "tencent-minimax-m3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "stream": true
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let mut stream = resp.into_body().into_data_stream();
+        let mut bytes = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            bytes.extend_from_slice(&chunk.unwrap());
+        }
+        let sse_out = String::from_utf8(bytes).unwrap();
+        let closing = sse_out
+            .lines()
+            .filter_map(|l| l.strip_prefix("data: "))
+            .filter_map(|d| serde_json::from_str::<serde_json::Value>(d).ok())
+            .find(|v| v["type"] == "message_delta")
+            .expect("closing message_delta emitted");
+        assert_eq!(closing["usage"]["input_tokens"], 8_274);
+        assert_eq!(closing["usage"]["cache_read_input_tokens"], 60_000);
+        assert_eq!(closing["usage"]["output_tokens"], 497);
+
+        let event = rx.recv().await.expect("usage event was never emitted");
+        assert_eq!(event.prompt_tokens, 68_274);
+        assert_eq!(event.cached_prompt_tokens, 60_000);
+        assert_eq!(event.completion_tokens, 497);
+        assert_eq!(event.cache_read_tokens, 0);
     }
 
     /// (Anthropic inbound) × (DeepSeek upstream).

--- a/tests/e2e/src/cases/messages-openai-cache-tokens-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-openai-cache-tokens-e2e.test.ts
@@ -4,6 +4,7 @@ import { gunzipSync } from "node:zlib";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  ProxyClient,
   SeedClient,
   pickFreePort,
   spawnApp,
@@ -106,6 +107,8 @@ const STREAM_EVENTS = [
 interface CapturedLog {
   path: string;
   logs: Record<string, unknown>[];
+  /** Set when the intake body did not decode as gzipped JSON. */
+  decodeError?: string;
 }
 
 interface MockDatadog {
@@ -124,14 +127,20 @@ async function startMockDatadog(): Promise<MockDatadog> {
       const path = (req.url ?? "").split("?")[0];
       if (req.method === "POST" && path === INTAKE_PATH) {
         let logs: Record<string, unknown>[] = [];
+        let decodeError: string | undefined;
         try {
           const parsed: unknown = JSON.parse(gunzipSync(Buffer.concat(chunks)).toString("utf8"));
-          if (Array.isArray(parsed)) logs = parsed as Record<string, unknown>[];
-        } catch {
-          // Leave empty: the poll below times out loudly rather than
-          // letting a malformed intake read as "nothing to assert".
+          if (Array.isArray(parsed)) {
+            logs = parsed as Record<string, unknown>[];
+          } else {
+            decodeError = `intake body decoded to ${typeof parsed}, expected a JSON array`;
+          }
+        } catch (err) {
+          // Keep the reason. Swallowing it would turn "the DP changed its
+          // intake encoding" into an unrelated poll timeout below.
+          decodeError = `intake body is not gzipped JSON: ${String(err)}`;
         }
-        requests.push({ path, logs });
+        requests.push({ path, logs, decodeError });
       }
       res.statusCode = 202;
       res.end();
@@ -165,6 +174,9 @@ async function waitForUsageEvent(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     for (const req of dd.requests) {
+      // A body the mock could not decode is a harness/wire failure, not a
+      // slow event — fail on it as itself instead of waiting out the poll.
+      if (req.decodeError) throw new Error(req.decodeError);
       const hit = req.logs.find((l) => l["aisix.requested_model"] === model);
       if (hit) return hit;
     }
@@ -262,19 +274,24 @@ describe("/v1/messages keeps an OpenAI upstream's prompt-cache hit (AISIX-Cloud#
         provider_key_id: pk.id,
       });
     }
+    // Caller key last, so gating on it authenticating implies the whole
+    // seed set has landed (tests/e2e/AGENTS.md).
     await seed.createApiKey({
       key_hash: CALLER_KEY_HASH,
       allowed_models: [NON_STREAM_MODEL, STREAM_MODEL],
     });
 
+    // Gate on an independent, non-throwing condition: driving `/v1/messages`
+    // here would let a usage regression surface as a propagation timeout
+    // instead of as the assertion that actually broke.
+    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
     await waitConfigPropagation(async () => {
-      try {
-        const r = await postMessages(app!, NON_STREAM_MODEL, false);
-        await r.text();
-        return r.status === 200;
-      } catch {
-        return false;
-      }
+      const res = await probe.listModels();
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return [NON_STREAM_MODEL, STREAM_MODEL].every((m) =>
+        data.some((row) => row.id === m),
+      );
     });
   });
 

--- a/tests/e2e/src/cases/messages-openai-cache-tokens-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-openai-cache-tokens-e2e.test.ts
@@ -1,0 +1,337 @@
+import { createHash } from "node:crypto";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { gunzipSync } from "node:zlib";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for AISIX-Cloud#1405: `/v1/messages` in front of an
+// OpenAI-compatible upstream that reports a prompt-cache hit.
+//
+// Pre-fix the hit was dropped on BOTH exits of the cross-protocol
+// bridge — the Anthropic `usage` handed to the client, and the
+// UsageEvent that drives Logs / billing — so an operator saw the full
+// 68k prompt billed at the uncached rate and had no cache detail to
+// reconcile against the provider's own bill. Worse, the absence read
+// as "the provider never cached", which is unfalsifiable from the
+// dashboard.
+//
+// The two exits carry the SAME facts in DIFFERENT shapes, and that is
+// the whole point of the fix:
+//
+//   client (Anthropic semantics: input excludes cache)
+//     input_tokens            = P - C
+//     cache_read_input_tokens = C
+//
+//   UsageEvent (upstream's own OpenAI semantics: cached ⊂ prompt)
+//     prompt_tokens           = P
+//     cached_prompt_tokens    = C
+//
+// Keeping the UsageEvent in the upstream's shape is what makes the same
+// upstream call bill identically whichever inbound protocol addressed
+// it, and it is the shape cp-api's pricing split expects (it charges
+// `prompt - cached` at the prompt rate and `cached` at the cache-read
+// rate, and rejects an event whose `cached` exceeds its `prompt`).
+//
+// The UsageEvent is observed through a mock Datadog intake — the DP's
+// only e2e-reachable surface that carries the full event, since the
+// OTLP span attributes stop at input/output tokens and the cache
+// counters have no Prometheus metric of their own yet (#1404).
+//
+// Reporter's numbers: MiniMax M3 behind an OpenAI-compatible provider,
+// addressed by the Claude CLI.
+// https://platform.minimax.io/docs/api-reference/text-prompt-caching
+
+const CALLER_PLAINTEXT = "sk-messages-cache-tokens-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const PROMPT_TOKENS = 68_274;
+const CACHED_TOKENS = 60_000;
+const COMPLETION_TOKENS = 497;
+const UNCACHED_TOKENS = PROMPT_TOKENS - CACHED_TOKENS;
+
+const CREDENTIAL_REF = "e2e";
+const DD_API_KEY = "dd-cache-tokens-test-key";
+const INTAKE_PATH = "/api/v2/logs";
+
+const NON_STREAM_MODEL = "cache-tokens-nonstream";
+const STREAM_MODEL = "cache-tokens-stream";
+
+const USAGE = {
+  prompt_tokens: PROMPT_TOKENS,
+  completion_tokens: COMPLETION_TOKENS,
+  total_tokens: PROMPT_TOKENS + COMPLETION_TOKENS,
+  prompt_tokens_details: { cached_tokens: CACHED_TOKENS },
+};
+
+const NON_STREAM_BODY = {
+  id: "chatcmpl-cache-test",
+  object: "chat.completion",
+  created: 1_700_000_000,
+  model: "MiniMax-M3",
+  choices: [
+    { index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+  ],
+  usage: USAGE,
+};
+
+function chunk(json: Record<string, unknown>): string {
+  return JSON.stringify({
+    id: "chatcmpl-cache-test",
+    object: "chat.completion.chunk",
+    created: 1_700_000_000,
+    model: "MiniMax-M3",
+    ...json,
+  });
+}
+
+// OpenAI's real `include_usage` shape: the usage-only frame lands AFTER
+// the stop chunk, so the cache hit is only knowable at stream close.
+const STREAM_EVENTS = [
+  chunk({ choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }),
+  chunk({ choices: [{ index: 0, delta: { content: "ok" }, finish_reason: null }] }),
+  chunk({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }),
+  chunk({ choices: [], usage: USAGE }),
+  "[DONE]",
+];
+
+interface CapturedLog {
+  path: string;
+  logs: Record<string, unknown>[];
+}
+
+interface MockDatadog {
+  site: string;
+  requests: CapturedLog[];
+  close(): Promise<void>;
+}
+
+/** Mock Datadog Logs intake — the DP's e2e window onto the full UsageEvent. */
+async function startMockDatadog(): Promise<MockDatadog> {
+  const requests: CapturedLog[] = [];
+  const server: Server = createServer((req: IncomingMessage, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const path = (req.url ?? "").split("?")[0];
+      if (req.method === "POST" && path === INTAKE_PATH) {
+        let logs: Record<string, unknown>[] = [];
+        try {
+          const parsed: unknown = JSON.parse(gunzipSync(Buffer.concat(chunks)).toString("utf8"));
+          if (Array.isArray(parsed)) logs = parsed as Record<string, unknown>[];
+        } catch {
+          // Leave empty: the poll below times out loudly rather than
+          // letting a malformed intake read as "nothing to assert".
+        }
+        requests.push({ path, logs });
+      }
+      res.statusCode = 202;
+      res.end();
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    site: `127.0.0.1:${port}`,
+    requests,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+/**
+ * Poll the intake for a UsageEvent of one model. `/v1/messages` does not
+ * emit the `x-aisix-call-id` response header the chat handler does, so the
+ * streaming and non-streaming legs use a model each and match on that —
+ * every event for a given model came from the same canned upstream, so any
+ * of them carries the counts under test.
+ */
+async function waitForUsageEvent(
+  dd: MockDatadog,
+  model: string,
+  timeoutMs = 15_000,
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const req of dd.requests) {
+      const hit = req.logs.find((l) => l["aisix.requested_model"] === model);
+      if (hit) return hit;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`no usage event for model ${model} within ${timeoutMs}ms`);
+}
+
+async function postMessages(
+  app: SpawnedApp,
+  model: string,
+  stream: boolean,
+): Promise<Response> {
+  return fetch(`${app.proxyUrl}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": CALLER_PLAINTEXT,
+      "user-agent": "claude-cli/2.1.118 (external, cli)",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 200,
+      stream,
+      messages: [{ role: "user", content: "issue 1405 regression" }],
+    }),
+  });
+}
+
+/** The closing `message_delta` — the only frame that can carry final usage. */
+function closingUsage(sse: string): Record<string, unknown> {
+  for (const line of sse.split("\n")) {
+    const data = line.startsWith("data: ") ? line.slice(6) : undefined;
+    if (!data) continue;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(data) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (parsed.type === "message_delta") {
+      return (parsed.usage ?? {}) as Record<string, unknown>;
+    }
+  }
+  throw new Error(`no message_delta in stream:\n${sse}`);
+}
+
+describe("/v1/messages keeps an OpenAI upstream's prompt-cache hit (AISIX-Cloud#1405)", () => {
+  let etcd: EtcdClient | undefined;
+  let etcdReachable = false;
+  let app: SpawnedApp | undefined;
+  let nonStreamUpstream: OpenAiUpstream | undefined;
+  let streamUpstream: OpenAiUpstream | undefined;
+  let dd: MockDatadog | undefined;
+
+  beforeAll(async () => {
+    etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    nonStreamUpstream = await startOpenAiUpstream({ nonStreamBody: NON_STREAM_BODY });
+    streamUpstream = await startOpenAiUpstream({ streamEvents: STREAM_EVENTS });
+    dd = await startMockDatadog();
+
+    app = await spawnApp({
+      admin: false,
+      extraEnv: { [`DD_CRED_${CREDENTIAL_REF.toUpperCase()}_API_KEY`]: DD_API_KEY },
+    });
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    await seed.createObservabilityExporter({
+      name: "cache-tokens-datadog",
+      enabled: true,
+      kind: "datadog",
+      site: dd.site,
+      credential_ref: CREDENTIAL_REF,
+      service: "aisix-e2e",
+      content_mode: "metadata_only",
+    });
+
+    for (const [model, upstream] of [
+      [NON_STREAM_MODEL, nonStreamUpstream],
+      [STREAM_MODEL, streamUpstream],
+    ] as const) {
+      const pk = await seed.createProviderKey({
+        display_name: `${model}-pk`,
+        secret: "sk-mock-minimax",
+        api_base: `${upstream.baseUrl}/v1`,
+        provider: "openai",
+        adapter: "openai",
+      });
+      await seed.createModel({
+        display_name: model,
+        provider: "openai",
+        model_name: "MiniMax-M3",
+        provider_key_id: pk.id,
+      });
+    }
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [NON_STREAM_MODEL, STREAM_MODEL],
+    });
+
+    await waitConfigPropagation(async () => {
+      try {
+        const r = await postMessages(app!, NON_STREAM_MODEL, false);
+        await r.text();
+        return r.status === 200;
+      } catch {
+        return false;
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await nonStreamUpstream?.close();
+    await streamUpstream?.close();
+    await dd?.close();
+  });
+
+  test("non-streaming: cache read reaches the Anthropic client and the usage event", async (ctx) => {
+    if (!etcdReachable || !app || !dd) {
+      ctx.skip();
+      return;
+    }
+    const res = await postMessages(app, NON_STREAM_MODEL, false);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { usage?: Record<string, unknown> };
+    const usage = body.usage ?? {};
+
+    // Anthropic semantics: input_tokens is the NON-cached input.
+    expect(usage.input_tokens).toBe(UNCACHED_TOKENS);
+    expect(usage.cache_read_input_tokens).toBe(CACHED_TOKENS);
+    expect(usage.output_tokens).toBe(COMPLETION_TOKENS);
+    // An OpenAI upstream reports no cache WRITE — never fabricate one.
+    expect(usage.cache_creation_input_tokens).toBeUndefined();
+
+    // UsageEvent keeps the upstream's own OpenAI shape.
+    const event = await waitForUsageEvent(dd, NON_STREAM_MODEL);
+    expect(event["gen_ai.usage.input_tokens"]).toBe(PROMPT_TOKENS);
+    expect(event["aisix.cached_prompt_tokens"]).toBe(CACHED_TOKENS);
+    expect(event["gen_ai.usage.output_tokens"]).toBe(COMPLETION_TOKENS);
+    // The hit is a SUBSET of prompt_tokens, so the Anthropic-shape
+    // additive counters stay absent and the total is not double-counted.
+    expect(event["aisix.cache_read_tokens"]).toBeUndefined();
+    expect(event["aisix.cache_creation_tokens"]).toBeUndefined();
+    expect(event["aisix.inbound_protocol"]).toBe("anthropic");
+  });
+
+  test("streaming: cache read rides the closing message_delta and the usage event", async (ctx) => {
+    if (!etcdReachable || !app || !dd) {
+      ctx.skip();
+      return;
+    }
+    const res = await postMessages(app, STREAM_MODEL, true);
+    expect(res.status).toBe(200);
+    const usage = closingUsage(await res.text());
+
+    expect(usage.input_tokens).toBe(UNCACHED_TOKENS);
+    expect(usage.cache_read_input_tokens).toBe(CACHED_TOKENS);
+    expect(usage.output_tokens).toBe(COMPLETION_TOKENS);
+    expect(usage.cache_creation_input_tokens).toBeUndefined();
+
+    const event = await waitForUsageEvent(dd, STREAM_MODEL);
+    expect(event["gen_ai.usage.input_tokens"]).toBe(PROMPT_TOKENS);
+    expect(event["aisix.cached_prompt_tokens"]).toBe(CACHED_TOKENS);
+    expect(event["gen_ai.usage.output_tokens"]).toBe(COMPLETION_TOKENS);
+    expect(event["aisix.cache_read_tokens"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

An OpenAI-compatible upstream reports its prompt-cache hit as `usage.prompt_tokens_details.cached_tokens`. The OpenAI wire already normalizes that into `UsageStats::cached_prompt_tokens` correctly — but the `/v1/messages` cross-protocol bridge then dropped it at **both** exits:

- `AnthropicUsageMetrics` had no field for it, so the UsageEvent that drives Logs, the Usage API, CSV export and billing never carried it.
- `chat_response_into_anthropic_json` and `AnthropicSseEncoder` rendered `input_tokens` + `output_tokens` only, so the Anthropic client never saw it either.

`/v1/chat/completions` has carried the counter since AISIX-Cloud#542; the cross-protocol path was never wired.

The effect is a silent cost error. The whole prompt bills at the uncached rate, and because a missing counter is indistinguishable from a provider that never cached, nothing looks wrong on the dashboard and there is no cache detail to reconcile against the provider's own bill.

Reported against 0.10.0 with MiniMax M3 behind an OpenAI-compatible provider, addressed by the Claude CLI: `prompt_tokens 68,274` / `cached_tokens 60,000` / `completion_tokens 497`, and no cache row anywhere.

## Implementation

The two exits carry the same facts in different shapes, and that distinction is the fix.

**The client-facing renderers convert.** Anthropic's `input_tokens` means NON-cached input, so the hit moves out into its own counter:

```
input_tokens            = P - C   = 8,274
cache_read_input_tokens = C       = 60,000
output_tokens           = O       = 497
```

The streaming half carries the same in the closing `message_delta` — on a translated stream `message_start` fires before any usage frame exists, so that is the only place the client can learn it. A cache counter is emitted **only when non-zero**: an OpenAI upstream reports no cache write, and a fabricated `0` would read as "reported, nothing hit" rather than "not reported".

**The UsageEvent does not convert.** It keeps the upstream's own shape (`prompt_tokens = P`, `cached_prompt_tokens = C`), so one upstream call bills identically whichever inbound protocol addressed it, and cp-api's pricing split (`prompt - cached` at the prompt rate, `cached` at the cache-read rate) plus its `cached <= prompt` validation both hold. The hit is a subset of `prompt_tokens`, so it is never summed into a total — `total_tokens_with_cache` still takes only the additive Anthropic-shape pair, and the total stays `P + O = 68,771`.

A shared `AnthropicInputUsage` does the shape conversion once for both renderers so they cannot drift. It subtracts only `cached_prompt_tokens`, never the Anthropic-shape `cache_creation_tokens` / `cache_read_tokens`, which sit *on top of* `prompt_tokens` rather than inside it — the two representations are disjoint by construction, so a bedrock/vertex Claude model bridged through this path keeps its counters additive and unchanged.

## Behavior changes

- `/v1/messages` responses against a non-Anthropic upstream now carry `cache_read_input_tokens` (and `cache_creation_input_tokens` where the bridged upstream reports one), and `input_tokens` excludes the cache read. Previously `input_tokens` reported the cache-inclusive prompt and neither cache field appeared.
- UsageEvents from `/v1/messages` now carry `cached_prompt_tokens`. CP-side handling is unchanged — the field is already persisted, exported and priced.
- No change on the native-Anthropic path (raw passthrough) or to any other endpoint.

## Compatibility

No cross-plane work. `UsageEvent.cached_prompt_tokens` is an existing field of the DP→CP wire contract that `/v1/chat/completions` has populated since #542; this only starts populating it from a second handler. Nothing is added to any etcd document or resource schema.

## Testing

- Unit, `aisix-provider-anthropic`: the OpenAI→Anthropic shape conversion in both renderers — the reporter's numbers, the additive Anthropic-shape case, the fully-cached prompt (`input_tokens: 0`), and the omit-when-absent case.
- Integration, `aisix-proxy`: `/v1/messages` through a wiremock OpenAI upstream, streaming and non-streaming, asserting the client's `usage` **and** the captured UsageEvent, including that the additive counters stay 0 and the total is not double-counted.
- DP E2E, `tests/e2e/src/cases/messages-openai-cache-tokens-e2e.test.ts`: a real `aisix` binary + etcd + mock OpenAI upstream, streaming and non-streaming, asserting the Anthropic client response and — through a mock Datadog intake, the DP's only e2e-reachable surface carrying the whole event — the UsageEvent.

Every new test fails on `main` and passes here.

Fixes api7/AISIX-Cloud#1405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added accurate prompt-cache usage reporting for Anthropic responses.
  - Preserved cached and uncached token counts across streaming and non-streaming responses.
  - Improved billing and usage telemetry for OpenAI-compatible upstreams.

- **Bug Fixes**
  - Fixed prompt-cache hits being dropped when translating OpenAI-compatible responses to the Anthropic messages format.

- **Tests**
  - Added regression coverage for cached-token reporting in streaming and non-streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->