### PR TITLE
fix(guardrails): sweep for inert guardrails on a timer, not on a config write

### DIFF
--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1096,30 +1096,130 @@ pub fn unattached_guardrail_names(
         .collect()
 }
 
+/// How long a guardrail must have been present-and-unattached before the
+/// notice is due.
+///
+/// A guardrail and its attachment are separate documents in separate outbox
+/// rows, so every ordinary creation has a build where the data plane holds
+/// the guardrail and not yet its attachment. Reporting there named
+/// correctly-attached guardrails as inspecting nothing — permanently, since
+/// the notice is deduplicated per id for the process lifetime.
+///
+/// The grace is measured in TIME, not in builds. A build is not a unit of
+/// duration: the index is rebuilt on every snapshot version change AND
+/// concurrently by every request that arrives during one rebuild, so two or
+/// more builds fit between the two writes — sometimes within a single
+/// version. Any "seen in the previous build" rule is therefore satisfied
+/// while the attachment is still in flight. Thirty seconds is two orders of
+/// magnitude above the gap the control plane leaves (it drains both rows
+/// from one outbox batch) and short enough to name a genuinely inert rule
+/// early in a deployment.
+const UNATTACHED_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Which enabled-but-unattached guardrails this build should report, given
-/// what the previous build saw and what has already been said.
+/// when each guardrail id was first SEEN — attached or not — and what has
+/// already been said.
 ///
-/// Pure, so the two-sighting rule is testable without a tracing subscriber —
-/// the shape the retired `implicit_env_scope_first_seen` helper had, and for
-/// the same reason.
+/// Timing from first sight rather than from first sight *unattached* is what
+/// separates the two states that look identical in one snapshot: a guardrail
+/// whose attachment has not arrived yet, and one whose attachment is gone.
+/// The first is new, so its clock has barely started; the second has been
+/// around, so it is due immediately. Timing from "first seen unattached"
+/// collapses them and makes a deleted attachment wait for a second build —
+/// which, since builds only happen on config changes, means waiting for an
+/// unrelated write that may never come.
 ///
-/// A row must have been unattached in the PREVIOUS build too. A guardrail and
-/// its attachment are separate documents in separate outbox rows, so every
-/// ordinary creation has a build where the data plane holds the guardrail and
-/// not yet its attachment; reporting on that first sighting fired on
-/// correctly-attached guardrails. Because the notice is deduplicated per id
-/// for the life of the process, that false alarm was permanent — a log line
-/// saying a security control inspects nothing, about one that does.
+/// Pure, and takes `now`, so the grace is testable without sleeping and
+/// without a tracing subscriber — the shape the retired
+/// `implicit_env_scope_first_seen` helper had, and for the same reason.
 fn unattached_to_report(
     unattached: &[(String, String)],
-    seen_before: &std::collections::HashSet<String>,
+    present_since: &std::collections::HashMap<String, std::time::Instant>,
     warned: &std::collections::HashSet<String>,
+    now: std::time::Instant,
 ) -> Vec<(String, String)> {
     unattached
         .iter()
-        .filter(|(id, _)| seen_before.contains(id) && !warned.contains(id))
+        .filter(|(id, _)| {
+            !warned.contains(id)
+                && present_since
+                    .get(id)
+                    .is_some_and(|t| now.saturating_duration_since(*t) >= UNATTACHED_GRACE)
+        })
         .cloned()
         .collect()
+}
+
+/// (already reported, first build each enabled guardrail id was seen in)
+type UnattachedState = (
+    std::collections::HashSet<String>,
+    std::collections::HashMap<String, std::time::Instant>,
+);
+
+/// Shared by the build-time notice and the startup report so a row named at
+/// boot is not named again by the first rebuild.
+static UNATTACHED_STATE: std::sync::OnceLock<std::sync::Mutex<UnattachedState>> =
+    std::sync::OnceLock::new();
+
+/// Cap on both halves of the state. Beyond it the notice degrades to
+/// silence rather than to repetition — the right direction for a log line.
+const MAX_REMEMBERED: usize = 4096;
+
+fn unattached_state() -> std::sync::MutexGuard<'static, UnattachedState> {
+    // Poison-tolerant: this state only shapes log lines, so a panic while the
+    // lock was held must not wedge every later index build.
+    UNATTACHED_STATE
+        .get_or_init(|| {
+            std::sync::Mutex::new((
+                std::collections::HashSet::new(),
+                std::collections::HashMap::new(),
+            ))
+        })
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn emit_unattached_notice(id: &str, name: &str) {
+    tracing::warn!(
+        guardrail_id = %id,
+        guardrail_name = %name,
+        "guardrail is enabled but has no attachment, so it inspects no traffic; \
+         attach it to an environment, model, MCP server, API key, team or \
+         passthrough route to put it in force",
+    );
+}
+
+/// Report the guardrails that are inert in the snapshot a process STARTED
+/// with, once the first full load has landed.
+///
+/// The build-time notice below cannot cover this. It fires from an index
+/// build, builds happen only when the snapshot version moves, and standing
+/// configuration moves nothing — so on a deployment nobody is editing, a
+/// restart would go quiet about rules that inspect no traffic until some
+/// unrelated write happened to trigger a rebuild.
+///
+/// No grace applies here, and none is needed: a boot snapshot is assembled
+/// in one pass (`apply_resync` builds it from every entry at once, and the
+/// file loader does the same), so nothing is in flight and there is no race
+/// to wait out. Ids named here are recorded as said, so the first rebuild
+/// does not repeat them.
+pub fn report_unattached_guardrails_at_startup(
+    guardrails: &ResourceTable<DomainGuardrail>,
+    attachments: &ResourceTable<GuardrailAttachment>,
+) {
+    let mut guard = unattached_state();
+    let (warned, present_since) = &mut *guard;
+    let now = std::time::Instant::now();
+    for (id, name) in unattached_ids(guardrails, attachments) {
+        if warned.contains(&id) {
+            continue;
+        }
+        emit_unattached_notice(&id, &name);
+        if warned.len() < MAX_REMEMBERED {
+            warned.insert(id.clone());
+        }
+        present_since.insert(id, now);
+    }
 }
 
 /// WARN once per guardrail id for the process lifetime: this row is enabled
@@ -1137,42 +1237,45 @@ fn warn_unattached_guardrails(
     guardrails: &ResourceTable<DomainGuardrail>,
     attachments: &ResourceTable<GuardrailAttachment>,
 ) {
-    use std::collections::HashSet;
-    use std::sync::{Mutex, OnceLock};
+    use std::collections::HashMap;
+    use std::time::Instant;
 
-    const MAX_REMEMBERED: usize = 1024;
-    // (already reported, seen unattached in the previous build)
-    static STATE: OnceLock<Mutex<(HashSet<String>, HashSet<String>)>> = OnceLock::new();
+    let mut guard = unattached_state();
+    let (warned, present_since) = &mut *guard;
 
-    // Poison-tolerant: this state only shapes log lines, so a panic while the
-    // lock was held must not wedge every later index build.
-    let mut guard = STATE
-        .get_or_init(|| Mutex::new((HashSet::new(), HashSet::new())))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let (warned, seen_before) = &mut *guard;
-
+    let now = Instant::now();
     let unattached = unattached_ids(guardrails, attachments);
-    for (id, name) in unattached_to_report(&unattached, seen_before, warned) {
-        tracing::warn!(
-            guardrail_id = %id,
-            guardrail_name = %name,
-            "guardrail is enabled but has no attachment, so it inspects no traffic; \
-             attach it to an environment, model, MCP server, API key, team or \
-             passthrough route to put it in force",
-        );
+
+    // Every enabled guardrail, not just the unattached ones: the timestamp
+    // is "when this row appeared", which is what tells a new guardrail
+    // (attachment still in flight) apart from an old one that just lost its
+    // attachment. Sorted, so the cap truncates the same ids every build
+    // rather than making rows drift in and out and restart their clocks.
+    let mut enabled: Vec<String> = guardrails
+        .entries()
+        .into_iter()
+        .filter(|e| e.value.enabled)
+        .map(|e| e.id.clone())
+        .collect();
+    enabled.sort();
+    let next: HashMap<String, Instant> = enabled
+        .into_iter()
+        .take(MAX_REMEMBERED)
+        .map(|id| {
+            let since = present_since.get(&id).copied().unwrap_or(now);
+            (id, since)
+        })
+        .collect();
+
+    for (id, name) in unattached_to_report(&unattached, &next, warned, now) {
+        emit_unattached_notice(&id, &name);
         if warned.len() < MAX_REMEMBERED {
             warned.insert(id);
         }
     }
-    // Replaced, not merged: a guardrail that GAINED an attachment has to drop
-    // out, or a later loss would report on its first build and reopen the race
-    // this closes.
-    *seen_before = unattached
-        .into_iter()
-        .map(|(id, _)| id)
-        .take(MAX_REMEMBERED)
-        .collect();
+    // Rebuilt rather than merged, so a guardrail that left the snapshot
+    // drops out and one that comes back starts a fresh clock.
+    *present_since = next;
 }
 
 // ---------------------------------------------------------------------------
@@ -2217,36 +2320,104 @@ mod tests {
         );
     }
 
-    /// A guardrail and its attachment arrive as separate documents, so every
-    /// ordinary creation has a build where the guardrail is present and the
-    /// attachment is not. Reporting on that first sighting named a
+    /// A guardrail and its attachment arrive as separate documents, so a build
+    /// falling between them holds the guardrail alone. Reporting there named a
     /// correctly-attached guardrail as inspecting nothing — permanently, since
     /// the notice is deduplicated per id for the process lifetime.
     #[test]
