### PR TITLE
fix(diagnostics): stop the partial-compat line guessing which side is newer

### DIFF
--- a/crates/aisix-core/src/config_status.rs
+++ b/crates/aisix-core/src/config_status.rs
@@ -174,8 +174,10 @@ pub struct IncomingRejection {
 
 /// One partially compatible observation, aggregated per (kind, field):
 /// `count` resources of `resource_kind` are currently served with `field`
-/// ignored because this gateway version does not know it — typically a
-/// field added by a newer control plane (issue #871). Shown next to
+/// ignored because this gateway version does not know it — a field the
+/// control plane added after this build, or one this build retired after
+/// the control plane; the two are indistinguishable from here (issue
+/// #871, AISIX-Cloud#1435). Shown next to
 /// `rejected[]` on `GET /status/config` so a matching `config_hash` can
 /// never silently hide that enforcement differs from the stored
 /// documents.

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -539,7 +539,8 @@ where
             }
             if !ignored.is_empty() {
                 // YELLOW: loaded, but fields this build does not know were
-                // ignored — typically written by a newer control plane.
+                // ignored. Which side is ahead is not knowable here — see
+                // `warn_partial_compat_deduped`.
                 ignored.sort_unstable();
                 ignored.dedup();
                 // A single document can carry an arbitrary number of
@@ -653,6 +654,21 @@ fn merge_partial_compat_fields(stats: &mut BuildStats, key: &str, kind: &str, fi
 /// combinations keep logging (never silently dropped) but are no longer
 /// remembered, so a pathological fleet re-logs on each resync instead
 /// of growing memory without bound.
+///
+/// The message names what this build knows and stops there. It used to
+/// add "likely written by a newer control plane", which is wrong exactly
+/// half the time and wrong in the situation that produces most of these
+/// lines: an UPGRADE, where the new data plane meets rows an OLDER
+/// control plane wrote with a field this build has since dropped
+/// (AISIX-Cloud#1435 saw `ignored_fields=mandatory` reported that way).
+/// A misdirected diagnostic on the one path where unknown fields are
+/// expected sends the reader looking at the wrong side of the fleet.
+///
+/// The direction is not merely unreported, it is unobservable from here:
+/// a retired field leaves no trace in this build — no tombstone, no
+/// "must not exist" list — so "unknown" cannot be split into "added
+/// since" and "removed since". Naming the field and its consequence is
+/// the whole of what this side can say.
 fn warn_partial_compat_deduped(key: &str, kind: &str, fields: &[String]) {
     use std::collections::HashSet;
     use std::sync::{Mutex, OnceLock};
@@ -676,8 +692,9 @@ fn warn_partial_compat_deduped(key: &str, kind: &str, fields: &[String]) {
         key = %key,
         kind = %kind,
         ignored_fields = %entry.1,
-        "row loaded with unknown fields ignored (partially compatible; \
-         likely written by a newer control plane)"
+        "row loaded with unknown fields ignored (partially compatible); this \
+         build does not define them, so whatever they configure is not \
+         enforced here"
     );
     if warned.len() < MAX_REMEMBERED {
         warned.insert(entry);

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -965,6 +965,57 @@ impl Guardrail for LiveGuardrailChain {
 ///
 /// The resulting index is pre-sorted by priority (descending) so
 /// `GuardrailIndex::resolve` can walk it linearly.
+/// INFO once per guardrail id for the process lifetime.
+///
+/// The index is rebuilt on every snapshot version change, and this arm
+/// describes a STANDING property of a row — it has no attachment records —
+/// not an event. Logging it per build re-stated the same unchanged fact on
+/// every configuration write in the environment, once per affected
+/// guardrail, which is what AISIX-Cloud#1435 saw on a busy deployment.
+///
+/// Deduped rather than demoted: the fallback means the row governs every
+/// request in the environment because nobody scoped it, which is worth
+/// saying out loud — once.
+fn log_implicit_env_scope_once(id: &str, name: &str) {
+    if !implicit_env_scope_first_seen(id) {
+        return;
+    }
+    tracing::info!(
+        guardrail_id = %id,
+        guardrail_name = %name,
+        "guardrail has no attachment rows; applying as implicit env-scope at priority 0 (backward-compat rolling-upgrade window)",
+    );
+}
+
+/// The memory behind [`log_implicit_env_scope_once`], split out so the
+/// once-per-id rule can be tested without a tracing subscriber.
+///
+/// `true` the first time an id is seen, `false` afterwards.
+fn implicit_env_scope_first_seen(id: &str) -> bool {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+
+    // Same shape and same cap as `warn_partial_compat_deduped` in
+    // aisix-etcd: past the cap new ids keep logging rather than being
+    // silently dropped, so the memory bound never costs a signal.
+    const MAX_REMEMBERED: usize = 1024;
+    static LOGGED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+    // Poison-tolerant: this set only dedupes log lines, so a panic while
+    // the lock was held must not wedge every later index build.
+    let mut logged = LOGGED
+        .get_or_init(|| Mutex::new(HashSet::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if logged.contains(id) {
+        return false;
+    }
+    if logged.len() < MAX_REMEMBERED {
+        logged.insert(id.to_string());
+    }
+    true
+}
+
 pub fn build_index_from_snapshot(
     guardrails: &ResourceTable<DomainGuardrail>,
     attachments: &ResourceTable<GuardrailAttachment>,
@@ -1082,11 +1133,7 @@ pub fn build_index_from_snapshot(
         }
         match build_one(row, bedrock_endpoint_url, embedder) {
             Ok(Some(g)) => {
-                tracing::info!(
-                    guardrail_id = %guardrail_arc.id,
-                    guardrail_name = %row.name,
-                    "guardrail has no attachment rows; applying as implicit env-scope at priority 0 (backward-compat rolling-upgrade window)",
-                );
+                log_implicit_env_scope_once(&guardrail_arc.id, &row.name);
                 entries.push(GuardrailIndex::push_entry(
                     guardrail_arc.id.clone(),
                     row.name.clone(),
@@ -1266,6 +1313,30 @@ mod tests {
     use aisix_core::models::Guardrail as DomainGuardrail;
     use aisix_core::resource::ResourceEntry;
     use aisix_gateway::{ChatFormat, ChatMessage};
+
+    /// AISIX-Cloud#1435: the implicit env-scope notice is a standing
+    /// property of a row, and the index is rebuilt on every snapshot
+    /// version change — so logging it per build restated the same
+    /// unchanged fact once per affected guardrail on every configuration
+    /// write in the environment.
+    ///
+    /// Ids are unique to this test: the memory is process-global, so a
+    /// shared id would make the result depend on which test ran first.
+    #[test]
+    fn the_implicit_env_scope_notice_is_logged_once_per_guardrail() {
+        assert!(
+            implicit_env_scope_first_seen("g-1435-a"),
+            "the first sighting of a guardrail must be reported",
+        );
+        assert!(
+            !implicit_env_scope_first_seen("g-1435-a"),
+            "a later index rebuild must not restate an unchanged fact",
+        );
+        assert!(
+            implicit_env_scope_first_seen("g-1435-b"),
+            "the dedupe is per guardrail — a different row is its own notice",
+        );
+    }
 
     fn entry(_name: &str, id: &str, row: DomainGuardrail) -> ResourceEntry<DomainGuardrail> {
         // `name` is documentary at the call site; the row's own

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -392,8 +392,10 @@ pub const M_CONFIG_RELOAD_FAILURES_TOTAL: &str = "aisix_config_reload_failures_t
 pub const M_CONFIG_REJECTED_RESOURCES: &str = "aisix_config_rejected_resources";
 /// Served resources per kind carrying fields this gateway version does not
 /// know (loaded with those fields ignored — partially compatible, #871).
-/// Non-zero typically means a newer control plane is writing ahead of this
-/// data plane's rollout.
+/// Non-zero means this data plane and the control plane writing to it are
+/// not the same generation; which one is ahead is not knowable from here
+/// (AISIX-Cloud#1435), since a field this build retired is as unknown to
+/// it as one it has never seen.
 pub const M_CONFIG_PARTIALLY_COMPATIBLE_RESOURCES: &str =
     "aisix_config_partially_compatible_resources";
 /// Served resources per kind whose latest source bytes are rejected and


### PR DESCRIPTION
Two diagnostics from the v0.11.0 promotion smoke (AISIX-Cloud#1435, items 6 and 9). Neither changes behaviour — both are about what an operator reads while trying to work out what happened.

## The partial-compat line pointed at the wrong side of the fleet

The lenient loader's WARN read *"row loaded with unknown fields ignored (partially compatible; likely written by a newer control plane)"*. On an upgrade it is the opposite: the new data plane meets rows an **older** control plane wrote carrying a field this build has since dropped. #1435 hit exactly that — `ignored_fields=mandatory` reported as probably-newer — and an upgrade is the one path where unknown fields are expected, so this is the moment the line is most likely to be read and most likely to be wrong.

The direction is not merely unreported, it is **unobservable from here**. A retired field leaves no trace in this build — no tombstone, no "must not exist" list — so "unknown" cannot be split into "added since" and "removed since". Naming the field and its consequence is the whole of what this side can honestly say:

```
row loaded with unknown fields ignored (partially compatible); this build
does not define them, so whatever they configure is not enforced here
```

The same claim appeared on two other surfaces reading the same signal and is removed from both: `M_CONFIG_PARTIALLY_COMPATIBLE_RESOURCES`' doc and `PartialCompatResource` (the `/status/config` field). The reasoning now lives once, at the dedupe helper.

Left alone deliberately: `config-forward-compat-e2e` and `guardrail_read_path_forward_compat` name a newer control plane in their titles and fixtures. There the scenario really is a newer CP — those are correct.

## The implicit env-scope notice restated a standing fact

`guardrail has no attachment rows; applying as implicit env-scope…` is a property of a row, not an event. But the guardrail index rebuilds on every snapshot version change, so the notice was re-emitted once per affected guardrail on **every configuration write in the environment** — saying nothing new each time.

Deduped per guardrail id for the process lifetime rather than demoted to debug: a row that governs every request in the environment because nobody scoped it is worth saying out loud, once. Same shape and cap as `warn_partial_compat_deduped` in `aisix-etcd`, including its behaviour past the cap — new ids keep logging rather than being silently dropped, so the memory bound never costs a signal.

## Tests

The dedupe memory is split into `implicit_env_scope_first_seen` so the once-per-id rule is testable without standing up a tracing subscriber; `the_implicit_env_scope_notice_is_logged_once_per_guardrail` pins first-sighting, the rebuild, and that the dedupe is per row rather than global. It uses ids unique to itself — the memory is process-global, so a shared id would make the result depend on test order.

The wording change carries no test: it is message text, and asserting the absence of a phrase would pin the sentence rather than the property. `cargo test -p aisix-guardrails --lib` (346) and `-p aisix-etcd --lib` (93) pass; `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean.

Fixes api7/AISIX-Cloud#1435