### PR TITLE
perf(e2e): give each vitest fork its own etcd instead of capping forks at two

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,9 +262,13 @@ jobs:
       # One etcd per vitest fork. The suite ran at maxForks=2 because
       # 20+ files' gateways watching a SINGLE cluster pushed watch
       # dispatch past `waitConfigPropagation` (#157); the fork count is
-      # derived from AISIX_E2E_ETCD_ENDPOINTS below, so adding a cluster
-      # here is what raises it — and removing one lowers it rather than
-      # doubling forks onto a shared cluster.
+      # derived from AISIX_E2E_ETCD_ENDPOINTS below, so removing a
+      # cluster here lowers it rather than doubling forks onto a shared
+      # one. It does NOT work in the other direction: forkBudget is also
+      # capped by the core count, and ubuntu-latest has exactly four — a
+      # fifth service would add no forks and only a fifth thing that has
+      # to be up. Raising concurrency means a bigger runner AND another
+      # cluster, in that order.
       etcd:
         image: quay.io/coreos/etcd:v3.5.15
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,12 +259,36 @@ jobs:
           - serving: work-stealing
             thread_per_core: "false"
     services:
+      # One etcd per vitest fork. The suite ran at maxForks=2 because
+      # 20+ files' gateways watching a SINGLE cluster pushed watch
+      # dispatch past `waitConfigPropagation` (#157); the fork count is
+      # derived from AISIX_E2E_ETCD_ENDPOINTS below, so adding a cluster
+      # here is what raises it — and removing one lowers it rather than
+      # doubling forks onto a shared cluster.
       etcd:
         image: quay.io/coreos/etcd:v3.5.15
         env:
           ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
           ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
         ports: ["2379:2379"]
+      etcd2:
+        image: quay.io/coreos/etcd:v3.5.15
+        env:
+          ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
+          ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
+        ports: ["2380:2379"]
+      etcd3:
+        image: quay.io/coreos/etcd:v3.5.15
+        env:
+          ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
+          ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
+        ports: ["2381:2379"]
+      etcd4:
+        image: quay.io/coreos/etcd:v3.5.15
+        env:
+          ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
+          ETCD_ADVERTISE_CLIENT_URLS: "http://0.0.0.0:2379"
+        ports: ["2382:2379"]
       redis:
         # redis:8 = vector-capable, so the semantic-cache redis e2e
         # exercises the real path against AISIX_E2E_REDIS.
@@ -324,6 +348,10 @@ jobs:
           # Vector-less redis for the semantic-cache degradation suite;
           # the main 6379 service is redis:8 (vector-capable).
           AISIX_E2E_REDIS_PLAIN: redis://127.0.0.1:6377
+          # One entry per etcd service above. vitest derives maxForks
+          # from this list (see tests/e2e/vitest.config.ts), and
+          # harness/etcd.ts hands each fork its own entry.
+          AISIX_E2E_ETCD_ENDPOINTS: http://127.0.0.1:2379,http://127.0.0.1:2380,http://127.0.0.1:2381,http://127.0.0.1:2382
         run: pnpm test
       - name: tag coverage by leg
         # The gate downloads every leg with `merge-multiple: true`, which

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,11 @@ jobs:
     name: e2e (vitest, ${{ matrix.serving }}) + coverage
     needs: [build-bin]
     runs-on: ubuntu-latest
+    # Explicit, so the job's token stays read-only regardless of the
+    # repository-level default (currently `read`, but that is a setting).
+    # Mirrors the mcp-conformance job below.
+    permissions:
+      contents: read
     strategy:
       # The two serving modes are separate products of the same binary:
       # thread-per-core answers a request on the thread that accepted it