-    fn the_unattached_notice_needs_two_consecutive_sightings() {
-        use std::collections::HashSet;
+    fn the_unattached_notice_waits_out_the_grace() {
+        use std::collections::{HashMap, HashSet};
+        use std::time::{Duration, Instant};
+
         let rows = vec![("g-1".to_string(), "one".to_string())];
-        let mut seen_before: HashSet<String> = HashSet::new();
+        let t0 = Instant::now();
+        let mut first_seen: HashMap<String, Instant> = HashMap::new();
         let mut warned: HashSet<String> = HashSet::new();
 
         assert!(
-            unattached_to_report(&rows, &seen_before, &warned).is_empty(),
-            "the first build a guardrail appears in is its attachment's window",
+            unattached_to_report(&rows, &first_seen, &warned, t0).is_empty(),
+            "an id with no recorded first sighting is inside its attachment's window",
         );
-        seen_before.insert("g-1".to_string());
+        first_seen.insert("g-1".to_string(), t0);
 
-        let due = unattached_to_report(&rows, &seen_before, &warned);
+        assert!(
+            unattached_to_report(&rows, &first_seen, &warned, t0 + UNATTACHED_GRACE / 2).is_empty(),
+            "half a grace in is still the window, however many builds have run",
+        );
+
+        let due = unattached_to_report(&rows, &first_seen, &warned, t0 + UNATTACHED_GRACE);
         assert_eq!(
             due.len(),
             1,
-            "still unattached one build later is a standing property, not a race",
+            "unattached for the whole grace is a standing property, not a race",
         );
         warned.insert("g-1".to_string());
 
         assert!(
-            unattached_to_report(&rows, &seen_before, &warned).is_empty(),
-            "and it is said once, not on every rebuild",
+            unattached_to_report(
+                &rows,
+                &first_seen,
+                &warned,
+                t0 + UNATTACHED_GRACE + Duration::from_secs(600),
+            )
+            .is_empty(),
+            "and it is said once, not on every rebuild after",
         );
+    }
+
+    /// A guardrail that has been around and just lost its attachment is due
+    /// at once. This is the one case the notice exists for — a scope target
+    /// was deleted and the rule is now inert — and timing from "first seen
+    /// UNATTACHED" instead of "first seen" would make it wait for a second
+    /// build, i.e. for an unrelated config write that may never come.
+    #[test]
+    fn losing_an_attachment_is_reported_on_the_next_build() {
+        use std::collections::{HashMap, HashSet};
+        use std::time::Instant;
+
+        let rows = vec![("g-1".to_string(), "one".to_string())];
+        let created = Instant::now();
+        let mut present_since: HashMap<String, Instant> = HashMap::new();
+        // Present, and attached, since well before the grace.
+        present_since.insert("g-1".to_string(), created);
+        let warned: HashSet<String> = HashSet::new();
+
+        let due = unattached_to_report(
+            &rows,
+            &present_since,
+            &warned,
+            created + UNATTACHED_GRACE * 2,
+        );
+        assert_eq!(
+            due.len(),
+            1,
+            "a row that has outlived the grace is due the build its attachment goes",
+        );
+    }
+
+    /// The clock has to be measured in time, not in builds. Two builds fit
+    /// between a guardrail and its attachment whenever anything else is being
+    /// written, so a consecutive-build rule reports a correctly-attached
+    /// guardrail under ordinary config churn — the very bug it was meant to
+    /// close, just harder to reproduce.
+    #[test]
+    fn many_builds_inside_the_grace_still_report_nothing() {
+        use std::collections::{HashMap, HashSet};
+        use std::time::Instant;
+
+        let rows = vec![("g-1".to_string(), "one".to_string())];
+        let t0 = Instant::now();
+        let mut first_seen: HashMap<String, Instant> = HashMap::new();
+        first_seen.insert("g-1".to_string(), t0);
+        let warned: HashSet<String> = HashSet::new();
+
+        for i in 1..=50 {
+            let now = t0 + (UNATTACHED_GRACE / 100) * i;
+            assert!(
+                unattached_to_report(&rows, &first_seen, &warned, now).is_empty(),
+                "build {i} is inside the grace and must stay quiet",
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1096,19 +1096,43 @@ pub fn unattached_guardrail_names(
         .collect()
 }
 
+/// Which enabled-but-unattached guardrails this build should report, given
+/// what the previous build saw and what has already been said.
+///
+/// Pure, so the two-sighting rule is testable without a tracing subscriber —
+/// the shape the retired `implicit_env_scope_first_seen` helper had, and for
+/// the same reason.
+///
+/// A row must have been unattached in the PREVIOUS build too. A guardrail and
+/// its attachment are separate documents in separate outbox rows, so every
+/// ordinary creation has a build where the data plane holds the guardrail and
+/// not yet its attachment; reporting on that first sighting fired on
+/// correctly-attached guardrails. Because the notice is deduplicated per id
+/// for the life of the process, that false alarm was permanent — a log line
+/// saying a security control inspects nothing, about one that does.
+fn unattached_to_report(
+    unattached: &[(String, String)],
+    seen_before: &std::collections::HashSet<String>,
+    warned: &std::collections::HashSet<String>,
+) -> Vec<(String, String)> {
+    unattached
+        .iter()
+        .filter(|(id, _)| seen_before.contains(id) && !warned.contains(id))
+        .cloned()
+        .collect()
+}
+
 /// WARN once per guardrail id for the process lifetime: this row is enabled
 /// but nothing attaches it, so it inspects no traffic at all.
 ///
-/// The state is legitimate — a scope target can be deleted, and a rule with
-/// no scope left is correctly inert — but it is also indistinguishable from a
-/// misconfiguration, and it is INVISIBLE otherwise: the guardrail is present
-/// in the snapshot, `/status/config` counts it as loaded, and no request ever
-/// mentions it. An operator who believes a rule is in force deserves to be
-/// told it is not.
+/// The state is legitimate — a scope target can be deleted, and a rule with no
+/// scope left is correctly inert — but it is invisible otherwise: the guardrail
+/// is in the snapshot, `/status/config` counts it as loaded, and no request
+/// ever mentions it.
 ///
-/// Deduped per id, not logged per build, for the reason AISIX-Cloud#1435
-/// documents: the index is rebuilt on every snapshot version change, and this
-/// describes a STANDING property of a row rather than an event.
+/// Deduped per id rather than logged per build, for the reason
+/// AISIX-Cloud#1435 documents: the index is rebuilt on every snapshot version
+/// change, and this describes a STANDING property of a row, not an event.
 fn warn_unattached_guardrails(
     guardrails: &ResourceTable<DomainGuardrail>,
     attachments: &ResourceTable<GuardrailAttachment>,
@@ -1117,18 +1141,19 @@ fn warn_unattached_guardrails(
     use std::sync::{Mutex, OnceLock};
 
     const MAX_REMEMBERED: usize = 1024;
-    static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
-    // Poison-tolerant: this set only dedupes log lines, so a panic while the
+    // (already reported, seen unattached in the previous build)
+    static STATE: OnceLock<Mutex<(HashSet<String>, HashSet<String>)>> = OnceLock::new();
+
+    // Poison-tolerant: this state only shapes log lines, so a panic while the
     // lock was held must not wedge every later index build.
-    let mut warned = WARNED
-        .get_or_init(|| Mutex::new(HashSet::new()))
+    let mut guard = STATE
+        .get_or_init(|| Mutex::new((HashSet::new(), HashSet::new())))
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let (warned, seen_before) = &mut *guard;
 
-    for (id, name) in unattached_ids(guardrails, attachments) {
-        if warned.contains(&id) {
-            continue;
-        }
+    let unattached = unattached_ids(guardrails, attachments);
+    for (id, name) in unattached_to_report(&unattached, seen_before, warned) {
         tracing::warn!(
             guardrail_id = %id,
             guardrail_name = %name,
@@ -1140,6 +1165,14 @@ fn warn_unattached_guardrails(
             warned.insert(id);
         }
     }
+    // Replaced, not merged: a guardrail that GAINED an attachment has to drop
+    // out, or a later loss would report on its first build and reopen the race
+    // this closes.
+    *seen_before = unattached
+        .into_iter()
+        .map(|(id, _)| id)
+        .take(MAX_REMEMBERED)
+        .collect();
 }
 
 // ---------------------------------------------------------------------------
@@ -2181,6 +2214,38 @@ mod tests {
                 .await
                 .is_block(),
             "env-scope enabled attachment must still fire",
+        );
+    }
+
+    /// A guardrail and its attachment arrive as separate documents, so every
+    /// ordinary creation has a build where the guardrail is present and the
+    /// attachment is not. Reporting on that first sighting named a
+    /// correctly-attached guardrail as inspecting nothing — permanently, since
+    /// the notice is deduplicated per id for the process lifetime.
+    #[test]
+    fn the_unattached_notice_needs_two_consecutive_sightings() {
+        use std::collections::HashSet;
+        let rows = vec![("g-1".to_string(), "one".to_string())];
+        let mut seen_before: HashSet<String> = HashSet::new();
+        let mut warned: HashSet<String> = HashSet::new();
+
+        assert!(
+            unattached_to_report(&rows, &seen_before, &warned).is_empty(),
+            "the first build a guardrail appears in is its attachment's window",
+        );
+        seen_before.insert("g-1".to_string());
+
+        let due = unattached_to_report(&rows, &seen_before, &warned);
+        assert_eq!(
+            due.len(),
+            1,
+            "still unattached one build later is a standing property, not a race",
+        );
+        warned.insert("g-1".to_string());
+
+        assert!(
+            unattached_to_report(&rows, &seen_before, &warned).is_empty(),
+            "and it is said once, not on every rebuild",
         );
     }
 

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1109,9 +1109,10 @@ pub fn unattached_guardrail_names(
 /// concurrently by every request that arrives during one rebuild, so two or
 /// more builds fit between the two writes — sometimes within a single
 /// version. Any "seen in the previous build" rule is therefore satisfied
-/// while the attachment is still in flight. Thirty seconds is two orders of
-/// magnitude above the gap the control plane leaves (it drains both rows
-/// from one outbox batch) and short enough to name a genuinely inert rule
+/// while the attachment is still in flight. Thirty seconds is far above the
+/// gap the control plane leaves — the two documents come from two separate
+/// API calls a client round trip apart, each with an outbox tick behind it,
+/// NOT from one batch — and short enough to name a genuinely inert rule
 /// early in a deployment.
 const UNATTACHED_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
 

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -2430,6 +2430,65 @@ mod tests {
             present_since <= MAX_REMEMBERED,
             "stamps grew to {present_since}"
         );
+
+        // …and past the cap it goes SILENT, rather than emitting rows it
+        // cannot remember. Stopping and skipping-the-insert both keep the
+        // set at the cap, so the size assertion above cannot tell them
+        // apart — and the second one re-emits the same rows on every sweep
+        // for the life of the process, which is the louder failure.
+        crate::keep_callsites_enabled();
+        let _capture_guard = crate::TRACING_CAPTURE_LOCK.blocking_lock();
+        let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .with_writer(CaptureWriter(buf.clone()))
+            .finish();
+        {
+            let _guard = tracing::subscriber::set_default(subscriber);
+            let overflow: ResourceTable<DomainGuardrail> = ResourceTable::default();
+            overflow.insert(entry(
+                "secrets",
+                "g-past-the-cap",
+                parse(
+                    r#"{
+                        "name": "past-the-cap",
+                        "kind": "keyword",
+                        "patterns": [{ "kind": "literal", "value": "AKIA" }]
+                    }"#,
+                ),
+            ));
+            sweep_unattached_guardrails(&overflow, &attachments);
+            backdate_unattached_stamps_for_test();
+            sweep_unattached_guardrails(&overflow, &attachments);
+        }
+        let logged = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(
+            !logged.contains("past-the-cap"),
+            "reported a row it could not remember; it will say the same thing \
+             again on every sweep from now on:\n{logged}",
+        );
+    }
+
+    /// Minimal `MakeWriter` for the capture above; the crate's other
+    /// capture helper is async and this test is not.
+    #[derive(Clone)]
+    struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
     }
 
     /// The grace's VALUE, not just its arithmetic. Every other test here
@@ -2442,10 +2501,12 @@ mod tests {
     /// sweep is the only thing that can observe a row, so a grace shorter
     /// than two sweep periods can be satisfied by the first two sweeps
     /// after a guardrail appears — which is where its attachment still is.
-    /// And the absolute floor is about the writer, not the reader: the
-    /// control plane drains a guardrail and its attachment from one outbox
-    /// batch, so the grace has to outlast a slow drain of that batch by a
-    /// wide margin.
+    /// And the absolute floor is about the writer, not the reader. The
+    /// guardrail and its attachment are not one write: the console creates
+    /// the guardrail, then reconciles its attachments in a second API call,
+    /// so the gap is a client round trip plus the outbox tick behind each —
+    /// and the grace has to outlast that by a wide margin on a loaded
+    /// control plane, not merely beat its median.
     #[test]
     fn the_grace_outlasts_two_sweeps_and_a_slow_two_document_write() {
         assert!(

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1054,7 +1054,6 @@ pub fn build_index_from_snapshot(
         ));
     }
 
-    warn_unattached_guardrails(guardrails, attachments);
     GuardrailIndex::from_entries(entries)
 }
 
@@ -1115,6 +1114,11 @@ pub fn unattached_guardrail_names(
 /// from one outbox batch) and short enough to name a genuinely inert rule
 /// early in a deployment.
 const UNATTACHED_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// How often `sweep_unattached_guardrails` should be called. Exported so the
+/// interval and the grace stay legible together: a row is named between one
+/// and two sweeps after the grace expires.
+pub const UNATTACHED_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Which enabled-but-unattached guardrails this build should report, given
 /// when each guardrail id was first SEEN — attached or not — and what has
@@ -1189,68 +1193,22 @@ fn emit_unattached_notice(id: &str, name: &str) {
     );
 }
 
-/// Report the guardrails that are inert in the snapshot a process STARTED
-/// with, once the first full load has landed.
+/// The presence timestamps for the next sweep: every enabled guardrail id,
+/// keeping the timestamp an id already had.
 ///
-/// The build-time notice below cannot cover this. It fires from an index
-/// build, builds happen only when the snapshot version moves, and standing
-/// configuration moves nothing — so on a deployment nobody is editing, a
-/// restart would go quiet about rules that inspect no traffic until some
-/// unrelated write happened to trigger a rebuild.
+/// Attached rows are timestamped too, and that is the whole point — the
+/// stamp says "when this row appeared", which is what tells a guardrail
+/// whose attachment has not arrived yet from one whose attachment is gone.
+/// Stamping only the unattached ones collapses the two and makes a deleted
+/// attachment serve out a fresh grace, as if the rule were new.
 ///
-/// No grace applies here, and none is needed: a boot snapshot is assembled
-/// in one pass (`apply_resync` builds it from every entry at once, and the
-/// file loader does the same), so nothing is in flight and there is no race
-/// to wait out. Ids named here are recorded as said, so the first rebuild
-/// does not repeat them.
-pub fn report_unattached_guardrails_at_startup(
+/// Sorted before the cap so truncation keeps the same ids each sweep,
+/// rather than letting rows drift in and out and restart their clocks.
+fn presence_timestamps(
     guardrails: &ResourceTable<DomainGuardrail>,
-    attachments: &ResourceTable<GuardrailAttachment>,
-) {
-    let mut guard = unattached_state();
-    let (warned, present_since) = &mut *guard;
-    let now = std::time::Instant::now();
-    for (id, name) in unattached_ids(guardrails, attachments) {
-        if warned.contains(&id) {
-            continue;
-        }
-        emit_unattached_notice(&id, &name);
-        if warned.len() < MAX_REMEMBERED {
-            warned.insert(id.clone());
-        }
-        present_since.insert(id, now);
-    }
-}
-
-/// WARN once per guardrail id for the process lifetime: this row is enabled
-/// but nothing attaches it, so it inspects no traffic at all.
-///
-/// The state is legitimate — a scope target can be deleted, and a rule with no
-/// scope left is correctly inert — but it is invisible otherwise: the guardrail
-/// is in the snapshot, `/status/config` counts it as loaded, and no request
-/// ever mentions it.
-///
-/// Deduped per id rather than logged per build, for the reason
-/// AISIX-Cloud#1435 documents: the index is rebuilt on every snapshot version
-/// change, and this describes a STANDING property of a row, not an event.
-fn warn_unattached_guardrails(
-    guardrails: &ResourceTable<DomainGuardrail>,
-    attachments: &ResourceTable<GuardrailAttachment>,
-) {
-    use std::collections::HashMap;
-    use std::time::Instant;
-
-    let mut guard = unattached_state();
-    let (warned, present_since) = &mut *guard;
-
-    let now = Instant::now();
-    let unattached = unattached_ids(guardrails, attachments);
-
-    // Every enabled guardrail, not just the unattached ones: the timestamp
-    // is "when this row appeared", which is what tells a new guardrail
-    // (attachment still in flight) apart from an old one that just lost its
-    // attachment. Sorted, so the cap truncates the same ids every build
-    // rather than making rows drift in and out and restart their clocks.
+    previous: &std::collections::HashMap<String, std::time::Instant>,
+    now: std::time::Instant,
+) -> std::collections::HashMap<String, std::time::Instant> {
     let mut enabled: Vec<String> = guardrails
         .entries()
         .into_iter()
@@ -1258,20 +1216,55 @@ fn warn_unattached_guardrails(
         .map(|e| e.id.clone())
         .collect();
     enabled.sort();
-    let next: HashMap<String, Instant> = enabled
+    enabled
         .into_iter()
         .take(MAX_REMEMBERED)
         .map(|id| {
-            let since = present_since.get(&id).copied().unwrap_or(now);
+            let since = previous.get(&id).copied().unwrap_or(now);
             (id, since)
         })
-        .collect();
+        .collect()
+}
+
+/// Name the enabled guardrails that have been attached to nothing for longer
+/// than the grace. Called on a timer; see `UNATTACHED_GRACE`.
+///
+/// A TIMER, and not the index build it used to ride on, because the thing
+/// being reported does not coincide with a configuration change. A build
+/// happens only when the snapshot version moves, so a notice emitted from
+/// one can only ever be delivered by somebody writing something — and the
+/// two cases that matter most are exactly the ones where nobody does:
+///
+///   - a scope target is deleted, its attachment goes with it, and the rule
+///     that was screening traffic yesterday is now inert. The delete itself
+///     is one version change, and if the row is younger than the grace at
+///     that moment the notice is not yet due; the next build may be days
+///     away, or never.
+///   - a gateway restarts onto standing configuration. Nothing has changed,
+///     so nothing rebuilds, so nothing is said.
+///
+/// Riding the build also put the emit on the request path, where
+/// `LiveGuardrailIndex::current()` builds outside the lock and every request
+/// arriving during one rebuild runs its own — which is how the original
+/// "seen in two consecutive builds" rule managed to see two builds inside a
+/// single snapshot version.
+pub fn sweep_unattached_guardrails(
+    guardrails: &ResourceTable<DomainGuardrail>,
+    attachments: &ResourceTable<GuardrailAttachment>,
+) {
+    let mut guard = unattached_state();
+    let (warned, present_since) = &mut *guard;
+
+    let now = std::time::Instant::now();
+    let unattached = unattached_ids(guardrails, attachments);
+    let next = presence_timestamps(guardrails, present_since, now);
 
     for (id, name) in unattached_to_report(&unattached, &next, warned, now) {
         emit_unattached_notice(&id, &name);
-        if warned.len() < MAX_REMEMBERED {
-            warned.insert(id);
-        }
+        // Unconditional: `next` is already capped, so `warned` cannot grow
+        // past it. Skipping the insert once full would make the notice
+        // repeat on every sweep instead of degrading to silence.
+        warned.insert(id);
     }
     // Rebuilt rather than merged, so a guardrail that left the snapshot
     // drops out and one that comes back starts a fresh clock.
@@ -2362,6 +2355,75 @@ mod tests {
             )
             .is_empty(),
             "and it is said once, not on every rebuild after",
+        );
+    }
+
+    /// The clock is kept for ATTACHED guardrails too. That is the whole of
+    /// what makes a deleted attachment reportable: without it the row is
+    /// "first seen" on the build its attachment goes, serves out a fresh
+    /// grace as if it were new, and — since a sweep only reports what has
+    /// outlived the grace — the moment that mattered is gone.
+    ///
+    /// Pinned here rather than only through the sweep, because stamping the
+    /// unattached rows alone leaves every other test in this file green.
+    #[test]
+    fn presence_is_timestamped_for_attached_rows_too() {
+        use std::collections::HashMap;
+        use std::time::Instant;
+
+        let guardrails: ResourceTable<DomainGuardrail> = ResourceTable::default();
+        guardrails.insert(entry(
+            "secrets",
+            "g-attached",
+            parse(
+                r#"{
+                    "name": "block-secrets",
+                    "kind": "keyword",
+                    "patterns": [{ "kind": "literal", "value": "AKIA" }]
+                }"#,
+            ),
+        ));
+        let attachments: ResourceTable<GuardrailAttachment> = ResourceTable::default();
+        attachments.insert(attachment_entry(
+            "a-1",
+            parse_attachment(
+                r#"{ "guardrail_id": "g-attached", "scope_type": "env", "priority": 100 }"#,
+            ),
+        ));
+        assert!(
+            unattached_ids(&guardrails, &attachments).is_empty(),
+            "fixture must be attached, or this test proves nothing",
+        );
+
+        let t0 = Instant::now();
+        let stamped = presence_timestamps(&guardrails, &HashMap::new(), t0);
+        assert_eq!(
+            stamped.get("g-attached"),
+            Some(&t0),
+            "an attached guardrail must carry a timestamp; without it, losing its \
+             attachment later reads as a brand-new row",
+        );
+
+        // …and the stamp survives, so age accumulates while it is attached.
+        let later = t0 + UNATTACHED_GRACE * 3;
+        let carried = presence_timestamps(&guardrails, &stamped, later);
+        assert_eq!(
+            carried.get("g-attached"),
+            Some(&t0),
+            "the clock must not restart on every sweep",
+        );
+
+        // Which is what makes the attachment's removal reportable at once.
+        let orphaned = vec![("g-attached".to_string(), "block-secrets".to_string())];
+        assert_eq!(
+            unattached_to_report(
+                &orphaned,
+                &carried,
+                &std::collections::HashSet::new(),
+                later,
+            )
+            .len(),
+            1,
         );
     }
 

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1183,6 +1183,28 @@ fn unattached_state() -> std::sync::MutexGuard<'static, UnattachedState> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Test-only view of the sweep's process-global state. The cap it exists to
+/// check is on the CUMULATIVE set, so nothing short of driving real sweeps
+/// across several generations of ids can see it.
+#[cfg(test)]
+fn unattached_state_for_test() -> (usize, usize) {
+    let guard = unattached_state();
+    (guard.0.len(), guard.1.len())
+}
+
+/// Test-only: backdate the presence stamps so a sweep sees rows that have
+/// already outlived the grace, instead of the test sleeping through it.
+#[cfg(test)]
+fn backdate_unattached_stamps_for_test() {
+    let mut guard = unattached_state();
+    let aged = std::time::Instant::now()
+        .checked_sub(UNATTACHED_GRACE * 2)
+        .expect("test clock is past the grace");
+    for stamp in guard.1.values_mut() {
+        *stamp = aged;
+    }
+}
+
 fn emit_unattached_notice(id: &str, name: &str) {
     tracing::warn!(
         guardrail_id = %id,
@@ -1260,10 +1282,17 @@ pub fn sweep_unattached_guardrails(
     let next = presence_timestamps(guardrails, present_since, now);
 
     for (id, name) in unattached_to_report(&unattached, &next, warned, now) {
+        // Stop rather than emit-without-remembering. `next` caps what ONE
+        // sweep can stamp, but `warned` is the union across every sweep, so
+        // it grows with each generation of ids and nothing bounds it —
+        // ~4096 rows reported, deleted, replaced, reported again. Skipping
+        // only the insert would keep emitting and re-emit the same row on
+        // every sweep from then on, which is a log flood rather than the
+        // silence this cap promises.
+        if warned.len() >= MAX_REMEMBERED {
+            break;
+        }
         emit_unattached_notice(&id, &name);
-        // Unconditional: `next` is already capped, so `warned` cannot grow
-        // past it. Skipping the insert once full would make the notice
-        // repeat on every sweep instead of degrading to silence.
         warned.insert(id);
     }
     // Rebuilt rather than merged, so a guardrail that left the snapshot
@@ -2355,6 +2384,78 @@ mod tests {
             )
             .is_empty(),
             "and it is said once, not on every rebuild after",
+        );
+    }
+
+    /// `warned` is the union across every sweep, not a per-sweep set, so
+    /// the cap on what one sweep can stamp does not bound it. Rows get
+    /// reported, deleted, and replaced by a new generation of ids, and the
+    /// set grows with each one — this asserted otherwise in a comment
+    /// before it was measured.
+    ///
+    /// The only test in this file that touches the process-global state;
+    /// nothing else drives `sweep_unattached_guardrails`, so it owns it.
+    #[test]
+    fn the_reported_set_stops_growing_at_the_cap() {
+        let attachments: ResourceTable<GuardrailAttachment> = ResourceTable::default();
+        for generation in 0..3 {
+            let guardrails: ResourceTable<DomainGuardrail> = ResourceTable::default();
+            for i in 0..MAX_REMEMBERED {
+                guardrails.insert(entry(
+                    "secrets",
+                    &format!("g-{generation}-{i}"),
+                    parse(
+                        r#"{
+                            "name": "inert",
+                            "kind": "keyword",
+                            "patterns": [{ "kind": "literal", "value": "AKIA" }]
+                        }"#,
+                    ),
+                ));
+            }
+            // First sweep stamps the generation, the backdate ages it past
+            // the grace, the second reports it — the shape of a fleet that
+            // churns guardrails faster than the cap.
+            sweep_unattached_guardrails(&guardrails, &attachments);
+            backdate_unattached_stamps_for_test();
+            sweep_unattached_guardrails(&guardrails, &attachments);
+        }
+
+        let (warned, present_since) = unattached_state_for_test();
+        assert!(
+            warned <= MAX_REMEMBERED,
+            "the reported set grew to {warned}, past its {MAX_REMEMBERED} cap",
+        );
+        assert!(
+            present_since <= MAX_REMEMBERED,
+            "stamps grew to {present_since}"
+        );
+    }
+
+    /// The grace's VALUE, not just its arithmetic. Every other test here
+    /// expresses its instants as multiples of `UNATTACHED_GRACE`, so they
+    /// hold for any positive value — including one small enough to put the
+    /// original bug back, where a guardrail is named while the second of
+    /// its two documents is still in flight.
+    ///
+    /// Two lower bounds, both load-bearing rather than arbitrary. The
+    /// sweep is the only thing that can observe a row, so a grace shorter
+    /// than two sweep periods can be satisfied by the first two sweeps
+    /// after a guardrail appears — which is where its attachment still is.
+    /// And the absolute floor is about the writer, not the reader: the
+    /// control plane drains a guardrail and its attachment from one outbox
+    /// batch, so the grace has to outlast a slow drain of that batch by a
+    /// wide margin.
+    #[test]
+    fn the_grace_outlasts_two_sweeps_and_a_slow_two_document_write() {
+        assert!(
+            UNATTACHED_GRACE >= UNATTACHED_SWEEP_INTERVAL * 2,
+            "grace {UNATTACHED_GRACE:?} must span at least two sweeps of \
+             {UNATTACHED_SWEEP_INTERVAL:?}",
+        );
+        assert!(
+            UNATTACHED_GRACE >= std::time::Duration::from_secs(20),
+            "grace {UNATTACHED_GRACE:?} is too short to outlast a slow outbox drain",
         );
     }
 

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -302,8 +302,9 @@ pub use audit::GuardrailAuditLog;
 #[cfg(feature = "bedrock")]
 pub use bedrock::BedrockGuardrail;
 pub use build::{
-    build_chain_from_snapshot, build_index_from_snapshot, unattached_guardrail_names,
-    unbuildable_guardrail_rows, LiveGuardrailChain, LiveGuardrailIndex, UnbuildableGuardrailRow,
+    build_chain_from_snapshot, build_index_from_snapshot, report_unattached_guardrails_at_startup,
+    unattached_guardrail_names, unbuildable_guardrail_rows, LiveGuardrailChain, LiveGuardrailIndex,
+    UnbuildableGuardrailRow,
 };
 pub use chain::GuardrailChain;
 pub use index::{GuardrailIndex, RequestContext};

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -302,9 +302,9 @@ pub use audit::GuardrailAuditLog;
 #[cfg(feature = "bedrock")]
 pub use bedrock::BedrockGuardrail;
 pub use build::{
-    build_chain_from_snapshot, build_index_from_snapshot, report_unattached_guardrails_at_startup,
+    build_chain_from_snapshot, build_index_from_snapshot, sweep_unattached_guardrails,
     unattached_guardrail_names, unbuildable_guardrail_rows, LiveGuardrailChain, LiveGuardrailIndex,
-    UnbuildableGuardrailRow,
+    UnbuildableGuardrailRow, UNATTACHED_SWEEP_INTERVAL,
 };
 pub use chain::GuardrailChain;
 pub use index::{GuardrailIndex, RequestContext};

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -429,7 +429,9 @@ fn select_managed_boot_path(bundle_on_disk: bool, bundle_provided: bool) -> Mana
     }
 }
 
-async fn run_metrics_upkeep<F>(mut cancel: watch::Receiver<bool>, period: Duration, upkeep: F)
+/// Run `job` every `period` until cancelled. Two callers: the metrics
+/// upkeep sweep and the inert-guardrail sweep.
+async fn run_periodic<F>(mut cancel: watch::Receiver<bool>, period: Duration, job: F)
 where
     F: Fn(),
 {
@@ -440,7 +442,7 @@ where
             break;
         }
         tokio::select! {
-            _ = interval.tick() => upkeep(),
+            _ = interval.tick() => job(),
             changed = cancel.changed() => {
                 if changed.is_err() || *cancel.borrow() {
                     break;
@@ -823,7 +825,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     ));
     let metrics_upkeep_task = {
         let metrics = metrics.clone();
-        tokio::spawn(run_metrics_upkeep(
+        tokio::spawn(run_periodic(
             cancel_rx.clone(),
             Duration::from_secs(5),
             move || metrics.run_upkeep(),
@@ -1032,28 +1034,24 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // satisfies before the watch task has reached etcd at all — a one-shot
     // report behind that gate reads the CACHED generation and never looks
     // again, so it goes quiet exactly when the cache is the stale thing
-    // (someone changed an attachment while this gateway was down), and can
-    // just as easily name a guardrail that is attached in live etcd. A
-    // sweep that keeps running converges either way.
+    // (someone changed an attachment while this gateway was down). A sweep
+    // that keeps running converges either way. It may still name a row
+    // that live etcd has attached, during a long outage: that is not a
+    // false alarm, because the gateway is serving the cached generation at
+    // that moment and in it the rule really does inspect nothing.
     {
         let sweep_snapshot = snapshot_handle.clone();
-        let mut sweep_cancel = cancel_rx.clone();
-        tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(aisix_guardrails::UNATTACHED_SWEEP_INTERVAL);
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                tokio::select! {
-                    _ = ticker.tick() => {
-                        let snap = sweep_snapshot.load();
-                        aisix_guardrails::sweep_unattached_guardrails(
-                            &snap.guardrails,
-                            &snap.guardrail_attachments,
-                        );
-                    }
-                    _ = sweep_cancel.changed() => break,
-                }
-            }
-        });
+        tokio::spawn(run_periodic(
+            cancel_rx.clone(),
+            aisix_guardrails::UNATTACHED_SWEEP_INTERVAL,
+            move || {
+                let snap = sweep_snapshot.load();
+                aisix_guardrails::sweep_unattached_guardrails(
+                    &snap.guardrails,
+                    &snap.guardrail_attachments,
+                );
+            },
+        ));
     }
 
     // Clone shared trackers before consuming proxy_state in build_router.
@@ -2520,19 +2518,15 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn metrics_upkeep_runs_periodically_and_stops_on_cancel() {
+    async fn a_periodic_job_runs_on_its_period_and_stops_on_cancel() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         let (cancel_tx, cancel_rx) = watch::channel(false);
         let calls = Arc::new(AtomicUsize::new(0));
         let observed = calls.clone();
-        let task = tokio::spawn(run_metrics_upkeep(
-            cancel_rx,
-            Duration::from_secs(5),
-            move || {
-                observed.fetch_add(1, Ordering::SeqCst);
-            },
-        ));
+        let task = tokio::spawn(run_periodic(cancel_rx, Duration::from_secs(5), move || {
+            observed.fetch_add(1, Ordering::SeqCst);
+        }));
 
         tokio::task::yield_now().await;
         assert_eq!(calls.load(Ordering::SeqCst), 1);

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -1017,33 +1017,41 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         heartbeat::spawn(h, cancel_rx.clone())
     });
 
-    // Say what the process STARTED with that inspects no traffic, once the
-    // first full load has landed.
+    // Name the guardrails that are attached to nothing, on a timer.
     //
-    // The runtime notice inside the guardrail index cannot cover this: it
-    // fires from an index build, builds happen only when the snapshot
-    // version moves, and standing configuration moves nothing. Without this
-    // a restart would go quiet about rules attached to nothing until some
-    // unrelated write happened to trigger a rebuild — on a deployment
-    // nobody is editing, never.
+    // On a timer rather than from the index build, because the thing being
+    // reported does not coincide with a configuration change. A build
+    // happens only when the snapshot version moves, so a notice emitted
+    // from one is delivered only if somebody writes something — and the two
+    // cases that matter most are the ones where nobody does: a scope target
+    // deleted out from under a rule that was screening traffic yesterday,
+    // and a gateway restarted onto standing configuration.
     //
-    // Bounded rather than waiting forever: if the source never becomes
-    // ready the proxy has louder problems than this line, and `/readyz`
-    // already reports them.
+    // Nor is it gated on a readiness flag. `ConfigStatus::is_ready` means
+    // "a load has been applied", which `Supervisor::restore_from_cache`
+    // satisfies before the watch task has reached etcd at all — a one-shot
+    // report behind that gate reads the CACHED generation and never looks
+    // again, so it goes quiet exactly when the cache is the stale thing
+    // (someone changed an attachment while this gateway was down), and can
+    // just as easily name a guardrail that is attached in live etcd. A
+    // sweep that keeps running converges either way.
     {
-        let startup_snapshot = snapshot_handle.clone();
-        let startup_status = config_status.clone();
+        let sweep_snapshot = snapshot_handle.clone();
+        let mut sweep_cancel = cancel_rx.clone();
         tokio::spawn(async move {
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
-            while !startup_status.is_ready() && tokio::time::Instant::now() < deadline {
-                tokio::time::sleep(Duration::from_millis(200)).await;
-            }
-            if startup_status.is_ready() {
-                let snap = startup_snapshot.load();
-                aisix_guardrails::report_unattached_guardrails_at_startup(
-                    &snap.guardrails,
-                    &snap.guardrail_attachments,
-                );
+            let mut ticker = tokio::time::interval(aisix_guardrails::UNATTACHED_SWEEP_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                tokio::select! {
+                    _ = ticker.tick() => {
+                        let snap = sweep_snapshot.load();
+                        aisix_guardrails::sweep_unattached_guardrails(
+                            &snap.guardrails,
+                            &snap.guardrail_attachments,
+                        );
+                    }
+                    _ = sweep_cancel.changed() => break,
+                }
             }
         });
     }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -1017,6 +1017,37 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         heartbeat::spawn(h, cancel_rx.clone())
     });
 
+    // Say what the process STARTED with that inspects no traffic, once the
+    // first full load has landed.
+    //
+    // The runtime notice inside the guardrail index cannot cover this: it
+    // fires from an index build, builds happen only when the snapshot
+    // version moves, and standing configuration moves nothing. Without this
+    // a restart would go quiet about rules attached to nothing until some
+    // unrelated write happened to trigger a rebuild — on a deployment
+    // nobody is editing, never.
+    //
+    // Bounded rather than waiting forever: if the source never becomes
+    // ready the proxy has louder problems than this line, and `/readyz`
+    // already reports them.
+    {
+        let startup_snapshot = snapshot_handle.clone();
+        let startup_status = config_status.clone();
+        tokio::spawn(async move {
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+            while !startup_status.is_ready() && tokio::time::Instant::now() < deadline {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            if startup_status.is_ready() {
+                let snap = startup_snapshot.load();
+                aisix_guardrails::report_unattached_guardrails_at_startup(
+                    &snap.guardrails,
+                    &snap.guardrail_attachments,
+                );
+            }
+        });
+    }
+
     // Clone shared trackers before consuming proxy_state in build_router.
     let health_tracker = proxy_state.health.clone();
     let livez_state = proxy_state.livez.clone();

--- a/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
@@ -1,0 +1,162 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for the notice a gateway logs about an enabled guardrail that
+// nothing attaches. The interesting property is WHEN it must stay quiet.
+//
+// A guardrail and its attachment are separate documents arriving as
+// separate writes, so every ordinary creation has an index build where the
+// gateway holds the guardrail and not yet its attachment. Warning there
+// named correctly-attached guardrails as inspecting nothing, permanently —
+// the notice is deduplicated per id for the life of the process, so the
+// false alarm never ages out. Nothing in the unit tests could see it: they
+// build the index once, and the race needs two builds with a write between.
+//
+// Both halves are asserted here because either alone is satisfiable the
+// wrong way: silence proves nothing if the notice never fires at all, and
+// firing proves nothing if it fires on everything.
+//
+// The index is rebuilt lazily — on the first request after a snapshot
+// version change, not on the write itself — so every step that needs a
+// rebuild sends traffic. A test that only wrote config would observe no
+// builds at all and pass while asserting nothing.
+
+const CALLER_PLAINTEXT = "sk-unattached-notice-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+const NOTICE = /guardrail is enabled but has no attachment/;
+
+function noticesFor(output: string, name: string): number {
+  return output.split("\n").filter((l) => NOTICE.test(l) && l.includes(name))
+    .length;
+}
+
+describe("guardrail unattached notice", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "un-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "un-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["un-model"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("an attached guardrail is never reported, however the two writes interleave", async () => {
+    if (!etcdReachable || !seed || !app) return;
+    // `createGuardrail` writes the guardrail and its env attachment as two
+    // separate etcd keys — the ordinary creation shape, and the window the
+    // notice used to fire in.
+    const name = "un-attached-guard";
+    await seed.createGuardrail({
+      name,
+      enabled: true,
+      hook_point: "input",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: "un-attached-probe" }],
+    });
+
+    // Force several index rebuilds with the attachment in place. If the
+    // notice were going to fire on this guardrail it would have by now, and
+    // being deduplicated per id it could never be withdrawn afterwards.
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    for (let i = 0; i < 3; i++) {
+      await seed.createProviderKey({
+        display_name: `un-churn-pk-${i}`,
+        secret: "sk-mock",
+        api_base: `${upstream!.baseUrl}/v1`,
+      });
+      await waitConfigPropagation();
+      await proxy.chat({
+        model: "un-model",
+        messages: [{ role: "user", content: "harmless" }],
+      });
+    }
+
+    expect(noticesFor(app.output(), name)).toBe(0);
+  });
+
+  test("a guardrail nothing attaches is reported, once", async () => {
+    if (!etcdReachable || !seed || !app) return;
+    const name = "un-orphan-guard";
+    await seed.createGuardrail(
+      {
+        name,
+        enabled: true,
+        hook_point: "input",
+        kind: "keyword",
+        patterns: [{ kind: "literal", value: "un-orphan-probe" }],
+      },
+      { attach: false },
+    );
+
+    // Two index builds have to pass before the notice is due — the first
+    // sighting is indistinguishable from an attachment still in flight — and
+    // a build only happens on a request.
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      await proxy.chat({
+        model: "un-model",
+        messages: [{ role: "user", content: "harmless" }],
+      });
+      return noticesFor(app!.output(), name) > 0;
+    });
+
+    // …and it is a standing property said once, not an event repeated on
+    // every later rebuild. Each iteration needs a WRITE as well as a
+    // request: the index is keyed on the snapshot version, so requests
+    // alone reuse the cached index and would prove nothing.
+    const after = noticesFor(app.output(), name);
+    for (let i = 0; i < 3; i++) {
+      await seed.createProviderKey({
+        display_name: `un-orphan-churn-pk-${i}`,
+        secret: "sk-mock",
+        api_base: `${upstream!.baseUrl}/v1`,
+      });
+      await waitConfigPropagation();
+      await proxy.chat({
+        model: "un-model",
+        messages: [{ role: "user", content: "harmless" }],
+      });
+    }
+    expect(noticesFor(app.output(), name)).toBe(after);
+  });
+});

