### PR TITLE
ci(docker): run PGO only on stable release tags; drop the poc branch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,22 +5,22 @@ name: docker-image
 # Tag strategy. Every push always carries a :sha-<shortsha> tag for
 # traceability; the other tags layer on top based on the trigger:
 #   - push to main              → :dev + :sha-<shortsha>
-#   - push to poc               → :poc + :sha-<shortsha>
 #   - push tag vX.Y.Z           → :X.Y.Z + :X.Y + :X + :latest
 #                                 + :sha-<shortsha>
 #   - push tag vX.Y.Z-rc.N      → :X.Y.Z-rc.N + :sha-<shortsha>  (NO rolling tags)
 #   - pull request              → build-only (no push), sanity check
 #   - workflow_dispatch         → :sha-<shortsha> + optional tag input
 #
-# Pre-release tags exist so a release candidate can be QA'd on the exact
-# artifacts customers receive before anything points at it. They must move
-# no rolling pointer: docker/metadata-action already skips :X.Y and :X for
+# Pre-release tags exist so a release candidate can be QA'd on the artifacts
+# customers receive before anything points at it — bar the PGO difference
+# noted at "Decide PGO build mode" below. They must move no rolling
+# pointer: docker/metadata-action already skips :X.Y and :X for
 # pre-release semver, and the guards below keep :latest and the published
 # `openapi-latest.json` on the last stable release.
 
 on:
   push:
-    branches: [main, poc]
+    branches: [main]
     tags: ["v*.*.*"]
   pull_request:
     branches: [main]
@@ -39,6 +39,10 @@ on:
       tag:
         description: "Optional extra tag to publish (e.g. aisix-e2e)"
         required: false
+      pgo:
+        description: "Run the full PGO build (pre-flight the release build path)"
+        type: boolean
+        default: false
 
 env:
   REGISTRY: ghcr.io
@@ -56,27 +60,54 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # PGO builds (#967) compile the workspace twice (instrumented + optimized)
-    # with a training run in between — roughly 2.5x the plain fat-LTO build
-    # that used to fit in 45 minutes.
+    # A PGO build (#967) compiles the workspace twice (instrumented +
+    # optimized) with a training run in between — ~30 min against ~11 min
+    # for the single-compile build. Only stable release tags take that path
+    # (see "Decide PGO build mode"), but the timeout has to cover them.
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
 
-      # PGO build mode (#967). Push builds (dev/poc/tags/dispatch) are always
-      # PGO=on: shipped artifacts are PGO'd, fail-closed, no fallback. PR
-      # builds default to PGO=off so review latency stays at one compile —
-      # EXCEPT when the PR touches the build pipeline or the training assets,
-      # in which case the full three-phase build must prove itself pre-merge.
+      # PGO build mode (#967). PGO is reserved for the artifact customers
+      # actually run: a STABLE release tag (vX.Y.Z). Everything else — PR,
+      # main/:dev, `-rc.N` candidates, plain dispatch — builds in one compile,
+      # because PGO cost ~20 min on every one of the ~40 main pushes per
+      # release cycle and bought nothing those images are used for.
+      #
+      # Two consequences are load-bearing and documented in RELEASING.md:
+      #   - the QA'd `-rc.N` image is NOT PGO'd while the released image is.
+      #     PGO changes code layout, never semantics (the workspace has no
+      #     `unsafe`), so the QA result still describes the shipped build —
+      #     but the two binaries are not bit-identical.
+      #   - the release tag is therefore the FIRST build to exercise the
+      #     three-phase pipeline on that commit. A training-shape regression
+      #     surfaces there, after QA. Pre-flight it on the release commit
+      #     with `workflow_dispatch` + pgo=true before tagging.
+      #
+      # The PR escape hatch survives and matters more now: it is the only
+      # pre-tag exercise of the PGO path that happens automatically.
       - name: Decide PGO build mode
         id: pgomode
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -eu
-          mode=on
+          mode=off
+          case "$GITHUB_REF" in
+            # Stable release tag only: `-rc.N` (and any other pre-release
+            # suffix) keeps the fast path. Same predicate the :latest tag
+            # guard uses, so the PGO'd image and :latest never disagree.
+            refs/tags/v*)
+              case "$GITHUB_REF_NAME" in
+                *-*) ;;
+                *) mode=on ;;
+              esac
+              ;;
+          esac
+          if [ "${{ github.event.inputs.pgo }}" = "true" ]; then
+            mode=on
+          fi
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            mode=off
             git fetch --no-tags --depth=1 origin "$BASE_SHA"
             # Capture the diff as a CHECKED command before matching: inside
             # an `if` condition a git failure is exempt from `set -e` and
