### PR TITLE
fix(realtime): send openai-beta only when the caller opted in

### DIFF
--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -73,10 +73,25 @@ const AZURE_REALTIME_API_VERSION: &str = "2024-10-01-preview";
 /// Subprotocol item carrying the caller's API key in the browser flow.
 const SUBPROTOCOL_KEY_PREFIX: &str = "openai-insecure-api-key.";
 
+/// Header value by which a client opts into the legacy beta event shape.
+const HEADER_BETA_VALUE: &str = "realtime=v1";
+
 /// Subprotocol item by which a browser client opts into the legacy beta
 /// event shape (a subprotocol token cannot contain `=`, so the header's
 /// `realtime=v1` is spelled `realtime-v1` here).
 const SUBPROTOCOL_BETA_ITEM: &str = "openai-beta.realtime-v1";
+
+/// Is `needle` one of the comma-separated items across every value of
+/// `name`? Both headers are list-valued and may repeat, so a first-value
+/// substring test would both miss a repeat and accept `realtime=v10`.
+fn header_list_has(headers: &HeaderMap, name: &str, needle: &str) -> bool {
+    headers
+        .get_all(name)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|v| v.split(','))
+        .any(|item| item.trim().eq_ignore_ascii_case(needle))
+}
 
 /// Did the caller ask for the legacy beta Realtime shape?
 ///
@@ -87,18 +102,8 @@ const SUBPROTOCOL_BETA_ITEM: &str = "openai-beta.realtime-v1";
 /// header (server-side clients) or the `sec-websocket-protocol` item
 /// (browser clients, which cannot set headers).
 fn client_requested_beta_realtime(headers: &HeaderMap) -> bool {
-    if let Some(v) = headers.get("openai-beta").and_then(|v| v.to_str().ok()) {
-        if v.to_ascii_lowercase().contains("realtime=v1") {
-            return true;
-        }
-    }
-    headers
-        .get("sec-websocket-protocol")
-        .and_then(|v| v.to_str().ok())
-        .is_some_and(|s| {
-            s.split(',')
-                .any(|i| i.trim().eq_ignore_ascii_case(SUBPROTOCOL_BETA_ITEM))
-        })
+    header_list_has(headers, "openai-beta", HEADER_BETA_VALUE)
+        || header_list_has(headers, "sec-websocket-protocol", SUBPROTOCOL_BETA_ITEM)
 }
 
 /// Dial the upstream Realtime endpoint under the deployment's outbound
@@ -1237,6 +1242,30 @@ mod tests {
             "openai-beta",
             "assistants=v2"
         )));
+        // A near match must NOT opt in: the value is a list item, not a
+        // substring, so a future `realtime=v10` stays GA.
+        assert!(!client_requested_beta_realtime(&hm(
+            "openai-beta",
+            "realtime=v10"
+        )));
+        // List-valued: the opt-in counts wherever it sits in the list.
+        assert!(client_requested_beta_realtime(&hm(
+            "openai-beta",
+            "assistants=v2, realtime=v1"
+        )));
+        // Repeated headers: `HeaderMap::get` would only see the first.
+        let mut repeated = HeaderMap::new();
+        repeated.append("openai-beta", "assistants=v2".parse().unwrap());
+        repeated.append("openai-beta", "realtime=v1".parse().unwrap());
+        assert!(client_requested_beta_realtime(&repeated));
+        // Same for the subprotocol list, which browsers may also repeat.
+        let mut split_proto = HeaderMap::new();
+        split_proto.append("sec-websocket-protocol", "realtime".parse().unwrap());
+        split_proto.append(
+            "sec-websocket-protocol",
+            "openai-beta.realtime-v1".parse().unwrap(),
+        );
+        assert!(client_requested_beta_realtime(&split_proto));
     }
 
     /// A caller that DOES opt in still gets the beta header forwarded,

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -15,6 +15,14 @@
 //! per-provider `transform_realtime_request/response` modules) — that is
 //! a separate feature, not part of this endpoint.
 //!
