### PR TITLE
fix(guardrails): a guardrail's scope is its attachments and nothing else

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,14 @@ The five kinds are the cross-plane taxonomy (cp-admin.yaml `kind`); this repo's 
 - **`ensemble` is an experimental surface.** Its known parity gaps — member `allowed_cidrs`/guardrail/cooldown/health consumption, Prometheus token+spend attribution, response caching, parent-level generic knobs — are deliberate TODOs under a single future design pass. Do NOT piecemeal-fix one gap ahead of that pass, and do NOT re-audit them as fresh findings. (The one exception is a marshal-family or shared-chokepoint change where covering ensemble is a one-line parallel edit, e.g. projecting an entry-level field the DP already enforces.)
 - Adding a NEW kind = sweeping every existing model-keyed mechanism against it (grep the kind predicates in `models/model.rs`; every hit re-answers the questions above).
 
+## A Guardrail's Scope Is Its Attachments and Nothing Else
+
+There is no implicit scope. `build_index_from_snapshot` puts a guardrail in the index once per enabled attachment, and a guardrail with none governs nothing — on either source. Declaring one without an attachment is not an error, because its scope target may simply have been deleted.
+
+It used to be the opposite: a guardrail carrying ZERO attachment rows was applied to the entire environment at priority 0, a rolling-upgrade fallback from the window where this side read attachments and the control plane had not written any yet. Keying on the ABSENCE of rows is what made it dangerous — deleting the one model a guardrail was scoped to removed its last attachment and thereby WIDENED the guardrail to all traffic, silently, on a security control (AISIX-Cloud#1450). Do not reintroduce a default of any shape, and in particular do not give the resources file one "for convenience": the file source declares `guardrail_attachments` exactly as the control plane projects them, references written as the identity each collection is keyed by, so both sources answer the scoping question the same way. A convenience default in one of them is a divergence a standalone user cannot see.
+
+The export follows from that: `aisix export` emits every guardrail plus every attachment it can name. An attachment it cannot name — `team`, which has no file collection, or a `scope_id` missing from the snapshot — is dropped with a warning rather than emitted dangling, because losing a scope makes the guardrail govern LESS. Inventing one would make it govern more.
+
 ## Time-Boxed Compat Code Carries a `COMPAT-SINCE:` Marker
 
 **A shim meant to live for exactly one release gets a machine-readable deadline, not a sentence in a comment. Prose deadlines never come due — both of the ones this repo was carrying were found by grep, not by process.**

--- a/crates/aisix-core/src/filesource/desugar.rs
+++ b/crates/aisix-core/src/filesource/desugar.rs
@@ -69,6 +69,12 @@ pub(crate) enum IdentityField {
     /// their own. Every entry shares the constant, so a second entry
     /// trips the pass-1 duplicate check.
     Fixed(&'static str),
+    /// The `(guardrail_id, scope_type, scope_id)` triple
+    /// (guardrail_attachments). An attachment has no name of its own,
+    /// and that triple is exactly what the control plane makes unique,
+    /// so it is the file's identity too — attaching the same guardrail
+    /// to the same target twice is a pass-1 duplicate.
+    AttachmentTriple,
 }
 
 impl IdentityField {
@@ -79,6 +85,7 @@ impl IdentityField {
             Self::Name => "name",
             Self::NameOrDisplayName => "name (or display_name)",
             Self::Fixed(_) => "the singleton identity",
+            Self::AttachmentTriple => "guardrail_id + scope_type (+ scope_id)",
         }
     }
 
@@ -96,6 +103,18 @@ impl IdentityField {
             Self::Name => field("name"),
             Self::NameOrDisplayName => field("name").or_else(|| field("display_name")),
             Self::Fixed(v) => Some(v.to_string()),
+            // Composed from the file-level names, before desugaring
+            // rewrites them to derived ids, so the identity a duplicate
+            // is reported against is what the operator actually wrote.
+            // `-` stands in for an absent scope_id (scope_type: env),
+            // which cannot collide with a resolved name because the
+            // triple always carries the scope_type as well.
+            Self::AttachmentTriple => {
+                let guardrail = field("guardrail_id")?;
+                let scope_type = field("scope_type")?;
+                let scope = field("scope_id").unwrap_or_else(|| "-".to_string());
+                Some(format!("{guardrail}/{scope_type}/{scope}"))
+            }
         }
     }
 }
@@ -332,6 +351,47 @@ pub(crate) fn desugar_rate_limit_policy(
     };
     let resolved = resolve_entity_name(maps, scope_kind, label, name, "`scope_ref`")?;
     obj.insert("scope_ref".into(), Value::String(resolved));
+    Ok(())
+}
+
+/// Resolve a guardrail attachment's two references from file-level names
+/// to derived ids: `guardrail_id` against the guardrails, and `scope_id`
+/// against whichever collection `scope_type` names.
+///
+/// `team` is deliberately absent from the scope table: the file source has
+/// no teams collection to resolve against, so a team-scoped attachment
+/// keeps whatever id the operator wrote. Callers running standalone have
+/// no teams either, so such an attachment simply never matches — which is
+/// the same outcome as any other scope whose target is gone.
+pub(crate) fn desugar_guardrail_attachment(
+    doc: &mut Value,
+    maps: &IdentityMaps,
+) -> Result<(), String> {
+    let obj = match doc.as_object_mut() {
+        Some(o) => o,
+        None => return Ok(()),
+    };
+    if let Some(name) = obj.get("guardrail_id").and_then(Value::as_str) {
+        let resolved =
+            resolve_entity_name(maps, "guardrails", "guardrail", name, "`guardrail_id`")?;
+        obj.insert("guardrail_id".into(), Value::String(resolved));
+    }
+
+    let scope_kind = match obj.get("scope_type").and_then(Value::as_str) {
+        Some("model") => ("models", "model"),
+        Some("mcp_server") => ("mcp_servers", "MCP server"),
+        Some("api_key") => ("api_keys", "api key"),
+        Some("passthrough_route") => ("passthrough_routes", "passthrough route"),
+        // `env` carries no scope_id; `team` has no file collection.
+        _ => return Ok(()),
+    };
+    let Some(name) = obj.get("scope_id").and_then(Value::as_str) else {
+        // Missing / non-string scope_id: canonical validation reports it.
+        return Ok(());
+    };
+    let (kind, label) = scope_kind;
+    let resolved = resolve_entity_name(maps, kind, label, name, "`scope_id`")?;
+    obj.insert("scope_id".into(), Value::String(resolved));
     Ok(())
 }
 

