### PR TITLE
feat(obs): carry `user_name` on every metric that carries `user_id`

### DIFF
--- a/crates/aisix-gateway/src/upstream_headers.rs
+++ b/crates/aisix-gateway/src/upstream_headers.rs
@@ -101,6 +101,15 @@ pub struct CallerIdentity {
     pub api_key_name: Option<String>,
     pub team_id: Option<String>,
     pub user_id: Option<String>,
+    /// Display name of the member `user_id` names, for the `user_name`
+    /// metric label (AISIX-Cloud#1455). Resolved here so it always comes
+    /// off the same ApiKey row as `user_id`, from the one place a request
+    /// reads its caller.
+    ///
+    /// NOT a header-template variable: `HeaderTemplateVars` names the
+    /// four `request.api_key.*` keys it exposes explicitly, and this is
+    /// not one of them.
+    pub user_name: Option<String>,
 }
 
 impl CallerIdentity {
@@ -111,6 +120,7 @@ impl CallerIdentity {
             api_key_name: entry.value.display_name.clone(),
             team_id: entry.value.team_id.clone(),
             user_id: entry.value.user_id.clone(),
+            user_name: entry.value.user_name.clone(),
         }
     }
 }

--- a/crates/aisix-gateway/src/upstream_headers.rs
+++ b/crates/aisix-gateway/src/upstream_headers.rs
@@ -106,9 +106,9 @@ pub struct CallerIdentity {
     /// off the same ApiKey row as `user_id`, from the one place a request
     /// reads its caller.
     ///
-    /// NOT a header-template variable: `HeaderTemplateVars` names the
-    /// four `request.api_key.*` keys it exposes explicitly, and this is
-    /// not one of them.
+    /// NOT a header-template variable: `HEADER_TEMPLATE_VARS` lists the
+    /// four `request.api_key.*` keys, and `HeaderVars::resolve` matches
+    /// them one by one — this is not among them.
     pub user_name: Option<String>,
 }
 

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -269,8 +269,9 @@ pub const M_GUARDRAIL_LATENCY_SECONDS: &str = "aisix_guardrail_latency_seconds";
 ///   series over `status_code` alone (the raw code determines the family),
 ///   and `status_code` is kept so dashboards and alerts written against
 ///   `status_code="4xx"` keep working unchanged.
-/// - `user_id`: the org member behind the request, from
-///   [`UsageEventLabels`].
+/// - `user_id` / `user_name`: the org member behind the request and
+///   their display name, from [`UsageEventLabels`]. The name is a
+///   function of the id off one ApiKey row, so it adds no series.
 /// - `inbound_protocol`: `openai` / `anthropic`. Matches the
 ///   wire-level field on UsageEvent.
 /// - `upstream_protocol`: the wire protocol of the ProviderKey the event
@@ -1973,6 +1974,7 @@ impl Metrics {
                 k.label(labels.api_key_id);
                 k.label(labels.team_id);
                 k.label(labels.user_id);
+                k.label(labels.user_name);
             },
             || {
                 metrics::gauge!(
@@ -1980,6 +1982,7 @@ impl Metrics {
                     "api_key_id" => labels.api_key_id.to_string(),
                     "team_id" => labels.team_id.to_string(),
                     "user_id" => labels.user_id.to_string(),
+                    "user_name" => labels.user_name.to_string(),
                 )
             },
         );