+//! OpenAI's Realtime API is GA and its GA endpoint **rejects**
+//! `openai-beta: realtime=v1` (`beta_api_shape_disabled`), so the
+//! gateway does not send it on its own. Beta and GA use different event
+//! vocabularies, so the opt-in belongs to the caller that parses those
+//! events: a client that sends the beta opt-in — as the `openai-beta`
+//! header, or as the `openai-beta.realtime-v1` subprotocol item that the
+//! browser flow uses — has it forwarded upstream, and nothing else does.
+//!
 //! ## Auth
 //!
 //! Two credential channels, checked before the upgrade completes:
@@ -64,6 +72,34 @@ const AZURE_REALTIME_API_VERSION: &str = "2024-10-01-preview";
 
 /// Subprotocol item carrying the caller's API key in the browser flow.
 const SUBPROTOCOL_KEY_PREFIX: &str = "openai-insecure-api-key.";
+
+/// Subprotocol item by which a browser client opts into the legacy beta
+/// event shape (a subprotocol token cannot contain `=`, so the header's
+/// `realtime=v1` is spelled `realtime-v1` here).
+const SUBPROTOCOL_BETA_ITEM: &str = "openai-beta.realtime-v1";
+
+/// Did the caller ask for the legacy beta Realtime shape?
+///
+/// OpenAI's beta and GA Realtime APIs use different event vocabularies,
+/// so the opt-in belongs to the client that has to parse those events —
+/// not to us. We forward `openai-beta: realtime=v1` upstream only when
+/// the caller sent the same opt-in, via either channel it has: the
+/// header (server-side clients) or the `sec-websocket-protocol` item
+/// (browser clients, which cannot set headers).
+fn client_requested_beta_realtime(headers: &HeaderMap) -> bool {
+    if let Some(v) = headers.get("openai-beta").and_then(|v| v.to_str().ok()) {
+        if v.to_ascii_lowercase().contains("realtime=v1") {
+            return true;
+        }
+    }
+    headers
+        .get("sec-websocket-protocol")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|s| {
+            s.split(',')
+                .any(|i| i.trim().eq_ignore_ascii_case(SUBPROTOCOL_BETA_ITEM))
+        })
+}
 
 /// Dial the upstream Realtime endpoint under the deployment's outbound
 /// TLS trust.
@@ -126,7 +162,7 @@ pub(crate) async fn realtime(
                 // auth extractor; do the same here so the session clone
                 // and the error emits below attribute the JWT identity.
                 client.jwt = auth.jwt.clone();
-                prepare(&state, &snapshot, &params, &client, auth.clone())
+                prepare(&state, &snapshot, &params, &headers, &client, auth.clone())
                     .await
                     .map(|prep| (ws, prep))
                     .map_err(|err| (Some(auth), err))
@@ -225,9 +261,11 @@ async fn prepare(
     state: &ProxyState,
     snapshot: &aisix_core::AisixSnapshot,
     params: &HashMap<String, String>,
+    headers: &HeaderMap,
     client: &ClientContext,
     auth: AuthenticatedKey,
 ) -> Result<Prepared, ProxyError> {
+    let beta_realtime = client_requested_beta_realtime(headers);
     let requested_model = params
         .get("model")
         .map(String::as_str)
@@ -277,10 +315,16 @@ async fn prepare(
                     ProxyError::InvalidRequest("provider secret is not header-safe".into())
                 })?,
             );