@@ -107,8 +138,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Release tags (vX.Y.Z) are additionally mirrored to the api7
-      # Docker Hub org for private/offline deployments (#789). dev / poc
-      # / sha builds stay GHCR-only.
+      # Docker Hub org for private/offline deployments (#789). dev / sha
+      # builds stay GHCR-only.
       - name: Log in to Docker Hub
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v4
@@ -131,7 +162,6 @@ jobs:
           # and {{major}} for pre-release semver.
           tags: |
             type=raw,value=dev,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-            type=raw,value=poc,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/poc' }}
             type=ref,event=pr
             type=sha,prefix=sha-,format=short
             type=semver,pattern={{version}}
@@ -205,12 +235,16 @@ jobs:
       # profile-optimized build succeeds. An absent marker, a short shape
       # list, or an undersized merged profile fails the workflow here —
       # before signing, and before any human treats the artifact as good.
-      # The `if` is deliberately NOT just `pgomode == 'on'`: every push build
-      # asserts unconditionally, so a future bug in the pgomode step itself
-      # (empty output, renamed id) cannot skip both the PGO build AND its
-      # guard in the same breath.
+      #
+      # The second clause is deliberately NOT derived from `pgomode`: it
+      # re-derives "stable release tag" from github.ref, so a future bug in
+      # the pgomode step (empty output, renamed id, a broken case pattern)
+      # cannot skip the PGO build AND its guard in the same breath. That
+      # independence is what keeps the now-default-off mode logic safe —
+      # a release tag that somehow built without PGO fails here instead of
+      # shipping silently un-optimized.
       - name: Assert PGO proof marker (#967)
-        if: github.event_name != 'pull_request' || steps.pgomode.outputs.value == 'on'
+        if: steps.pgomode.outputs.value == 'on' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-'))
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,9 +77,16 @@ COPY schemas ./schemas
 # above.
 COPY bench/pgo-training ./bench/pgo-training
 
-# Profile-guided optimization gate. Default ON: release artifacts are always
-# PGO-built, and a forgotten build-arg ships a PGO'd image — never a silently
-# un-optimized one. CI passes PGO=off only for pull-request smoke builds.
+# Profile-guided optimization gate. The default stays ON so a bare
+# `docker build` — a local release rehearsal, a one-off customer image —
+# produces the same shape as the published artifact rather than a silently
+# un-optimized one; opting out is explicit.
+#
+# CI inverts that default and passes PGO=on only for a STABLE release tag
+# (vX.Y.Z). PR, main/:dev and `-rc.N` builds pass PGO=off: PGO cost ~20 min
+# on every one of the ~40 main pushes per release cycle, and none of those
+# images are the artifact a customer runs. See "Decide PGO build mode" in
+# .github/workflows/docker-image.yml and the PGO section of RELEASING.md.
 ARG PGO=on
 
 # `--locked` forces the build to use the exact versions in Cargo.lock —

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,9 +27,9 @@ Pushing the tag triggers two workflows:
   curated-notes scaffold to fill in, then GitHub's auto-generated **What's
   Changed** list as a starting skeleton.
 
-### PGO is mandatory and fail-closed
+### PGO applies to the stable release tag only — and it is fail-closed there
 
-Published images are profile-guided-optimized (#967): the Docker build
+The `vX.Y.Z` image is profile-guided-optimized (#967): the Docker build
 compiles an instrumented gateway, drives the committed training matrix
 (`bench/pgo-training/`) against it, and rebuilds with the merged profile.
 Any phase failing — instrumented build, training, profile merge, optimized
@@ -43,6 +43,35 @@ shipped image's marker:
 docker run --rm --entrypoint cat ghcr.io/api7/aisix:X.Y.Z \
   /usr/local/share/aisix/pgo-verified.json
 ```
+
+**`-rc.N`, `:dev` and PR images are NOT PGO'd** — PGO cost ~20 min on every
+one of the ~40 main pushes per cycle and none of those images are what a
+customer runs. Two things follow, and both belong to the release flow:
+
+- **The QA'd candidate is not bit-identical to the shipped image.** PGO
+  changes code layout, inlining and block ordering — never semantics; the
+  workspace contains no `unsafe`, so there is no undefined behaviour for a
+  different inlining decision to expose. The functional QA result therefore
+  still describes the shipped build. What it does *not* describe is the
+  released image's performance: any perf number must come from a `vX.Y.Z`
+  image or a local `--build-arg PGO=on` build, never from `:dev` or an rc.
+- **The release tag is the first build to run the PGO pipeline on that
+  commit**, so a training-shape regression surfaces *after* QA has passed —
+  the most expensive moment to find it, since the fix moves the commit and
+  costs a fresh rc plus a re-run of QA. Pre-flight it instead: once the
+  release commit is final and before tagging, run the `docker-image`
+  workflow via `workflow_dispatch` on that commit with **pgo = true**. It
+  builds the exact three-phase path and asserts the proof marker, publishing
+  only a `:sha-<short>` tag that moves no pointer.
+
+```bash
+gh workflow run docker-image.yml --ref <release-sha> -f pgo=true
+```
+
+A PR that touches `Dockerfile`, `Cargo.toml`, `Cargo.lock`,
+`rust-toolchain.toml`, `bench/pgo-training/**` or the workflow itself still
+flips to PGO=on automatically — that is the one pre-tag exercise of the
+pipeline that needs no one to remember it.
 
 Local note: each retrained profile is content-addressed, so repeated local
 PGO builds accumulate build artifacts in the persistent BuildKit cache


### PR DESCRIPTION
## Problem

Every image build took the PGO path: ~30 min against ~11 min for a single
compile. Pushes to `main` are the bulk of that — roughly 40 per release
cycle — and those `:dev` images are never what a customer runs, so the
~20 min premium bought nothing on the builds that dominate the cost.

## Change

`PGO=on` is now derived from the ref. A stable `vX.Y.Z` tag takes the
three-phase build (instrumented → 12-shape training → profile-use rebuild);
PR, `main`/`:dev` and `-rc.N` candidates build in one compile.

The PR escape hatch is unchanged and now matters more — it is the only
automatic pre-tag exercise of the pipeline. A diff touching `Dockerfile`,
`Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `bench/pgo-training/**`
or this workflow still forces the full build pre-merge.

Flipping the default from on to off inverts the fail-safe direction, so the
proof-marker guard is decoupled from the mode step: its condition
re-derives "stable release tag" from `github.ref` rather than reading
`steps.pgomode.outputs.value`. A bug in the mode logic therefore cannot
skip the PGO build *and* its assertion in the same breath — a release tag
that somehow built without PGO fails the workflow instead of shipping
silently un-optimized. `ARG PGO=on` stays the Dockerfile default so a bare
`docker build` still reproduces the release shape.

A new `pgo` `workflow_dispatch` input runs the full build on demand. It is
the pre-flight for a release: run it on the release SHA before tagging and
a training-shape regression surfaces *before* the tag rather than after QA
has passed. It publishes only `:sha-<short>` and moves no pointer.

Separately, the `poc` branch trigger and the `:poc` tag are removed. The
branch no longer exists on the remote and the POC environment tracks
release tags.

## Behavior changes

- `-rc.N`, `:dev` and PR images are no longer PGO-built. The QA'd candidate
  is therefore not bit-identical to the released image. PGO changes code
  layout, inlining and block ordering — never semantics, and the workspace
  contains no `unsafe`, so there is no undefined behavior for a different
  inlining decision to expose. Functional QA still describes the shipped
  build; **performance numbers must come from a `vX.Y.Z` image or a local
  `--build-arg PGO=on` build**, never from an rc or `:dev`.
- The release tag is now the first build to run the training matrix on its
  commit. `RELEASING.md` documents the pre-flight that keeps that from
  being discovered after QA.
- `:poc` is no longer published.

## Tests

No test exception: this is CI-configuration only and has no runtime code
path to cover. The decision logic was exercised against every trigger
(main push, stable tag, `rc.1`/`rc.10`, ordinary PR, pipeline-touching PR,
dispatch with and without `pgo=true`) and matches the table above.

This PR touches `Dockerfile` and the workflow, so the escape hatch fires
and **this PR's own image build runs the full PGO path** — the change
proves the three-phase pipeline and the new mode logic in the same run.