--- a/crates/aisix-guardrails/src/index.rs
+++ b/crates/aisix-guardrails/src/index.rs
@@ -627,11 +627,20 @@ mod tests {
     // -----------------------------------------------------------------------
 
     /// Performance pin: building the index from 1000 entries and resolving
-    /// 100 contexts must complete in well under 100ms on any CI runner.
-    /// Uses a simple wall-clock assertion — not a criterion benchmark — so
-    /// it runs in `cargo test` without extra tooling.
+    /// 100 contexts must stay far away from quadratic. Uses a simple
+    /// wall-clock assertion — not a criterion benchmark — so it runs in
+    /// `cargo test` without extra tooling.
+    ///
+    /// The bound is 500ms, not the 100ms this originally claimed was
+    /// safe "on any CI runner". CI runs this under `cargo llvm-cov`, and
+    /// instrumentation plus a contended shared runner took a passing
+    /// build to 138ms — a spurious red on a required check, in a test
+    /// whose point is the SHAPE of the cost curve. 500ms keeps that
+    /// point intact: a resolve that went quadratic over 1000 entries ×
+    /// 100 contexts is ~10^8 operations and misses this by orders of
+    /// magnitude, not by the 1.4x a busy runner costs.
     #[test]
-    fn index_rebuild_and_resolve_1000_attachments_under_100ms() {
+    fn index_rebuild_and_resolve_1000_attachments_stays_linear() {
         let mut entries = Vec::with_capacity(1000);
         for i in 0..1000u32 {
             let scope_kind = match i % 4 {
@@ -678,8 +687,9 @@ mod tests {
 
         let elapsed = start.elapsed();
         assert!(
-            elapsed.as_millis() < 100,
-            "index build + 100 resolves took {}ms, expected < 100ms",
+            elapsed.as_millis() < 500,
+            "index build + 100 resolves took {}ms, expected < 500ms — that is \
+             far past runner noise and means the cost curve changed shape",
             elapsed.as_millis()
         );
     }

--- a/crates/aisix-guardrails/src/index.rs
+++ b/crates/aisix-guardrails/src/index.rs
@@ -246,7 +246,7 @@ mod tests {
     use super::*;
     use crate::{GuardrailVerdict, KeywordBlocklist, KeywordRule};
     use aisix_gateway::{ChatFormat, ChatMessage};
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
 
     fn kw(_name: &'static str, literal: &str) -> Arc<dyn Guardrail> {
         Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal(
@@ -623,7 +623,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Benchmark: 1000 attachment entries, resolve < 100ms
+    // Benchmark: 1000 attachment entries, build + 100 resolves stay linear
     // -----------------------------------------------------------------------
 
     /// Performance pin: building the index from 1000 entries and resolving
@@ -686,11 +686,13 @@ mod tests {
         }
 
         let elapsed = start.elapsed();
+        // Compare Durations, not as_millis(): the latter truncates, so
+        // 500.9ms would read as 500 and pass a `< 500` check.
         assert!(
-            elapsed.as_millis() < 500,
-            "index build + 100 resolves took {}ms, expected < 500ms — that is \
+            elapsed < Duration::from_millis(500),
+            "index build + 100 resolves took {:?}, expected < 500ms — that is \
              far past runner noise and means the cost curve changed shape",
-            elapsed.as_millis()
+            elapsed
         );
     }
 }

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -25,3 +25,25 @@ Two things the gate must not be:
   invalid-response failure must surface as itself rather than as a timeout.
   Prefer a gate that cannot throw (`ProxyClient.listModels`) over a `try/catch`
   around an SDK call.
+
+## etcd is per-fork, and on CI it must be there
+
+CI runs one etcd cluster per vitest fork and hands each fork its own
+(`AISIX_E2E_ETCD_ENDPOINTS`, mapped by `VITEST_POOL_ID`). Two
+consequences a spec author cannot see from the 200-odd call sites they
+would otherwise copy:
+
+- **`etcdEndpoint()` is the only permitted way to name an etcd.** Reading
+  `AISIX_E2E_ETCD` / `AISIX_E2E_ETCD_ENDPOINTS`, or writing a
+  `127.0.0.1:2379` literal, pins ONE fork's cluster while the gateway
+  the spec just spawned talks to its own — surfacing as a
+  `waitConfigPropagation` timeout that reads like a product bug.
+  `harness/etcd-endpoint.test.ts` fails the build on it.
+
+- **`ping()` throws on CI**, so the familiar
+  `if (!(await etcd.ping())) ctx.skip()` prologue is a local-only escape
+  hatch there; do not add a second `if (process.env.CI) throw` beside
+  it. The skip exists for a developer with no etcd running. On CI a
+  skipped file contributes no assertions while the leg still reports
+  green, and with a cluster per fork one dead endpoint would take out
+  only the quarter of the suite bound to it — quietly.

--- a/tests/e2e/src/cases/cache-env-namespace-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-env-namespace-e2e.test.ts
@@ -3,6 +3,7 @@ import { connect } from "node:net";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  etcdEndpoint,
   SeedClient,
   ProxyClient,
   spawnApp,
@@ -34,7 +35,7 @@ const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
   .digest("hex");
 
-const ETCD_ENDPOINT = process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379";
+const ETCD_ENDPOINT = etcdEndpoint();
 const REDIS_URL = process.env.AISIX_E2E_REDIS ?? "redis://127.0.0.1:6379";
 
 // Both envs use the SAME model alias so the request fingerprints collide

--- a/tests/e2e/src/cases/export-roundtrip-e2e.test.ts
+++ b/tests/e2e/src/cases/export-roundtrip-e2e.test.ts
@@ -5,6 +5,7 @@ import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  etcdEndpoint,
   ProxyClient,
   SeedClient,
   spawnApp,
@@ -35,7 +36,7 @@ const execFileP = promisify(execFile);
 
 const BIN_PATH =
   process.env.AISIX_BIN ?? join(process.cwd(), "..", "..", "target", "debug", "aisix");
-const ETCD_ENDPOINT = process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379";
+const ETCD_ENDPOINT = etcdEndpoint();
 
 const CALLER_PLAINTEXT = "sk-export-roundtrip-caller";
 const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");

--- a/tests/e2e/src/cases/file-resource-source-e2e.test.ts
+++ b/tests/e2e/src/cases/file-resource-source-e2e.test.ts
@@ -316,15 +316,10 @@ describe("file resource source: differential vs etcd mode", () => {
   beforeAll(async () => {
     const etcd = new EtcdClient();
     etcdReachable = await etcd.ping();
-    if (!etcdReachable) {
-      // Local runs may skip quietly; on CI the differential pin is the
-      // point of this file — a silent skip would let the equivalence
-      // contract rot invisibly.
-      if (process.env.CI) {
-        throw new Error("differential case requires etcd on CI (AISIX_E2E_ETCD)");
-      }
-      return;
-    }
+    // Local runs may skip quietly. On CI they cannot: ping() throws
+    // there, for every case file, so the equivalence contract this file
+    // pins can no longer rot behind a silent skip.
+    if (!etcdReachable) return;
 
     upstream = await startOpenAiUpstream();
 

--- a/tests/e2e/src/cases/listener-tls-e2e.test.ts
+++ b/tests/e2e/src/cases/listener-tls-e2e.test.ts
@@ -6,7 +6,7 @@ import { randomUUID } from "node:crypto";
 import { stringify as yamlStringify } from "yaml";
 import { Agent, request } from "undici";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
-import { EtcdClient, pickFreePorts, suiteThreadPerCore } from "../harness/index.js";
+import { EtcdClient, etcdEndpoint, pickFreePorts, suiteThreadPerCore } from "../harness/index.js";
 
 // E2E: `proxy.tls` / `admin.tls` actually serve HTTPS.
 //
@@ -68,7 +68,7 @@ describe("listener TLS (#473)", () => {
     const adminKey = `admin-${randomUUID()}`;
     const cfg = {
       etcd: {
-        endpoints: [process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379"],
+        endpoints: [etcdEndpoint()],
         prefix: `/aisix-e2e-tls-${randomUUID()}`,
         dial_timeout_ms: 5000,
         request_timeout_ms: 5000,

--- a/tests/e2e/src/cases/ratelimit-cluster-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-cluster-e2e.test.ts
@@ -3,6 +3,7 @@ import { connect } from "node:net";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  etcdEndpoint,
   SeedClient,
   ProxyClient,
   spawnApp,
@@ -32,7 +33,7 @@ const CALLER_KEY_HASH = createHash("sha256")
   .update(CALLER_PLAINTEXT)
   .digest("hex");
 
-const ETCD_ENDPOINT = process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379";
+const ETCD_ENDPOINT = etcdEndpoint();
 const REDIS_URL = process.env.AISIX_E2E_REDIS ?? "redis://127.0.0.1:6379";
 
 /** RESP-level PING so the suite skips honestly when no redis is reachable

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -235,7 +235,8 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   if (!fileMode && !(await etcd.ping())) {
     throw new Error(
       `etcd not reachable at ${etcdEndpoint()} ` +
-        "(set AISIX_E2E_ETCD or run `docker run --rm -p 2379:2379 quay.io/coreos/etcd:v3.5.15`)",
+        "(set AISIX_E2E_ETCD_ENDPOINTS — which takes precedence — or AISIX_E2E_ETCD, " +
+          "or run `docker run --rm -p 2379:2379 quay.io/coreos/etcd:v3.5.15`)",
     );
   }
 

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -6,7 +6,7 @@ import { randomUUID } from "node:crypto";
 import { stringify as yamlStringify } from "yaml";
 
 import { pickFreePorts } from "./ports.js";
-import { EtcdClient } from "./etcd.js";
+import { EtcdClient, etcdEndpoint } from "./etcd.js";
 import { harnessRequest } from "./http.js";
 
 export interface AppOverrides {
@@ -234,7 +234,7 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   // file source stays exercisable even without the shared etcd.
   if (!fileMode && !(await etcd.ping())) {
     throw new Error(
-      `etcd not reachable at ${process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379"} ` +
+      `etcd not reachable at ${etcdEndpoint()} ` +
         "(set AISIX_E2E_ETCD or run `docker run --rm -p 2379:2379 quay.io/coreos/etcd:v3.5.15`)",
     );
   }
@@ -268,7 +268,7 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
       ? { resources_file: resourcesPath }
       : {
           etcd: {
-            endpoints: [process.env.AISIX_E2E_ETCD ?? "http://127.0.0.1:2379"],
+            endpoints: [etcdEndpoint()],
             prefix: etcdPrefix,
             dial_timeout_ms: 5000,
             request_timeout_ms: 5000,

--- a/tests/e2e/src/harness/etcd-endpoint.test.ts
+++ b/tests/e2e/src/harness/etcd-endpoint.test.ts
@@ -26,8 +26,8 @@ describe("etcdEndpoint", () => {
   // _ENDPOINTS list (`\b` does NOT separate them — `_` is a word
   // character — so a case doing `AISIX_E2E_ETCD_ENDPOINTS.split(",")[0]`
   // would pin fork 1's cluster and pass a narrower guard), and writing a
-  // literal in the 2379-2382 range CI publishes its clusters on, by
-  // either host spelling. (A deliberately dead endpoint like
+  // literal in the 2379-2382 range CI publishes its clusters on, in any
+  // of its three host spellings. (A deliberately dead endpoint like
   // 127.0.0.1:1, which several cases use to prove a failure path, is
   // outside that range and stays allowed.)
   it("is the only place the etcd endpoint is resolved", () => {
@@ -42,7 +42,7 @@ describe("etcdEndpoint", () => {
       const src = readFileSync(file, "utf8");
       return (
         /process\.env\.AISIX_E2E_ETCD/.test(src) ||
-        /(?:127\.0\.0\.1|localhost):23[78][0-9]/.test(src)
+        /(?:127\.0\.0\.1|localhost|\[::1\]):(?:2379|238[0-2])\b/.test(src)
       );
     });
     expect(offenders.map((f) => f.slice(srcDir.length + 1))).toEqual([]);

--- a/tests/e2e/src/harness/etcd-endpoint.test.ts
+++ b/tests/e2e/src/harness/etcd-endpoint.test.ts
@@ -32,9 +32,13 @@ describe("etcdEndpoint", () => {
   // outside that range and stays allowed.)
   it("is the only place the etcd endpoint is resolved", () => {
     const offenders = sourceFiles(srcDir).filter((file) => {
+      // Exactly two files may resolve an endpoint from the
+      // environment: forks.ts parses the list (everyone else asks it),
+      // and etcd.ts owns the single-endpoint fallback and the
+      // fork-to-cluster mapping. Anything else is the bug this catches.
       if (
+        file.endsWith(join("harness", "forks.ts")) ||
         file.endsWith(join("harness", "etcd.ts")) ||
-        file.endsWith(join("harness", "global-setup.ts")) ||
         file.endsWith(join("harness", "etcd-endpoint.test.ts"))
       ) {
         return false;

--- a/tests/e2e/src/harness/etcd-endpoint.test.ts
+++ b/tests/e2e/src/harness/etcd-endpoint.test.ts
@@ -1,0 +1,60 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { etcdEndpoint } from "./etcd.js";
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+describe("etcdEndpoint", () => {
+  // The whole point of the helper is that a fork's gateway and the test
+  // driving it agree on which cluster they mean. A file that resolves
+  // AISIX_E2E_ETCD itself pins fork 1's endpoint while the gateway it
+  // spawned talks to fork N's, and the symptom is a config-propagation
+  // timeout that looks like a product bug.
+  it("is the only place the etcd endpoint is resolved from the environment", () => {
+    const offenders = sourceFiles(srcDir).filter(
+      (file) =>
+        !file.endsWith(join("harness", "etcd.ts")) &&
+        !file.endsWith(join("harness", "etcd-endpoint.test.ts")) &&
+        /process\.env\.AISIX_E2E_ETCD\b/.test(readFileSync(file, "utf8")),
+    );
+    expect(offenders.map((f) => f.slice(srcDir.length + 1))).toEqual([]);
+  });
+
+  it("spreads forks across the configured endpoints", () => {
+    const prev = { ...process.env };
+    try {
+      process.env.AISIX_E2E_ETCD_ENDPOINTS = "http://a:2379, http://b:2379,http://c:2379";
+      const seen = new Set<string>();
+      for (const poolId of ["1", "2", "3"]) {
+        process.env.VITEST_POOL_ID = poolId;
+        seen.add(etcdEndpoint());
+      }
+      expect(seen.size).toBe(3);
+    } finally {
+      process.env = prev;
+    }
+  });
+
+  it("falls back to the single-endpoint form when no list is set", () => {
+    const prev = { ...process.env };
+    try {
+      delete process.env.AISIX_E2E_ETCD_ENDPOINTS;
+      process.env.AISIX_E2E_ETCD = "http://only:2379";
+      process.env.VITEST_POOL_ID = "7";
+      expect(etcdEndpoint()).toBe("http://only:2379");
+    } finally {
+      process.env = prev;
+    }
+  });
+});

--- a/tests/e2e/src/harness/etcd-endpoint.test.ts
+++ b/tests/e2e/src/harness/etcd-endpoint.test.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import { etcdEndpoint } from "./etcd.js";
+import { etcdEndpoint, etcdEndpointForPool } from "./etcd.js";
 
 const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -84,6 +84,23 @@ describe("etcdEndpoint", () => {
         expect(seen.size).toBe(3);
       },
     );
+  });
+
+  // VITEST_POOL_ID is ONE-based, so "the endpoints N forks use" is NOT
+  // the first N entries. The global setup probes exactly the clusters
+  // the run will reach, and it has to derive them the same way this
+  // does — deriving them independently is how it came to clear an
+  // unused endpoint while leaving a used one unchecked.
+  it("maps one-based pool ids, so N forks are not the first N entries", () => {
+    withEnv({ AISIX_E2E_ETCD_ENDPOINTS: "http://a:2379,http://b:2379,http://c:2379,http://d:2379" }, () => {
+      expect([1, 2].map(etcdEndpointForPool)).toEqual(["http://b:2379", "http://c:2379"]);
+      expect([1, 2, 3, 4].map(etcdEndpointForPool)).toEqual([
+        "http://b:2379",
+        "http://c:2379",
+        "http://d:2379",
+        "http://a:2379",
+      ]);
+    });
   });
 
   it("falls back to the single-endpoint form when no list is set", () => {

--- a/tests/e2e/src/harness/etcd-endpoint.test.ts
+++ b/tests/e2e/src/harness/etcd-endpoint.test.ts
@@ -22,20 +22,28 @@ describe("etcdEndpoint", () => {
   // spawned talks to fork N's, and the symptom is a config-propagation
   // timeout that looks like a product bug.
   //
-  // Both spellings count: reading AISIX_E2E_ETCD, and writing a literal
-  // in the 2379-2382 range CI publishes its clusters on. (A deliberately
-  // dead endpoint like 127.0.0.1:1, which several cases use to prove a
-  // failure path, is outside that range and stays allowed.)
+  // Three spellings count: reading AISIX_E2E_ETCD, reading the
+  // _ENDPOINTS list (`\b` does NOT separate them — `_` is a word
+  // character — so a case doing `AISIX_E2E_ETCD_ENDPOINTS.split(",")[0]`
+  // would pin fork 1's cluster and pass a narrower guard), and writing a
+  // literal in the 2379-2382 range CI publishes its clusters on, by
+  // either host spelling. (A deliberately dead endpoint like
+  // 127.0.0.1:1, which several cases use to prove a failure path, is
+  // outside that range and stays allowed.)
   it("is the only place the etcd endpoint is resolved", () => {
     const offenders = sourceFiles(srcDir).filter((file) => {
       if (
         file.endsWith(join("harness", "etcd.ts")) ||
+        file.endsWith(join("harness", "global-setup.ts")) ||
         file.endsWith(join("harness", "etcd-endpoint.test.ts"))
       ) {
         return false;
       }
       const src = readFileSync(file, "utf8");
-      return /process\.env\.AISIX_E2E_ETCD\b/.test(src) || /127\.0\.0\.1:23[78][0-9]/.test(src);
+      return (
+        /process\.env\.AISIX_E2E_ETCD/.test(src) ||
+        /(?:127\.0\.0\.1|localhost):23[78][0-9]/.test(src)
+      );
     });
     expect(offenders.map((f) => f.slice(srcDir.length + 1))).toEqual([]);
   });

--- a/tests/e2e/src/harness/etcd-endpoint.test.ts
+++ b/tests/e2e/src/harness/etcd-endpoint.test.ts
@@ -18,43 +18,72 @@ function sourceFiles(dir: string): string[] {
 describe("etcdEndpoint", () => {
   // The whole point of the helper is that a fork's gateway and the test
   // driving it agree on which cluster they mean. A file that resolves
-  // AISIX_E2E_ETCD itself pins fork 1's endpoint while the gateway it
+  // the endpoint itself pins fork 1's cluster while the gateway it
   // spawned talks to fork N's, and the symptom is a config-propagation
   // timeout that looks like a product bug.
-  it("is the only place the etcd endpoint is resolved from the environment", () => {
-    const offenders = sourceFiles(srcDir).filter(
-      (file) =>
-        !file.endsWith(join("harness", "etcd.ts")) &&
-        !file.endsWith(join("harness", "etcd-endpoint.test.ts")) &&
-        /process\.env\.AISIX_E2E_ETCD\b/.test(readFileSync(file, "utf8")),
-    );
+  //
+  // Both spellings count: reading AISIX_E2E_ETCD, and writing a literal
+  // in the 2379-2382 range CI publishes its clusters on. (A deliberately
+  // dead endpoint like 127.0.0.1:1, which several cases use to prove a
+  // failure path, is outside that range and stays allowed.)
+  it("is the only place the etcd endpoint is resolved", () => {
+    const offenders = sourceFiles(srcDir).filter((file) => {
+      if (
+        file.endsWith(join("harness", "etcd.ts")) ||
+        file.endsWith(join("harness", "etcd-endpoint.test.ts"))
+      ) {
+        return false;
+      }
+      const src = readFileSync(file, "utf8");
+      return /process\.env\.AISIX_E2E_ETCD\b/.test(src) || /127\.0\.0\.1:23[78][0-9]/.test(src);
+    });
     expect(offenders.map((f) => f.slice(srcDir.length + 1))).toEqual([]);
   });
 
-  it("spreads forks across the configured endpoints", () => {
-    const prev = { ...process.env };
-    try {
-      process.env.AISIX_E2E_ETCD_ENDPOINTS = "http://a:2379, http://b:2379,http://c:2379";
-      const seen = new Set<string>();
-      for (const poolId of ["1", "2", "3"]) {
-        process.env.VITEST_POOL_ID = poolId;
-        seen.add(etcdEndpoint());
-      }
-      expect(seen.size).toBe(3);
-    } finally {
-      process.env = prev;
+  // Restore the individual keys rather than reassigning process.env:
+  // replacing the object detaches it from the live environment, which
+  // spawnApp reads to build a child's env.
+  const withEnv = (vars: Record<string, string | undefined>, fn: () => void) => {
+    const keys = Object.keys(vars);
+    const prev = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+    for (const [k, v] of Object.entries(vars)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
     }
+    try {
+      fn();
+    } finally {
+      for (const k of keys) {
+        if (prev[k] === undefined) delete process.env[k];
+        else process.env[k] = prev[k];
+      }
+    }
+  };
+
+  it("spreads forks across the configured endpoints", () => {
+    withEnv(
+      { AISIX_E2E_ETCD_ENDPOINTS: "http://a:2379, http://b:2379,http://c:2379", VITEST_POOL_ID: "1" },
+      () => {
+        const seen = new Set<string>();
+        for (const poolId of ["1", "2", "3"]) {
+          process.env.VITEST_POOL_ID = poolId;
+          seen.add(etcdEndpoint());
+        }
+        expect(seen.size).toBe(3);
+      },
+    );
   });
 
   it("falls back to the single-endpoint form when no list is set", () => {
-    const prev = { ...process.env };
-    try {
-      delete process.env.AISIX_E2E_ETCD_ENDPOINTS;
-      process.env.AISIX_E2E_ETCD = "http://only:2379";
-      process.env.VITEST_POOL_ID = "7";
-      expect(etcdEndpoint()).toBe("http://only:2379");
-    } finally {
-      process.env = prev;
-    }
+    withEnv(
+      {
+        AISIX_E2E_ETCD_ENDPOINTS: undefined,
+        AISIX_E2E_ETCD: "http://only:2379",
+        VITEST_POOL_ID: "7",
+      },
+      () => {
+        expect(etcdEndpoint()).toBe("http://only:2379");
+      },
+    );
   });
 });

--- a/tests/e2e/src/harness/etcd.ts
+++ b/tests/e2e/src/harness/etcd.ts
@@ -1,3 +1,4 @@
+import { configuredEtcdEndpoints } from "./forks.js";
 import { harnessRequest } from "./http.js";
 
 const DEFAULT_ETCD = "http://127.0.0.1:2379";
@@ -29,10 +30,7 @@ export function onCI(): boolean {
  * before.
  */
 export function etcdEndpoint(): string {
-  const list = (process.env.AISIX_E2E_ETCD_ENDPOINTS ?? "")
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const list = configuredEtcdEndpoints();
   if (list.length === 0) return process.env.AISIX_E2E_ETCD ?? DEFAULT_ETCD;
   const poolId = Number(process.env.VITEST_POOL_ID);
   const slot = Number.isFinite(poolId) && poolId >= 0 ? poolId : process.pid;

--- a/tests/e2e/src/harness/etcd.ts
+++ b/tests/e2e/src/harness/etcd.ts
@@ -93,16 +93,21 @@ export class EtcdClient {
    * endpoint rather than throw on the first.
    */
   async reachable(timeoutMs = 1000): Promise<boolean> {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
     try {
-      const ctrl = new AbortController();
-      const t = setTimeout(() => ctrl.abort(), timeoutMs);
       const res = await harnessRequest(`${this.endpoint}/v3/maintenance/status`, {
         method: "POST",
         body: "{}",
         headers: { "content-type": "application/json" },
         signal: ctrl.signal,
       });
-      clearTimeout(t);
+      // The timer stays armed until the BODY is consumed, not just until
+      // the headers land. The 200 this method distrusts is exactly the
+      // kind that can come from something that is not etcd, and one that
+      // then never finishes its body would hang here forever with the
+      // abort disarmed — blocking the global setup that probes every
+      // endpoint at once, or a case file's beforeAll.
       if (res.statusCode !== 200) {
         await res.body.dump();
         return false;
@@ -116,6 +121,8 @@ export class EtcdClient {
       }
     } catch {
       return false;
+    } finally {
+      clearTimeout(t);
     }
   }
 

--- a/tests/e2e/src/harness/etcd.ts
+++ b/tests/e2e/src/harness/etcd.ts
@@ -2,6 +2,11 @@ import { harnessRequest } from "./http.js";
 
 const DEFAULT_ETCD = "http://127.0.0.1:2379";
 
+/** True inside GitHub Actions (or anything else setting CI). */
+export function onCI(): boolean {
+  return process.env.CI !== undefined && process.env.CI !== "";
+}
+
 /**
  * The etcd endpoint THIS vitest fork uses. Every etcd reference in the
  * suite must come from here — the spawned gateway's config, the seeder,
@@ -42,14 +47,52 @@ export class EtcdClient {
   constructor(private readonly endpoint: string = etcdEndpoint()) {}
 
   /**
-   * Best-effort connectivity probe — returns false if etcd isn't reachable.
+   * Connectivity probe. Returns false when etcd isn't reachable — but
+   * THROWS instead when running on CI.
+   *
+   * ~246 call sites read this as `if (!(await etcd.ping())) return;` or
+   * `ctx.skip()`, which is right for a developer without etcd running
+   * and wrong for CI, where a skipped file is a coverage hole that
+   * still reports green. That mattered less when one dead cluster took
+   * the whole suite down at once; with a cluster per fork it costs only
+   * the files bound to that fork, so the run stays green while a
+   * quarter of it silently evaporates. `file-resource-source-e2e`
+   * already carried this rule for itself; it belongs here, once, for
+   * everyone.
+   *
+   * Retries before concluding "down", and only on CI: a 1s one-shot
+   * against a contended container is a coin flip under fork
+   * concurrency, and a false negative now reds the build rather than
+   * quietly dropping a file. Locally the single probe keeps the skip
+   * fast — retrying 226 files' worth of beforeAll hooks would not be.
+   */
+  async ping(timeoutMs = 1000): Promise<boolean> {
+    const attempts = onCI() ? 3 : 1;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      if (await this.reachable(timeoutMs * attempt)) return true;
+    }
+    if (onCI()) {
+      throw new Error(
+        `etcd not reachable at ${this.endpoint} after ${attempts} attempts. ` +
+          "On CI this fails the run instead of skipping the test, because a " +
+          "skipped file contributes no assertions and the leg still reports green.",
+      );
+    }
+    return false;
+  }
+
+  /**
+   * The raw probe: true when the endpoint answers as etcd.
    *
    * Beyond a 200 status we also confirm the response is JSON containing the
    * expected `header.cluster_id` field. A stray Docker port-mapping or a
    * dev-tool's "service unavailable" HTML page can return 200 to anything
    * on port 2379 and we don't want to misidentify those as etcd.
+   *
+   * Used directly by the global setup, which needs to report EVERY dead
+   * endpoint rather than throw on the first.
    */
-  async ping(timeoutMs = 1000): Promise<boolean> {
+  async reachable(timeoutMs = 1000): Promise<boolean> {
     try {
       const ctrl = new AbortController();
       const t = setTimeout(() => ctrl.abort(), timeoutMs);

--- a/tests/e2e/src/harness/etcd.ts
+++ b/tests/e2e/src/harness/etcd.ts
@@ -30,11 +30,24 @@ export function onCI(): boolean {
  * before.
  */
 export function etcdEndpoint(): string {
+  const poolId = Number(process.env.VITEST_POOL_ID);
+  return etcdEndpointForPool(Number.isFinite(poolId) && poolId >= 0 ? poolId : process.pid);
+}
+
+/**
+ * The endpoint a given VITEST_POOL_ID maps to.
+ *
+ * Exported so the global setup can probe exactly the clusters the run
+ * will reach instead of re-deriving the mapping. Re-deriving is how the
+ * two drift: `VITEST_POOL_ID` is ONE-based, so a 4-entry list running 2
+ * forks uses entries 1 and 2 — not the first two — and a setup that
+ * probed `slice(0, 2)` would clear an endpoint nobody touches while
+ * leaving the one fork 2 depends on unchecked.
+ */
+export function etcdEndpointForPool(poolId: number): string {
   const list = configuredEtcdEndpoints();
   if (list.length === 0) return process.env.AISIX_E2E_ETCD ?? DEFAULT_ETCD;
-  const poolId = Number(process.env.VITEST_POOL_ID);
-  const slot = Number.isFinite(poolId) && poolId >= 0 ? poolId : process.pid;
-  return list[slot % list.length];
+  return list[poolId % list.length];
 }
 
 /**

--- a/tests/e2e/src/harness/etcd.ts
+++ b/tests/e2e/src/harness/etcd.ts
@@ -3,9 +3,17 @@ import { harnessRequest } from "./http.js";
 
 const DEFAULT_ETCD = "http://127.0.0.1:2379";
 
-/** True inside GitHub Actions (or anything else setting CI). */
+/**
+ * True inside GitHub Actions (or anything else setting CI).
+ *
+ * `CI=false` and `CI=0` mean NOT on CI — a widely used way to turn CI
+ * behaviour off — and a bare presence check reads them as true. That
+ * would flip ping() to throwing for a developer who exports either,
+ * across all 246 call sites, against the promise that a machine without
+ * etcd keeps the quiet skip. Same test std-env uses.
+ */
 export function onCI(): boolean {
-  return process.env.CI !== undefined && process.env.CI !== "";
+  return !["", "0", "false"].includes(process.env.CI ?? "");
 }
 
 /**
@@ -76,11 +84,18 @@ export class EtcdClient {
    * concurrency, and a false negative now reds the build rather than
    * quietly dropping a file. Locally the single probe keeps the skip
    * fast — retrying 226 files' worth of beforeAll hooks would not be.
+   *
+   * The SLEEP between attempts is the part that does the work. A
+   * container that is restarting REFUSES the connection in about a
+   * millisecond rather than hanging, so escalating only the abort
+   * timeout spans nothing at all: three attempts against a closed port
+   * complete in ~8ms and prove only that it was closed 8ms ago.
    */
   async ping(timeoutMs = 1000): Promise<boolean> {
     const attempts = onCI() ? 3 : 1;
     for (let attempt = 1; attempt <= attempts; attempt++) {
       if (await this.reachable(timeoutMs * attempt)) return true;
+      if (attempt < attempts) await new Promise((r) => setTimeout(r, 500 * attempt));
     }
     if (onCI()) {
       throw new Error(

--- a/tests/e2e/src/harness/etcd.ts
+++ b/tests/e2e/src/harness/etcd.ts
@@ -1,14 +1,45 @@
 import { harnessRequest } from "./http.js";
 
+const DEFAULT_ETCD = "http://127.0.0.1:2379";
+
+/**
+ * The etcd endpoint THIS vitest fork uses. Every etcd reference in the
+ * suite must come from here — the spawned gateway's config, the seeder,
+ * and any case that talks to etcd directly. A case that resolves the
+ * endpoint itself will read a different cluster than the gateway it just
+ * spawned the moment more than one is in play, and the failure looks
+ * like a propagation bug rather than a wiring one.
+ * (harness/etcd-endpoint.test.ts fails if a file resolves it itself.)
+ *
+ * With `AISIX_E2E_ETCD_ENDPOINTS` set to a comma-separated list, forks
+ * are spread across the entries by `VITEST_POOL_ID`. Concurrency in this
+ * suite was capped at two forks because 20+ files' gateways sharing one
+ * etcd pushed watch-dispatch latency past `waitConfigPropagation` (#157);
+ * one cluster per fork is what lifts that cap, the same way ports.ts
+ * carves a disjoint port range per fork rather than serialising.
+ *
+ * Correctness never depends on the split — every spawned gateway already
+ * gets a fresh random etcd prefix — so more forks than endpoints only
+ * costs the contention back, and a single endpoint behaves exactly as
+ * before.
+ */
+export function etcdEndpoint(): string {
+  const list = (process.env.AISIX_E2E_ETCD_ENDPOINTS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (list.length === 0) return process.env.AISIX_E2E_ETCD ?? DEFAULT_ETCD;
+  const poolId = Number(process.env.VITEST_POOL_ID);
+  const slot = Number.isFinite(poolId) && poolId >= 0 ? poolId : process.pid;
+  return list[slot % list.length];
+}
+
 /**
  * Minimal etcd v3 helper that talks to the JSON gRPC-gateway
  * (`/v3/kv/*` endpoints). Avoids pulling a heavy etcd npm dependency.
  */
 export class EtcdClient {
-  constructor(
-    private readonly endpoint: string = process.env.AISIX_E2E_ETCD ??
-      "http://127.0.0.1:2379",
-  ) {}
+  constructor(private readonly endpoint: string = etcdEndpoint()) {}
 
   /**
    * Best-effort connectivity probe — returns false if etcd isn't reachable.

--- a/tests/e2e/src/harness/forks.ts
+++ b/tests/e2e/src/harness/forks.ts
@@ -1,0 +1,37 @@
+import { availableParallelism } from "node:os";
+
+import { RANGE_SLOTS } from "./ports.js";
+
+/** Endpoints from AISIX_E2E_ETCD_ENDPOINTS, trimmed, in order. */
+export function configuredEtcdEndpoints(): string[] {
+  return (process.env.AISIX_E2E_ETCD_ENDPOINTS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * How many vitest forks this run may use.
+ *
+ * One per etcd cluster, because that is the constraint that forced
+ * maxForks=2 in the first place (#157: every fork's gateway watching one
+ * shared cluster blew past waitConfigPropagation). Bounded three ways:
+ *
+ *   - floor 2, the value the suite ran at before the split, and what a
+ *     developer with a single local etcd gets;
+ *   - RANGE_SLOTS, because ports.ts hands fork `poolId % RANGE_SLOTS`
+ *     its own port range and beyond that two forks share one;
+ *   - the core count, because each fork drives a real `aisix` process
+ *     and several cases assert wall-clock bounds derived on a loaded
+ *     runner (audio-timeout, ttft-first-frame, per-attempt-telemetry).
+ *
+ * The core cap is why adding a fifth etcd service to a 4-core runner
+ * would buy nothing: the endpoint list is a ceiling on concurrency, not
+ * a target.
+ */
+export function forkBudget(): number {
+  const ceiling = Math.min(RANGE_SLOTS, Math.max(2, availableParallelism()));
+  const override = Number(process.env.AISIX_E2E_MAX_FORKS);
+  if (Number.isInteger(override) && override >= 1) return Math.min(override, ceiling);
+  return Math.min(Math.max(2, configuredEtcdEndpoints().length), ceiling);
+}

--- a/tests/e2e/src/harness/forks.ts
+++ b/tests/e2e/src/harness/forks.ts
@@ -28,10 +28,20 @@ export function configuredEtcdEndpoints(): string[] {
  * The core cap is why adding a fifth etcd service to a 4-core runner
  * would buy nothing: the endpoint list is a ceiling on concurrency, not
  * a target.
+ *
+ * AISIX_E2E_MAX_FORKS can only LOWER the result. Letting it raise past
+ * the endpoint count would put two gateways' watch sets on one cluster
+ * — #157 exactly — while vitest.config.ts advertises the opposite as a
+ * guarantee, so the knob is clamped by the same bound everything else
+ * is.
  */
 export function forkBudget(): number {
-  const ceiling = Math.min(RANGE_SLOTS, Math.max(2, availableParallelism()));
+  const derived = Math.min(
+    Math.max(2, configuredEtcdEndpoints().length),
+    RANGE_SLOTS,
+    Math.max(2, availableParallelism()),
+  );
   const override = Number(process.env.AISIX_E2E_MAX_FORKS);
-  if (Number.isInteger(override) && override >= 1) return Math.min(override, ceiling);
-  return Math.min(Math.max(2, configuredEtcdEndpoints().length), ceiling);
+  if (Number.isInteger(override) && override >= 1) return Math.min(override, derived);
+  return derived;
 }

--- a/tests/e2e/src/harness/forks.ts
+++ b/tests/e2e/src/harness/forks.ts
@@ -36,8 +36,9 @@ export function configuredEtcdEndpoints(): string[] {
  * is.
  */
 export function forkBudget(): number {
+  const endpoints = configuredEtcdEndpoints().length;
   const derived = Math.min(
-    Math.max(2, configuredEtcdEndpoints().length),
+    endpoints > 0 ? endpoints : 2,
     RANGE_SLOTS,
     Math.max(2, availableParallelism()),
   );

--- a/tests/e2e/src/harness/forks.ts
+++ b/tests/e2e/src/harness/forks.ts
@@ -37,10 +37,15 @@ export function configuredEtcdEndpoints(): string[] {
  */
 export function forkBudget(): number {
   const endpoints = configuredEtcdEndpoints().length;
+  const cores = availableParallelism();
   const derived = Math.min(
     endpoints > 0 ? endpoints : 2,
     RANGE_SLOTS,
-    Math.max(2, availableParallelism()),
+    // The floor of 2 belongs to the UNCONFIGURED case only — it is the
+    // historical value, not a claim about the hardware. With a list
+    // present the core count is honoured literally, so a one-core host
+    // runs one fork rather than two gateways on one core.
+    endpoints > 0 ? cores : Math.max(2, cores),
   );
   const override = Number(process.env.AISIX_E2E_MAX_FORKS);
   if (Number.isInteger(override) && override >= 1) return Math.min(override, derived);

--- a/tests/e2e/src/harness/global-setup.ts
+++ b/tests/e2e/src/harness/global-setup.ts
@@ -2,26 +2,6 @@ import { EtcdClient, etcdEndpoint, etcdEndpointForPool, onCI } from "./etcd.js";
 import { configuredEtcdEndpoints, forkBudget } from "./forks.js";
 
 /**
- * Fail the run when a configured etcd cluster is not answering.
- *
- * Nearly every case file opens with `if (!(await etcd.ping())) return;`
- * or `ctx.skip()`, which is right for a developer without etcd running
- * — but it means an unreachable cluster produces a GREEN run with those
- * files contributing nothing. With one shared cluster that was at least
- * all-or-nothing and impossible to miss. Splitting the suite across four
- * clusters (see etcdEndpoint) turns it into a partial, silent loss: one
- * dead endpoint takes out only the quarter of the files whose fork was
- * assigned to it, and `e2e (vitest) + coverage` still reports success.
- *
- * So the reachability check moves here, once, before any fork starts:
- *
- *   - on CI, every configured endpoint must answer. A skipped file on CI
- *     is a coverage hole, not a convenience.
- *   - locally, the same applies as soon as MORE THAN ONE endpoint is
- *     configured, because that is the partial-loss shape. A developer
- *     with no etcd at all, or one, keeps the quiet skip.
- */
-/**
  * Probe one endpoint, retrying before calling it dead.
  *
  * A generous single timeout buys nothing against the failure this
@@ -41,6 +21,26 @@ async function reachableWithRetry(endpoint: string): Promise<boolean> {
   return false;
 }
 
+/**
+ * Fail the run when a configured etcd cluster is not answering.
+ *
+ * Nearly every case file opens with `if (!(await etcd.ping())) return;`
+ * or `ctx.skip()`, which is right for a developer without etcd running
+ * — but it means an unreachable cluster produces a GREEN run with those
+ * files contributing nothing. With one shared cluster that was at least
+ * all-or-nothing and impossible to miss. Splitting the suite across four
+ * clusters (see etcdEndpoint) turns it into a partial, silent loss: one
+ * dead endpoint takes out only the quarter of the files whose fork was
+ * assigned to it, and `e2e (vitest) + coverage` still reports success.
+ *
+ * So the reachability check moves here, once, before any fork starts:
+ *
+ *   - on CI, every configured endpoint must answer. A skipped file on CI
+ *     is a coverage hole, not a convenience.
+ *   - locally, the same applies as soon as MORE THAN ONE endpoint is
+ *     configured, because that is the partial-loss shape. A developer
+ *     with no etcd at all, or one, keeps the quiet skip.
+ */
 export async function setup(): Promise<void> {
   // Only the endpoints this run will actually USE. forkBudget is capped
   // by the core count too, so a 4-entry list on a 2-core runner drives
@@ -71,7 +71,7 @@ export async function setup(): Promise<void> {
   if (dead.length === 0) return;
 
   throw new Error(
-    `etcd not reachable at ${dead.join(", ")} (of ${endpoints.length} configured). ` +
+    `etcd not reachable at ${dead.join(", ")} (of ${endpoints.length} in use). ` +
       "Every case file that landed on one of these would SKIP silently and the run " +
       "would still pass, so it fails here instead. Check the etcd services in " +
       ".github/workflows/ci.yml against AISIX_E2E_ETCD_ENDPOINTS — the two lists " +

--- a/tests/e2e/src/harness/global-setup.ts
+++ b/tests/e2e/src/harness/global-setup.ts
@@ -1,4 +1,4 @@
-import { EtcdClient, etcdEndpoint } from "./etcd.js";
+import { EtcdClient, etcdEndpoint, onCI } from "./etcd.js";
 
 /**
  * Fail the run when a configured etcd cluster is not answering.
@@ -27,16 +27,18 @@ export async function setup(): Promise<void> {
     .filter(Boolean);
   const endpoints = configured.length > 0 ? configured : [etcdEndpoint()];
 
-  const onCI = process.env.CI !== undefined && process.env.CI !== "";
-  if (!onCI && endpoints.length < 2) return;
+  if (!onCI() && endpoints.length < 2) return;
 
   const probes = await Promise.all(
     endpoints.map(async (endpoint) => ({
       endpoint,
+      // `reachable`, not `ping`: ping throws on CI, and this needs to
+      // name EVERY dead endpoint rather than stop at the first.
+      //
       // 5s, not the client's 1s default: this runs before any fork, so
       // a cold container that is still opening its listener must not be
       // mistaken for a dead one.
-      up: await new EtcdClient(endpoint).ping(5000),
+      up: await new EtcdClient(endpoint).reachable(5000),
     })),
   );
   const dead = probes.filter((p) => !p.up).map((p) => p.endpoint);

--- a/tests/e2e/src/harness/global-setup.ts
+++ b/tests/e2e/src/harness/global-setup.ts
@@ -1,4 +1,4 @@
-import { EtcdClient, etcdEndpoint, onCI } from "./etcd.js";
+import { EtcdClient, etcdEndpoint, etcdEndpointForPool, onCI } from "./etcd.js";
 import { configuredEtcdEndpoints, forkBudget } from "./forks.js";
 
 /**
@@ -44,11 +44,17 @@ async function reachableWithRetry(endpoint: string): Promise<boolean> {
 export async function setup(): Promise<void> {
   // Only the endpoints this run will actually USE. forkBudget is capped
   // by the core count too, so a 4-entry list on a 2-core runner drives
-  // two forks — and failing there because clusters 3 and 4 are missing
-  // would be a demand the run never makes. etcdEndpoint assigns
-  // `poolId % list.length`, so with fewer forks than entries the ones in
-  // use are the leading slice.
-  const configured = configuredEtcdEndpoints().slice(0, forkBudget());
+  // two forks, and failing there over clusters the run never touches
+  // would be a demand it does not make.
+  //
+  // Asking etcdEndpointForPool per pool id rather than slicing the list:
+  // VITEST_POOL_ID is ONE-based, so two forks over four entries use
+  // entries 1 and 2 — `slice(0, 2)` would have probed 0 and 1, clearing
+  // an unused cluster while leaving fork 2's unchecked.
+  const budget = forkBudget();
+  const inUse = new Set<string>();
+  for (let poolId = 1; poolId <= budget; poolId++) inUse.add(etcdEndpointForPool(poolId));
+  const configured = configuredEtcdEndpoints().filter((e) => inUse.has(e));
   const endpoints = configured.length > 0 ? configured : [etcdEndpoint()];
 
   if (!onCI() && endpoints.length < 2) return;

--- a/tests/e2e/src/harness/global-setup.ts
+++ b/tests/e2e/src/harness/global-setup.ts
@@ -1,4 +1,5 @@
 import { EtcdClient, etcdEndpoint, onCI } from "./etcd.js";
+import { configuredEtcdEndpoints, forkBudget } from "./forks.js";
 
 /**
  * Fail the run when a configured etcd cluster is not answering.
@@ -20,11 +21,34 @@ import { EtcdClient, etcdEndpoint, onCI } from "./etcd.js";
  *     configured, because that is the partial-loss shape. A developer
  *     with no etcd at all, or one, keeps the quiet skip.
  */
+/**
+ * Probe one endpoint, retrying before calling it dead.
+ *
+ * A generous single timeout buys nothing against the failure this
+ * actually guards: a container still opening its listener REFUSES the
+ * connection in a few milliseconds rather than hanging, so a 5s budget
+ * returns false just as fast as a 50ms one. Only a retry spans a cold
+ * start — and it has to, because a false negative here fails the whole
+ * merge-blocking e2e leg before a single test runs. ping() escalates the
+ * same way on CI for the same reason.
+ */
+async function reachableWithRetry(endpoint: string): Promise<boolean> {
+  const client = new EtcdClient(endpoint);
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    if (await client.reachable(2000)) return true;
+    if (attempt < 5) await new Promise((r) => setTimeout(r, 500 * attempt));
+  }
+  return false;
+}
+
 export async function setup(): Promise<void> {
-  const configured = (process.env.AISIX_E2E_ETCD_ENDPOINTS ?? "")
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
+  // Only the endpoints this run will actually USE. forkBudget is capped
+  // by the core count too, so a 4-entry list on a 2-core runner drives
+  // two forks — and failing there because clusters 3 and 4 are missing
+  // would be a demand the run never makes. etcdEndpoint assigns
+  // `poolId % list.length`, so with fewer forks than entries the ones in
+  // use are the leading slice.
+  const configured = configuredEtcdEndpoints().slice(0, forkBudget());
   const endpoints = configured.length > 0 ? configured : [etcdEndpoint()];
 
   if (!onCI() && endpoints.length < 2) return;
@@ -34,11 +58,7 @@ export async function setup(): Promise<void> {
       endpoint,
       // `reachable`, not `ping`: ping throws on CI, and this needs to
       // name EVERY dead endpoint rather than stop at the first.
-      //
-      // 5s, not the client's 1s default: this runs before any fork, so
-      // a cold container that is still opening its listener must not be
-      // mistaken for a dead one.
-      up: await new EtcdClient(endpoint).reachable(5000),
+      up: await reachableWithRetry(endpoint),
     })),
   );
   const dead = probes.filter((p) => !p.up).map((p) => p.endpoint);

--- a/tests/e2e/src/harness/global-setup.ts
+++ b/tests/e2e/src/harness/global-setup.ts
@@ -1,0 +1,52 @@
+import { EtcdClient, etcdEndpoint } from "./etcd.js";
+
+/**
+ * Fail the run when a configured etcd cluster is not answering.
+ *
+ * Nearly every case file opens with `if (!(await etcd.ping())) return;`
+ * or `ctx.skip()`, which is right for a developer without etcd running
+ * — but it means an unreachable cluster produces a GREEN run with those
+ * files contributing nothing. With one shared cluster that was at least
+ * all-or-nothing and impossible to miss. Splitting the suite across four
+ * clusters (see etcdEndpoint) turns it into a partial, silent loss: one
+ * dead endpoint takes out only the quarter of the files whose fork was
+ * assigned to it, and `e2e (vitest) + coverage` still reports success.
+ *
+ * So the reachability check moves here, once, before any fork starts:
+ *
+ *   - on CI, every configured endpoint must answer. A skipped file on CI
+ *     is a coverage hole, not a convenience.
+ *   - locally, the same applies as soon as MORE THAN ONE endpoint is
+ *     configured, because that is the partial-loss shape. A developer
+ *     with no etcd at all, or one, keeps the quiet skip.
+ */
+export async function setup(): Promise<void> {
+  const configured = (process.env.AISIX_E2E_ETCD_ENDPOINTS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const endpoints = configured.length > 0 ? configured : [etcdEndpoint()];
+
+  const onCI = process.env.CI !== undefined && process.env.CI !== "";
+  if (!onCI && endpoints.length < 2) return;
+
+  const probes = await Promise.all(
+    endpoints.map(async (endpoint) => ({
+      endpoint,
+      // 5s, not the client's 1s default: this runs before any fork, so
+      // a cold container that is still opening its listener must not be
+      // mistaken for a dead one.
+      up: await new EtcdClient(endpoint).ping(5000),
+    })),
+  );
+  const dead = probes.filter((p) => !p.up).map((p) => p.endpoint);
+  if (dead.length === 0) return;
+
+  throw new Error(
+    `etcd not reachable at ${dead.join(", ")} (of ${endpoints.length} configured). ` +
+      "Every case file that landed on one of these would SKIP silently and the run " +
+      "would still pass, so it fails here instead. Check the etcd services in " +
+      ".github/workflows/ci.yml against AISIX_E2E_ETCD_ENDPOINTS — the two lists " +
+      "must match entry for entry.",
+  );
+}

--- a/tests/e2e/src/harness/index.ts
+++ b/tests/e2e/src/harness/index.ts
@@ -1,7 +1,7 @@
 export { spawnApp, suiteThreadPerCore, type SpawnedApp, type AppOverrides } from "./app.js";
 export { AdminClient, waitConfigPropagation, awaitWindowHeadroom } from "./admin.js";
 export { ProxyClient } from "./proxy.js";
-export { EtcdClient } from "./etcd.js";
+export { EtcdClient, etcdEndpoint } from "./etcd.js";
 export { SeedClient } from "./seed.js";
 export { startOpenAiUpstream, type OpenAiUpstream, type ReceivedRequest } from "./upstream-openai.js";
 export {

--- a/tests/e2e/src/harness/ports.ts
+++ b/tests/e2e/src/harness/ports.ts
@@ -25,7 +25,9 @@ import { createServer } from "node:net";
 
 const RANGE_BASE = 21000;
 const RANGE_SIZE = 800;
-const RANGE_SLOTS = 14; // 21000..32199, below the ephemeral range
+// Exported so vitest.config.ts can cap fork concurrency at it: a fork
+// beyond this shares a port range with an earlier one.
+export const RANGE_SLOTS = 14; // 21000..32199, below the ephemeral range
 
 function rangeSlot(): number {
   const poolId = Number(process.env.VITEST_POOL_ID);

--- a/tests/e2e/vitest.config.ts
+++ b/tests/e2e/vitest.config.ts
@@ -11,11 +11,17 @@ export default defineConfig({
     globalSetup: "./src/harness/global-setup.ts",
 
     // E2E tests spin up the aisix binary, so what bounds concurrency is
-    // the shared infrastructure underneath — CPU has never been the
-    // observed limit here, though it is the one to suspect first if the
-    // wall-clock assertions in audio-timeout / ttft-first-frame /
-    // per-attempt-telemetry start flaking. Both constraints that forced
-    // maxForks=2 are removed at the source rather than by serialising:
+    // the shared infrastructure underneath. CPU is the thing to suspect
+    // first if the wall-clock assertions in audio-timeout /
+    // ttft-first-frame / per-attempt-telemetry start flaking — each
+    // fork's gateway sizes its proxy pool to the whole machine, so four
+    // forks put appreciably more threads on the same cores than two.
+    // Measured over three CI runs at four forks, those three files pass
+    // with stable timings (audio-timeout 1283/1409/1543ms against a
+    // 2800ms bound, ttft-first-frame 24.59/24.65/24.65s); if that stops
+    // holding, lower the budget rather than widening the assertions.
+    // Both constraints that forced maxForks=2 are removed at the source
+    // rather than by serialising:
     //
     //   - ports: harness/ports.ts carves a disjoint port range per fork
     //     off VITEST_POOL_ID, so no two forks can be issued the same one.

--- a/tests/e2e/vitest.config.ts
+++ b/tests/e2e/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 
+import { availableParallelism } from "node:os";
+
 import { RANGE_SLOTS } from "./src/harness/ports.js";
 
 /**
@@ -14,14 +16,21 @@ import { RANGE_SLOTS } from "./src/harness/ports.js";
  * Ceiling RANGE_SLOTS — ports.ts hands fork `poolId % RANGE_SLOTS` its
  * own port range, so beyond that two forks collide on a range and the
  * AddrInUse flake that module exists to prevent comes back.
+ *
+ * Also ceilinged by the core count. Each fork drives a real `aisix`
+ * process, and several cases assert wall-clock bounds derived on a
+ * loaded runner (audio-timeout, ttft-first-frame,
+ * per-attempt-telemetry) — handing out more forks than cores would eat
+ * their margin whatever the endpoint list says.
  */
 function forkBudget(): number {
+  const ceiling = Math.min(RANGE_SLOTS, Math.max(2, availableParallelism()));
   const override = Number(process.env.AISIX_E2E_MAX_FORKS);
-  if (Number.isInteger(override) && override >= 1) return Math.min(override, RANGE_SLOTS);
+  if (Number.isInteger(override) && override >= 1) return Math.min(override, ceiling);
   const endpoints = (process.env.AISIX_E2E_ETCD_ENDPOINTS ?? "")
     .split(",")
     .filter((s) => s.trim() !== "").length;
-  return Math.min(Math.max(2, endpoints), RANGE_SLOTS);
+  return Math.min(Math.max(2, endpoints), ceiling);
 }
 
 export default defineConfig({

--- a/tests/e2e/vitest.config.ts
+++ b/tests/e2e/vitest.config.ts
@@ -1,19 +1,42 @@
 import { defineConfig } from "vitest/config";
 
+/** One fork per etcd cluster the run was given, never fewer than 2. */
+function forkBudget(): number {
+  const override = Number(process.env.AISIX_E2E_MAX_FORKS);
+  if (Number.isFinite(override) && override >= 1) return override;
+  const endpoints = (process.env.AISIX_E2E_ETCD_ENDPOINTS ?? "")
+    .split(",")
+    .filter((s) => s.trim() !== "").length;
+  return Math.max(2, endpoints);
+}
+
 export default defineConfig({
   test: {
-    // E2E tests spin up the aisix binary; keep concurrency low so
-    // distinct test files don't contend for ports OR for etcd watch
-    // dispatch (each file's `aisix` instance opens watches against
-    // a single shared etcd; under maxForks=4 with 20+ files, watch
-    // dispatch latency for the LAST resource in a multi-resource
-    // write batch can exceed even a 10s `waitConfigPropagation`
-    // budget — observed flake on #157, persisting after the budget
-    // bump). maxForks=2 halves the concurrent watcher count and
-    // doubles wall time but eliminates the contention.
+    // E2E tests spin up the aisix binary, so concurrency is bounded by
+    // what the shared infrastructure underneath tolerates rather than by
+    // CPU. Both constraints that once forced maxForks=2 are now removed
+    // at the source rather than by serialising:
+    //
+    //   - ports: harness/ports.ts carves a disjoint port range per fork
+    //     off VITEST_POOL_ID, so no two forks can be issued the same one.
+    //
+    //   - etcd watch dispatch: every file's `aisix` opened watches
+    //     against ONE shared etcd, and at 4 forks over 20+ files the
+    //     dispatch latency for the last resource of a write batch blew
+    //     past even a 10s `waitConfigPropagation` (#157, still flaky
+    //     after the budget bump). harness/etcd.ts now gives each fork
+    //     its own cluster from AISIX_E2E_ETCD_ENDPOINTS, which is what
+    //     CI sets; the watchers per cluster go back to what they were
+    //     at maxForks=2.
+    //
+    // The cap is therefore DERIVED from the endpoint count rather than
+    // written down next to it: one fork per cluster, floor 2 (the old
+    // value, which is what a developer with a single local etcd gets).
+    // Writing a number here instead would let a shortened endpoint list
+    // silently double forks onto one cluster and bring #157 back.
     pool: "forks",
     poolOptions: {
-      forks: { singleFork: false, minForks: 1, maxForks: 2 },
+      forks: { singleFork: false, minForks: 1, maxForks: forkBudget() },
     },
     testTimeout: 60_000,
     hookTimeout: 60_000,

--- a/tests/e2e/vitest.config.ts
+++ b/tests/e2e/vitest.config.ts
@@ -1,21 +1,43 @@
 import { defineConfig } from "vitest/config";
 
-/** One fork per etcd cluster the run was given, never fewer than 2. */
+import { RANGE_SLOTS } from "./src/harness/ports.js";
+
+/**
+ * One fork per etcd cluster the run was given.
+ *
+ * Floor 2 — the value this suite ran at before the clusters were split,
+ * and what a developer with a single local etcd gets. Note the floor
+ * means ONE configured endpoint still yields two forks sharing it; that
+ * is the pre-existing arrangement, not a regression, but it is also why
+ * "fewer endpoints => fewer forks" only holds above 2.
+ *
+ * Ceiling RANGE_SLOTS — ports.ts hands fork `poolId % RANGE_SLOTS` its
+ * own port range, so beyond that two forks collide on a range and the
+ * AddrInUse flake that module exists to prevent comes back.
+ */
 function forkBudget(): number {
   const override = Number(process.env.AISIX_E2E_MAX_FORKS);
-  if (Number.isFinite(override) && override >= 1) return override;
+  if (Number.isInteger(override) && override >= 1) return Math.min(override, RANGE_SLOTS);
   const endpoints = (process.env.AISIX_E2E_ETCD_ENDPOINTS ?? "")
     .split(",")
     .filter((s) => s.trim() !== "").length;
-  return Math.max(2, endpoints);
+  return Math.min(Math.max(2, endpoints), RANGE_SLOTS);
 }
 
 export default defineConfig({
   test: {
-    // E2E tests spin up the aisix binary, so concurrency is bounded by
-    // what the shared infrastructure underneath tolerates rather than by
-    // CPU. Both constraints that once forced maxForks=2 are now removed
-    // at the source rather than by serialising:
+    // Fails the run when a configured etcd is not answering. Case files
+    // skip themselves when etcd is unreachable, which with four clusters
+    // means a dead one silently drops the quarter of the suite bound to
+    // it while the leg still reports green.
+    globalSetup: "./src/harness/global-setup.ts",
+
+    // E2E tests spin up the aisix binary, so what bounds concurrency is
+    // the shared infrastructure underneath — CPU has never been the
+    // observed limit here, though it is the one to suspect first if the
+    // wall-clock assertions in audio-timeout / ttft-first-frame /
+    // per-attempt-telemetry start flaking. Both constraints that forced
+    // maxForks=2 are removed at the source rather than by serialising:
     //
     //   - ports: harness/ports.ts carves a disjoint port range per fork
     //     off VITEST_POOL_ID, so no two forks can be issued the same one.
@@ -29,11 +51,9 @@ export default defineConfig({
     //     CI sets; the watchers per cluster go back to what they were
     //     at maxForks=2.
     //
-    // The cap is therefore DERIVED from the endpoint count rather than
-    // written down next to it: one fork per cluster, floor 2 (the old
-    // value, which is what a developer with a single local etcd gets).
-    // Writing a number here instead would let a shortened endpoint list
-    // silently double forks onto one cluster and bring #157 back.
+    // The cap is DERIVED (see forkBudget) rather than written down next
+    // to the endpoint list, so a shortened list cannot silently double
+    // forks onto one cluster and bring #157 back.
     pool: "forks",
     poolOptions: {
       forks: { singleFork: false, minForks: 1, maxForks: forkBudget() },

--- a/tests/e2e/vitest.config.ts
+++ b/tests/e2e/vitest.config.ts
@@ -1,37 +1,6 @@
 import { defineConfig } from "vitest/config";
 
-import { availableParallelism } from "node:os";
-
-import { RANGE_SLOTS } from "./src/harness/ports.js";
-
-/**
- * One fork per etcd cluster the run was given.
- *
- * Floor 2 — the value this suite ran at before the clusters were split,
- * and what a developer with a single local etcd gets. Note the floor
- * means ONE configured endpoint still yields two forks sharing it; that
- * is the pre-existing arrangement, not a regression, but it is also why
- * "fewer endpoints => fewer forks" only holds above 2.
- *
- * Ceiling RANGE_SLOTS — ports.ts hands fork `poolId % RANGE_SLOTS` its
- * own port range, so beyond that two forks collide on a range and the
- * AddrInUse flake that module exists to prevent comes back.
- *
- * Also ceilinged by the core count. Each fork drives a real `aisix`
- * process, and several cases assert wall-clock bounds derived on a
- * loaded runner (audio-timeout, ttft-first-frame,
- * per-attempt-telemetry) — handing out more forks than cores would eat
- * their margin whatever the endpoint list says.
- */
-function forkBudget(): number {
-  const ceiling = Math.min(RANGE_SLOTS, Math.max(2, availableParallelism()));
-  const override = Number(process.env.AISIX_E2E_MAX_FORKS);
-  if (Number.isInteger(override) && override >= 1) return Math.min(override, ceiling);
-  const endpoints = (process.env.AISIX_E2E_ETCD_ENDPOINTS ?? "")
-    .split(",")
-    .filter((s) => s.trim() !== "").length;
-  return Math.min(Math.max(2, endpoints), ceiling);
-}
+import { forkBudget } from "./src/harness/forks.js";
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Problem

The DP e2e leg is 6.4 minutes and two thirds of the CI critical path (`build aisix` 2.9min → `e2e` 6.4min ≈ 10min wall). It is not CPU-bound: 226 files / 713 tests sum to 666s of file time, run across 2 forks.

The cap comes from #157 — 20+ files' gateways all watching a **single** shared etcd pushed watch-dispatch latency for the last resource of a multi-resource write batch past even a 10s `waitConfigPropagation`. `maxForks: 2` fixed it by halving the concurrent watcher count, and doubled wall time to do so.

## Change

Remove the constraint at its source instead of living under it.

- CI runs four etcd services (2379–2382) and passes them as `AISIX_E2E_ETCD_ENDPOINTS`.
- `harness/etcd.ts` gains `etcdEndpoint()`, which hands each fork its own cluster by `VITEST_POOL_ID` — the same shape `harness/ports.ts` already uses to carve a disjoint port range per fork rather than serialising.
- `maxForks` is **derived** from the endpoint count (floor 2), not written beside it, so shortening the list lowers concurrency instead of silently doubling forks onto one cluster and reintroducing #157. `AISIX_E2E_MAX_FORKS` overrides. A developer with one local etcd keeps today's 2.

Watchers per cluster are back to what they were at `maxForks: 2` while four files run concurrently.

## Endpoint resolution had to be centralised

Correctness never depended on the fork split — every spawned gateway already gets a fresh random etcd prefix — but four case files (`ratelimit-cluster`, `listener-tls`, `export-roundtrip`, `cache-env-namespace`) read `AISIX_E2E_ETCD` directly. With more than one cluster in play that pins fork 1's endpoint while the gateway the test just spawned talks to fork N's, and the symptom is a config-propagation timeout that reads like a product bug. They now call `etcdEndpoint()`.

## Tests

`src/harness/etcd-endpoint.test.ts`:

- fails if any file under `src/` resolves `process.env.AISIX_E2E_ETCD` itself (verified: reverting one case file to the direct read reds it),
- asserts distinct forks get distinct endpoints,
- asserts the single-endpoint fallback is unchanged.

The e2e suite itself is the test for the concurrency change — the whole point is that it stays green at 4 forks. No test was skipped, filtered, or retimed.

## Measured effect

e2e leg **6.4 min → 3m52s / 4m4s** (thread-per-core / work-stealing), green on the first run and on every run since. DP CI wall ~10 min → ~7 min.

Coverage went up, not sideways: the leg reports **229 test files / 723 tests passed**, against 226 / 713 before — the three added are this PR's own harness tests, and no file was silently dropped by the split. `etcd-endpoint.test.ts (3 tests)` is confirmed on the PASS side of the real job log rather than inferred from a green check.

## Review rounds

Local review (mechanical cross-repo filter + `/code-review` + a cross-plane reviewer) ran against every head, and CodeRabbit reviewed the second. The findings that changed the design:

- **A dead cluster used to be loud; splitting it made it quiet.** 226 case files open with `if (!(await etcd.ping())) return;`. With one shared etcd, losing it zeroed the suite and was unmissable. With four, losing one drops only the quarter of the files bound to that fork while the leg still reports green — verified directly: pointing one endpoint at a dead port ran 165 files, skipped 55, and exited 0. `ping()` now throws on CI instead of returning false (retrying three times first, so a load blip cannot cause a false negative), which turns all 226 sites into hard failures there while keeping the quiet skip for a developer with no etcd. A `globalSetup` probes every endpoint in use before any fork starts, with its own retry.
- **The abort timer was disarmed before the body was read** (CodeRabbit). `reachable()` cleared its timeout as soon as headers landed, so a 200 that never finishes its body — exactly what the method distrusts on principle — would hang forever. Pre-existing, but this PR puts the probe on two hot paths.
- **The fork budget is capped three ways**, not just by the endpoint list: floor 2, `RANGE_SLOTS` from ports.ts, and the core count. The last one means adding a fifth etcd to a 4-core runner buys no forks and only a fifth thing that must be up; the ci.yml comment says so now.
- **Endpoint resolution is centralised and guarded.** Four case files read `AISIX_E2E_ETCD` directly, which with more than one cluster pins fork 1's endpoint while the gateway the test spawned talks to fork N's. A harness test fails if any file resolves an endpoint itself — including the `_ENDPOINTS` spelling (`\b` does not separate them; `_` is a word character) and hardcoded 2379-2382 literals in all three host spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end test isolation by distributing parallel runs across independent configuration services.
  - Added reliable endpoint selection, fallback handling, and availability checks.
  - Added coverage for endpoint resolution, service distribution, and failure scenarios.
  - Dynamically adjusted test concurrency based on available CPU capacity, service availability, and configured limits.
  - Improved CI reliability by retrying service connectivity checks and reporting unreachable services clearly.
  - Updated performance coverage to better validate linear scaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->