-            // LiteLLM parity (OpenAIRealtime.async_realtime): the beta
-            // header is sent unconditionally; GA endpoints ignore it.
-            req.headers_mut()
-                .insert("openai-beta", "realtime=v1".parse().unwrap());
+            // Only when the CALLER opted into the legacy beta shape.
+            // OpenAI's GA `/v1/realtime` rejects the header outright
+            // (`beta_api_shape_disabled`) and closes the session, so
+            // sending it unconditionally broke every GA connection.
+            // LiteLLM parity (OpenAIRealtime._get_additional_headers):
+            // forward it iff the client asked for it.
+            if beta_realtime {
+                req.headers_mut()
+                    .insert("openai-beta", "realtime=v1".parse().unwrap());
+            }
             req
         }
         Some(Adapter::AzureOpenai) => {
@@ -1000,14 +1044,16 @@ mod tests {
     }
 
     /// Scripted mock upstream: accepts ONE WebSocket, records the request
-    /// path + auth header, waits for one text frame, replies with a
-    /// `response.done` usage frame, then closes.
+    /// path + auth header + any `openai-beta` header, waits for one text
+    /// frame, replies with a `response.done` usage frame, then closes.
+    type SeenHandshake = Option<(String, String, Option<String>)>;
+
     async fn spawn_upstream() -> (
         std::net::SocketAddr,
-        Arc<Mutex<Option<(String, String)>>>,
+        Arc<Mutex<SeenHandshake>>,
         Arc<Mutex<Vec<String>>>,
     ) {
-        let seen_handshake: Arc<Mutex<Option<(String, String)>>> = Arc::new(Mutex::new(None));
+        let seen_handshake: Arc<Mutex<SeenHandshake>> = Arc::new(Mutex::new(None));
         let seen_frames: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -1026,7 +1072,12 @@ mod tests {
                         .and_then(|v| v.to_str().ok())
                         .unwrap_or("")
                         .to_string();
-                    *hs2.lock().unwrap() = Some((req.uri().to_string(), auth));
+                    let beta = req
+                        .headers()
+                        .get("openai-beta")
+                        .and_then(|v| v.to_str().ok())
+                        .map(str::to_string);
+                    *hs2.lock().unwrap() = Some((req.uri().to_string(), auth, beta));
                     Ok(resp)
                 },
             )
@@ -1096,7 +1147,7 @@ mod tests {
         // Upstream saw the relayed client frame + the gateway's provider auth.
         assert_eq!(frames.lock().unwrap().len(), 1);
         assert!(frames.lock().unwrap()[0].contains("session.update"));
-        let (uri, auth) = handshake
+        let (uri, auth, beta) = handshake
             .lock()
             .unwrap()
             .clone()
@@ -1106,6 +1157,11 @@ mod tests {
             "upstream URI must be the realtime path with the UPSTREAM model id, got {uri}"
         );
         assert_eq!(auth, "Bearer sk-up");
+        assert_eq!(
+            beta, None,
+            "a caller that did not opt in must not have `openai-beta` forwarded upstream: \
+             OpenAI's GA endpoint rejects it with beta_api_shape_disabled"
+        );
 
         // Session-aggregate usage event.
         let ev = tokio::time::timeout(Duration::from_secs(3), rx.recv())
@@ -1147,6 +1203,79 @@ mod tests {
             "the gateway must echo the `realtime` subprotocol"
         );
         drop(ws);
+    }
+
+    /// The predicate itself: neither channel set => GA (no header).
+    #[test]
+    fn beta_opt_in_is_recognised_on_both_channels() {
+        let hm = |k: &'static str, v: &str| {
+            let mut h = HeaderMap::new();
+            h.insert(k, v.parse().unwrap());
+            h
+        };
+        assert!(!client_requested_beta_realtime(&HeaderMap::new()));
+        assert!(client_requested_beta_realtime(&hm(
+            "openai-beta",
+            "realtime=v1"
+        )));
+        assert!(client_requested_beta_realtime(&hm(
+            "openai-beta",
+            "Realtime=v1"
+        )));
+        // Browser flow: the opt-in rides the subprotocol list.
+        assert!(client_requested_beta_realtime(&hm(
+            "sec-websocket-protocol",
+            "realtime, openai-insecure-api-key.sk-x, openai-beta.realtime-v1"
+        )));
+        // A plain browser handshake carrying only the credential is GA.
+        assert!(!client_requested_beta_realtime(&hm(
+            "sec-websocket-protocol",
+            "realtime, openai-insecure-api-key.sk-x"
+        )));
+        // Assistants-style beta values are not the realtime opt-in.
+        assert!(!client_requested_beta_realtime(&hm(
+            "openai-beta",
+            "assistants=v2"
+        )));
+    }
+
+    /// A caller that DOES opt in still gets the beta header forwarded,
+    /// so legacy beta clients keep working against upstreams that serve
+    /// the beta shape.
+    #[tokio::test]
+    async fn client_beta_opt_in_is_forwarded_upstream() {
+        let (up_addr, handshake, _frames) = spawn_upstream().await;
+        let snap = snapshot(&format!("http://{up_addr}/v1"), "openai", "openai");
+        let (addr, _state, _rx) = serve(snap).await;
+
+        let mut req = format!("ws://{addr}/v1/realtime?model=rt-model")
+            .into_client_request()
+            .unwrap();
+        req.headers_mut()
+            .insert("authorization", "Bearer sk-caller".parse().unwrap());
+        req.headers_mut()
+            .insert("openai-beta", "realtime=v1".parse().unwrap());
+        let (ws, _) = tokio_tungstenite::connect_async(req)
+            .await
+            .expect("handshake");
+        let (mut tx, mut client_rx) = ws.split();
+        tx.send(TgMessage::Text(
+            serde_json::json!({"type": "session.update"}).to_string(),
+        ))
+        .await
+        .unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(3), client_rx.next()).await;
+
+        let (_uri, _auth, beta) = handshake
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("handshake recorded");
+        assert_eq!(
+            beta.as_deref(),
+            Some("realtime=v1"),
+            "an explicit client opt-in must reach the upstream"
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -427,8 +427,11 @@ async fn authenticate(
         }
         return crate::auth::authenticate_token(state, token, ctx).await;
     }
