### PR TITLE
docs(releasing): run the PGO pre-flight beside QA, not in front of the tag

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,9 +68,18 @@ customer runs. Two things follow, and both belong to the release flow:
   tag time would put ~30 minutes on the critical path of every release for a
   result that was already knowable hours earlier.
 
+`--ref` takes a **branch or tag name, never a raw commit SHA**, so dispatch on
+the release line's branch — at this point its HEAD *is* the candidate commit.
+Do NOT dispatch on the `vX.Y.Z-rc.N` tag: a tag ref makes metadata-action
+re-emit the candidate's own image tags, republishing the very artifact QA is
+testing as a PGO'd build QA never saw. A branch ref publishes one GHCR
+`:sha-<short>` and nothing else.
+
 ```bash
 # when the candidate is cut — fire and carry on
-gh workflow run docker-image.yml --ref <candidate-sha> -f pgo=true
+gh workflow run docker-image.yml --ref release/<X.Y> -f pgo=true
+# confirm it caught the candidate commit and not a later push to the branch
+gh run list --workflow=docker-image.yml --limit 1 --json databaseId,headSha --jq '.[0]'
 # when you come to tag — a lookup, not a wait
 gh run view <run-id> --json conclusion --jq .conclusion
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,14 +58,21 @@ customer runs. Two things follow, and both belong to the release flow:
 - **The release tag is the first build to run the PGO pipeline on that
   commit**, so a training-shape regression surfaces *after* QA has passed —
   the most expensive moment to find it, since the fix moves the commit and
-  costs a fresh rc plus a re-run of QA. Pre-flight it instead: once the
-  release commit is final and before tagging, run the `docker-image`
-  workflow via `workflow_dispatch` on that commit with **pgo = true**. It
+  costs a fresh rc plus a re-run of QA. Pre-flight it instead, and do it
+  **concurrently, not as a gate before tagging**: the check needs only the
+  candidate's commit, which `vX.Y.Z-rc.N` already fixes, so fire it as soon
+  as the candidate is cut and read the verdict when you come to tag. It
   builds the exact three-phase path and asserts the proof marker, publishing
-  only a `:sha-<short>` tag that moves no pointer.
+  only a `:sha-<short>` tag that moves no pointer — and it finishes well
+  inside the QA window, so it costs no extra wall clock. Blocking on it at
+  tag time would put ~30 minutes on the critical path of every release for a
+  result that was already knowable hours earlier.
 
 ```bash
-gh workflow run docker-image.yml --ref <release-sha> -f pgo=true
+# when the candidate is cut — fire and carry on
+gh workflow run docker-image.yml --ref <candidate-sha> -f pgo=true
+# when you come to tag — a lookup, not a wait
+gh run view <run-id> --json conclusion --jq .conclusion
 ```
 
 A PR that touches `Dockerfile`, `Cargo.toml`, `Cargo.lock`,


### PR DESCRIPTION
## Problem

#1067 documented the PGO pre-flight as a step to run "once the release commit is
final and before tagging". That reads as a gate, and as a gate it puts the full
~30-minute three-phase build on the critical path of every release — to answer a
question whose input stopped changing when the release candidate was cut.

## Change

Describe it as a concurrent check instead. The pre-flight needs only the
candidate's commit, which `vX.Y.Z-rc.N` already fixes, so it is fired as soon as
the candidate exists and finishes well inside the QA window; at tag time it is a
lookup rather than a wait. The snippet now shows both halves — the dispatch at
candidate-cut time and the `gh run view … --jq .conclusion` read at tag time.

Nothing about what the pre-flight *does* changes: same three-phase path, same
`pgo-verified.json` assertion, same `:sha-<short>`-only publish that moves no
rolling pointer. Only its position in the release sequence does.

## Behavior changes

None — documentation only. The `pgo` workflow_dispatch input added in #1067 is
unchanged.

## Tests

No test exception: this file is a runbook, not a code path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Release candidates now complete preflight checks concurrently, reducing time to create candidate releases.
  * Release tagging uses the completed preflight result and publishes a stable image tag tied to the release commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->