@@ -2028,8 +2031,8 @@ impl Metrics {
     /// (`handler` / `status_code` / `status` / `inbound_protocol`
     /// are the emit counter's own arguments, not attribution, and stay
     /// one-sided — `emitted == delivered + dropped` is an invariant over
-    /// the attribution dimensions, which is why `user_id` DOES appear on
-    /// both.)
+    /// the attribution dimensions, which is why the member pair `user_id`
+    /// / `user_name` DOES appear on both.)
     pub fn record_usage_event_drop(&self, reason: &str, labels: UsageEventLabels<'_>) {
         self.cached_counter(
             M_USAGE_EVENT_DROPS_TOTAL,
@@ -2040,6 +2043,7 @@ impl Metrics {
                 k.label(labels.provider_key_id);
                 k.label(labels.provider_key_name);
                 k.label(labels.user_id);
+                k.label(labels.user_name);
                 k.label(labels.upstream_protocol);
             },
             || {
@@ -2050,6 +2054,7 @@ impl Metrics {
                     "provider_key_id" => labels.provider_key_id.to_string(),
                     "provider_key_name" => labels.provider_key_name.to_string(),
                     "user_id" => labels.user_id.to_string(),
+                    "user_name" => labels.user_name.to_string(),
                     "upstream_protocol" => labels.upstream_protocol.to_string(),
                 )
             },
@@ -2071,8 +2076,8 @@ impl Metrics {
     ///   `&'static str` here prevents user-controlled cardinality)
     ///
     /// [`UsageEventLabels`] adds the model, the ProviderKey the event was
-    /// attributed to (AISIX-Cloud#1317) and that key's `upstream_protocol`
-    /// (AISIX-Cloud#1403). Those cannot be `&'static str`, so they are
+    /// attributed to (AISIX-Cloud#1317), that key's `upstream_protocol`
+    /// (AISIX-Cloud#1403) and the member pair `user_id` / `user_name`. Those cannot be `&'static str`, so they are
     /// bounded at the proxy's emit chokepoint instead — see that type. The
     /// dimensions they add are ones `aisix_llm_requests_total` already
     /// carries, so this counter stays well inside the request families'
@@ -2097,6 +2102,7 @@ impl Metrics {
                 k.label(labels.provider_key_id);
                 k.label(labels.provider_key_name);
                 k.label(labels.user_id);
+                k.label(labels.user_name);
                 k.label(labels.upstream_protocol);
             },
             || {
@@ -2111,6 +2117,7 @@ impl Metrics {
                     "provider_key_id" => labels.provider_key_id.to_string(),
                     "provider_key_name" => labels.provider_key_name.to_string(),
                     "user_id" => labels.user_id.to_string(),
+                    "user_name" => labels.user_name.to_string(),
                 )
             },
         );
@@ -2706,10 +2713,9 @@ pub struct UsageEventLabels<'a> {
     pub provider_key_name: &'a str,
     /// Org member the authenticating key belongs to (AISIX-Cloud#1389) —
     /// the same `user_id` `aisix_proxy_requests_total` carries, so a
-    /// member's request rate and their usage-event rate slice alike, and
-    /// the readable `user_name` is joinable from that family rather than
-    /// duplicated here. `unknown` when the key is bound to no member, or
-    /// when auth never resolved a key.
+    /// member's request rate and their usage-event rate slice alike.
+    /// `unknown` when the key is bound to no member, or when auth never
+    /// resolved a key.
     ///
     /// This is attribution, so it sits on BOTH counters: "which member's
     /// usage records were lost" is exactly the question the shared label
@@ -2717,6 +2723,13 @@ pub struct UsageEventLabels<'a> {
     /// the event's own `user_id`, so the counter and the row cp-api
     /// persists can never name different people.
     pub user_id: &'a str,
+    /// Readable display name of the member `user_id` names
+    /// (AISIX-Cloud#1455). A function of `user_id` off the same ApiKey
+    /// row, so it adds no series — and it is filled from the event
+    /// beside `user_id` in `UsageSink::try_emit` rather than by each
+    /// handler's label builder, so the two cannot name different people.
+    /// `unknown` whenever `user_id` is.
+    pub user_name: &'a str,
     /// The upstream wire protocol of the key named by `provider_key_id`
     /// (AISIX-Cloud#1403) — the same value, resolved the same way, that
     /// the request and usage families carry, so an operator can align
@@ -2738,6 +2751,7 @@ impl Default for UsageEventLabels<'_> {
             provider_key_id: "unknown",
             provider_key_name: "unknown",
             user_id: "unknown",
+            user_name: "unknown",
             upstream_protocol: "unknown",
         }
     }
@@ -2799,6 +2813,10 @@ pub struct BudgetLabels<'a> {
     pub api_key_id: &'a str,
     pub team_id: &'a str,
     pub user_id: &'a str,
+    /// Readable display name of the member `user_id` names
+    /// (AISIX-Cloud#1455), read off the same ApiKey row so the pair adds
+    /// no series over `user_id` alone. `unknown` whenever `user_id` is.
+    pub user_name: &'a str,
 }
 
 impl Default for BudgetLabels<'_> {
@@ -2807,6 +2825,7 @@ impl Default for BudgetLabels<'_> {
             api_key_id: "unknown",
             team_id: "unknown",
             user_id: "unknown",
+            user_name: "unknown",
         }
     }
 }
@@ -3728,11 +3747,13 @@ mod tests {
             api_key_id: "ak-a",
             team_id: "team-a",
             user_id: "user-a",
+            user_name: "alice",
         };
         let key_b = BudgetLabels {
             api_key_id: "ak-b",
             team_id: "team-b",
             user_id: "user-b",
+            user_name: "bob",
         };
         metrics.set_budget_gauges(
             key_a,
@@ -3768,7 +3789,15 @@ mod tests {
             let line = series(metric, "team-a")
                 .unwrap_or_else(|| panic!("{metric} missing for team-a:\n{rendered}"));
             assert!(line.ends_with(&format!(" {value}")), "got: {line}");
-            assert!(line.contains("api_key_id=\"ak-a\"") && line.contains("user_id=\"user-a\""));
+            assert!(
+                line.contains("api_key_id=\"ak-a\"")
+                    && line.contains("user_id=\"user-a\"")
+                    // AISIX-Cloud#1455: the member's readable name rides
+                    // beside their id here for the same reason it does on
+                    // the request families — a budget alert that can only
+                    // name a UUID is one an operator has to go look up.
+                    && line.contains("user_name=\"alice\"")
+            );
         }
         // Key B must have its OWN spent series, not overwrite A's.
         assert!(series(M_BUDGET_SPENT_USD, "team-b").is_some_and(|l| l.ends_with(" 7")));
@@ -4081,6 +4110,7 @@ mod tests {
             api_key_id: "ak",
             team_id: "t",
             user_id: "u",
+            user_name: "n",
         };
         let variants = [
             BudgetLabels {
@@ -4093,6 +4123,13 @@ mod tests {
             },
             BudgetLabels {
                 user_id: "u2",
+                ..base
+            },
+            // A rename keeps the id and changes only the name. Off the
+            // worker key, the gauge would keep reporting this member
+            // under their old name for as long as the worker lives.
+            BudgetLabels {
+                user_name: "n2",
                 ..base
             },
         ];
@@ -4317,6 +4354,7 @@ mod tests {
         provider_key_id: "pk-1",
         provider_key_name: "openai-prod",
         user_id: "member-1",
+        user_name: "alice",
         upstream_protocol: "openai",
     };
 
@@ -4363,7 +4401,19 @@ mod tests {
                 ..PK_A
             },
         );
-        assert_one_series_per_label_set(&m.render(), M_USAGE_EVENT_EMITS_TOTAL, 7);
+        // AISIX-Cloud#1455: a renamed member keeps their id, so the name
+        // has to be part of the key or this counter reports them under
+        // the old name for the worker's lifetime.
+        m.record_usage_event_emit(
+            "chat",
+            200,
+            "openai",
+            UsageEventLabels {
+                user_name: "alice-renamed",
+                ..PK_A
+            },
+        );
+        assert_one_series_per_label_set(&m.render(), M_USAGE_EVENT_EMITS_TOTAL, 8);
     }
 
     /// AISIX-Cloud#1403: the label survives onto the exposition, with the