--- a/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
@@ -4,31 +4,41 @@ import {
   EtcdClient,
   ProxyClient,
   SeedClient,
-  scrapeMetrics,
   spawnApp,
   startOpenAiUpstream,
-  sumMetric,
   waitConfigPropagation,
   type OpenAiUpstream,
   type SpawnedApp,
 } from "../harness/index.js";
 
 // E2E for the notice a gateway logs about an enabled guardrail that
-// nothing attaches. The interesting property is WHEN it must stay quiet.
+// nothing attaches.
 //
-// A guardrail and its attachment are separate documents arriving as
-// separate writes, so every ordinary creation has an index build where the
-// gateway holds the guardrail and not yet its attachment. Warning there
-// named correctly-attached guardrails as inspecting nothing, permanently —
-// the notice is deduplicated per id for the life of the process, so the
-// false alarm never ages out. Nothing in the unit tests could see it: they
-// build the index once, and the race needs two builds with a write between.
+// The gateway sweeps for these on a timer rather than reporting from an
+// index build, and this file exists because both halves of that are easy
+// to get wrong in ways nothing else catches.
 //
-// Both halves are asserted here because either alone is satisfiable the
-// wrong way: silence proves nothing if the notice never fires at all, and
-// firing proves nothing if it fires on everything.
+// It must stay QUIET on a guardrail that is correctly attached. The
+// guardrail and its attachment are separate documents arriving as separate
+// writes, so there is always a window where the gateway holds one and not
+// the other; naming a row there is a log line saying a security control
+// inspects no traffic, about one that does — and, deduplicated per id for
+// the life of the process, it never ages out.
+//
+// It must SPEAK on a guardrail that really is attached to nothing, and the
+// case that matters is not the one that is easy to test: a scope target
+// deleted out from under a rule that was screening traffic yesterday.
+// Nobody writes anything afterwards, so a notice that rides a config change
+// is never delivered.
+//
+// The timings below are the gateway's own (`UNATTACHED_GRACE`,
+// `UNATTACHED_SWEEP_INTERVAL`). They are wall time, which is why this file
+// is slow; the arithmetic of the grace itself is unit-tested with an
+// injected clock.
 
 const MODEL = "un-model";