--- a/crates/aisix-core/src/filesource/desugar.rs
+++ b/crates/aisix-core/src/filesource/desugar.rs
@@ -358,11 +358,13 @@ pub(crate) fn desugar_rate_limit_policy(
 /// to derived ids: `guardrail_id` against the guardrails, and `scope_id`
 /// against whichever collection `scope_type` names.
 ///
-/// `team` is deliberately absent from the scope table: the file source has
-/// no teams collection to resolve against, so a team-scoped attachment
-/// keeps whatever id the operator wrote. Callers running standalone have
-/// no teams either, so such an attachment simply never matches — which is
-/// the same outcome as any other scope whose target is gone.
+/// `team` is absent from the scope table on purpose, and its `scope_id` is
+/// carried through verbatim rather than resolved: there is no teams
+/// collection to name, but `api_keys[].team_id` IS a file field and
+/// `IndexEntry::applies_to` compares the two ids as bare strings — so a
+/// team-scoped attachment does resolve standalone, against whatever id the
+/// operator wrote on both sides. Same treatment a team-scoped rate-limit
+/// policy's `scope_ref` already gets.
 pub(crate) fn desugar_guardrail_attachment(
     doc: &mut Value,
     maps: &IdentityMaps,

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -2,9 +2,10 @@
 //! config.yaml).
 //!
 //! Loads every dynamic resource — provider keys, models, API keys,
-//! guardrails, MCP servers, A2A agents, cache policies, observability
-//! exporters, rate-limit policies — from one YAML file instead of etcd,
-//! so a single container can run fully declaratively.
+//! guardrails and their attachments, MCP servers, A2A agents, cache
+//! policies, observability exporters, rate-limit policies — from one YAML
+//! file instead of etcd, so a single container can run fully
+//! declaratively.
 //!
 //! Pipeline (identical for boot, SIGHUP reload, and `aisix validate`):
 //!
@@ -22,8 +23,8 @@
 //! per-entry and across entries.)
 //!
 //! File format v1 (`_format_version: "1"`, mandatory):
-//! - nine top-level collection keys, each a sequence of maps, named by
-//!   the plural resource kind; unknown top-level keys are load errors.
+//! - fourteen top-level collection keys, each a sequence of maps, named
+//!   by the plural resource kind; unknown top-level keys are load errors.
 //! - after desugaring, every entry must be exactly a canonical resource
 //!   document (`schemas/resources/*.schema.json`) — the file source
 //!   never relaxes the canonical schemas.
@@ -31,6 +32,12 @@
 //!   (UUIDv5 of `"<kind>/<identity>"`, see
 //!   [`desugar::FILE_RESOURCE_NAMESPACE`]) and identities must be
 //!   unique per kind.
+//! - cross-collection references are written as the identity the target
+//!   collection is keyed by, and desugaring rewrites them to derived ids
+//!   — including a guardrail attachment's `guardrail_id` and `scope_id`.
+//!   A guardrail with no attachment is not an error: its scope target may
+//!   simply be gone, and a guardrail's scope is its attachments and
+//!   nothing else, so it governs nothing until something attaches it.
 
 mod desugar;
 mod status;
@@ -46,11 +53,12 @@ use yaml_rust2::{Yaml, YamlLoader};
 
 use crate::models::{
     validate_a2a_agent, validate_apikey, validate_cache_policy, validate_claim_mapping,
-    validate_guardrail, validate_mcp_auth_settings, validate_mcp_server, validate_model,
-    validate_observability_exporter, validate_oidc_provider, validate_passthrough_route,
-    validate_provider_key, validate_rate_limit_policy, A2aAgent, ApiKey, CachePolicy, ClaimMapping,
-    Guardrail, McpAuthSettings, McpServer, Model, ObservabilityExporter, OidcProvider,
-    PassthroughRoute, ProviderKey, RateLimitPolicy, SchemaError,
+    validate_guardrail, validate_guardrail_attachment, validate_mcp_auth_settings,
+    validate_mcp_server, validate_model, validate_observability_exporter, validate_oidc_provider,
+    validate_passthrough_route, validate_provider_key, validate_rate_limit_policy, A2aAgent,
+    ApiKey, CachePolicy, ClaimMapping, Guardrail, GuardrailAttachment, McpAuthSettings, McpServer,
+    Model, ObservabilityExporter, OidcProvider, PassthroughRoute, ProviderKey, RateLimitPolicy,
+    SchemaError,
 };
 use crate::resource::ResourceEntry;
 use crate::AisixSnapshot;
@@ -131,12 +139,13 @@ pub(crate) fn url_has_credentials(url: &str) -> bool {
     false
 }
 
-/// Fixed processing order for the thirteen resource collections.
-const KINDS: [(&str, IdentityField); 13] = [
+/// Fixed processing order for the fourteen resource collections.
+const KINDS: [(&str, IdentityField); 14] = [
     ("provider_keys", IdentityField::DisplayName),
     ("models", IdentityField::DisplayName),
     ("api_keys", IdentityField::DisplayName),
     ("guardrails", IdentityField::Name),
+    ("guardrail_attachments", IdentityField::AttachmentTriple),
     ("mcp_servers", IdentityField::NameOrDisplayName),
     ("a2a_agents", IdentityField::NameOrDisplayName),
     ("cache_policies", IdentityField::Name),
@@ -349,6 +358,7 @@ pub fn load_from_str(
     let mut apikeys: Vec<(String, String, ApiKey)> = Vec::new();
     let mut provider_keys: Vec<(String, String, ProviderKey)> = Vec::new();
     let mut guardrails: Vec<(String, String, Guardrail)> = Vec::new();
+    let mut guardrail_attachments: Vec<(String, String, GuardrailAttachment)> = Vec::new();
     let mut mcp_servers: Vec<(String, String, McpServer)> = Vec::new();
     let mut a2a_agents: Vec<(String, String, A2aAgent)> = Vec::new();
     let mut cache_policies: Vec<(String, String, CachePolicy)> = Vec::new();
@@ -385,6 +395,9 @@ pub fn load_from_str(
                 desugar::desugar_rate_limit_policy(&mut entry.doc, &identity_maps)
             }
             "claim_mappings" => desugar::desugar_claim_mapping(&mut entry.doc, &identity_maps),
+            "guardrail_attachments" => {
+                desugar::desugar_guardrail_attachment(&mut entry.doc, &identity_maps)
+            }
             "passthrough_routes" => {
                 desugar::desugar_passthrough_route(&mut entry.doc, &identity_maps)
             }
@@ -414,6 +427,16 @@ pub fn load_from_str(
             "guardrails" => {
                 if let Some(t) = finish(&scope, &entry.doc, validate_guardrail, &mut errors) {
                     guardrails.push((id, scope, t));
+                }
+            }
+            "guardrail_attachments" => {
+                if let Some(t) = finish(
+                    &scope,
+                    &entry.doc,
+                    validate_guardrail_attachment,
+                    &mut errors,
+                ) {
+                    guardrail_attachments.push((id, scope, t));
                 }
             }
             "mcp_servers" => {
@@ -772,6 +795,11 @@ pub fn load_from_str(
     for (id, _, v) in guardrails {
         snapshot
             .guardrails
+            .insert(ResourceEntry::new(id, v, revision));
+    }
+    for (id, _, v) in guardrail_attachments {
+        snapshot
+            .guardrail_attachments
             .insert(ResourceEntry::new(id, v, revision));
     }
     for (id, _, v) in mcp_servers {

--- a/crates/aisix-core/src/filesource/tests.rs
+++ b/crates/aisix-core/src/filesource/tests.rs
@@ -69,6 +69,11 @@ guardrails:
       - kind: literal
         value: topsecret
 
+guardrail_attachments:
+  - guardrail_id: no-secrets
+    scope_type: env
+    priority: 100
+
 mcp_servers:
   - name: github
     url: https://mcp.example.com/mcp
@@ -156,6 +161,7 @@ fn full_valid_file_loads_every_kind() {
     assert_eq!(snap.models.len(), 3);
     assert_eq!(snap.apikeys.len(), 2);
     assert_eq!(snap.guardrails.len(), 1);
+    assert_eq!(snap.guardrail_attachments.len(), 1);
     assert_eq!(snap.mcp_servers.len(), 1);
     assert_eq!(snap.a2a_agents.len(), 1);
     assert_eq!(snap.cache_policies.len(), 1);
@@ -995,4 +1001,129 @@ claim_mappings:
     let errors = errors_of(load(&file, &env_of(&[])));
     assert_eq!(errors.len(), 1, "{errors:?}");
     assert!(errors[0].contains("match"), "{errors:?}");
+}
+
+/// A guardrail's scope comes only from its attachments, so the file source
+/// needs the same collection the control plane projects (AISIX-Cloud#1450).
+/// References are written as the names the file already uses and resolved to
+/// derived ids, the way `scope_ref` and `provider_key` are.
+#[test]
+fn guardrail_attachment_resolves_its_references_by_name() {
+    const FILE: &str = r#"
+_format_version: "1"
+
+provider_keys:
+  - display_name: openai-prod
+    provider: openai
+    api_key: sk-test
+
+models:
+  - display_name: gpt-4o
+    provider: openai
+    model_name: gpt-4o-2024-11-20
+    provider_key: openai-prod
+
+guardrails:
+  - name: no-secrets
+    kind: keyword
+    patterns:
+      - kind: literal
+        value: topsecret
+
+guardrail_attachments:
+  - guardrail_id: no-secrets
+    scope_type: model
+    scope_id: gpt-4o
+    priority: 100
+"#;
+    let snap = load(FILE, &HashMap::new()).expect("file must load");
+    assert_eq!(snap.guardrail_attachments.len(), 1);
+
+    let attachment = &snap.guardrail_attachments.entries()[0].value;
+    assert_eq!(
+        attachment.guardrail_id,
+        snap.guardrails.get_by_name("no-secrets").unwrap().id,
+        "guardrail_id must resolve to the guardrail's derived id",
+    );
+    assert_eq!(
+        attachment.scope_id.as_deref(),
+        Some(snap.models.get_by_name("gpt-4o").unwrap().id.as_str()),
+        "scope_id must resolve to the model's derived id",
+    );
+}
+
+/// The reference has to be checked, not silently carried: an attachment
+/// naming a guardrail that is not in the file would load as a scope pointing
+/// at nothing, which is precisely the state that used to be indistinguishable
+/// from "unscoped".
+#[test]
+fn guardrail_attachment_referencing_an_unknown_guardrail_is_a_load_error() {
+    const FILE: &str = r#"
+_format_version: "1"
+
+guardrail_attachments:
+  - guardrail_id: does-not-exist
+    scope_type: env
+    priority: 100
+"#;
+    let errs = errors_of(load(FILE, &HashMap::new()));
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("`guardrail_id` references unknown guardrail")),
+        "unknown guardrail must be named in the error: {errs:?}",
+    );
+}
+
+/// Same triple twice is the control plane's uniqueness constraint, so it is
+/// the file's duplicate too.
+#[test]
+fn attaching_the_same_guardrail_to_the_same_scope_twice_is_a_load_error() {
+    const FILE: &str = r#"
+_format_version: "1"
+
+guardrails:
+  - name: no-secrets
+    kind: keyword
+    patterns:
+      - kind: literal
+        value: topsecret
+
+guardrail_attachments:
+  - guardrail_id: no-secrets
+    scope_type: env
+    priority: 100
+  - guardrail_id: no-secrets
+    scope_type: env
+    priority: 50
+"#;
+    let errs = errors_of(load(FILE, &HashMap::new()));
+    assert!(
+        errs.iter().any(|e| e.contains("duplicate")),
+        "duplicate attachment triple must be reported: {errs:?}",
+    );
+}
+
+/// An unattached guardrail is NOT an error. Its scope target may simply have
+/// been deleted, and refusing to load — or inventing an env attachment for it
+/// — would each be a worse answer than the honest one: it governs nothing
+/// until something attaches it.
+#[test]
+fn a_guardrail_with_no_attachment_loads_without_complaint() {
+    const FILE: &str = r#"
+_format_version: "1"
+
+guardrails:
+  - name: no-secrets
+    kind: keyword
+    patterns:
+      - kind: literal
+        value: topsecret
+"#;
+    let snap = load(FILE, &HashMap::new()).expect("an unattached guardrail must still load");
+    assert_eq!(snap.guardrails.len(), 1);
+    assert_eq!(
+        snap.guardrail_attachments.len(),
+        0,
+        "nothing may be synthesized on the guardrail's behalf",
+    );
 }

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1054,7 +1054,92 @@ pub fn build_index_from_snapshot(
         ));
     }
 
+    warn_unattached_guardrails(guardrails, attachments);
     GuardrailIndex::from_entries(entries)
+}
+
+/// Ids of the enabled guardrails no attachment names — the rows that are
+/// loaded, counted, and inert.
+///
+/// A DISABLED attachment still counts as naming its guardrail: switching an
+/// attachment off is the operator saying "not here, for now", and reporting
+/// that as an oversight would train them to ignore the line.
+fn unattached_ids(
+    guardrails: &ResourceTable<DomainGuardrail>,
+    attachments: &ResourceTable<GuardrailAttachment>,
+) -> Vec<(String, String)> {
+    let attached: std::collections::HashSet<String> = attachments
+        .entries()
+        .into_iter()
+        .map(|a| a.value.guardrail_id.clone())
+        .collect();
+    let mut out: Vec<(String, String)> = guardrails
+        .entries()
+        .into_iter()
+        .filter(|e| e.value.enabled && !attached.contains(e.id.as_str()))
+        .map(|e| (e.id.clone(), e.value.name.clone()))
+        .collect();
+    out.sort();
+    out
+}
+
+/// Names of the enabled-but-unattached guardrails, for `aisix validate` —
+/// the one place an operator looks BEFORE deploying, where the runtime WARN
+/// below has not had a chance to fire yet.
+pub fn unattached_guardrail_names(
+    guardrails: &ResourceTable<DomainGuardrail>,
+    attachments: &ResourceTable<GuardrailAttachment>,
+) -> Vec<String> {
+    unattached_ids(guardrails, attachments)
+        .into_iter()
+        .map(|(_, name)| name)
+        .collect()
+}
+
+/// WARN once per guardrail id for the process lifetime: this row is enabled
+/// but nothing attaches it, so it inspects no traffic at all.
+///
+/// The state is legitimate — a scope target can be deleted, and a rule with
+/// no scope left is correctly inert — but it is also indistinguishable from a
+/// misconfiguration, and it is INVISIBLE otherwise: the guardrail is present
+/// in the snapshot, `/status/config` counts it as loaded, and no request ever
+/// mentions it. An operator who believes a rule is in force deserves to be
+/// told it is not.
+///
+/// Deduped per id, not logged per build, for the reason AISIX-Cloud#1435
+/// documents: the index is rebuilt on every snapshot version change, and this
+/// describes a STANDING property of a row rather than an event.
+fn warn_unattached_guardrails(
+    guardrails: &ResourceTable<DomainGuardrail>,
+    attachments: &ResourceTable<GuardrailAttachment>,
+) {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+
+    const MAX_REMEMBERED: usize = 1024;
+    static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    // Poison-tolerant: this set only dedupes log lines, so a panic while the
+    // lock was held must not wedge every later index build.
+    let mut warned = WARNED
+        .get_or_init(|| Mutex::new(HashSet::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    for (id, name) in unattached_ids(guardrails, attachments) {
+        if warned.contains(&id) {
+            continue;
+        }
+        tracing::warn!(
+            guardrail_id = %id,
+            guardrail_name = %name,
+            "guardrail is enabled but has no attachment, so it inspects no traffic; \
+             attach it to an environment, model, MCP server, API key, team or \
+             passthrough route to put it in force",
+        );
+        if warned.len() < MAX_REMEMBERED {
+            warned.insert(id);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1282,10 +1282,9 @@ impl LiveGuardrailIndex {
         chain.with_audit_log(Some(Arc::new(crate::GuardrailAuditLog::new())))
     }
 
-    /// `true` when the resolved index has no guardrail entries — neither
-    /// from explicit attachment rows nor from the backward-compat implicit
-    /// env-scope fallback for no-attachment guardrails. Callers can use
-    /// this to skip chain allocation on the hot path.
+    /// `true` when the index has no entries — no enabled attachment names a
+    /// guardrail this build can run. Callers use it to skip chain allocation
+    /// on the hot path.
     pub fn is_empty(&self) -> bool {
         self.current().is_empty()
     }
@@ -1963,11 +1962,11 @@ mod tests {
         assert_eq!(chain.member_names(), ["y", "x", "z"]);
     }
 
-    /// The production per-request path: guardrails with no attachment
-    /// rows fall back to implicit env-scope entries that all share
-    /// priority 0, so their relative order in the resolved chain is
-    /// decided by the index build's iteration — which must be the same
-    /// created_at-ascending order as the chain-build path (#519 B.4a).
+    /// The production per-request path. Every guardrail here carries an
+    /// env attachment at the same priority, so nothing but the build's own
+    /// iteration order separates them — which must be deterministic, or the
+    /// DashMap's run-to-run order decides which Block fires first
+    /// (#519 B.4a).
     #[test]
     fn index_ties_resolve_in_attachment_id_order() {
         // The index sorts by (priority desc, scope-specificity desc) with a
@@ -2132,9 +2131,9 @@ mod tests {
 
     #[tokio::test]
     async fn one_enabled_one_disabled_attachment_fires_exactly_once() {
-        // Verifies the HashSet boundary: a guardrail with one enabled + one disabled
-        // attachment must fire exactly once (via the enabled attachment) and must NOT
-        // trigger the backward-compat env-scope fallback.
+        // A guardrail with one enabled + one disabled attachment must fire
+        // exactly once — through the enabled one, with the disabled row
+        // contributing no second entry that `resolve` would have to dedupe.
         let guardrails: ResourceTable<DomainGuardrail> = ResourceTable::default();
         guardrails.insert(entry(
             "g",

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -965,57 +965,21 @@ impl Guardrail for LiveGuardrailChain {
 ///
 /// The resulting index is pre-sorted by priority (descending) so
 /// `GuardrailIndex::resolve` can walk it linearly.
-/// INFO once per guardrail id for the process lifetime.
 ///
-/// The index is rebuilt on every snapshot version change, and this arm
-/// describes a STANDING property of a row — it has no attachment records —
-/// not an event. Logging it per build re-stated the same unchanged fact on
-/// every configuration write in the environment, once per affected
-/// guardrail, which is what AISIX-Cloud#1435 saw on a busy deployment.
+/// **Attachments are the whole of a guardrail's scope.** A guardrail with no
+/// enabled attachment governs nothing — it is not a no-op by oversight but by
+/// definition, because an attachment is the only thing that says which traffic
+/// the rule inspects.
 ///
-/// Deduped rather than demoted: the fallback means the row governs every
-/// request in the environment because nobody scoped it, which is worth
-/// saying out loud — once.
-fn log_implicit_env_scope_once(id: &str, name: &str) {
-    if !implicit_env_scope_first_seen(id) {
-        return;
-    }
-    tracing::info!(
-        guardrail_id = %id,
-        guardrail_name = %name,
-        "guardrail has no attachment rows; applying as implicit env-scope at priority 0 (backward-compat rolling-upgrade window)",
-    );
-}
-
-/// The memory behind [`log_implicit_env_scope_once`], split out so the
-/// once-per-id rule can be tested without a tracing subscriber.
-///
-/// `true` the first time an id is seen, `false` afterwards.
-fn implicit_env_scope_first_seen(id: &str) -> bool {
-    use std::collections::HashSet;
-    use std::sync::{Mutex, OnceLock};
-
-    // Same shape and same cap as `warn_partial_compat_deduped` in
-    // aisix-etcd: past the cap new ids keep logging rather than being
-    // silently dropped, so the memory bound never costs a signal.
-    const MAX_REMEMBERED: usize = 1024;
-    static LOGGED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
-
-    // Poison-tolerant: this set only dedupes log lines, so a panic while
-    // the lock was held must not wedge every later index build.
-    let mut logged = LOGGED
-        .get_or_init(|| Mutex::new(HashSet::new()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if logged.contains(id) {
-        return false;
-    }
-    if logged.len() < MAX_REMEMBERED {
-        logged.insert(id.to_string());
-    }
-    true
-}
-
+/// This used to have a backward-compat arm that applied a guardrail carrying
+/// ZERO attachment rows to the entire environment at priority 0, for the P0c
+/// rolling-upgrade window where the data plane had attachments and the control
+/// plane had not written any yet. That window closed, and the arm was actively
+/// harmful: because it keyed on the ABSENCE of rows, removing a guardrail's
+/// last attachment WIDENED it. Deleting the one model a guardrail was scoped
+/// to promoted that guardrail to the whole environment (AISIX-Cloud#1450) —
+/// the exact opposite of what the operator asked for, silently, on a security
+/// control. Scope now comes from the attachments and from nothing else.
 pub fn build_index_from_snapshot(
     guardrails: &ResourceTable<DomainGuardrail>,
     attachments: &ResourceTable<GuardrailAttachment>,
@@ -1023,11 +987,6 @@ pub fn build_index_from_snapshot(
     embedder: &GuardrailEmbedderSlot,
 ) -> GuardrailIndex {
     let mut entries = Vec::new();
-    // Track guardrail IDs that have ANY attachment record (enabled or not).
-    // The backward-compat fallback below only fires for guardrails that have
-    // zero attachment rows — operators who explicitly disabled an attachment
-    // are expressing intent; we must not override it with the env-scope fallback.
-    let mut attached_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     // Deterministic attachment order: `GuardrailIndex::new` sorts by
     // (priority desc, scope-specificity desc) with a STABLE sort, so
@@ -1040,11 +999,6 @@ pub fn build_index_from_snapshot(
 
     for attachment_arc in attachment_entries.iter() {
         let attachment = &attachment_arc.value;
-        // Track ALL attachment references (enabled or not) so the backward-compat
-        // fallback below treats "has an explicit attachment" as opt-in to P0c
-        // attachment semantics — even if all attachments are currently disabled.
-        attached_ids.insert(attachment.guardrail_id.clone());
-
         if !attachment.enabled {
             continue;
         }
@@ -1098,61 +1052,6 @@ pub fn build_index_from_snapshot(
             runtime_guardrail,
             applied_for(row),
         ));
-    }
-
-    // Backward compat: a guardrail definition that has no enabled attachment
-    // fires on every request in the env at priority 0 (same as the pre-P0c
-    // behavior where all guardrails in the snapshot were applied globally).
-    // This covers the rolling-upgrade window where the DP has been updated to
-    // P0c but the CP hasn't yet written attachment rows for existing guardrails.
-    //
-    // TODO(P0c-cleanup): Remove this block once the CP is fully rolled out and
-    // guaranteed to write at least one attachment row for every guardrail
-    // (tracked in https://github.com/api7/ai-gateway/issues/417).
-    // After removal, a guardrail with zero attachment rows is a silent no-op —
-    // operators must explicitly attach it to a scope.
-    //
-    // NOTE: the standalone resources-file source (aisix-core::filesource)
-    // deliberately writes NO attachment rows — its v1 format has no
-    // attachment collection, so file-defined guardrails are env-global
-    // through exactly this fallback. Do not remove this block without
-    // giving the file format a scoping surface (or synthesizing env-scope
-    // attachments in the file loader). The file-resource-source e2e pins
-    // that a file-defined guardrail fires.
-    // Same deterministic created_at-ascending order as the chain-build
-    // path: these implicit entries all share priority 0 + env scope, so
-    // without a pre-sort their relative order — and which Block fires
-    // first — would follow the DashMap's arbitrary iteration (#519 B.4a).
-    for guardrail_arc in sorted_guardrail_entries(guardrails) {
-        if attached_ids.contains(guardrail_arc.id.as_str()) {
-            continue; // explicit attachment governs this guardrail
-        }
-        let row = &guardrail_arc.value;
-        if !row.enabled {
-            continue;
-        }
-        match build_one(row, bedrock_endpoint_url, embedder) {
-            Ok(Some(g)) => {
-                log_implicit_env_scope_once(&guardrail_arc.id, &row.name);
-                entries.push(GuardrailIndex::push_entry(
-                    guardrail_arc.id.clone(),
-                    row.name.clone(),
-                    ScopeKind::Env,
-                    None,
-                    0,
-                    g,
-                    applied_for(row),
-                ));
-            }
-            Ok(None) => {}
-            Err(err) => {
-                tracing::warn!(
-                    guardrail_id = %guardrail_arc.id,
-                    error = %err,
-                    "skipping guardrail with invalid config (no-attachment backward-compat path)",
-                );
-            }
-        }
     }
 
     GuardrailIndex::from_entries(entries)
@@ -1313,30 +1212,6 @@ mod tests {
     use aisix_core::models::Guardrail as DomainGuardrail;
     use aisix_core::resource::ResourceEntry;
     use aisix_gateway::{ChatFormat, ChatMessage};
-
-    /// AISIX-Cloud#1435: the implicit env-scope notice is a standing
-    /// property of a row, and the index is rebuilt on every snapshot
-    /// version change — so logging it per build restated the same
-    /// unchanged fact once per affected guardrail on every configuration
-    /// write in the environment.
-    ///
-    /// Ids are unique to this test: the memory is process-global, so a
-    /// shared id would make the result depend on which test ran first.
-    #[test]
-    fn the_implicit_env_scope_notice_is_logged_once_per_guardrail() {
-        assert!(
-            implicit_env_scope_first_seen("g-1435-a"),
-            "the first sighting of a guardrail must be reported",
-        );
-        assert!(
-            !implicit_env_scope_first_seen("g-1435-a"),
-            "a later index rebuild must not restate an unchanged fact",
-        );
-        assert!(
-            implicit_env_scope_first_seen("g-1435-b"),
-            "the dedupe is per guardrail — a different row is its own notice",
-        );
-    }
 
     fn entry(_name: &str, id: &str, row: DomainGuardrail) -> ResourceEntry<DomainGuardrail> {
         // `name` is documentary at the call site; the row's own
@@ -2009,8 +1884,33 @@ mod tests {
     /// decided by the index build's iteration — which must be the same
     /// created_at-ascending order as the chain-build path (#519 B.4a).
     #[test]
-    fn no_attachment_fallback_resolves_in_created_at_order() {
+    fn index_ties_resolve_in_attachment_id_order() {
+        // The index sorts by (priority desc, scope-specificity desc) with a
+        // STABLE sort, so insertion order decides what is left — and insertion
+        // walks attachments sorted by their own id. Every attachment here is
+        // env-scope at the same priority, so attachment id is the ONLY
+        // tiebreak; without the build-time sort the DashMap's arbitrary,
+        // run-to-run-varying order would make this flap (#519 B.4a).
+        //
+        // Guardrail `created_at` deliberately does not decide this order: that
+        // is the chain path's rule (`chain_order_is_created_at_ascending_with_id_tiebreak`),
+        // and the two are different mechanisms. This test used to exercise the
+        // index through the zero-attachment fallback, which borrowed the
+        // chain's ordering; with that fallback retired (AISIX-Cloud#1450) the
+        // index is reached only through explicit attachments.
         let attachments: ResourceTable<GuardrailAttachment> = ResourceTable::default();
+        for (i, (guardrail_id, _, _)) in SHUFFLED_ROWS.iter().enumerate() {
+            // Attachment ids run opposite to the row order they attach, so a
+            // pass that forgot to sort would surface as the insertion order.
+            let attachment_id = format!("a-{:02}", SHUFFLED_ROWS.len() - i);
+            attachments.insert(attachment_entry(
+                &attachment_id,
+                parse_attachment(&format!(
+                    r#"{{ "guardrail_id": "{guardrail_id}", "scope_type": "env", "priority": 100 }}"#
+                )),
+            ));
+        }
+
         let index = build_index_from_snapshot(
             &shuffled_table(),
             &attachments,
@@ -2024,7 +1924,14 @@ mod tests {
             api_key_id: "k",
             team_id: None,
         });
-        assert_eq!(chain.member_names(), EXPECTED_ORDER);
+        // a-01 attaches the LAST row, a-10 the first — so ascending attachment
+        // id walks SHUFFLED_ROWS backwards.
+        let expected: Vec<&str> = SHUFFLED_ROWS
+            .iter()
+            .rev()
+            .map(|(_, name, _)| *name)
+            .collect();
+        assert_eq!(chain.member_names(), expected);
     }
 
     // -----------------------------------------------------------------------
@@ -2194,10 +2101,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_attachment_guardrail_fires_globally_backward_compat() {
-        // Core backward-compat contract: a guardrail with ZERO attachment rows
-        // must fire on every request (env-scope at priority 0), preserving
-        // the pre-P0c "apply globally" behavior during rolling upgrade.
+    async fn guardrail_without_attachment_governs_nothing() {
+        // AISIX-Cloud#1450. This used to assert the opposite: a guardrail with
+        // ZERO attachment rows fired on every request, a rolling-upgrade
+        // fallback from the window where the data plane read attachments and
+        // the control plane had not written any yet.
+        //
+        // Keying on the ABSENCE of rows made removing a guardrail's last
+        // attachment a scope WIDENING — delete the one model it was scoped to
+        // and it started inspecting the entire environment. An attachment is
+        // the only thing that says which traffic a rule sees, so no attachment
+        // now means no traffic.
         let guardrails: ResourceTable<DomainGuardrail> = ResourceTable::default();
         guardrails.insert(entry(
             "g",
@@ -2220,8 +2134,8 @@ mod tests {
         );
         assert_eq!(
             index.len(),
-            1,
-            "no-attachment guardrail must appear as env-scope entry",
+            0,
+            "an unattached guardrail must not enter the index",
         );
 
         let ctx = RequestContext {
@@ -2232,12 +2146,12 @@ mod tests {
             team_id: None,
         };
         assert!(
-            index
+            !index
                 .resolve(&ctx)
                 .check_input(&req("here AKIA"))
                 .await
                 .is_block(),
-            "no-attachment guardrail must block matching requests",
+            "an unattached guardrail must not block anything, however well its pattern matches",
         );
     }
 
@@ -2430,6 +2344,17 @@ mod tests {
                 }"#,
             ),
         ));
+        // Both rows need an explicit env attachment: scope comes only from
+        // attachments now, so an unattached guardrail never reaches the index
+        // (AISIX-Cloud#1450).
+        for (attachment_id, guardrail_id) in [("a-1", "g-1"), ("a-2", "g-2")] {
+            snap.guardrail_attachments.insert(attachment_entry(
+                attachment_id,
+                parse_attachment(&format!(
+                    r#"{{ "guardrail_id": "{guardrail_id}", "scope_type": "env", "priority": 100 }}"#
+                )),
+            ));
+        }
         let sink = Arc::new(RecordingSink::default());
         let live = LiveGuardrailIndex::new_with_sink(
             SnapshotHandle::new(snap),

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -302,8 +302,8 @@ pub use audit::GuardrailAuditLog;
 #[cfg(feature = "bedrock")]
 pub use bedrock::BedrockGuardrail;
 pub use build::{
-    build_chain_from_snapshot, build_index_from_snapshot, unbuildable_guardrail_rows,
-    LiveGuardrailChain, LiveGuardrailIndex, UnbuildableGuardrailRow,
+    build_chain_from_snapshot, build_index_from_snapshot, unattached_guardrail_names,
+    unbuildable_guardrail_rows, LiveGuardrailChain, LiveGuardrailIndex, UnbuildableGuardrailRow,
 };
 pub use chain::GuardrailChain;
 pub use index::{GuardrailIndex, RequestContext};

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -2355,7 +2355,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(tts_model("my-tts"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);
@@ -2395,7 +2395,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(tts_model("my-tts"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let resp = tower::ServiceExt::oneshot(
@@ -2434,7 +2434,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(tts_model("my-tts"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let resp = tower::ServiceExt::oneshot(
@@ -2566,7 +2566,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(whisper_model("my-whisper"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let mut body: Vec<u8> = Vec::new();
         body.extend_from_slice(
@@ -3519,7 +3519,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(tts_model("my-tts"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(pii_guardrail("input"));
+        crate::seed_env_scoped_guardrail(&snap, pii_guardrail("input"));
 
         let app = build_app(snap);
         let body = serde_json::json!({
@@ -3557,7 +3557,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(whisper_model("my-whisper"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let (ct, body) = transcription_multipart_with_prompt("my-whisper", "please BLOCKME now");
@@ -3587,7 +3587,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(whisper_model("my-whisper"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(pii_guardrail("input"));
+        crate::seed_env_scoped_guardrail(&snap, pii_guardrail("input"));
 
         let app = build_app(snap);
         let (ct, body) =
@@ -3630,7 +3630,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(whisper_model("my-whisper"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(pii_guardrail("output"));
+        crate::seed_env_scoped_guardrail(&snap, pii_guardrail("output"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);
@@ -3681,7 +3681,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(whisper_model("my-whisper"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);
@@ -3737,7 +3737,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(whisper_model("my-whisper"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);
@@ -3781,7 +3781,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(tts_model("my-tts"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);
@@ -3856,7 +3856,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(whisper_model("my-transcribe"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(masking_input_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, masking_input_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);
@@ -3915,7 +3915,7 @@ data: [DONE]\n\n";
         let snap = new_snap(&upstream.uri());
         snap.models.insert(whisper_model("my-transcribe"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(masking_input_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, masking_input_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -976,7 +976,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("instruct"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let body = serde_json::json!({"model": "instruct", "prompt": "please BLOCKME now"});
@@ -1013,7 +1013,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("instruct"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let body = serde_json::json!({"model": "instruct", "prompt": "a fine prompt"});
@@ -1630,7 +1630,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("my-completions"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -1699,7 +1699,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("instruct"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(masking_input_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, masking_input_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -979,7 +979,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        snap.guardrails.insert(ResourceEntry::new("g-mask", row, 1));
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-mask", row, 1));
 
         let hub = Arc::new(Hub::new());
         hub.register_specialized(

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -906,7 +906,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -1050,7 +1050,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let body = serde_json::json!({"model": "my-embed", "input": "please BLOCKME now"});
@@ -1082,7 +1082,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let body =
@@ -1113,7 +1113,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let body = serde_json::json!({"model": "my-embed", "input": "a perfectly fine request"});
@@ -1947,7 +1947,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -2018,7 +2018,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("my-embed"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(masking_input_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, masking_input_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -871,8 +871,8 @@ mod tests {
         })
     }
 
-    /// An env-scoped keyword input guardrail (no attachment row → applies
-    /// to every request via the backward-compat fallback) that blocks on a
+    /// A keyword input guardrail, attached env-wide by
+    /// `seed_env_scoped_guardrail` so it applies to every request. Blocks on a
     /// literal. `fail_open:false` is irrelevant for keyword (local, never
     /// errors) but keeps the row explicit.
     fn keyword_input_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {

--- a/crates/aisix-proxy/src/guardrail_blocked_telemetry.rs
+++ b/crates/aisix-proxy/src/guardrail_blocked_telemetry.rs
@@ -169,8 +169,8 @@ fn snapshot() -> AisixSnapshot {
     snap.passthrough_routes
         .insert(ResourceEntry::new("route-1", route, 1));
 
-    // Env-scoped (no attachment row → the backward-compat fallback applies
-    // it to every request), input hook, fail-closed. A keyword row is the
+    // Attached env-wide by `seed_env_scoped_guardrail`, input hook,
+    // fail-closed. A keyword row is the
     // deterministic stand-in for any input-hook kind and, unlike a
     // text-independent script, keeps the clean run genuinely clean.
     let guardrail: aisix_core::Guardrail = serde_json::from_value(serde_json::json!({

--- a/crates/aisix-proxy/src/guardrail_blocked_telemetry.rs
+++ b/crates/aisix-proxy/src/guardrail_blocked_telemetry.rs
@@ -182,8 +182,7 @@ fn snapshot() -> AisixSnapshot {
         "patterns": [{ "kind": "literal", "value": BLOCK }],
     }))
     .expect("valid guardrail");
-    snap.guardrails
-        .insert(ResourceEntry::new("g-1", guardrail, 1));
+    crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-1", guardrail, 1));
 
     snap
 }

--- a/crates/aisix-proxy/src/guardrail_coverage.rs
+++ b/crates/aisix-proxy/src/guardrail_coverage.rs
@@ -382,8 +382,7 @@ fn census_snapshot() -> AisixSnapshot {
         "timeout_ms": 5000,
     }))
     .expect("valid guardrail");
-    snap.guardrails
-        .insert(ResourceEntry::new("g-census", guardrail, 1));
+    crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-census", guardrail, 1));
 
     snap
 }
@@ -745,8 +744,7 @@ async fn surfaces_refused_with(row: Option<serde_json::Value>) -> Vec<&'static s
     if let Some(row) = row {
         let guardrail: aisix_core::Guardrail =
             serde_json::from_value(row).expect("valid guardrail");
-        snap.guardrails
-            .insert(ResourceEntry::new("g-census", guardrail, 2));
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-census", guardrail, 2));
     }
     let handle = SnapshotHandle::new(snap);
     let index = aisix_guardrails::LiveGuardrailIndex::new(handle.clone(), None);

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -780,7 +780,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("dalle"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let body = serde_json::json!({"model": "dalle", "prompt": "draw BLOCKME please"});
@@ -813,7 +813,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("dalle"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let body = serde_json::json!({"model": "dalle", "prompt": "a serene landscape"});
@@ -1204,7 +1204,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("dall-e"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);
@@ -1303,7 +1303,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("img"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(pii_mask_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, pii_mask_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);
@@ -1382,7 +1382,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("my-image"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -1447,7 +1447,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("dalle"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(masking_input_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, masking_input_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-proxy/src/images_edits.rs
+++ b/crates/aisix-proxy/src/images_edits.rs
@@ -947,7 +947,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("img-edit-prod"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let resp = tower::ServiceExt::oneshot(app, make_req("img-edit-prod", "please BLOCKME now"))
@@ -982,7 +982,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("img-edit-prod"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let mut body: Vec<u8> = Vec::new();
         body.extend_from_slice(
@@ -1206,7 +1206,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("my-image"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);
@@ -1259,7 +1259,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(model_entry("my-image"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(masking_input_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, masking_input_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let app = build_app_with_sink(snap, tx);

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -2676,8 +2676,10 @@ mod tests {
             r#"{"name":"test-block","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{"kind":"literal","value":"custom_id"}]}"#,
         )
         .unwrap();
-        snap.guardrails
-            .insert(aisix_core::resource::ResourceEntry::new("g-1", g, 1));
+        crate::seed_env_scoped_guardrail(
+            &snap,
+            aisix_core::resource::ResourceEntry::new("g-1", g, 1),
+        );
         let (app, mut rx) = build_app_with_sink(snap);
 
         let boundary = "XBOUNDARYX";

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -1035,6 +1035,34 @@ async fn readyz(
     crate::health::readyz_response(&state.livez, config_block, params.contains_key("verbose"))
 }
 
+/// Inserts a guardrail together with the env-scoped attachment that puts it
+/// in force.
+///
+/// A guardrail's scope is its attachments and nothing else — an unattached
+/// guardrail governs nothing (AISIX-Cloud#1450 retired the fallback that
+/// applied a zero-attachment guardrail to the whole environment). Tests that
+/// want a guardrail to fire on the request under test go through here rather
+/// than inserting into `snap.guardrails` alone; a test about scoping writes
+/// the attachment it means instead.
+#[cfg(test)]
+pub(crate) fn seed_env_scoped_guardrail(
+    snap: &aisix_core::AisixSnapshot,
+    guardrail: aisix_core::ResourceEntry<aisix_core::Guardrail>,
+) {
+    let attachment: aisix_core::models::GuardrailAttachment = serde_json::from_str(&format!(
+        r#"{{"guardrail_id": "{}", "scope_type": "env", "priority": 100}}"#,
+        guardrail.id
+    ))
+    .expect("env attachment must parse");
+    snap.guardrail_attachments
+        .insert(aisix_core::ResourceEntry::new(
+            format!("att-{}", guardrail.id),
+            attachment,
+            1,
+        ));
+    snap.guardrails.insert(guardrail);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -5699,7 +5699,7 @@ data: [DONE]\n\n";
             }"#,
         )
         .unwrap();
-        snap.guardrails.insert(ResourceEntry::new("g-mask", row, 1));
+        crate::seed_env_scoped_guardrail(snap, ResourceEntry::new("g-mask", row, 1));
     }
 
     #[track_caller]
@@ -5911,7 +5911,7 @@ data: [DONE]\n\n";
                 r#"{"name":"out-block","enabled":true,"kind":"keyword","hook_point":"output","fail_open":false,"patterns":[{"kind":"literal","value":"BLOCKME"}]}"#,
             )
             .unwrap();
-            snap.guardrails.insert(ResourceEntry::new("g-out", row, 1));
+            crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-out", row, 1));
 
             let (tx, mut rx) = tokio::sync::mpsc::channel(4);
             let hub = Arc::new(Hub::new());
@@ -6007,7 +6007,7 @@ event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n"
             r#"{"name":"out-block","enabled":true,"kind":"keyword","hook_point":"output","fail_open":false,"patterns":[{"kind":"literal","value":"NEVERAPPEARS"}]}"#,
         )
         .unwrap();
-        snap.guardrails.insert(ResourceEntry::new("g-out", row, 1));
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-out", row, 1));
 
         let hub = Arc::new(Hub::new());
         hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));

--- a/crates/aisix-proxy/src/passthrough_route.rs
+++ b/crates/aisix-proxy/src/passthrough_route.rs
@@ -3213,7 +3213,7 @@ mod tests {
             r#"{"name":"test-block","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{"kind":"literal","value":"BLOCKME"}]}"#,
         )
         .unwrap();
-        snap.guardrails.insert(ResourceEntry::new("g-1", g, 1));
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-1", g, 1));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -1615,8 +1615,10 @@ mod tests {
             r#"{"name":"test-block","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{"kind":"literal","value":"BLOCKME"}]}"#,
         )
         .unwrap();
-        snap.guardrails
-            .insert(aisix_core::resource::ResourceEntry::new("g-1", g, 1));
+        crate::seed_env_scoped_guardrail(
+            &snap,
+            aisix_core::resource::ResourceEntry::new("g-1", g, 1),
+        );
         let (addr, _state, mut rx) = serve(snap).await;
 
         let mut req = format!("ws://{addr}/v1/realtime?model=rt-model")

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -1001,7 +1001,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(cohere_model("rr"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let resp = app
@@ -1037,7 +1037,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(cohere_model("rr"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let app = build_app(snap);
         let resp = app
@@ -1083,7 +1083,7 @@ mod tests {
         snap.provider_keys.insert(ResourceEntry::new(PK_ID, pk, 1));
         snap.models.insert(cohere_model("rr"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -1535,7 +1535,7 @@ mod tests {
         snap.apikeys.insert(apikey_entry(&["*"]));
         // ALLOW guardrail: a literal the benign request below never matches, so
         // it governs the request (non-empty applied set) without blocking it.
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -1942,7 +1942,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(openai_model("rr"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(pii_mask_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, pii_mask_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -1993,7 +1993,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(openai_model("rerank-model"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -2065,7 +2065,7 @@ mod tests {
         let snap = new_snap(&upstream.uri());
         snap.models.insert(openai_model("rerank-model"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(masking_input_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, masking_input_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -3475,7 +3475,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -3538,7 +3538,7 @@ mod tests {
                 snap.models
                     .insert(routing_model("resp-group", "gpt-4o-resp"));
                 snap.apikeys.insert(apikey_entry(&["*"]));
-                snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+                crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
 
                 let (tx, mut rx) = tokio::sync::mpsc::channel(8);
                 let hub = Arc::new(Hub::new());
@@ -3599,7 +3599,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -3638,7 +3638,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -3676,7 +3676,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -3717,7 +3717,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -3755,7 +3755,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -3808,7 +3808,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -3849,7 +3849,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -3889,7 +3889,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -3931,7 +3931,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -3993,7 +3993,7 @@ mod tests {
         let snap = new_snap_anthropic_at(&upstream.uri());
         snap.models.insert(anthropic_model("claude-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -4039,7 +4039,7 @@ mod tests {
         let snap = new_snap_anthropic_at(&upstream.uri());
         snap.models.insert(anthropic_model("claude-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -4080,7 +4080,7 @@ mod tests {
         let snap = new_snap_anthropic_at(&upstream.uri());
         snap.models.insert(anthropic_model("claude-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -4142,7 +4142,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -4198,8 +4198,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails
-            .insert(keyword_output_guardrail_monitor("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail_monitor("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -4249,8 +4248,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails
-            .insert(keyword_output_guardrail_monitor("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail_monitor("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -4341,8 +4339,7 @@ mod tests {
             acs.uri()
         );
         let g: aisix_core::Guardrail = serde_json::from_str(&textmod_json).unwrap();
-        snap.guardrails
-            .insert(ResourceEntry::new("g-textmod-mon", g, 1));
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-textmod-mon", g, 1));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -4417,8 +4414,7 @@ mod tests {
         let snap = new_snap_anthropic_at(&upstream.uri());
         snap.models.insert(anthropic_model("claude-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails
-            .insert(keyword_output_guardrail_monitor("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail_monitor("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -4482,7 +4478,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -4526,7 +4522,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -4575,7 +4571,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -4623,7 +4619,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -4665,7 +4661,7 @@ mod tests {
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         let resp = app
@@ -4707,7 +4703,7 @@ mod tests {
         )
         .unwrap();
         snap.apikeys.insert(ResourceEntry::new("k-1", apikey, 1));
-        snap.guardrails.insert(keyword_input_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_input_guardrail("BLOCKME"));
         let app = build_app(snap);
 
         // Blocked by the guardrail — must NOT reserve the single RPM slot.
@@ -5278,7 +5274,7 @@ data: [DONE]\n\n";
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(keyword_output_guardrail("BLOCKME"));
+        crate::seed_env_scoped_guardrail(&snap, keyword_output_guardrail("BLOCKME"));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -5910,7 +5906,7 @@ data: [DONE]\n\n";
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(masking_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, masking_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());
@@ -5963,7 +5959,7 @@ data: [DONE]\n\n";
         let snap = new_snap_openai(&upstream.uri());
         snap.models.insert(openai_model("gpt-4o-resp"));
         snap.apikeys.insert(apikey_entry(&["*"]));
-        snap.guardrails.insert(masking_guardrail());
+        crate::seed_env_scoped_guardrail(&snap, masking_guardrail());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -3442,8 +3442,8 @@ mod tests {
             .unwrap()
     }
 
-    /// An env-scoped keyword input guardrail (no attachment row → applies to
-    /// every request via the backward-compat fallback) that blocks on a
+    /// A keyword input guardrail, attached env-wide by
+    /// `seed_env_scoped_guardrail` so it applies to every request. Blocks on a
     /// literal substring. Keyword is local (no remote call), so it's the
     /// deterministic stand-in for any input-hook guardrail kind.
     fn keyword_input_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
@@ -3774,8 +3774,8 @@ mod tests {
         assert_eq!(v["error"]["type"], "content_filter");
     }
 
-    /// An env-scoped keyword guardrail on the OUTPUT hook (no attachment →
-    /// applies to every request). `runs_on_output()` is true, so the
+    /// A keyword guardrail on the OUTPUT hook, attached env-wide by
+    /// `seed_env_scoped_guardrail`. `runs_on_output()` is true, so the
     /// handler scans the assistant output.
     fn keyword_output_guardrail(literal: &str) -> ResourceEntry<aisix_core::Guardrail> {
         let json = format!(

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -2801,7 +2801,7 @@ mod tests {
             r#"{"name":"test-block","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{"kind":"literal","value":"BLOCKME"}]}"#,
         )
         .unwrap();
-        snap.guardrails.insert(ResourceEntry::new("g-1", g, 1));
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-1", g, 1));
 
         let app = build_app(snap);
         let resp = tower::ServiceExt::oneshot(
@@ -3931,7 +3931,7 @@ mod tests {
             r#"{"name":"test-block","enabled":true,"hook_point":"input","fail_open":false,"kind":"keyword","patterns":[{"kind":"literal","value":"BLOCKME"}]}"#,
         )
         .unwrap();
-        snap.guardrails.insert(ResourceEntry::new("g-1", g, 1));
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-1", g, 1));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -159,26 +159,13 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
 
     // guardrails — identity: name; recursive credential redaction.
     //
-    // The file has no attachment collection, so every file-defined
-    // guardrail applies gateway-wide. Only a guardrail already gateway-wide
-    // in etcd (via an env-scoped attachment) round-trips without changing
-    // its effect; an attachment-scoped or unattached guardrail would widen
-    // to ALL traffic on import (or activate a rule that was never attached).
-    // Those are omitted with a warning — the file still loads without them.
-    let gateway_wide = gateway_wide_guardrail_ids(snapshot);
-    let mut gateway_wide_names: BTreeSet<String> = BTreeSet::new();
-    for entry in snapshot.guardrails.entries() {
-        if gateway_wide.contains(&entry.id) {
-            gateway_wide_names.insert(entry.value.name.clone());
-        } else {
-            diag.warnings.push(format!(
-                "guardrail {:?} is attachment-scoped or unattached in etcd; the resources file \
-                 has no attachment collection, so exporting it would apply it to ALL traffic — \
-                 omitted. Re-declare it in the file only if a gateway-wide rule is intended.",
-                entry.value.name
-            ));
-        }
-    }
+    // Every guardrail is exported, attached or not: the file format now
+    // carries `guardrail_attachments`, and both sources agree that a
+    // guardrail's scope is its attachments and nothing else, so an
+    // unattached guardrail is inert on either side (AISIX-Cloud#1450). It
+    // used to be the opposite — the file had no attachment collection and a
+    // file-defined guardrail applied gateway-wide — so anything not already
+    // env-scoped had to be dropped or it would WIDEN on import.
     let mut guardrails = emit_entries(
         &snapshot.guardrails,
         |g| g.name.clone(),
@@ -196,12 +183,21 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
             redact_by_key(doc, GUARDRAIL_SECRET_KEYS, &mut ctx);
         },
     );
-    guardrails.retain(|v| {
-        v.get("name")
+    guardrails.sort_by(|a, b| {
+        a.get("name")
             .and_then(Value::as_str)
-            .is_some_and(|n| gateway_wide_names.contains(n))
+            .cmp(&b.get("name").and_then(Value::as_str))
     });
     push_kind(&mut collections, "guardrails", guardrails);
+
+    // guardrail_attachments — the scope that makes each guardrail apply.
+    // References are emitted as the file identities the other collections
+    // use, since the loader resolves them back to derived ids.
+    push_kind(
+        &mut collections,
+        "guardrail_attachments",
+        emit_guardrail_attachments(snapshot, &model_names, &api_key_names, &mut diag),
+    );
 
     // mcp_servers — identity: name; secret: secret.
     push_kind(
@@ -380,18 +376,103 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
     }
 }
 
-/// Ids of guardrails that already apply gateway-wide in etcd — i.e. that
-/// have at least one env-scoped guardrail attachment (`scope_type: env`
-/// matches every request). These are the only guardrails whose effect is
-/// unchanged when exported into the attachment-less file format.
-fn gateway_wide_guardrail_ids(snapshot: &AisixSnapshot) -> BTreeSet<String> {
-    snapshot
-        .guardrail_attachments
-        .entries()
-        .into_iter()
-        .filter(|a| matches!(a.value.scope_type, GuardrailScopeType::Env))
-        .map(|a| a.value.guardrail_id.clone())
-        .collect()
+/// Build the file's `guardrail_attachments` entries, rewriting every id
+/// reference into the identity its own collection is keyed by in the file.
+///
+/// An attachment the file cannot express is dropped with a warning rather
+/// than emitted with a dangling reference: `team` has no file collection to
+/// name, and a `scope_id` pointing at a resource missing from the snapshot
+/// has no name to resolve. Dropping is the safe direction — the guardrail
+/// loses that scope and governs less, never more.
+fn emit_guardrail_attachments(
+    snapshot: &AisixSnapshot,
+    model_names: &BTreeMap<String, String>,
+    api_key_names: &BTreeMap<String, String>,
+    diag: &mut Diagnostics,
+) -> Vec<Value> {
+    let guardrail_names = id_to_name(&snapshot.guardrails, |g| g.name.clone());
+    let mcp_server_names = id_to_name(&snapshot.mcp_servers, |s| s.name.clone());
+    let route_names = id_to_name(&snapshot.passthrough_routes, |r| r.name.clone());
+
+    let mut out: Vec<Value> = Vec::new();
+    for entry in snapshot.guardrail_attachments.entries() {
+        let a = &entry.value;
+        let Some(guardrail) = guardrail_names.get(&a.guardrail_id) else {
+            diag.warnings.push(format!(
+                "guardrail attachment {:?} references a guardrail that is not in the snapshot; omitted",
+                entry.id
+            ));
+            continue;
+        };
+        let scope_name = match a.scope_type {
+            GuardrailScopeType::Env => None,
+            GuardrailScopeType::Model => Some(("model", model_names.get(scope_ref(a)))),
+            GuardrailScopeType::McpServer => {
+                Some(("MCP server", mcp_server_names.get(scope_ref(a))))
+            }
+            GuardrailScopeType::ApiKey => Some(("api key", api_key_names.get(scope_ref(a)))),
+            GuardrailScopeType::PassthroughRoute => {
+                Some(("passthrough route", route_names.get(scope_ref(a))))
+            }
+            GuardrailScopeType::Team => {
+                diag.warnings.push(format!(
+                    "guardrail {guardrail:?} has a team-scoped attachment; the resources file has \
+                     no teams collection to name, so that scope is omitted",
+                ));
+                continue;
+            }
+        };
+        let resolved = match scope_name {
+            None => None,
+            Some((label, Some(name))) => {
+                let _ = label;
+                Some(name.clone())
+            }
+            Some((label, None)) => {
+                diag.warnings.push(format!(
+                    "guardrail {guardrail:?} is scoped to a {label} that is not in the snapshot; \
+                     that scope is omitted",
+                ));
+                continue;
+            }
+        };
+
+        let mut doc = serde_json::Map::new();
+        doc.insert("guardrail_id".into(), Value::String(guardrail.clone()));
+        doc.insert(
+            "scope_type".into(),
+            serde_json::to_value(&a.scope_type).unwrap_or(Value::Null),
+        );
+        if let Some(name) = resolved {
+            doc.insert("scope_id".into(), Value::String(name));
+        }
+        doc.insert("priority".into(), Value::from(a.priority));
+        if !a.enabled {
+            doc.insert("enabled".into(), Value::Bool(false));
+        }
+        out.push(Value::Object(doc));
+    }
+    // Deterministic file output: same snapshot must emit the same bytes.
+    out.sort_by(|a, b| {
+        (
+            a.get("guardrail_id").and_then(Value::as_str),
+            a.get("scope_type").and_then(Value::as_str),
+            a.get("scope_id").and_then(Value::as_str),
+        )
+            .cmp(&(
+                b.get("guardrail_id").and_then(Value::as_str),
+                b.get("scope_type").and_then(Value::as_str),
+                b.get("scope_id").and_then(Value::as_str),
+            ))
+    });
+    out
+}
+
+/// An attachment's `scope_id`, or the empty string — which never matches a
+/// real resource id, so an absent scope on a narrow scope_type resolves to
+/// "not in the snapshot" and is reported as such.
+fn scope_ref(a: &aisix_core::models::GuardrailAttachment) -> &str {
+    a.scope_id.as_deref().unwrap_or("")
 }
 
 /// Deterministic file identity for a canonical api-key document, which

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -344,8 +344,8 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
         ),
     );
 
-    // guardrail_attachments are consumed above to decide which guardrails
-    // are gateway-wide; they are not a file collection of their own.
+    // guardrail_attachments are emitted above as their own collection, with
+    // every id reference rewritten to the identity its collection is keyed by.
 
     // Two entries whose identities differ only in characters `sanitize`
     // folds to `_` (e.g. `openai-prod` vs `openai.prod`) derive the SAME
@@ -379,11 +379,18 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
 /// Build the file's `guardrail_attachments` entries, rewriting every id
 /// reference into the identity its own collection is keyed by in the file.
 ///
-/// An attachment the file cannot express is dropped with a warning rather
-/// than emitted with a dangling reference: `team` has no file collection to
-/// name, and a `scope_id` pointing at a resource missing from the snapshot
-/// has no name to resolve. Dropping is the safe direction — the guardrail
-/// loses that scope and governs less, never more.
+/// A `team` scope carries its id through verbatim, the way
+/// `resugar_scope_ref` already does for a team-scoped rate-limit policy:
+/// there is no teams collection to name, but `api_keys[].team_id` IS a file
+/// field and the runtime compares the two ids as bare strings, so the scope
+/// really does resolve standalone. Dropping it would narrow a guardrail while
+/// the rate limit beside it survived.
+///
+/// An attachment the file genuinely cannot express is dropped with a warning
+/// rather than emitted dangling: a `passthrough_route` scope (the export
+/// carries no routes collection to point at) and a `scope_id` naming a
+/// resource missing from the snapshot. Dropping is the safe direction — the
+/// guardrail loses that scope and governs less, never more.
 fn emit_guardrail_attachments(
     snapshot: &AisixSnapshot,
     model_names: &BTreeMap<String, String>,
@@ -392,7 +399,6 @@ fn emit_guardrail_attachments(
 ) -> Vec<Value> {
     let guardrail_names = id_to_name(&snapshot.guardrails, |g| g.name.clone());
     let mcp_server_names = id_to_name(&snapshot.mcp_servers, |s| s.name.clone());
-    let route_names = id_to_name(&snapshot.passthrough_routes, |r| r.name.clone());
 
     let mut out: Vec<Value> = Vec::new();
     for entry in snapshot.guardrail_attachments.entries() {
@@ -411,16 +417,19 @@ fn emit_guardrail_attachments(
                 Some(("MCP server", mcp_server_names.get(scope_ref(a))))
             }
             GuardrailScopeType::ApiKey => Some(("api key", api_key_names.get(scope_ref(a)))),
+            // The export carries no `passthrough_routes` collection, so a
+            // route-scoped attachment has nothing to point at in the file —
+            // emitting the name anyway makes the whole file fail to load.
             GuardrailScopeType::PassthroughRoute => {
-                Some(("passthrough route", route_names.get(scope_ref(a))))
-            }
-            GuardrailScopeType::Team => {
                 diag.warnings.push(format!(
-                    "guardrail {guardrail:?} has a team-scoped attachment; the resources file has \
-                     no teams collection to name, so that scope is omitted",
+                    "guardrail {guardrail:?} has a passthrough-route-scoped attachment; the \
+                     export does not carry passthrough routes, so that scope is omitted",
                 ));
                 continue;
             }
+            // Verbatim: `api_keys[].team_id` is a file field and
+            // `IndexEntry::applies_to` compares the two ids as bare strings.
+            GuardrailScopeType::Team => Some(("team", a.scope_id.as_ref())),
         };
         let resolved = match scope_name {
             None => None,
@@ -450,7 +459,13 @@ fn emit_guardrail_attachments(
         if !a.enabled {
             doc.insert("enabled".into(), Value::Bool(false));
         }
-        out.push(Value::Object(doc));
+        // Same `$` escaping every other collection gets from `emit_entries`:
+        // the loader unescapes `$$` before interpolating, so a name carrying
+        // a `$` must be written escaped on BOTH sides of the reference or the
+        // two stop matching.
+        let mut doc = Value::Object(doc);
+        escape_dollars(&mut doc);
+        out.push(doc);
     }
     // Deterministic file output: same snapshot must emit the same bytes.
     out.sort_by(|a, b| {

--- a/crates/aisix-server/src/export/document_tests.rs
+++ b/crates/aisix-server/src/export/document_tests.rs
@@ -318,10 +318,9 @@ fn attachment(guardrail_id: &str, scope_type: &str, scope_id: Option<&str>) -> V
 }
 
 #[test]
-fn env_scoped_guardrail_is_exported_gateway_wide() {
-    // An env-scoped attachment already applies to every request, so
-    // exporting the guardrail (which the file applies gateway-wide)
-    // is behavior-equivalent.
+fn env_scoped_guardrail_exports_with_its_attachment() {
+    // The file carries the scope now, so the guardrail and the attachment
+    // that puts it in force are exported together.
     let snap = AisixSnapshot::new();
     snap.guardrails.insert(ResourceEntry::new(
         "g-1",
@@ -337,13 +336,34 @@ fn env_scoped_guardrail_is_exported_gateway_wide() {
     let guardrails = find(&doc, "guardrails");
     assert_eq!(guardrails.len(), 1);
     assert_eq!(guardrails[0]["name"], json!("global-guard"));
+
+    let attachments = find(&doc, "guardrail_attachments");
+    assert_eq!(attachments.len(), 1);
+    assert_eq!(attachments[0]["guardrail_id"], json!("global-guard"));
+    assert_eq!(attachments[0]["scope_type"], json!("env"));
+    assert!(attachments[0].get("scope_id").is_none());
 }
 
 #[test]
-fn attachment_scoped_or_unattached_guardrail_is_omitted_with_a_warning() {
-    // A guardrail attached to one model — or attached to nothing — would
-    // widen (or activate) gateway-wide on import, so it must be omitted.
+fn narrow_scope_survives_the_export_as_a_reference_by_name() {
+    // AISIX-Cloud#1450. This used to assert the opposite: a model-scoped
+    // guardrail was DROPPED, because the file had no attachment collection
+    // and anything it did carry applied gateway-wide — exporting a narrow
+    // rule would have widened it to all traffic. The file expresses scope
+    // now, so the scope round-trips instead of being discarded, and the
+    // reference is emitted as the model's file identity.
     let snap = AisixSnapshot::new();
+    snap.models.insert(ResourceEntry::new(
+        "m-1",
+        serde_json::from_value(json!({
+            "display_name": "gpt-4o",
+            "provider": "openai",
+            "model_name": "gpt-4o-2024-11-20",
+            "provider_key_id": "pk-1"
+        }))
+        .unwrap(),
+        1,
+    ));
     snap.guardrails.insert(ResourceEntry::new(
         "g-scoped",
         keyword_guardrail("model-guard"),
@@ -354,24 +374,85 @@ fn attachment_scoped_or_unattached_guardrail_is_omitted_with_a_warning() {
         serde_json::from_value(attachment("g-scoped", "model", Some("m-1"))).unwrap(),
         1,
     ));
+
+    let doc = build_export_document(&snap, false);
+    let attachments = find(&doc, "guardrail_attachments");
+    assert_eq!(attachments.len(), 1);
+    assert_eq!(attachments[0]["guardrail_id"], json!("model-guard"));
+    assert_eq!(attachments[0]["scope_type"], json!("model"));
+    assert_eq!(
+        attachments[0]["scope_id"],
+        json!("gpt-4o"),
+        "scope must be emitted as the model's file identity, not its etcd id",
+    );
+}
+
+#[test]
+fn an_unattached_guardrail_exports_with_no_attachment() {
+    // Inert on both sides now, so exporting it is faithful rather than
+    // dangerous: it governs nothing in etcd and nothing in the file.
+    let snap = AisixSnapshot::new();
     snap.guardrails.insert(ResourceEntry::new(
         "g-inert",
         keyword_guardrail("inert-guard"),
         1,
     ));
     let doc = build_export_document(&snap, false);
-    // Neither guardrail is exported…
-    assert!(doc.collections.iter().all(|(k, _)| *k != "guardrails"));
-    // …and both are surfaced as would-widen-to-all-traffic warnings.
-    for name in ["model-guard", "inert-guard"] {
-        assert!(
-            doc.warnings
-                .iter()
-                .any(|w| w.contains(name) && w.contains("ALL traffic")),
-            "missing warning for {name}: {:?}",
-            doc.warnings
-        );
-    }
+    let guardrails = find(&doc, "guardrails");
+    assert_eq!(guardrails.len(), 1);
+    assert_eq!(guardrails[0]["name"], json!("inert-guard"));
+    assert!(
+        doc.collections
+            .iter()
+            .all(|(k, _)| *k != "guardrail_attachments"),
+        "nothing may be synthesized on the guardrail's behalf",
+    );
+}
+
+#[test]
+fn an_attachment_the_file_cannot_name_is_dropped_with_a_warning() {
+    // Dropping loses scope, which makes the guardrail govern LESS — the
+    // safe direction. Emitting a dangling reference would fail the import
+    // outright, and inventing one would widen it.
+    let snap = AisixSnapshot::new();
+    snap.guardrails.insert(ResourceEntry::new(
+        "g-1",
+        keyword_guardrail("team-guard"),
+        1,
+    ));
+    snap.guardrail_attachments.insert(ResourceEntry::new(
+        "att-team",
+        serde_json::from_value(attachment("g-1", "team", Some("t-1"))).unwrap(),
+        1,
+    ));
+    snap.guardrail_attachments.insert(ResourceEntry::new(
+        "att-missing-model",
+        serde_json::from_value(attachment("g-1", "model", Some("m-gone"))).unwrap(),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    assert!(
+        doc.collections
+            .iter()
+            .all(|(k, _)| *k != "guardrail_attachments"),
+        "neither attachment can be named in the file: {:?}",
+        doc.collections
+    );
+    assert!(
+        doc.warnings
+            .iter()
+            .any(|w| w.contains("no teams collection")),
+        "team scope must be reported: {:?}",
+        doc.warnings
+    );
+    assert!(
+        doc.warnings
+            .iter()
+            .any(|w| w.contains("not in the snapshot")),
+        "dangling model scope must be reported: {:?}",
+        doc.warnings
+    );
 }
 
 #[test]

--- a/crates/aisix-server/src/export/document_tests.rs
+++ b/crates/aisix-server/src/export/document_tests.rs
@@ -413,7 +413,8 @@ fn an_unattached_guardrail_exports_with_no_attachment() {
 fn an_attachment_the_file_cannot_name_is_dropped_with_a_warning() {
     // Dropping loses scope, which makes the guardrail govern LESS — the
     // safe direction. Emitting a dangling reference would fail the import
-    // outright, and inventing one would widen it.
+    // outright (the loader rejects the whole file), and inventing one would
+    // widen it.
     let snap = AisixSnapshot::new();
     snap.guardrails.insert(ResourceEntry::new(
         "g-1",
@@ -421,13 +422,17 @@ fn an_attachment_the_file_cannot_name_is_dropped_with_a_warning() {
         1,
     ));
     snap.guardrail_attachments.insert(ResourceEntry::new(
-        "att-team",
-        serde_json::from_value(attachment("g-1", "team", Some("t-1"))).unwrap(),
-        1,
-    ));
-    snap.guardrail_attachments.insert(ResourceEntry::new(
         "att-missing-model",
         serde_json::from_value(attachment("g-1", "model", Some("m-gone"))).unwrap(),
+        1,
+    ));
+    // The export carries no passthrough_routes collection at all, so a
+    // route-scoped attachment has nothing to point at. Emitting the name
+    // anyway produced a file the loader rejected WHOLE, with export still
+    // exiting 0.
+    snap.guardrail_attachments.insert(ResourceEntry::new(
+        "att-route",
+        serde_json::from_value(attachment("g-1", "passthrough_route", Some("r-1"))).unwrap(),
         1,
     ));
 
@@ -442,15 +447,15 @@ fn an_attachment_the_file_cannot_name_is_dropped_with_a_warning() {
     assert!(
         doc.warnings
             .iter()
-            .any(|w| w.contains("no teams collection")),
-        "team scope must be reported: {:?}",
+            .any(|w| w.contains("not in the snapshot")),
+        "dangling model scope must be reported: {:?}",
         doc.warnings
     );
     assert!(
         doc.warnings
             .iter()
-            .any(|w| w.contains("not in the snapshot")),
-        "dangling model scope must be reported: {:?}",
+            .any(|w| w.contains("does not carry passthrough routes")),
+        "route scope must be reported: {:?}",
         doc.warnings
     );
 }
@@ -629,5 +634,39 @@ fn dangling_claim_mapping_target_is_kept_and_blocking() {
             .any(|w| w.contains("dangling") && w.contains("finance-dept")),
         "{:?}",
         doc.blocking
+    );
+}
+
+/// A team scope has no collection to name, but it still round-trips: the id
+/// goes through verbatim, `api_keys[].team_id` is a file field, and the
+/// runtime compares the two as bare strings. Dropping it would narrow a
+/// guardrail while the team-scoped rate limit beside it survived.
+#[test]
+fn a_team_scope_is_carried_through_verbatim() {
+    let snap = AisixSnapshot::new();
+    snap.guardrails.insert(ResourceEntry::new(
+        "g-1",
+        keyword_guardrail("team-guard"),
+        1,
+    ));
+    snap.guardrail_attachments.insert(ResourceEntry::new(
+        "att-team",
+        serde_json::from_value(attachment("g-1", "team", Some("team-alpha"))).unwrap(),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    let attachments = find(&doc, "guardrail_attachments");
+    assert_eq!(attachments.len(), 1);
+    assert_eq!(attachments[0]["scope_type"], json!("team"));
+    assert_eq!(
+        attachments[0]["scope_id"],
+        json!("team-alpha"),
+        "a team id has no name to resolve to and must survive unchanged",
+    );
+    assert!(
+        doc.warnings.is_empty(),
+        "a team scope is expressible, so nothing should be reported: {:?}",
+        doc.warnings
     );
 }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -273,6 +273,28 @@ fn run_validate(resources: &Path) -> anyhow::Result<()> {
         }
         std::process::exit(1);
     }
+    // An enabled guardrail nothing attaches is inert — a scope target can be
+    // deleted, so this is legitimate rather than malformed, and the exit code
+    // stays 0. But `validate` is the one place an operator looks BEFORE
+    // deploying, and the runtime WARN they would otherwise have to notice in
+    // a log is the only other signal: the row loads, the resource count
+    // includes it, and no request ever mentions it.
+    let unattached = aisix_guardrails::unattached_guardrail_names(
+        &snapshot.guardrails,
+        &snapshot.guardrail_attachments,
+    );
+    if !unattached.is_empty() {
+        eprintln!(
+            "resources file {}: {} enabled guardrail(s) have no attachment and inspect no traffic:",
+            resources.display(),
+            unattached.len(),
+        );
+        for name in &unattached {
+            eprintln!(
+                "  - guardrails ({name:?}): add a guardrail_attachments entry to put it in force"
+            );
+        }
+    }
     println!(
         "OK: {} loaded {} resource(s)",
         resources.display(),

--- a/tests/e2e/src/cases/export-roundtrip-e2e.test.ts
+++ b/tests/e2e/src/cases/export-roundtrip-e2e.test.ts
@@ -236,9 +236,10 @@ describe("aisix export: etcd → export → file round-trip", () => {
         kind: "openai_moderation",
         api_key: marker.guardrailApiKey,
       }, { attach: false });
-      // Attach it env-wide so it is already gateway-wide in etcd and the
-      // exporter emits it (exercising guardrail-credential redaction);
-      // an attachment-scoped guardrail would be omitted by design.
+      // Attach it env-wide explicitly (hence `attach: false` above — this
+      // test writes the attachment it means). The exporter emits the
+      // guardrail and this attachment, exercising guardrail-credential
+      // redaction on the round-trip.
       await seed.update("guardrail_attachments", randomUUID(), {
         guardrail_id: guardrail.id,
         scope_type: "env",

--- a/tests/e2e/src/cases/export-roundtrip-e2e.test.ts
+++ b/tests/e2e/src/cases/export-roundtrip-e2e.test.ts
@@ -235,7 +235,7 @@ describe("aisix export: etcd → export → file round-trip", () => {
         name: "noleak-guardrail",
         kind: "openai_moderation",
         api_key: marker.guardrailApiKey,
-      });
+      }, { attach: false });
       // Attach it env-wide so it is already gateway-wide in etcd and the
       // exporter emits it (exercising guardrail-credential redaction);
       // an attachment-scoped guardrail would be omitted by design.

--- a/tests/e2e/src/cases/file-resource-source-e2e.test.ts
+++ b/tests/e2e/src/cases/file-resource-source-e2e.test.ts
@@ -65,6 +65,24 @@ guardrails:
     patterns:
       - kind: literal
         value: file-mode-forbidden-phrase
+  - name: file-model-scoped
+    kind: keyword
+    patterns:
+      - kind: literal
+        value: file-mode-model-scoped-phrase
+  - name: file-unattached
+    kind: keyword
+    patterns:
+      - kind: literal
+        value: file-mode-unattached-phrase
+guardrail_attachments:
+  - guardrail_id: file-no-secrets
+    scope_type: env
+    priority: 100
+  - guardrail_id: file-model-scoped
+    scope_type: model
+    scope_id: file-allowed
+    priority: 100
 `;
 }
 
@@ -215,11 +233,11 @@ describe("file resource source: smoke + read-only admin surface", () => {
 
   test("file-defined guardrail fires on matching input", async () => {
     if (!app || !upstream) throw new Error("setup failed");
-    // The file format has no attachment collection, so file-defined
-    // guardrails apply env-globally. Pin that they actually fire — the
-    // runtime executes them through the zero-attachment fallback in the
-    // guardrail index, and this test is the regression trap for that
-    // dependency.
+    // A guardrail fires because an attachment says so — the file declares
+    // an env-scoped one alongside it, and the loader resolves the
+    // `guardrail_id` reference from the name to the derived id. There is no
+    // implicit scope any more (AISIX-Cloud#1450), so this pins both halves:
+    // the reference resolves, and the resolved attachment reaches the index.
     const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
     const hitsBefore = upstream.receivedRequests.length;
     const blocked = await proxy.chat({
@@ -236,6 +254,38 @@ describe("file resource source: smoke + read-only admin surface", () => {
       messages: [{ role: "user", content: "clean input" }],
     });
     expect(clean.status).toBe(200);
+  });
+
+  test("a model-scoped attachment resolves its target by name", async () => {
+    if (!app || !upstream) throw new Error("setup failed");
+    // `scope_id: file-allowed` names the model the way the models
+    // collection keys it; the loader rewrites both references to derived
+    // ids, and the request must resolve to the same id for the scope to
+    // match. Nothing else in the pipeline proves that mapping end to end.
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    const hitsBefore = upstream.receivedRequests.length;
+    const blocked = await proxy.chat({
+      model: "file-allowed",
+      messages: [{ role: "user", content: "contains file-mode-model-scoped-phrase here" }],
+    });
+    expect(blocked.status).toBe(422);
+    expect(upstream.receivedRequests.length).toBe(hitsBefore);
+  });
+
+  test("a guardrail with no attachment governs nothing", async () => {
+    if (!app || !upstream) throw new Error("setup failed");
+    // AISIX-Cloud#1450: a guardrail's scope is its attachments and nothing
+    // else. `file-unattached` is declared and loads cleanly — declaring it
+    // is not an error — but nothing attaches it, so its pattern must pass
+    // straight through to the upstream.
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    const hitsBefore = upstream.receivedRequests.length;
+    const allowed = await proxy.chat({
+      model: "file-allowed",
+      messages: [{ role: "user", content: "contains file-mode-unattached-phrase here" }],
+    });
+    expect(allowed.status).toBe(200);
+    expect(upstream.receivedRequests.length).toBe(hitsBefore + 1);
   });
 });
 

--- a/tests/e2e/src/cases/file-resource-source-e2e.test.ts
+++ b/tests/e2e/src/cases/file-resource-source-e2e.test.ts
@@ -55,10 +55,16 @@ models:
     provider: openai
     model_name: gpt-4o-mini
     provider_key: file-pk
+  # Reachable by the caller, and deliberately NOT the model the scoped
+  # guardrail names — the negative half of the scope assertion.
+  - display_name: file-unscoped
+    provider: openai
+    model_name: gpt-4o-mini
+    provider_key: file-pk
 api_keys:
   - display_name: file-caller
     key_env: ${CALLER_KEY_ENV}
-    allowed_models: ["file-allowed"]
+    allowed_models: ["file-allowed", "file-unscoped"]
 guardrails:
   - name: file-no-secrets
     kind: keyword
@@ -180,6 +186,7 @@ describe("file resource source: smoke + read-only admin surface", () => {
     expect(listed.map((e) => e.value.display_name).sort()).toEqual([
       "file-allowed",
       "file-forbidden",
+      "file-unscoped",
     ]);
 
     // The write endpoints were removed: the routes serve GET only, so
@@ -270,6 +277,17 @@ describe("file resource source: smoke + read-only admin surface", () => {
     });
     expect(blocked.status).toBe(422);
     expect(upstream.receivedRequests.length).toBe(hitsBefore);
+
+    // …and the other half: the same phrase on a model the attachment does
+    // NOT name passes. Blocking on the scoped model alone would also be
+    // satisfied by a guardrail that runs everywhere, which is exactly the
+    // behaviour this release removed.
+    const allowed = await proxy.chat({
+      model: "file-unscoped",
+      messages: [{ role: "user", content: "contains file-mode-model-scoped-phrase here" }],
+    });
+    expect(allowed.status).toBe(200);
+    expect(upstream.receivedRequests.length).toBe(hitsBefore + 1);
   });
 
   test("a guardrail with no attachment governs nothing", async () => {

--- a/tests/e2e/src/cases/file-resource-source-e2e.test.ts
+++ b/tests/e2e/src/cases/file-resource-source-e2e.test.ts
@@ -207,7 +207,7 @@ describe("file resource source: smoke + read-only admin surface", () => {
 
     // The refused write did not change the resource set.
     const relist = await fetch(`${app.adminUrl}/admin/v1/models`, { headers: auth });
-    expect(((await relist.json()) as unknown[]).length).toBe(2);
+    expect(((await relist.json()) as unknown[]).length).toBe(3);
 
     const delRes = await fetch(`${app.adminUrl}/admin/v1/models/any-id`, {
       method: "DELETE",

--- a/tests/e2e/src/cases/guardrail-custom-verdict-diagnostics-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-custom-verdict-diagnostics-e2e.test.ts
@@ -121,8 +121,8 @@ describe("custom guardrail e2e: a broken script is distinguishable from an enfor
     });
 
     // One model per script, each with its own guardrail attached by model
-    // scope — the scripts must not shadow each other, and an attachment row
-    // suppresses the implicit env-wide fallback.
+    // scope — the scripts must not shadow each other, and a model scope is
+    // the guardrail's only scope.
     for (const [model, script] of Object.entries(CASES)) {
       const m = await seed.createModel({
         display_name: model,

--- a/tests/e2e/src/cases/guardrail-custom-verdict-diagnostics-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-custom-verdict-diagnostics-e2e.test.ts
@@ -140,7 +140,7 @@ describe("custom guardrail e2e: a broken script is distinguishable from an enfor
         kind: "custom",
         script,
         timeout_ms: 5000,
-      });
+      }, { attach: false });
       await etcd.put(
         `${app.etcdPrefix}/guardrail_attachments/${randomUUID()}`,
         JSON.stringify({

--- a/tests/e2e/src/cases/guardrail-model-scope-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-model-scope-e2e.test.ts
@@ -20,10 +20,11 @@ import {
 // fired on a request to glm5.1 (an unselected model). The DP's
 // `GuardrailIndex::resolve` matches model scope by the virtual-model UUID,
 // so a correctly-loaded model attachment never matches an unscoped model.
-// The failure mode is the implicit-env fallback: if the model attachments
-// are NOT present in the DP snapshot (e.g. a pre-#630 image that dropped
-// watch-applied attachments), the guardrail has zero loaded attachments and
-// falls back to env-scope at priority 0 — running GLOBALLY on every model.
+// The failure mode this guards is a model attachment that never reaches the
+// DP snapshot (e.g. a pre-#630 image that dropped watch-applied
+// attachments): the guardrail then has zero loaded attachments and, since
+// AISIX-Cloud#1450 retired the implicit-env fallback, inspects NOTHING —
+// the rule is silently absent rather than silently global.
 //
 // This test creates the attachment via the same etcd watch path cp-api
 // uses (`/<prefix>/guardrail_attachments/<uuid>`), so it exercises the
@@ -90,9 +91,9 @@ describe("guardrail e2e: model-scope attachment runs only for the scoped model (
     // Attach the guardrail to the SCOPED model only. Wire shape mirrors
     // cp-api's `marshalGuardrailAttachmentKV` (P0c): snake_case fields,
     // `scope_id` = the virtual-model UUID returned by createModel, plus the
-    // `env_id` cp-api always includes (the DP ignores it). Having ANY
-    // attachment row suppresses the implicit-env fallback, so the only way
-    // the guardrail can apply is via a matching model scope.
+    // `env_id` cp-api always includes (the DP ignores it). This is the
+    // guardrail's only scope, so a matching model is the only way it can
+    // apply at all.
     await etcd!.put(
       `${app.etcdPrefix}/guardrail_attachments/${randomUUID()}`,
       JSON.stringify({

--- a/tests/e2e/src/cases/guardrail-model-scope-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-model-scope-e2e.test.ts
@@ -85,7 +85,7 @@ describe("guardrail e2e: model-scope attachment runs only for the scoped model (
       hook_point: "input",
       kind: "keyword",
       patterns: [{ kind: "literal", value: FORBIDDEN_WORD }],
-    });
+    }, { attach: false });
 
     // Attach the guardrail to the SCOPED model only. Wire shape mirrors
     // cp-api's `marshalGuardrailAttachmentKV` (P0c): snake_case fields,

--- a/tests/e2e/src/cases/guardrail-semantic-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-semantic-e2e.test.ts
@@ -299,7 +299,7 @@ describe("semantic guardrail kind e2e", () => {
     row: Record<string, unknown>,
   ): Promise<void> {
     if (!seed) throw new Error("seed not ready");
-    const guardrail = await seed.createGuardrail({ enabled: true, ...row });
+    const guardrail = await seed.createGuardrail({ enabled: true, ...row }, { attach: false });
     await seed.update("guardrail_attachments", randomUUID(), {
       guardrail_id: guardrail.id,
       scope_type: "model",

--- a/tests/e2e/src/cases/mcp-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-guardrail-e2e.test.ts
@@ -117,18 +117,18 @@ describe("mcp guardrails e2e: /mcp", () => {
       name: "mcp-alpha-only",
       kind: "keyword",
       patterns: [{ kind: "literal", value: ALPHA_ONLY_PATTERN }],
-    });
+    }, { attach: false });
     const everywhere = await seed.createGuardrail({
       name: "mcp-everywhere",
       kind: "keyword",
       patterns: [{ kind: "literal", value: EVERYWHERE_PATTERN }],
-    });
+    }, { attach: false });
     const structured = await seed.createGuardrail({
       name: "mcp-structured",
       kind: "keyword",
       hook_point: "output",
       patterns: [{ kind: "literal", value: STRUCTURED_PATTERN }],
-    });
+    }, { attach: false });
 
     await seed.update("guardrail_attachments", randomUUID(), {
       guardrail_id: alphaOnly.id,

--- a/tests/e2e/src/harness/seed.ts
+++ b/tests/e2e/src/harness/seed.ts
@@ -53,10 +53,40 @@ export class SeedClient {
     return this.put("observability_exporters", exporter);
   }
 
+  /**
+   * Seeds a guardrail and, unless `attach` is false, the env-scoped
+   * attachment that puts it in force.
+   *
+   * A guardrail's scope comes only from its attachments — an unattached
+   * one governs nothing (AISIX-Cloud#1450 retired the fallback that used
+   * to apply a zero-attachment guardrail to the whole environment, because
+   * keying on the ABSENCE of rows made removing a guardrail's last
+   * attachment WIDEN it). Attaching by default mirrors the console, which
+   * always writes an attachment alongside the guardrail; a test that
+   * manages its own scope passes `{ attach: false }` and writes the
+   * attachment it wants.
+   */
   async createGuardrail(
     guardrail: Record<string, unknown>,
+    opts: { attach?: boolean } = {},
   ): Promise<{ id: string; value: Record<string, unknown> }> {
-    return this.put("guardrails", guardrail);
+    const created = await this.put("guardrails", guardrail);
+    if (opts.attach !== false) {
+      await this.attachGuardrailToEnv(created.id);
+    }
+    return created;
+  }
+
+  /** Env-scope attachment: the guardrail applies to every request. */
+  async attachGuardrailToEnv(
+    guardrailID: string,
+    priority = 100,
+  ): Promise<{ id: string; value: Record<string, unknown> }> {
+    return this.put("guardrail_attachments", {
+      guardrail_id: guardrailID,
+      scope_type: "env",
+      priority,
+    });
   }
 
   async createCachePolicy(


### PR DESCRIPTION
`build_index_from_snapshot` applied a guardrail carrying **zero** attachment rows to the entire environment at priority 0 — a rolling-upgrade fallback from the window where this side read attachments and the control plane had not written any yet.

Keying on the *absence* of rows is what made it dangerous:

> guardrail scoped only to model `M` → delete `M` → its last attachment goes → the guardrail now inspects **every** request in the environment

Silently, on a security control, and in the ordinary case — saving a guardrail as model-scoped is exactly how the console expresses narrow scope, and doing so deletes its env attachment. A dangling attachment, by contrast, matches nothing and is inert. Reported as api7/AISIX-Cloud#1450.

## What changes

An unattached guardrail governs nothing. Declaring one is still **not** an error: its scope target may simply have been deleted, which is the very situation that produced the bug. This is a bugfix, not a compatibility event — a guardrail that only ever applied env-wide because nobody had scoped it was doing something no operator asked for.

**The resources file gains `guardrail_attachments`** — the collection it never had, and the reason a file-defined guardrail depended on the fallback in the first place. Same shape the control plane projects, with `guardrail_id` and `scope_id` written as the identity each collection is keyed by and rewritten to derived ids at load, exactly like `provider_key` and `scope_ref`:

```yaml
guardrails:
  - name: no-secrets
    kind: keyword
    patterns: [{ kind: literal, value: topsecret }]

guardrail_attachments:
  - guardrail_id: no-secrets     # the guardrail's name
    scope_type: model
    scope_id: gpt-4o             # the model's display_name
    priority: 100
```

The file's identity for an attachment is the `(guardrail_id, scope_type, scope_id)` triple — what the control plane makes unique — so attaching the same guardrail to the same target twice is a duplicate. `team` scope has no file collection to resolve against and passes through untouched.

**`aisix export` emits attachments** instead of dropping every guardrail that was not already env-scoped. That filter existed only because the file could not express scope; now the scope round-trips. An attachment the file cannot name — `team`, or a `scope_id` absent from the snapshot — is still dropped with a warning, because losing a scope makes a guardrail govern **less** while inventing one makes it govern **more**.

## Tests

The contract test that pinned the fallback is inverted: an unattached guardrail must not enter the index and must not block however well its pattern matches.

Everything that reached the index *through* the fallback now writes the env attachment it meant. The proxy suites go through one `seed_env_scoped_guardrail` helper rather than inserting into `snap.guardrails` directly, so the next test cannot silently depend on an implicit scope again. The index's tie-break test was rewritten around explicit attachments — the ordering rule there is attachment id, not guardrail `created_at`, which is the chain path's rule and a different mechanism.

New file-source unit tests cover reference resolution, an unknown-guardrail reference, a duplicate triple, and an unattached guardrail loading without complaint. The file-source e2e pins all three runtime outcomes: an env attachment fires, a model-scoped one resolves its target by name, and an unattached guardrail passes traffic through.

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` are green locally.

## Control-plane half

Once this ships, the `deleteModel` / `deleteAPIKey` / team-delete attachment sweeps that AISIX-Cloud#1449 pulled back become safe and can land — that is the other half of api7/AISIX-Cloud#1450 and follows in its own CP PR against the new image.

Fixes api7/AISIX-Cloud#1450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guardrails can be explicitly attached to environments, models, MCP servers, API keys, and passthrough routes.
  * Attachment priorities control guardrail evaluation order.
  * Exports retain guardrails and their attachment relationships.

* **Behavior Changes**
  * Unattached guardrails no longer apply globally or block requests.
  * Validation reports enabled guardrails without attachments.
  * Invalid or unsupported attachment targets are omitted from exports with warnings.

* **Bug Fixes**
  * Improved attachment resolution, validation, and round-trip consistency for file-based configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