@@ -4414,7 +4464,14 @@ mod tests {
                 ..PK_A
             },
         );
-        assert_one_series_per_label_set(&m.render(), M_USAGE_EVENT_DROPS_TOTAL, 3);
+        m.record_usage_event_drop(
+            "sink_full",
+            UsageEventLabels {
+                user_name: "alice-renamed",
+                ..PK_A
+            },
+        );
+        assert_one_series_per_label_set(&m.render(), M_USAGE_EVENT_DROPS_TOTAL, 4);
     }
 
     /// AISIX-Cloud#1317: the two counters are read as one pair —

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -270,8 +270,9 @@ pub const M_GUARDRAIL_LATENCY_SECONDS: &str = "aisix_guardrail_latency_seconds";
 ///   and `status_code` is kept so dashboards and alerts written against
 ///   `status_code="4xx"` keep working unchanged.
 /// - `user_id` / `user_name`: the org member behind the request and
-///   their display name, from [`UsageEventLabels`]. The name is a
-///   function of the id off one ApiKey row, so it adds no series.
+///   their display name, from [`UsageEventLabels`]. Both come off one
+///   ApiKey row, so the name is determined by the id and the pair is one
+///   series, not one per name.
 /// - `inbound_protocol`: `openai` / `anthropic`. Matches the
 ///   wire-level field on UsageEvent.
 /// - `upstream_protocol`: the wire protocol of the ProviderKey the event
@@ -2724,11 +2725,16 @@ pub struct UsageEventLabels<'a> {
     /// persists can never name different people.
     pub user_id: &'a str,
     /// Readable display name of the member `user_id` names
-    /// (AISIX-Cloud#1455). A function of `user_id` off the same ApiKey
-    /// row, so it adds no series — and it is filled from the event
-    /// beside `user_id` in `UsageSink::try_emit` rather than by each
-    /// handler's label builder, so the two cannot name different people.
-    /// `unknown` whenever `user_id` is.
+    /// (AISIX-Cloud#1455). One series per (id, name) pair rather than per
+    /// name: the two are read off one ApiKey row, so at any instant the
+    /// name is determined by the id and the label costs nothing. A rename
+    /// that reaches the row splits the counter into a before and an after
+    /// series, exactly as a ProviderKey rename already does to
+    /// `provider_key_name`.
+    ///
+    /// Filled from the event beside `user_id` in `UsageSink::try_emit`
+    /// rather than by each handler's label builder, so the two cannot
+    /// name different people. `unknown` whenever `user_id` is.
     pub user_name: &'a str,
     /// The upstream wire protocol of the key named by `provider_key_id`
     /// (AISIX-Cloud#1403) — the same value, resolved the same way, that
@@ -2814,8 +2820,19 @@ pub struct BudgetLabels<'a> {
     pub team_id: &'a str,
     pub user_id: &'a str,
     /// Readable display name of the member `user_id` names
-    /// (AISIX-Cloud#1455), read off the same ApiKey row so the pair adds
-    /// no series over `user_id` alone. `unknown` whenever `user_id` is.
+    /// (AISIX-Cloud#1455), read off the same ApiKey row so the name is
+    /// determined by the id and the pair costs no series over `user_id`
+    /// alone. `unknown` whenever `user_id` is.
+    ///
+    /// These are GAUGES, and this recorder registers no idle timeout, so
+    /// a label set that stops being written stays at its last value: a
+    /// rename that reaches the ApiKey row leaves the pre-rename sample
+    /// behind, and a `sum` that does not group by the member counts both.
+    /// That is true of every label on this family that can change under a
+    /// fixed `api_key_id`: rebinding a key's team or owner strands its
+    /// samples the same way. `clear_budget_gauges` does not help — it
+    /// zeroes `details_present` for the label set it is handed, which is
+    /// the new one.
     pub user_name: &'a str,
 }
 