+const GRACE = 30_000;
+const SWEEP = 10_000;
 const CALLER_PLAINTEXT = "sk-unattached-notice-caller";
 const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
@@ -36,8 +46,15 @@ const CALLER_KEY_HASH = createHash("sha256")
 
 const NOTICE = /guardrail is enabled but has no attachment/;
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Matches the `guardrail_name` field exactly, not as a substring: with
+// names like `un-inert` and `un-orphaned` in the same file, a substring
+// test silently counts one row's notice against another and the assertion
+// that a guardrail was named ONCE quietly reads two.
 function noticesFor(output: string, name: string): number {
-  return output.split("\n").filter((l) => NOTICE.test(l) && l.includes(name))
+  const named = new RegExp(`guardrail_name=${name}(\\s|$)`);
+  return output.split("\n").filter((l) => NOTICE.test(l) && named.test(l))
     .length;
 }
 
@@ -47,7 +64,6 @@ describe("guardrail unattached notice", () => {
   let seed: SeedClient | undefined;
   let proxy: ProxyClient | undefined;
   let etcdReachable = false;
-  let churn = 0;
 
   async function chat(content: string): Promise<number> {
     return (
@@ -55,45 +71,13 @@ describe("guardrail unattached notice", () => {
     ).status;
   }
 
-  async function appliedRevision(): Promise<number> {
-    return sumMetric(
-      await scrapeMetrics(app!.metricsUrl),
-      "aisix_config_applied_revision",
-    );
-  }
-
-  // rebuildIndex forces exactly one guardrail-index build.
-  //
-  // It takes BOTH a write and a request, and neither alone will do: the
-  // index is keyed on the snapshot version, so requests without a write
-  // reuse the cached index, and a write without a request builds nothing —
-  // the rebuild is lazy, deferred to the first request after the version
-  // moves. A loop missing either half observes no builds at all and passes
-  // while asserting nothing.
-  //
-  // The write is gated on the gateway having APPLIED it rather than on a
-  // fixed delay, because that is the event a build hangs off: a request
-  // sent while the snapshot is still at the old revision reuses the cached
-  // index, so the round silently builds nothing and the loop does fewer
-  // builds than it reads as having done.
-  async function rebuildIndex(): Promise<void> {
-    const before = await appliedRevision();
-    await seed!.createProviderKey({
-      display_name: `un-churn-pk-${churn++}`,
-      secret: "sk-mock",
-      api_base: `${upstream!.baseUrl}/v1`,
-    });
-    await waitConfigPropagation(async () => (await appliedRevision()) > before);
-    await chat("harmless");
-  }
-
-  // awaitInForce gates on the guardrail actually screening traffic — its
-  // own pattern coming back blocked. The notice assertions are all
+  // awaitInForce gates on a guardrail actually screening traffic — its own
+  // pattern coming back blocked. Every assertion about the notice is
   // negative, so without a positive gate they pass just as well on a
   // guardrail that never reached the snapshot. Blocking is a different
   // surface from the log line under test, and `chat` returns a status
-  // rather than throwing, so a real transport failure still surfaces as
-  // itself rather than as this timeout.
+  // rather than throwing, so a transport failure still surfaces as itself
+  // rather than as this timeout.
   async function awaitInForce(probe: string): Promise<void> {
     await waitConfigPropagation(async () => (await chat(probe)) === 422);
   }
@@ -135,97 +119,86 @@ describe("guardrail unattached notice", () => {
     await upstream?.close();
   });
 
-  test("an attached guardrail is never reported, however the two writes interleave", async (ctx) => {
-    if (!etcdReachable || !seed || !app || !proxy) {
-      ctx.skip();
-      return;
-    }
-
-    // The ordinary creation shape first: guardrail and env attachment
-    // written back to back, then traffic.
-    const settled = "un-attached-guard";
-    await seed.createGuardrail({
-      name: settled,
-      enabled: true,
-      hook_point: "input",
-      kind: "keyword",
-      patterns: [{ kind: "literal", value: "un-attached-probe" }],
-    });
-    await awaitInForce("un-attached-probe");
-    for (let i = 0; i < 3; i++) await rebuildIndex();
-    expect(noticesFor(app.output(), settled)).toBe(0);
-
-    // …then the window the notice actually fired in, opened deliberately.
-    // The two documents are separate writes, so a request landing between
-    // them builds an index holding the guardrail alone — routine under live
-    // traffic, and never reached by a test that writes both back to back.
-    const raced = "un-raced-guard";
-    const g = await seed.createGuardrail(
-      {
-        name: raced,
-        enabled: true,
-        hook_point: "input",
-        kind: "keyword",
-        patterns: [{ kind: "literal", value: "un-raced-probe" }],
-      },
-      { attach: false },
-    );
-    await rebuildIndex();
-    await seed.attachGuardrailToEnv(g.id);
-    await awaitInForce("un-raced-probe");
-    for (let i = 0; i < 3; i++) await rebuildIndex();
-
-    // Nothing, and nothing later either: the notice is deduplicated per id
-    // for the life of the process, so one report here could never be
-    // withdrawn once the attachment landed.
-    expect(noticesFor(app.output(), raced)).toBe(0);
-  });
-
-  test("a guardrail nothing attaches is reported at startup, once", async (ctx) => {
-    if (!etcdReachable || !seed || !app || !proxy) {
-      ctx.skip();
-      return;
-    }
-    const name = "un-orphan-guard";
-    await seed.createGuardrail(
-      {
+  test(
+    "named only when attached to nothing, and then exactly once",
+    async (ctx) => {
+      if (!etcdReachable || !seed || !app || !proxy) {
+        ctx.skip();
+        return;
+      }
+      const guard = (name: string, probe: string) => ({
         name,
         enabled: true,
         hook_point: "input",
         kind: "keyword",
-        patterns: [{ kind: "literal", value: "un-orphan-probe" }],
-      },
-      { attach: false },
-    );
+        patterns: [{ kind: "literal", value: probe }],
+      });
 
-    // Asserted through a fresh process on the same configuration rather
-    // than by waiting out the grace on the running one. Two reasons: it is
-    // seconds instead of half a minute, and it covers the half the grace
-    // cannot — a gateway that RESTARTS onto standing configuration. The
-    // notice fires from an index build, builds happen only when the
-    // snapshot version moves, and configuration nobody is editing moves
-    // nothing, so without the startup report a restarted gateway would say
-    // nothing about a rule that inspects no traffic until some unrelated
-    // write happened to come along.
-    //
-    // The grace's own arithmetic is covered by the unit tests, which can
-    // inject `now` instead of sleeping.
-    const restarted = await spawnApp({ etcdPrefix: app.etcdPrefix });
-    try {
-      await waitConfigPropagation(
-        async () => noticesFor(restarted.output(), name) > 0,
+      // ORDINARY: guardrail and env attachment written back to back.
+      await seed.createGuardrail(guard("un-settled", "un-settled-probe"));
+      // INERT: attached to nothing, ever. The one row that must be named.
+      await seed.createGuardrail(guard("un-inert", "un-inert-probe"), {
+        attach: false,
+      });
+      // RACED: written alone now, attached after a sweep has already seen
+      // it unattached — the window every ordinary creation passes through
+      // under live traffic, held open deliberately here.
+      const raced = await seed.createGuardrail(guard("un-raced", "un-raced-probe"), {
+        attach: false,
+      });
+      // ORPHANED-LATER: attached now, its attachment removed after the
+      // grace. A scope target deleted out from under a rule that has been
+      // screening traffic — the case the notice exists for.
+      // `attach: false` plus one explicit attachment, so there is exactly
+      // one row to remove later — the default would add a second and the
+      // guardrail would still be attached after the delete.
+      const orphaned = await seed.createGuardrail(
+        guard("un-orphaned", "un-orphaned-probe"),
+        { attach: false },
       );
-      // Once, not once per rebuild: it is a standing property of the row.
-      const seenOnce = noticesFor(restarted.output(), name);
-      expect(seenOnce).toBe(1);
+      const orphanedAttachment = await seed.attachGuardrailToEnv(orphaned.id);
 
-      // And the guardrails that ARE attached are not swept up in it — the
-      // startup report has no grace, so if it were reading the snapshot
-      // wrongly this is where it would show.
-      expect(noticesFor(restarted.output(), "un-attached-guard")).toBe(0);
-      expect(noticesFor(restarted.output(), "un-raced-guard")).toBe(0);
-    } finally {
-      await restarted.exit();
-    }
-  });
+      await awaitInForce("un-settled-probe");
+
+      // One sweep must observe `un-raced` unattached before it is attached,
+      // or the window this case exists to open was never opened.
+      await sleep(SWEEP + 2_000);
+      await seed.attachGuardrailToEnv(raced.id);
+      await awaitInForce("un-raced-probe");
+
+      // Past the grace, plus a sweep to act on it.
+      await sleep(GRACE + SWEEP);
+      const out = () => app!.output();
+      expect(noticesFor(out(), "un-inert")).toBe(1);
+      expect(noticesFor(out(), "un-settled")).toBe(0);
+      expect(noticesFor(out(), "un-raced")).toBe(0);
+      expect(noticesFor(out(), "un-orphaned")).toBe(0);
+
+      // Now take the attachment away. `un-orphaned` has been present since
+      // well before the grace, so it is due on the next sweep — it does NOT
+      // serve out a fresh one as if it were a new row.
+      await seed.delete("guardrail_attachments", orphanedAttachment.id);
+      // Gate on the rule actually going inert before waiting on the log, so
+      // a delete that never landed fails as itself rather than as a silent
+      // sweep.
+      await waitConfigPropagation(async () => (await chat("un-orphaned-probe")) === 200);
+      // Two sweeps, not more: the row is already older than the grace, so
+      // the very next one is due. A window wide enough to also cover a
+      // fresh grace would pass on an implementation that restarts the
+      // clock when the attachment goes — which is the whole bug.
+      await waitConfigPropagation(
+        async () => noticesFor(out(), "un-orphaned") > 0,
+        SWEEP * 2,
+      );
+      expect(noticesFor(out(), "un-orphaned")).toBe(1);
+
+      // Said once, not once per sweep, and the others still silent.
+      await sleep(SWEEP * 2);
+      expect(noticesFor(out(), "un-orphaned")).toBe(1);
+      expect(noticesFor(out(), "un-inert")).toBe(1);
+      expect(noticesFor(out(), "un-settled")).toBe(0);
+      expect(noticesFor(out(), "un-raced")).toBe(0);
+    },
+    3 * (GRACE + SWEEP * 3),
+  );
 });

--- a/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
@@ -4,8 +4,10 @@ import {
   EtcdClient,
   ProxyClient,
   SeedClient,
+  scrapeMetrics,
   spawnApp,
   startOpenAiUpstream,
+  sumMetric,
   waitConfigPropagation,
   type OpenAiUpstream,
   type SpawnedApp,
@@ -53,6 +55,13 @@ describe("guardrail unattached notice", () => {
     ).status;
   }
 
+  async function appliedRevision(): Promise<number> {
+    return sumMetric(
+      await scrapeMetrics(app!.metricsUrl),
+      "aisix_config_applied_revision",
+    );
+  }
+
   // rebuildIndex forces exactly one guardrail-index build.
   //
   // It takes BOTH a write and a request, and neither alone will do: the
@@ -61,13 +70,20 @@ describe("guardrail unattached notice", () => {
   // the rebuild is lazy, deferred to the first request after the version
   // moves. A loop missing either half observes no builds at all and passes
   // while asserting nothing.
+  //
+  // The write is gated on the gateway having APPLIED it rather than on a
+  // fixed delay, because that is the event a build hangs off: a request
+  // sent while the snapshot is still at the old revision reuses the cached
+  // index, so the round silently builds nothing and the loop does fewer
+  // builds than it reads as having done.
   async function rebuildIndex(): Promise<void> {
+    const before = await appliedRevision();
     await seed!.createProviderKey({
       display_name: `un-churn-pk-${churn++}`,
       secret: "sk-mock",
       api_base: `${upstream!.baseUrl}/v1`,
     });
-    await waitConfigPropagation();
+    await waitConfigPropagation(async () => (await appliedRevision()) > before);
     await chat("harmless");
   }
 
@@ -165,7 +181,7 @@ describe("guardrail unattached notice", () => {
     expect(noticesFor(app.output(), raced)).toBe(0);
   });
 
-  test("a guardrail nothing attaches is reported, once", async (ctx) => {
+  test("a guardrail nothing attaches is reported at startup, once", async (ctx) => {
     if (!etcdReachable || !seed || !app || !proxy) {
       ctx.skip();
       return;
@@ -182,23 +198,34 @@ describe("guardrail unattached notice", () => {
       { attach: false },
     );
 
-    // No positive gate is available here — a guardrail attached to nothing
-    // screens nothing, which is the point — but none is needed: the
-    // assertion is that the notice DID arrive, so a guardrail that never
-    // reached the snapshot fails it rather than passing quietly.
+    // Asserted through a fresh process on the same configuration rather
+    // than by waiting out the grace on the running one. Two reasons: it is
+    // seconds instead of half a minute, and it covers the half the grace
+    // cannot — a gateway that RESTARTS onto standing configuration. The
+    // notice fires from an index build, builds happen only when the
+    // snapshot version moves, and configuration nobody is editing moves
+    // nothing, so without the startup report a restarted gateway would say
+    // nothing about a rule that inspects no traffic until some unrelated
+    // write happened to come along.
     //
-    // Two builds have to pass before the notice is due; the first sighting
-    // is indistinguishable from an attachment still in flight. A couple of
-    // spare rounds absorb an unrelated write landing in between, and the
-    // assertion is on the count, so a late notice still fails.
-    for (let i = 0; i < 4 && noticesFor(app.output(), name) === 0; i++) {
-      await rebuildIndex();
-    }
-    expect(noticesFor(app.output(), name)).toBe(1);
+    // The grace's own arithmetic is covered by the unit tests, which can
+    // inject `now` instead of sleeping.
+    const restarted = await spawnApp({ etcdPrefix: app.etcdPrefix });
+    try {
+      await waitConfigPropagation(
+        async () => noticesFor(restarted.output(), name) > 0,
+      );
+      // Once, not once per rebuild: it is a standing property of the row.
+      const seenOnce = noticesFor(restarted.output(), name);
+      expect(seenOnce).toBe(1);
 
-    // …and it is a standing property said once, not an event repeated on
-    // every later build.
-    for (let i = 0; i < 3; i++) await rebuildIndex();
-    expect(noticesFor(app.output(), name)).toBe(1);
+      // And the guardrails that ARE attached are not swept up in it — the
+      // startup report has no grace, so if it were reading the snapshot
+      // wrongly this is where it would show.
+      expect(noticesFor(restarted.output(), "un-attached-guard")).toBe(0);
+      expect(noticesFor(restarted.output(), "un-raced-guard")).toBe(0);
+    } finally {
+      await restarted.exit();
+    }
   });
 });

--- a/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
@@ -160,15 +160,19 @@ describe("guardrail unattached notice", () => {
 
       await awaitInForce("un-settled-probe");
 
-      // Hold `un-raced` unattached for a grace MINUS a sweep before
-      // attaching it. Two sweeps are then guaranteed to have seen it — the
-      // first lands within one period of its creation, the second one
-      // period after that, both before the attachment — so a grace short
-      // enough to be satisfied by two sweeps names it and this case fails.
-      // Derived from the grace, not from the sweep period: a window sized
-      // in sweeps measures the sweep, and the thing under test here is the
-      // grace.
-      await sleep(GRACE - SWEEP);
+      // Just over one sweep, so at least one lands with `un-raced` present
+      // and unattached — the window every ordinary creation passes through.
+      //
+      // Deliberately NOT sized from the grace. The row's clock starts at
+      // the first sweep after it is WRITTEN, which is before this sleep
+      // begins — the `awaitInForce` above sits in between, and the harness
+      // budgets up to 30s for guardrail propagation on a loaded runner. A
+      // window of `GRACE - SWEEP` would leave a correctly-attached
+      // guardrail unattached for that plus the propagation wait, and past
+      // the grace it gets named: a false red on the assertion below. The
+      // grace's lower bound is asserted directly in the unit tests, which
+      // is where a value can be checked without racing anything.
+      await sleep(SWEEP + 2_000);
       await seed.attachGuardrailToEnv(raced.id);
       await awaitInForce("un-raced-probe");
 

--- a/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
@@ -160,9 +160,15 @@ describe("guardrail unattached notice", () => {
 
       await awaitInForce("un-settled-probe");
 
-      // One sweep must observe `un-raced` unattached before it is attached,
-      // or the window this case exists to open was never opened.
-      await sleep(SWEEP + 2_000);
+      // Hold `un-raced` unattached for a grace MINUS a sweep before
+      // attaching it. Two sweeps are then guaranteed to have seen it — the
+      // first lands within one period of its creation, the second one
+      // period after that, both before the attachment — so a grace short
+      // enough to be satisfied by two sweeps names it and this case fails.
+      // Derived from the grace, not from the sweep period: a window sized
+      // in sweeps measures the sweep, and the thing under test here is the
+      // grace.
+      await sleep(GRACE - SWEEP);
       await seed.attachGuardrailToEnv(raced.id);
       await awaitInForce("un-raced-probe");
 

--- a/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
@@ -26,6 +26,7 @@ import {
 // wrong way: silence proves nothing if the notice never fires at all, and
 // firing proves nothing if it fires on everything.
 
+const MODEL = "un-model";
 const CALLER_PLAINTEXT = "sk-unattached-notice-caller";
 const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
@@ -46,6 +47,12 @@ describe("guardrail unattached notice", () => {
   let etcdReachable = false;
   let churn = 0;
 
+  async function chat(content: string): Promise<number> {
+    return (
+      await proxy!.chat({ model: MODEL, messages: [{ role: "user", content }] })
+    ).status;
+  }
+
   // rebuildIndex forces exactly one guardrail-index build.
   //
   // It takes BOTH a write and a request, and neither alone will do: the
@@ -61,10 +68,18 @@ describe("guardrail unattached notice", () => {
       api_base: `${upstream!.baseUrl}/v1`,
     });
     await waitConfigPropagation();
-    await proxy!.chat({
-      model: "un-model",
-      messages: [{ role: "user", content: "harmless" }],
-    });
+    await chat("harmless");
+  }
+
+  // awaitInForce gates on the guardrail actually screening traffic — its
+  // own pattern coming back blocked. The notice assertions are all
+  // negative, so without a positive gate they pass just as well on a
+  // guardrail that never reached the snapshot. Blocking is a different
+  // surface from the log line under test, and `chat` returns a status
+  // rather than throwing, so a real transport failure still surfaces as
+  // itself rather than as this timeout.
+  async function awaitInForce(probe: string): Promise<void> {
+    await waitConfigPropagation(async () => (await chat(probe)) === 422);
   }
 
   beforeAll(async () => {
@@ -82,16 +97,21 @@ describe("guardrail unattached notice", () => {
       api_base: `${upstream.baseUrl}/v1`,
     });
     await seed.createModel({
-      display_name: "un-model",
+      display_name: MODEL,
       provider: "openai",
       model_name: "gpt-4o-mini",
       provider_key_id: pk.id,
     });
+    // Caller key last, then gate on it authenticating: that one condition
+    // implies every resource above it is in the snapshot.
     await seed.createApiKey({
       key_hash: CALLER_KEY_HASH,
-      allowed_models: ["un-model"],
+      allowed_models: [MODEL],
     });
     proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(
+      async () => (await proxy!.listModels()).status === 200,
+    );
   });
 
   afterAll(async () => {
@@ -99,8 +119,11 @@ describe("guardrail unattached notice", () => {
     await upstream?.close();
   });
 
-  test("an attached guardrail is never reported, however the two writes interleave", async () => {
-    if (!etcdReachable || !seed || !app) return;
+  test("an attached guardrail is never reported, however the two writes interleave", async (ctx) => {
+    if (!etcdReachable || !seed || !app || !proxy) {
+      ctx.skip();
+      return;
+    }
 
     // The ordinary creation shape first: guardrail and env attachment
     // written back to back, then traffic.
@@ -112,6 +135,7 @@ describe("guardrail unattached notice", () => {
       kind: "keyword",
       patterns: [{ kind: "literal", value: "un-attached-probe" }],
     });
+    await awaitInForce("un-attached-probe");
     for (let i = 0; i < 3; i++) await rebuildIndex();
     expect(noticesFor(app.output(), settled)).toBe(0);
 
@@ -132,6 +156,7 @@ describe("guardrail unattached notice", () => {
     );
     await rebuildIndex();
     await seed.attachGuardrailToEnv(g.id);
+    await awaitInForce("un-raced-probe");
     for (let i = 0; i < 3; i++) await rebuildIndex();
 
     // Nothing, and nothing later either: the notice is deduplicated per id
@@ -140,8 +165,11 @@ describe("guardrail unattached notice", () => {
     expect(noticesFor(app.output(), raced)).toBe(0);
   });
 
-  test("a guardrail nothing attaches is reported, once", async () => {
-    if (!etcdReachable || !seed || !app) return;
+  test("a guardrail nothing attaches is reported, once", async (ctx) => {
+    if (!etcdReachable || !seed || !app || !proxy) {
+      ctx.skip();
+      return;
+    }
     const name = "un-orphan-guard";
     await seed.createGuardrail(
       {
@@ -154,9 +182,14 @@ describe("guardrail unattached notice", () => {
       { attach: false },
     );
 
-    // Two builds have to pass before the notice is due — the first sighting
+    // No positive gate is available here — a guardrail attached to nothing
+    // screens nothing, which is the point — but none is needed: the
+    // assertion is that the notice DID arrive, so a guardrail that never
+    // reached the snapshot fails it rather than passing quietly.
+    //
+    // Two builds have to pass before the notice is due; the first sighting
     // is indistinguishable from an attachment still in flight. A couple of
-    // spare rounds absorb an unrelated write landing in between; the
+    // spare rounds absorb an unrelated write landing in between, and the
     // assertion is on the count, so a late notice still fails.
     for (let i = 0; i < 4 && noticesFor(app.output(), name) === 0; i++) {
       await rebuildIndex();

--- a/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
@@ -158,7 +158,14 @@ describe("guardrail unattached notice", () => {
       );
       const orphanedAttachment = await seed.attachGuardrailToEnv(orphaned.id);
 
-      await awaitInForce("un-settled-probe");
+      // Gate on the LAST guardrail written, not the first. etcd applies in
+      // revision order, so `un-orphaned` being in force implies every row
+      // above it is in the snapshot — including `un-raced`, which the
+      // window below is measured against. Gating on `un-settled` (the
+      // first write) would leave that implication to chance, and a
+      // `un-raced` arriving late turns the assertion on it into a silent
+      // no-op rather than a failure.
+      await awaitInForce("un-orphaned-probe");
 
       // Just over one sweep, so at least one lands with `un-raced` present
       // and unattached — the window every ordinary creation passes through.

--- a/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-unattached-notice-e2e.test.ts
@@ -25,11 +25,6 @@ import {
 // Both halves are asserted here because either alone is satisfiable the
 // wrong way: silence proves nothing if the notice never fires at all, and
 // firing proves nothing if it fires on everything.
-//
-// The index is rebuilt lazily — on the first request after a snapshot
-// version change, not on the write itself — so every step that needs a
-// rebuild sends traffic. A test that only wrote config would observe no
-// builds at all and pass while asserting nothing.
 
 const CALLER_PLAINTEXT = "sk-unattached-notice-caller";
 const CALLER_KEY_HASH = createHash("sha256")
@@ -47,7 +42,30 @@ describe("guardrail unattached notice", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
   let seed: SeedClient | undefined;
+  let proxy: ProxyClient | undefined;
   let etcdReachable = false;
+  let churn = 0;
+
+  // rebuildIndex forces exactly one guardrail-index build.
+  //
+  // It takes BOTH a write and a request, and neither alone will do: the
+  // index is keyed on the snapshot version, so requests without a write
+  // reuse the cached index, and a write without a request builds nothing —
+  // the rebuild is lazy, deferred to the first request after the version
+  // moves. A loop missing either half observes no builds at all and passes
+  // while asserting nothing.
+  async function rebuildIndex(): Promise<void> {
+    await seed!.createProviderKey({
+      display_name: `un-churn-pk-${churn++}`,
+      secret: "sk-mock",
+      api_base: `${upstream!.baseUrl}/v1`,
+    });
+    await waitConfigPropagation();
+    await proxy!.chat({
+      model: "un-model",
+      messages: [{ role: "user", content: "harmless" }],
+    });
+  }
 
   beforeAll(async () => {
     const etcd = new EtcdClient();
@@ -73,6 +91,7 @@ describe("guardrail unattached notice", () => {
       key_hash: CALLER_KEY_HASH,
       allowed_models: ["un-model"],
     });
+    proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
   });
 
   afterAll(async () => {
@@ -82,36 +101,43 @@ describe("guardrail unattached notice", () => {
 
   test("an attached guardrail is never reported, however the two writes interleave", async () => {
     if (!etcdReachable || !seed || !app) return;
-    // `createGuardrail` writes the guardrail and its env attachment as two
-    // separate etcd keys — the ordinary creation shape, and the window the
-    // notice used to fire in.
-    const name = "un-attached-guard";
+
+    // The ordinary creation shape first: guardrail and env attachment
+    // written back to back, then traffic.
+    const settled = "un-attached-guard";
     await seed.createGuardrail({
-      name,
+      name: settled,
       enabled: true,
       hook_point: "input",
       kind: "keyword",
       patterns: [{ kind: "literal", value: "un-attached-probe" }],
     });
+    for (let i = 0; i < 3; i++) await rebuildIndex();
+    expect(noticesFor(app.output(), settled)).toBe(0);
 
-    // Force several index rebuilds with the attachment in place. If the
-    // notice were going to fire on this guardrail it would have by now, and
-    // being deduplicated per id it could never be withdrawn afterwards.
-    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
-    for (let i = 0; i < 3; i++) {
-      await seed.createProviderKey({
-        display_name: `un-churn-pk-${i}`,
-        secret: "sk-mock",
-        api_base: `${upstream!.baseUrl}/v1`,
-      });
-      await waitConfigPropagation();
-      await proxy.chat({
-        model: "un-model",
-        messages: [{ role: "user", content: "harmless" }],
-      });
-    }
+    // …then the window the notice actually fired in, opened deliberately.
+    // The two documents are separate writes, so a request landing between
+    // them builds an index holding the guardrail alone — routine under live
+    // traffic, and never reached by a test that writes both back to back.
+    const raced = "un-raced-guard";
+    const g = await seed.createGuardrail(
+      {
+        name: raced,
+        enabled: true,
+        hook_point: "input",
+        kind: "keyword",
+        patterns: [{ kind: "literal", value: "un-raced-probe" }],
+      },
+      { attach: false },
+    );
+    await rebuildIndex();
+    await seed.attachGuardrailToEnv(g.id);
+    for (let i = 0; i < 3; i++) await rebuildIndex();
 
-    expect(noticesFor(app.output(), name)).toBe(0);
+    // Nothing, and nothing later either: the notice is deduplicated per id
+    // for the life of the process, so one report here could never be
+    // withdrawn once the attachment landed.
+    expect(noticesFor(app.output(), raced)).toBe(0);
   });
 
   test("a guardrail nothing attaches is reported, once", async () => {
@@ -128,35 +154,18 @@ describe("guardrail unattached notice", () => {
       { attach: false },
     );
 
-    // Two index builds have to pass before the notice is due — the first
-    // sighting is indistinguishable from an attachment still in flight — and
-    // a build only happens on a request.
-    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
-    await waitConfigPropagation(async () => {
-      await proxy.chat({
-        model: "un-model",
-        messages: [{ role: "user", content: "harmless" }],
-      });
-      return noticesFor(app!.output(), name) > 0;
-    });
+    // Two builds have to pass before the notice is due — the first sighting
+    // is indistinguishable from an attachment still in flight. A couple of
+    // spare rounds absorb an unrelated write landing in between; the
+    // assertion is on the count, so a late notice still fails.
+    for (let i = 0; i < 4 && noticesFor(app.output(), name) === 0; i++) {
+      await rebuildIndex();
+    }
+    expect(noticesFor(app.output(), name)).toBe(1);
 
     // …and it is a standing property said once, not an event repeated on
-    // every later rebuild. Each iteration needs a WRITE as well as a
-    // request: the index is keyed on the snapshot version, so requests
-    // alone reuse the cached index and would prove nothing.
-    const after = noticesFor(app.output(), name);
-    for (let i = 0; i < 3; i++) {
-      await seed.createProviderKey({
-        display_name: `un-orphan-churn-pk-${i}`,
-        secret: "sk-mock",
-        api_base: `${upstream!.baseUrl}/v1`,
-      });
-      await waitConfigPropagation();
-      await proxy.chat({
-        model: "un-model",
-        messages: [{ role: "user", content: "harmless" }],
-      });
-    }
-    expect(noticesFor(app.output(), name)).toBe(after);
+    // every later build.
+    for (let i = 0; i < 3; i++) await rebuildIndex();
+    expect(noticesFor(app.output(), name)).toBe(1);
   });
 });


### PR DESCRIPTION
#1073 added a WARN naming an enabled guardrail that nothing attaches, and emitted it from the guardrail index build, on the first build that saw the row unattached. A guardrail and its attachment are separate documents written as separate outbox rows, so **every normal creation** passes through a build that holds one and not the other. Correctly-attached guardrails were reported as inspecting no traffic — permanently, since the notice is deduplicated per id for the life of the process.

A log line saying a security control is not in force, about one that is, is worse than no line at all: an operator can act on it.

## What changes

**The notice is swept on a timer, not emitted from an index build.** A build happens only when the snapshot version moves, so a notice that rides one is delivered only if somebody writes configuration — and the two cases this line exists for are exactly the ones where nobody does:

- a scope target is deleted, its attachment goes with it, and a rule that was screening traffic yesterday is now inert. The delete is one version change; the next build may be days away, or never.
- a gateway restarts onto standing configuration. Nothing changed, so nothing rebuilds, so nothing is said.

Riding the build also put the emit on the request path, where `LiveGuardrailIndex::current()` builds outside the lock and every request arriving during one rebuild runs its own — two builds inside a *single* snapshot version, which is how the first attempt at this fix ("unattached in the previous build too") was still satisfied while an attachment was in flight.

`sweep_unattached_guardrails` runs every ten seconds over the current snapshot. One mechanism covers boot, cache restore, resync and runtime deletion.

**A row is named after thirty seconds of being continuously present-and-unattached.** Measured in time, because a build is not a unit of duration. Thirty seconds is two orders of magnitude above the gap the control plane leaves — it drains both rows from one outbox batch — and short enough to name a genuinely inert rule early.

**The clock starts when a guardrail is first seen, not when it is first seen unattached.** That is what separates the two states that look identical in one snapshot: an attachment that has not arrived yet, and one that is gone. Stamping only the unattached rows makes a deleted attachment serve out a fresh grace as if the rule were new.

**No startup special case.** An earlier revision had a one-shot report gated on `ConfigStatus::is_ready`, and that was wrong: `is_ready` means "a load has been applied", which `Supervisor::restore_from_cache` satisfies *before* the watch task has reached etcd. Managed mode enables the cache by default, so the report read the **cached** generation and never looked again — going quiet precisely when the cache is the stale thing (someone changed an attachment while this gateway was down), and able to name a guardrail that is attached in live etcd, permanently. A sweep that keeps running converges either way.

**The reported set is bounded, which it was not.** `warned` is the union across every sweep, while the cap applies to what one sweep can stamp — so it grew with each generation of ids, measured at 12288 entries while the stamp map held at 4096. A comment had asserted the opposite; that assertion is a test now. Past the cap the sweep stops reporting rather than emitting rows it cannot remember, which would re-emit the same ones every ten seconds.

## How each of these surfaced

The first false alarm came from the control-plane e2e (api7/AISIX-Cloud#1451), whose data-plane log scan refuses un-allowlisted WARN lines.

The second came from this PR's own e2e once its rebuilds were gated on `aisix_config_applied_revision` moving instead of a fixed delay: the tighter timing put two builds between the two writes and the notice fired on a correctly-attached row.

The rest came from review, each reproduced against a real binary — the same thing under concurrency (sixty PII guardrails, one 2.4s index build, forty-eight concurrent requests, a single version bump); the deleted-attachment silence; and the cached-generation read, which loses the notice at 300 ms of etcd latency.

## Tests

Unit, with an injected clock: silence inside the grace however many sweeps run, a report at the boundary, said once and not again ten minutes later, an attachment lost after the grace reported at once, and — pinned directly, because it is the load-bearing half — that **attached** rows are timestamped too.

E2E, one case, because every assertion needs the same clock to have run. It covers an ordinary creation; a creation whose attachment arrives only after a sweep has already seen the row unattached; a guardrail nothing ever attaches; and one whose attachment is removed after the grace. The window on that last one is two sweeps rather than three, so an implementation that restarts the clock when an attachment goes fails instead of squeaking through.

The grace's VALUE is asserted directly, not just its arithmetic: every other test expresses its instants as multiples of the constant, so they hold for any positive value — and at one second the original bug is back while the whole suite stays green. The e2e's window is deliberately NOT sized off the grace; the row's clock starts before that sleep begins, so a window wide enough to measure the grace turns a slow runner into a false red. The unit assertion is the net there, and it is load-bearing.

Verified by mutation, since these are the mistakes that got this far. Reverting the attached-row timestamps leaves the unit suite and the e2e green one revision back, and fails both here. Setting the grace to zero fails the negative half. Replacing the cap's `break` with emit-then-`continue` keeps the set at its cap — so the size assertion cannot see it — and is caught by captured tracing instead.

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` are green locally.

Follows #1073. Fixes api7/AISIX-Cloud#1450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unattached guardrails are now reported after a 30-second grace period instead of during index builds.
  * Guardrails that lose their attachment are detected and reported during periodic checks.
  * Duplicate warnings are suppressed, while attached or briefly unattached guardrails avoid false alerts.
* **Reliability**
  * Background monitoring continues safely through timer delays and internal state issues.
* **Tests**
  * Expanded coverage for delayed reporting, attachment changes, grace periods, and deduplicated notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