-    if let Some(proto) = headers.get("sec-websocket-protocol") {
-        let s = proto.to_str().map_err(|_| ProxyError::MissingAuth)?;
+    // List-valued and splittable across repeated fields, like the beta
+    // opt-in above: reading only the first field 401s a caller whose
+    // credential rides a later one.
+    for proto in headers.get_all("sec-websocket-protocol").iter() {
+        let Ok(s) = proto.to_str() else { continue };
         for item in s.split(',') {
             if let Some(token) = item.trim().strip_prefix(SUBPROTOCOL_KEY_PREFIX) {
                 if !token.is_empty() {
@@ -1208,6 +1211,46 @@ mod tests {
             "the gateway must echo the `realtime` subprotocol"
         );
         drop(ws);
+    }
+
+    /// A browser may split its subprotocol offer across repeated header
+    /// fields; the credential must still be found wherever it lands.
+    #[tokio::test]
+    async fn subprotocol_credential_is_found_in_a_repeated_header_field() {
+        let (up_addr, handshake, _frames) = spawn_upstream().await;
+        let snap = snapshot(&format!("http://{up_addr}/v1"), "openai", "openai");
+        let (addr, _state, _rx) = serve(snap).await;
+
+        let mut req = format!("ws://{addr}/v1/realtime?model=rt-model")
+            .into_client_request()
+            .unwrap();
+        // Two fields: the credential and the beta opt-in ride the second.
+        req.headers_mut()
+            .append("sec-websocket-protocol", "realtime".parse().unwrap());
+        req.headers_mut().append(
+            "sec-websocket-protocol",
+            "openai-insecure-api-key.sk-caller, openai-beta.realtime-v1"
+                .parse()
+                .unwrap(),
+        );
+        let (ws, _) = tokio_tungstenite::connect_async(req)
+            .await
+            .expect("a credential in a later subprotocol field must authenticate");
+        let (mut tx, mut client_rx) = ws.split();
+        tx.send(TgMessage::Text(
+            serde_json::json!({"type": "session.update"}).to_string(),
+        ))
+        .await
+        .unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(3), client_rx.next()).await;
+
+        // The opt-in rode the same later field, so it reaches upstream.
+        let (_uri, _auth, beta) = handshake
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("handshake recorded");
+        assert_eq!(beta.as_deref(), Some("realtime=v1"));
     }
 
     /// The predicate itself: neither channel set => GA (no header).

--- a/tests/e2e/src/cases/realtime-ws-e2e.test.ts
+++ b/tests/e2e/src/cases/realtime-ws-e2e.test.ts
@@ -34,6 +34,10 @@ import { startMockOtlp, type MockOtlp } from "../harness/otlp-mock.js";
 //      key or the gateway alias.
 //   4. Auth failure rejects the HTTP upgrade (native client fires
 //      an error/close, never `open`).
+//   5. The `openai-beta: realtime=v1` opt-in is CLIENT-driven: forwarded
+//      upstream only when the caller asked for it. Sending it
+//      unconditionally made OpenAI's GA endpoint kill the session with
+//      `beta_api_shape_disabled`.
 
 const CALLER_PLAINTEXT = "sk-realtime-e2e-caller";
 const CALLER_KEY_HASH = createHash("sha256")
@@ -42,7 +46,7 @@ const CALLER_KEY_HASH = createHash("sha256")
 
 interface RealtimeUpstream {
   port: number;
-  handshakes: { url: string; authorization: string }[];
+  handshakes: { url: string; authorization: string; openaiBeta?: string }[];
   frames: string[];
   close(): Promise<void>;
 }
@@ -57,6 +61,7 @@ async function startRealtimeUpstream(): Promise<RealtimeUpstream> {
     handshakes.push({
       url: req.url ?? "",
       authorization: (req.headers.authorization as string) ?? "",
+      openaiBeta: req.headers["openai-beta"] as string | undefined,
     });
     socket.on("message", (data) => {
       frames.push(data.toString());
@@ -234,8 +239,42 @@ describe("realtime e2e: /v1/realtime WebSocket relay (#721)", () => {
     );
     expect(upstream.handshakes[0].url).toContain("model=gpt-realtime-mock");
     expect(upstream.handshakes[0].url).not.toContain(CALLER_PLAINTEXT);
+    // This client offered `openai-beta.realtime-v1`, so the opt-in is
+    // forwarded upstream in the header form.
+    expect(upstream.handshakes[0].openaiBeta).toBe("realtime=v1");
 
     ws.close();
+  });
+
+  test("a caller that did not opt in gets NO openai-beta header upstream", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    // The regression: the gateway used to send `openai-beta: realtime=v1`
+    // on every upstream dial. OpenAI's GA /v1/realtime answers that with
+    // `beta_api_shape_disabled` and closes the session before the client
+    // can send anything, so a plain GA caller must dial clean.
+    const before = upstream.handshakes.length;
+    const wsUrl = `${app.proxyUrl.replace("http://", "ws://")}/v1/realtime?model=realtime-e2e-model`;
+    // `ws` sets headers: a server-side caller with no beta opt-in.
+    const c = new WsClient(wsUrl, {
+      headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+    });
+    const relayed = await new Promise<string>((resolve, reject) => {
+      c.on("open", () => c.send(JSON.stringify({ type: "session.update" })));
+      c.on("message", (d) => resolve(d.toString()));
+      c.on("unexpected-response", (_q, res) =>
+        reject(new Error(`upgrade refused: ${res.statusCode}`)),
+      );
+      c.on("error", (e) => reject(e));
+    });
+    expect(JSON.parse(relayed).type).toBe("response.done");
+    c.terminate();
+
+    const hs = upstream.handshakes[before];
+    expect(hs).toBeDefined();
+    expect(hs.openaiBeta).toBeUndefined();
   });
 
   test("a plain http GET answers the envelope, not a bare rejection", async (ctx) => {


### PR DESCRIPTION
## Problem

`/v1/realtime` dialled every OpenAI upstream with `openai-beta: realtime=v1`. That was correct when the Realtime API was in beta, but the API is GA now and **the GA endpoint rejects the header**: the socket opens and OpenAI immediately answers

```
{"type":"error","error":{"type":"invalid_request_error","code":"beta_api_shape_disabled",
 "message":"The Realtime Beta API is no longer supported. Please use /v1/realtime for the GA API."}}
```

and kills the session before the client sends anything. So `/v1/realtime` could not reach `api.openai.com` at all — both deployment modes, both provider-key shapes. Found by release QA on `v0.11.0-rc.3`; it reproduces identically on `rc.2`, so it is pre-existing rather than a regression.

Verified against real OpenAI, directly and through the gateway. Direct `wss://api.openai.com/v1/realtime`: **with** the header the first frame is `beta_api_shape_disabled`, **without** it the first frame is `session.created`. Through the gateway with a live provider key, the same split: `error` before the change, `session.created` (real `sess_…` id) after.

## Shape

Not an unconditional removal, and not a new config knob either — **the opt-in is client-driven**.

Beta and GA use different event vocabularies, so the choice belongs to the client that has to parse those events, not to the gateway. The header is now forwarded upstream **iff the caller sent the same opt-in**, via either channel a caller has:

- the `openai-beta` header — server-side clients;
- the `openai-beta.realtime-v1` `sec-websocket-protocol` item — browser clients, which cannot set headers, and which the endpoint already supports for credentials.

A caller that does not ask for beta dials clean and reaches `session.created`. A legacy beta client keeps working against an upstream that still serves the beta shape. This needs no provider-key field, so no control-plane surface changes.

This also converges with the upstream reference implementation, which moved off the unconditional send to exactly this client-conditioned rule for the same reason; the stale parity claim in the code comment is updated.

The **Azure** branch never sent the header (it authenticates with `api-key` and its own `api-version`) and is unchanged.

Side effect worth noting: `aisix_llm_spend_micro_usd_total` is only ever rendered by `/v1/realtime`, so this also makes that metric family reachable against real OpenAI.

## Sibling audit

The standing rule is to fix the class, not the site, so every upstream-facing hard-coded beta/preview opt-in was swept:

- **`anthropic-beta`** — every occurrence is *operator-configured*, through the provider key's `request.default_headers` or the `forward_client_headers` allowlist. Nothing hard-codes it. Correct as-is, left alone.
- **`openai-beta` elsewhere** — none. The only other mentions are the inbound browser subprotocol list, which is the client-side opt-in this PR now reads rather than a header we emit.
- **`AZURE_REALTIME_API_VERSION = "2024-10-01-preview"`** (`realtime.rs`) — a hard-coded *preview* api-version whose doc comment calls it "GA" and claims it mirrors the jobs twin, while that twin is `2024-10-21`, a real GA value. `azure-openai`'s `DEFAULT_API_VERSION` even has a test asserting `!v.contains("preview")`, which this constant escapes. Flagged, **not changed**: there is no Azure endpoint available here to verify a replacement against, and swapping an api-version blind is how the next incident starts. Worth its own PR with a real Azure tenant.

## Tests

The mock upstream now records `openai-beta`, so the default path can be asserted rather than assumed. Each assertion was confirmed to fail before the change and pass after:

- `relays_frames_and_emits_aggregated_usage_event` — the ordinary caller's upstream handshake carries no `openai-beta`.
- `beta_opt_in_is_recognised_on_both_channels` — the predicate: neither channel set is GA; header and subprotocol forms both opt in; `assistants=v2` does not.
- `client_beta_opt_in_is_forwarded_upstream` — an explicit opt-in still reaches the upstream.
- **DP e2e** `a caller that did not opt in gets NO openai-beta header upstream` — drives a real `aisix` binary + etcd with a header-auth caller and asserts the mock upstream saw no `openai-beta`. The existing browser-flow case offers `openai-beta.realtime-v1`, so it now pins the opt-in leg.

A real-OpenAI test is deliberately not added to CI; that verification is recorded above.

Local: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test -p aisix-proxy` 1037 passed, `realtime-ws-e2e` 5 passed against a live binary + etcd.

## Docs

No user-facing doc in this repo (docs live in `api7/docs` + `api7/docs.apiseven.com`). This does change documented-able behavior — the gateway no longer forces the beta shape, and a beta client must now opt in — so the release owner may want the paired bilingual note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added caller-controlled beta opt-in for realtime connections through request headers or browser subprotocols.
  - Valid beta opt-ins are recognized across repeated and comma-separated values.
  - Beta-enabled requests forward the realtime beta header upstream, while standard connections use GA behavior.

- **Bug Fixes**
  - Rejected near-match beta values that do not exactly identify the supported realtime version.
  - Prevented beta headers from being forwarded when beta mode is not explicitly requested.

- **Tests**
  - Expanded coverage for beta, standard, repeated-header, and comma-separated opt-in scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->