@@ -5133,7 +5150,17 @@ mod tests {
         assert!(out.contains("status_class=\"2xx\""));
         assert!(out.contains("streaming=\"false\""));
         assert!(out.contains("streaming=\"true\""));
-        for high_card in ["api_key_id", "user_id", "team_id", "provider_key_id"] {
+        // Substring matches, so each NAME label has to be listed beside its
+        // id: `contains("user_id")` does not see `user_name`, and these
+        // histograms are the one family the id/name pair must NOT reach.
+        for high_card in [
+            "api_key_id",
+            "user_id",
+            "user_name",
+            "team_id",
+            "provider_key_id",
+            "provider_key_name",
+        ] {
             for line in out.lines().filter(|l| l.contains("aisix_request_")) {
                 assert!(
                     !line.contains(high_card),

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -2727,10 +2727,12 @@ pub struct UsageEventLabels<'a> {
     /// Readable display name of the member `user_id` names
     /// (AISIX-Cloud#1455). One series per (id, name) pair rather than per
     /// name: the two are read off one ApiKey row, so at any instant the
-    /// name is determined by the id and the label costs nothing. A rename
-    /// that reaches the row splits the counter into a before and an after
-    /// series, exactly as a ProviderKey rename already does to
-    /// `provider_key_name`.
+    /// name is determined by the id and the label costs nothing. The name
+    /// is a SNAPSHOT of the row, not a live read: cp-api stamps it when it
+    /// projects the ApiKey, and nothing reprojects a key just because its
+    /// member was renamed — so a rename shows up here only once that key is
+    /// next written for some other reason, and splits the counter into a
+    /// before and an after series when it does.
     ///
     /// Filled from the event beside `user_id` in `UsageSink::try_emit`
     /// rather than by each handler's label builder, so the two cannot
@@ -2825,8 +2827,9 @@ pub struct BudgetLabels<'a> {
     /// alone. `unknown` whenever `user_id` is.
     ///
     /// These are GAUGES, and this recorder registers no idle timeout, so
-    /// a label set that stops being written stays at its last value: a
-    /// rename that reaches the ApiKey row leaves the pre-rename sample
+    /// a label set that stops being written stays at its last value: if a
+    /// rename ever does reach the ApiKey row (see [`UsageEventLabels`] —
+    /// it takes a later write of that key), the pre-rename sample stays
     /// behind, and a `sum` that does not group by the member counts both.
     /// That is true of every label on this family that can change under a
     /// fixed `api_key_id`: rebinding a key's team or owner strands its

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -87,6 +87,20 @@ pub struct UsageEvent {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub user_id: String,
 
+    /// Display name of the member `user_id` names, for the `user_name`
+    /// metric label the usage-event counters carry beside `user_id`
+    /// (AISIX-Cloud#1455). Read off the same ApiKey row as `user_id` by
+    /// `apply_caller_identity`, which is what keeps the pair from ever
+    /// naming a member and someone else's name.
+    ///
+    /// NOT part of the DP -> cp-api wire contract: cp-api resolves member
+    /// names from its own tables, so shipping a second copy would only
+    /// give that name a way to disagree with itself. It rides the event
+    /// purely so `UsageSink::try_emit` — the one place `user_id` becomes a
+    /// label — can stamp both halves together.
+    #[serde(skip)]
+    pub user_name: String,
+
     /// The model alias exactly as the client sent it in the request
     /// body (`model` field) — a Model-Group name for routed requests,
     /// a direct model's display name otherwise. `model_id` records the
@@ -787,21 +801,31 @@ impl UsageSink {
     /// them: its `requested_model` is caller-controlled text (#451) and it
     /// carries no ProviderKey id at all.
     ///
-    /// The one attribution dimension that DOES come off the event is
-    /// `user_id` (AISIX-Cloud#1389): it is a resolved ApiKey field, not
-    /// caller text, and taking it here rather than from each handler's
-    /// label builder is what makes the counter and the row cp-api persists
-    /// structurally incapable of naming different members.
+    /// The attribution dimensions that DO come off the event are the
+    /// member pair `user_id` / `user_name` (AISIX-Cloud#1389, #1455): both
+    /// are resolved ApiKey fields, not caller text, and taking them here
+    /// rather than from each handler's label builder is what makes the
+    /// counter and the row cp-api persists structurally incapable of
+    /// naming different members. They are stamped together for the same
+    /// reason `PkLabels` keeps a key's id and name together — a name that
+    /// can be sourced separately from its id is a name that will
+    /// eventually be wrong.
     pub fn try_emit(&self, handler: &'static str, event: UsageEvent, labels: UsageEventLabels<'_>) {
         log_provider_call(handler, &event);
         // Owned because `event` is moved into the channel below while the
-        // drop counter still needs the label.
+        // drop counter still needs the labels.
         let user_id = event.user_id.clone();
+        let user_name = event.user_name.clone();
         let labels = UsageEventLabels {
             user_id: if user_id.is_empty() {
                 "unknown"
             } else {
                 user_id.as_str()
+            },
+            user_name: if user_name.is_empty() {
+                "unknown"
+            } else {
+                user_name.as_str()
             },
             ..labels
         };
@@ -1208,13 +1232,17 @@ mod tests {
                 // Attribution the sink reads off the event itself, not off
                 // the label set the handler built.
                 user_id: "member-1".into(),
+                user_name: "Alice Example".into(),
                 ..Default::default()
             },
             UsageEventLabels {
                 model: "customer-chat",
                 provider_key_id: "pk-1",
                 provider_key_name: "openai-prod",
+                // Both halves of the member pair are the sink's to fill:
+                // whatever a handler puts here has to lose to the event.
                 user_id: "unknown",
+                user_name: "unknown",
                 upstream_protocol: "openai",
             },
         );
@@ -1229,6 +1257,7 @@ mod tests {
                 ("provider_key_id", "pk-1"),
                 ("provider_key_name", "openai-prod"),
                 ("user_id", "member-1"),
+                ("user_name", "Alice Example"),
                 // The raw code sits beside the family, so a query can name
                 // one failure mode without giving up the family rollup.
                 ("status_code", "4xx"),
@@ -1244,6 +1273,7 @@ mod tests {
                 ("provider_key_id", "pk-1"),
                 ("provider_key_name", "openai-prod"),
                 ("user_id", "member-1"),
+                ("user_name", "Alice Example"),
             ],
         );
         assert_eq!(

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -893,6 +893,7 @@ fn emit_a2a_usage(
         &mut event,
         auth.jwt.as_ref(),
         auth.key().user_id.as_deref(),
+        auth.key().user_name.as_deref(),
     );
     // The client-perceived duration of the call. Nothing else records it for
     // `/a2a`: the handler returns the moment a stream's response head is out,

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -2108,6 +2108,7 @@ fn emit_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     let usage_model =
         crate::usage_attr::usage_event_model_label(snap, &event.requested_model).into_owned();

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -4280,6 +4280,7 @@ fn record_budget_gauges(
         api_key_id: &auth.entry.id,
         team_id: auth.key().team_id.as_deref().unwrap_or("unknown"),
         user_id: auth.key().user_id.as_deref().unwrap_or("unknown"),
+        user_name: auth.key().user_name.as_deref().unwrap_or("unknown"),
     };
     if let Some(budget) = budget {
         metrics.set_budget_gauges(
@@ -4413,6 +4414,7 @@ fn emit_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     // Guardrail outcome counters (#379). Recorded here — the one place every
     // chat path (success / error / streaming / cache-hit) funnels through —

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -770,6 +770,7 @@ fn emit_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     let usage_model =
         crate::usage_attr::usage_event_model_label(snap, &event.requested_model).into_owned();

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -793,6 +793,7 @@ fn emit_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     let usage_model =
         crate::usage_attr::usage_event_model_label(snap, &event.requested_model).into_owned();

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -719,6 +719,7 @@ fn emit_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     let usage_model =
         crate::usage_attr::usage_event_model_label(snap, &event.requested_model).into_owned();

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -555,6 +555,7 @@ pub(crate) fn emit_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     let usage_model =
         crate::usage_attr::usage_event_model_label(snap, &event.requested_model).into_owned();

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -627,6 +627,7 @@ fn emit_job_usage_event(
         &mut event,
         auth.jwt.as_ref(),
         auth.key().user_id.as_deref(),
+        auth.key().user_name.as_deref(),
     );
     let usage_model =
         crate::usage_attr::usage_event_model_label(snap, &event.requested_model).into_owned();
@@ -1807,6 +1808,7 @@ fn maybe_attribute_batch(
     let state = state.clone();
     let api_key_id = auth.entry.id.clone();
     let user_id = auth.entry.value.user_id.clone();
+    let user_name = auth.entry.value.user_name.clone();
     let jwt = auth.jwt.clone();
     let model_id = target.model_entry.id.clone();
     let display_name = target.display_name().to_string();
@@ -1824,6 +1826,7 @@ fn maybe_attribute_batch(
             &api_key_id,
             jwt.as_ref(),
             user_id.as_deref(),
+            user_name.as_deref(),
             &model_id,
             &display_name,
             cost.as_ref(),
@@ -1857,6 +1860,7 @@ async fn attribute_batch_usage(
     api_key_id: &str,
     jwt: Option<&std::sync::Arc<crate::auth::JwtIdentity>>,
     user_id: Option<&str>,
+    user_name: Option<&str>,
     model_id: &str,
     display_name: &str,
     cost: Option<&aisix_core::models::model::ModelCost>,
@@ -1969,7 +1973,7 @@ async fn attribute_batch_usage(
         crate::usage_attr::apply_pk_telemetry(&mut event, &pk);
         // Attribution names the identity that observed completion — the
         // same caller the event's api_key_id already reflects.
-        crate::usage_attr::apply_caller_identity(&mut event, jwt, user_id);
+        crate::usage_attr::apply_caller_identity(&mut event, jwt, user_id, user_name);
         let usage_model =
             crate::usage_attr::usage_event_model_label(&snap, &event.requested_model).into_owned();
         state.usage_sink.try_emit(

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -1192,6 +1192,7 @@ fn emit_tool_call_usage(
         &mut event,
         auth.jwt.as_ref(),
         auth.key().user_id.as_deref(),
+        auth.key().user_name.as_deref(),
     );
     crate::usage_attr::apply_auth_type(&mut event, auth);
     // A tool call resolves neither a model nor a ProviderKey, so the

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3000,6 +3000,7 @@ fn emit_anthropic_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     let usage_model = crate::usage_attr::usage_event_model_label(snap, &event.requested_model);
     // The metric code below still reads `event`, so the chokepoint gets

--- a/crates/aisix-proxy/src/passthrough_route.rs
+++ b/crates/aisix-proxy/src/passthrough_route.rs
@@ -796,6 +796,7 @@ async fn dispatch(
         request_id: client.request_id.clone(),
         api_key_id: auth.entry.id.clone(),
         user_id: auth.entry.value.user_id.clone(),
+        user_name: auth.entry.value.user_name.clone(),
         jwt: auth.jwt.clone(),
         anonymous: auth.anonymous,
         client_identity,
@@ -1968,10 +1969,13 @@ struct RouteTelemetry {
     path: String,
     request_id: String,
     api_key_id: String,
-    /// Org member the authenticating key belongs to (AISIX-Cloud#1389).
-    /// `None` for a key bound to no member — including the anonymous
-    /// route key, which belongs to the route rather than to a person.
+    /// Org member the authenticating key belongs to (AISIX-Cloud#1389),
+    /// and that member's display name for the `user_name` metric label
+    /// (AISIX-Cloud#1455). Both `None` for a key bound to no member —
+    /// including the anonymous route key, which belongs to the route
+    /// rather than to a person.
     user_id: Option<String>,
+    user_name: Option<String>,
     jwt: Option<Arc<crate::auth::JwtIdentity>>,
     /// Whether the caller reached this route through `auth_mode:
     /// anonymous` rather than a credential of its own. Stamped onto the
@@ -2142,6 +2146,7 @@ impl RouteTelemetry {
             &mut event,
             self.jwt.as_ref(),
             self.user_id.as_deref(),
+            self.user_name.as_deref(),
         );
         if self.anonymous {
             event.auth_type = "anonymous".to_string();

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -486,6 +486,7 @@ async fn check_budget(state: &ProxyState, auth: &AuthenticatedKey) -> Result<(),
         api_key_id: &auth.entry.id,
         team_id: auth.key().team_id.as_deref().unwrap_or("unknown"),
         user_id: auth.key().user_id.as_deref().unwrap_or("unknown"),
+        user_name: auth.key().user_name.as_deref().unwrap_or("unknown"),
     };
     if let Some(budget) = decision.budget.as_ref() {
         state.metrics.set_budget_gauges(

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -853,6 +853,7 @@ async fn run_session(
         &mut event,
         auth.jwt.as_ref(),
         auth.key().user_id.as_deref(),
+        auth.key().user_name.as_deref(),
     );
     let usage_model =
         crate::usage_attr::usage_event_model_label(&snap, &event.requested_model).into_owned();

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -729,6 +729,7 @@ fn emit_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     let usage_model =
         crate::usage_attr::usage_event_model_label(snap, &event.requested_model).into_owned();

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -3039,6 +3039,7 @@ fn emit_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     let usage_model = crate::usage_attr::usage_event_model_label(snap, &event.requested_model);
     crate::usage_attr::emit_usage(
@@ -3168,6 +3169,7 @@ fn emit_zero_token_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     let usage_model = crate::usage_attr::usage_event_model_label(snap, &event.requested_model);
     crate::usage_attr::emit_usage(

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -407,13 +407,23 @@ pub(crate) fn apply_pk_telemetry(event: &mut UsageEvent, pk: &ResolvedPk<'_>) {
 /// the key the token resolved to — a JWT request runs AS a key, so one
 /// argument covers both and the member filter sees every credential a
 /// member calls through.
+///
+/// `user_name` is that member's display name for the metric label of the
+/// same name (AISIX-Cloud#1455). It is a separate argument rather than a
+/// separate call so the compiler makes every emitting path hand over both
+/// halves of one ApiKey row: a name sourced anywhere but beside its id is
+/// a name that will eventually label the wrong member.
 pub(crate) fn apply_caller_identity(
     event: &mut UsageEvent,
     jwt: Option<&std::sync::Arc<crate::auth::JwtIdentity>>,
     user_id: Option<&str>,
+    user_name: Option<&str>,
 ) {
     if let Some(user_id) = user_id {
         event.user_id = sanitize_tag(user_id.to_string());
+    }
+    if let Some(user_name) = user_name {
+        event.user_name = sanitize_tag(user_name.to_string());
     }
     let Some(jwt) = jwt else {
         return;
@@ -531,6 +541,7 @@ pub(crate) fn build_error_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     event
 }
@@ -575,10 +586,11 @@ pub(crate) fn usage_event_labels<'a>(
             labels.id()
         },
         provider_key_name: labels.name(),
-        // Overwritten by `UsageSink::try_emit` from the event's own
-        // `user_id` (AISIX-Cloud#1389) — one place, so no handler in this
-        // family can build a label set that disagrees with the row.
+        // Both overwritten by `UsageSink::try_emit` from the event's own
+        // member pair (AISIX-Cloud#1389, #1455) — one place, so no handler
+        // in this family can build a label set that disagrees with the row.
         user_id: "unknown",
+        user_name: "unknown",
         // Same `PkLabels` the request families read (AISIX-Cloud#1403), so
         // `aisix_usage_events_emitted_total` joins with them on
         // `upstream_protocol` instead of dropping out of the aggregation.

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -423,7 +423,17 @@ pub(crate) fn apply_caller_identity(
         event.user_id = sanitize_tag(user_id.to_string());
     }
     if let Some(user_name) = user_name {
-        event.user_name = sanitize_tag(user_name.to_string());
+        // NOT `sanitize_tag`, unlike the id above. That call exists to keep
+        // operator-typed text safe on the cp-api wire and in the log line;
+        // `user_name` reaches neither (`#[serde(skip)]`, and
+        // `log_provider_call` does not render it). Its only destination is
+        // the `user_name` metric label, which the four #890 families
+        // already stamp raw off the same ApiKey row — sanitising this one
+        // copy would make a long or odd name read differently on
+        // `aisix_usage_event*` than on `aisix_llm_*`, and break the
+        // cross-family join on the pair for exactly that member. The
+        // prometheus exporter escapes exposition characters itself.
+        event.user_name = user_name.to_string();
     }
     let Some(jwt) = jwt else {
         return;

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -2029,6 +2029,7 @@ fn emit_submit_usage_event(
         &mut event,
         client.jwt.as_ref(),
         client.caller.user_id.as_deref(),
+        client.caller.user_name.as_deref(),
     );
     let usage_model =
         crate::usage_attr::usage_event_model_label(snap, &event.requested_model).into_owned();

--- a/tests/e2e/src/cases/usage-member-attribution-e2e.test.ts
+++ b/tests/e2e/src/cases/usage-member-attribution-e2e.test.ts
@@ -11,6 +11,7 @@ import {
   startMockIdp,
   startMockSls,
   startOpenAiUpstream,
+  sumMetric,
   waitConfigPropagation,
   waitForSlsLog,
   type MetricSample,
@@ -71,6 +72,10 @@ const GATEWAY_LIMITED_PLAINTEXT = "sk-usage-member-gateway-limited";
 // The member every owned credential in this case belongs to. A uuid-shaped
 // value because that is what cp-api projects (`api_keys.user_id`).
 const ALICE = "3f1b7c62-9d4e-4a51-8f0b-2c6d5e4a1b90";
+// The display name cp-api projects beside that id (AISIX-Cloud#1455). The
+// counter carries the pair so "show me Alice's 429s" can be asked with the
+// name an operator already knows instead of a uuid they have to go look up.
+const ALICE_NAME = "Alice Example";
 
 describe("usage member attribution e2e: a usage row names the org member (#1389)", () => {
   let upstream: OpenAiUpstream | undefined;
@@ -169,6 +174,7 @@ describe("usage member attribution e2e: a usage row names the org member (#1389)
       key_hash: hash("sk-usage-member-jwt-bound"),
       allowed_models: [MODEL, THROTTLED_MODEL],
       user_id: ALICE,
+      user_name: ALICE_NAME,
       jwt_subject: "alice",
       jwt_provider: "uma-idp",
     });
@@ -186,6 +192,7 @@ describe("usage member attribution e2e: a usage row names the org member (#1389)
       key_hash: hash(GATEWAY_LIMITED_PLAINTEXT),
       allowed_models: [MODEL],
       user_id: ALICE,
+      user_name: ALICE_NAME,
       rate_limit: { rpm: 1 },
     });
 
@@ -195,6 +202,7 @@ describe("usage member attribution e2e: a usage row names the org member (#1389)
       key_hash: hash(OWNED_PLAINTEXT),
       allowed_models: [MODEL, THROTTLED_MODEL],
       user_id: ALICE,
+      user_name: ALICE_NAME,
     });
 
     const proxy = new ProxyClient(app.proxyUrl, OWNED_PLAINTEXT);
@@ -264,6 +272,16 @@ describe("usage member attribution e2e: a usage row names the org member (#1389)
     // Absent, not a placeholder: a member filter must not sweep up traffic
     // that belongs to no member.
     expect(log.get("user_id")).toBeUndefined();
+
+    // On the counter the same absence reads as the placeholder both halves
+    // share — a metric label set has to be uniform across the family, and
+    // an unowned key must not borrow a name from anywhere.
+    const after: MetricSample[] = await scrapeMetrics(app.metricsUrl);
+    expect(
+      sumMetric(after, "aisix_usage_events_emitted_total", (l) =>
+        l.user_id === "unknown" && l.user_name !== "unknown",
+      ),
+    ).toBe(0);
   });
 
   test("a gateway rate-limit 429 reaches the feed with the member on it", async (ctx) => {
@@ -297,6 +315,7 @@ describe("usage member attribution e2e: a usage row names the org member (#1389)
     expect(
       metricDelta(before, after, "aisix_usage_events_emitted_total", {
         user_id: ALICE,
+        user_name: ALICE_NAME,
         status: "429",
       }),
     ).toBeGreaterThanOrEqual(1);
@@ -330,6 +349,21 @@ describe("usage member attribution e2e: a usage row names the org member (#1389)
         status: "429",
       }),
     ).toBeGreaterThanOrEqual(1);
+    // AISIX-Cloud#1455: the readable name rides on the same sample. It is
+    // filled from the event beside the id, so a sample carrying one and
+    // not the other would mean the two came from different places.
+    expect(
+      metricDelta(before, after, "aisix_usage_events_emitted_total", {
+        user_id: ALICE,
+        user_name: ALICE_NAME,
+        status: "429",
+      }),
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      metricDelta(before, after, "aisix_usage_events_emitted_total", (l) =>
+        l.user_id === ALICE && l.user_name !== ALICE_NAME,
+      ),
+    ).toBe(0);
     // The status family survives beside the raw code, so a dashboard
     // written against `status_code="4xx"` keeps working unchanged.
     expect(

--- a/tests/e2e/src/cases/usage-member-attribution-e2e.test.ts
+++ b/tests/e2e/src/cases/usage-member-attribution-e2e.test.ts
@@ -11,7 +11,6 @@ import {
   startMockIdp,
   startMockSls,
   startOpenAiUpstream,
-  sumMetric,
   waitConfigPropagation,
   waitForSlsLog,
   type MetricSample,
@@ -261,6 +260,7 @@ describe("usage member attribution e2e: a usage row names the org member (#1389)
       return;
     }
     const marker = "uma-unowned-1d93";
+    const before: MetricSample[] = await scrapeMetrics(app.metricsUrl);
     expect((await chat(UNOWNED_PLAINTEXT, marker)).status).toBe(200);
 
     const log = await waitForSlsLog(
@@ -275,13 +275,23 @@ describe("usage member attribution e2e: a usage row names the org member (#1389)
 
     // On the counter the same absence reads as the placeholder both halves
     // share — a metric label set has to be uniform across the family, and
-    // an unowned key must not borrow a name from anywhere.
+    // an unowned key must not borrow a name from anywhere. A delta, per
+    // this suite's rule: the whole file shares one app, so an absolute
+    // sum would be answering for every other case's traffic too.
     const after: MetricSample[] = await scrapeMetrics(app.metricsUrl);
     expect(
-      sumMetric(after, "aisix_usage_events_emitted_total", (l) =>
+      metricDelta(before, after, "aisix_usage_events_emitted_total", (l) =>
         l.user_id === "unknown" && l.user_name !== "unknown",
       ),
     ).toBe(0);
+    // …and the request DID land on the paired placeholder, so the zero
+    // above is an absence of mismatches rather than an absence of traffic.
+    expect(
+      metricDelta(before, after, "aisix_usage_events_emitted_total", {
+        user_id: "unknown",
+        user_name: "unknown",
+      }),
+    ).toBeGreaterThanOrEqual(1);
   });
 
   test("a gateway rate-limit 429 reaches the feed with the member on it", async (ctx) => {


### PR DESCRIPTION
Pairs with api7/docs#2244 and api7/docs.apiseven.com#532.

## Problem

`aisix_proxy_requests_total` and the `aisix_llm_*` usage families have carried the member pair `user_id` + `user_name` since #890. Two families that also name a member carried the id alone:

- `aisix_usage_events_emitted_total` / `aisix_usage_event_drops_total`
- the `aisix_budget_*` gauges (`limit_usd`, `spent_usd`, `remaining_usd`, `reset_seconds`, `details_present`)

So a usage-event alert or a budget dashboard could only name a member by uuid, and answering "whose" meant a lookup outside Prometheus.

An audit of every metric this gateway emits — they are all registered in `aisix-obs/src/metrics.rs`, and the control plane emits none carrying `user_id` — turns up exactly those two label sets. The two SLO histograms (`aisix_request_e2e_latency_seconds`, `aisix_request_ttft_seconds`) deliberately carry no per-caller dimension at all and are left alone.

## Implementation

cp-api already projects `user_name` onto the `api_keys` etcd row (#890) and the DP already parses it into `ApiKey.user_name`, so this is data-plane-only — no schema, no projection, no wire change.

The pair is sourced from ONE place per family so that it cannot split:

- The usage-event counters take **both** halves from the event in `UsageSink::try_emit`, which is where `user_id` already came from. `UsageEvent` gains a `#[serde(skip)]` `user_name` to carry it there. It is deliberately not added to the DP → cp-api wire: cp-api resolves member names from its own tables, and a second copy on the wire would only give that name a way to disagree with itself.
- `apply_caller_identity` takes the name as a **required** argument beside the id, so the compiler makes every emitting handler hand over both halves of the same ApiKey row rather than leaving a path to be found later with an id and no name.
- `CallerIdentity` resolves the name once per request beside `user_id`. It does **not** become a header-template variable — `HEADER_TEMPLATE_VARS` lists the four `request.api_key.*` keys and `HeaderVars::resolve` matches them one by one.
- The budget gauges read both off `auth.key()`.

Unlike `user_id`, the name is not run through `sanitize_tag`. That call protects the cp-api wire and the provider-call log line, and `user_name` reaches neither; its only destination is the metric label, which the four #890 families already stamp raw off the same row. Sanitising this one copy would let a long or odd name read differently on `aisix_usage_event*` than on `aisix_llm_*` and drop that member out of a cross-family join on the pair.

## Behavior change

Two counters and five gauges gain a `user_name` label. Existing queries keep working: nothing is renamed or removed, and grouping by `user_id` is unaffected. A query that pins the full label tuple would need the new label, as with any added dimension.

`user_name` is `unknown` wherever `user_id` is (a key bound to no member, or auth that never resolved a key), so the label set stays uniform across the family.

The value is a **snapshot**, not a live read: cp-api stamps it when it projects the ApiKey row, and no path reprojects a key because its member was renamed. A rename therefore does not reach these metrics until that key is written again for some other reason — the same semantics `user_name` has had on the request families since #890. When it does land, it opens a new series; on the gauges, where a series is never retired, the pre-rename sample stays behind and an ungrouped `sum` counts both. That is pre-existing behavior of the family — `team_id` and `user_id` strand samples on the same writes — and it is now stated at `BudgetLabels` where a query author will meet it, rather than fixed here.

## Tests

- `user_name` is part of the worker cache key on both usage-event counters and on the budget gauges, so a name change opens a new series instead of folding into the stale one. Each of those assertions was checked by mutation — dropping the label from the emit counter, from the drop counter, from the budget gauges, or from `try_emit` each turns a distinct set of tests red.
- The sink test pins that a handler's own `user_name` label value loses to the event's, the same way `user_id` does.
- The guard that keeps per-caller dimensions off the SLO histograms matched label names by substring, so `contains("user_id")` could not see `user_name` — the one label this change spreads across every attribution family. It now lists both name labels beside their ids; a mutation that leaks either onto `aisix_request_*` turns it red.
- The #1389 member-attribution e2e asserts the pair on `aisix_usage_events_emitted_total` from a real seeded `api_keys` row, that no sample carries the member's id with a different name, and that a key owned by nobody lands on `unknown` for both halves rather than splitting.

The budget gauges have no e2e leg: they are fed by a cp-api budget decision, which the data-plane-standalone e2e stack has no control plane to produce. Their coverage is the unit level.

Fixes api7/AISIX-Cloud#1455