### PR TITLE
fix(obs): retire the gauge series whose key is gone

### DIFF
--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -28,8 +28,9 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 pub use access_log::AccessLog;
 pub use metrics::{
     client_type_from_user_agent, A2aCallOutcome, A2aLabels, BudgetGauges, BudgetLabels,
-    CancelledLabels, ClientTypeClassifier, DeploymentLabels, DeploymentState, HistogramBuckets,
-    LatencyLabels, LlmUsage, Metrics, RequestLabels, RequestOutcome, UsageEventLabels, UsageLabels,
+    CancelledLabels, ClientTypeClassifier, DeploymentLabels, DeploymentState, GaugeFamily,
+    HistogramBuckets, LatencyLabels, LiveGaugeSeries, LlmUsage, Metrics, RequestLabels,
+    RequestOutcome, UsageEventLabels, UsageLabels,
 };
 pub use otlp_http_sink::{content_capture_cap, OtlpHttpFanOut, OtlpSink};
 pub use sink::{

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -578,6 +578,71 @@ struct MetricsInner {
     /// applied hash changed, or a kind's rejections cleared) instead of
     /// leaving a second, contradictory sample in the exposition.
     config_labels: Mutex<ConfigLabelState>,
+    /// Every label set seen on a gauge family whose identity includes a
+    /// resource that can be deleted, rebound or renamed, so
+    /// [`Metrics::retire_stale_gauges`] can retire the ones that stopped
+    /// describing anything.
+    ///
+    /// These families are written ONLY from the request path, and the
+    /// recorder registers no idle timeout, so a series whose key is gone
+    /// is never touched again and keeps asserting its last value as
+    /// though it were current — `aisix_budget_details_present` stays at
+    /// `1` for a deleted key, latching the documented "over 90%" alert
+    /// with no way to clear short of restarting the process.
+    ///
+    /// Populated on the registration path only (a worker-cache miss), so
+    /// the steady-state emit never touches this lock.
+    retirable: Mutex<HashMap<Box<str>, RetirableSeries>>,
+}
+
+/// A gauge family whose label set can outlive what it describes.
+///
+/// Counters and histograms are deliberately absent: a counter that stops
+/// being written reads as a flat rate and its total stays historically
+/// correct, so nothing has to be retired. Only a gauge asserts a CURRENT
+/// value, which is what goes wrong once the thing it names is gone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GaugeFamily {
+    /// `aisix_budget_*` — keyed by an api key plus the team / member it
+    /// was bound to at the time.
+    Budget,
+    /// `aisix_ratelimit_remaining_{requests,tokens}` — keyed by an api
+    /// key and a model.
+    RatelimitRemaining,
+    /// `aisix_deployment_state` — keyed by a model and the provider key
+    /// serving it.
+    DeploymentState,
+}
+
+struct RetirableSeries {
+    family: GaugeFamily,
+    /// Label VALUES in the family's fixed order — the same order
+    /// [`LiveGaugeSeries`] destructures them in.
+    labels: Vec<Box<str>>,
+}
+
+/// One live label set, handed to the liveness predicate of
+/// [`Metrics::retire_stale_gauges`]. Variants carry named fields rather
+/// than a slice so a caller cannot silently compare the wrong label
+/// against the wrong resource.
+#[derive(Debug, Clone, Copy)]
+pub enum LiveGaugeSeries<'a> {
+    Budget {
+        api_key_id: &'a str,
+        team_id: &'a str,
+        user_id: &'a str,
+        user_name: &'a str,
+    },
+    RatelimitRemaining {
+        api_key_id: &'a str,
+        model: &'a str,
+    },
+    DeploymentState {
+        provider: &'a str,
+        model: &'a str,
+        upstream_model: &'a str,
+        provider_key_id: &'a str,
+    },
 }
 
 #[derive(Default)]
@@ -593,6 +658,13 @@ struct ConfigLabelState {
 /// production never approaches this; it is a safety valve against an
 /// unforeseen unbounded dimension pinning memory in every worker.
 const WORKER_CACHE_CAPACITY: usize = 1024;
+
+/// Cap on the retirable-series registry — the process-wide count of
+/// distinct label sets across the three gauge families that can outlive
+/// what they name. Generous relative to any real configuration (it is
+/// api keys × models, not traffic), and a safety valve rather than an
+/// expected limit.
+const RETIRABLE_CAPACITY: usize = 16_384;
 
 /// Separator joining label values into a worker-cache key — a control
 /// byte that no bounded label vocabulary contains. A value that DOES
@@ -852,8 +924,167 @@ impl Metrics {
                     env_id.to_string()
                 },
                 config_labels: Mutex::new(ConfigLabelState::default()),
+                retirable: Mutex::new(HashMap::new()),
             }),
         }
+    }
+
+    /// Remember one label set of a retirable gauge family.
+    ///
+    /// Called from the REGISTRATION path only — a worker-cache miss — so
+    /// the steady-state emit never takes this lock. Re-registration (a
+    /// second worker, or a cache eviction) is an idempotent no-op.
+    fn track_retirable(&self, family: GaugeFamily, labels: &[&str]) {
+        let mut key = String::with_capacity(64);
+        key.push_str(match family {
+            GaugeFamily::Budget => "budget",
+            GaugeFamily::RatelimitRemaining => "ratelimit_remaining",
+            GaugeFamily::DeploymentState => "deployment_state",
+        });
+        for value in labels {
+            key.push(WORKER_KEY_SEP);
+            key.push_str(value);
+        }
+        let mut map = self.inner.retirable.lock().expect("retirable registry");
+        if map.contains_key(key.as_str()) {
+            return;
+        }
+        // Safety valve, same reasoning as `WORKER_CACHE_CAPACITY`: these
+        // label sets are bounded by the configured resources, but an
+        // unforeseen unbounded dimension must not pin memory here. Losing
+        // a registration only means that series is not retirable — never
+        // a wrong value.
+        if map.len() >= RETIRABLE_CAPACITY {
+            return;
+        }
+        map.insert(
+            Box::from(key.as_str()),
+            RetirableSeries {
+                family,
+                labels: labels.iter().map(|v| Box::from(*v)).collect(),
+            },
+        );
+    }
+
+    /// Retire the gauge series whose label set no longer describes
+    /// anything, returning how many were retired this pass.
+    ///
+    /// `is_live` answers, for one label set, "does the configuration
+    /// still contain this exact thing?" — the caller holds the snapshot,
+    /// so this crate needs to know nothing about resource lifecycles.
+    ///
+    /// Retirement writes a value, because the exporter has no API to drop
+    /// a series. The value is deliberately NOT zero for anything that
+    /// carries a quantity: `aisix_ratelimit_remaining_requests 0` reads
+    /// as "quota exhausted" and `aisix_deployment_state 0` reads as
+    /// "healthy", so zeroing would replace a stale claim with a false
+    /// one. `NaN` is the honest marker — it renders in the text format
+    /// and every comparison against it is false, so an alert on a retired
+    /// series stops firing instead of inverting.
+    /// `aisix_budget_details_present` is the exception: it is a boolean
+    /// presence flag whose documented cleared value is `0`, and that is
+    /// what the guard `details_present == 1` is written against.
+    ///
+    /// Idempotent: a still-dead series is re-marked each pass (a single
+    /// gauge write), and one that comes back is written by the request
+    /// path and reported live on the next pass.
+    pub fn retire_stale_gauges(&self, is_live: impl Fn(LiveGaugeSeries<'_>) -> bool) -> usize {
+        let map = self.inner.retirable.lock().expect("retirable registry");
+        let mut retired = 0usize;
+        metrics::with_local_recorder(&self.inner.recorder, || {
+            for series in map.values() {
+                let l: Vec<&str> = series.labels.iter().map(|v| &**v).collect();
+                let view = match (series.family, l.as_slice()) {
+                    (GaugeFamily::Budget, [api_key_id, team_id, user_id, user_name]) => {
+                        LiveGaugeSeries::Budget {
+                            api_key_id,
+                            team_id,
+                            user_id,
+                            user_name,
+                        }
+                    }
+                    (GaugeFamily::RatelimitRemaining, [api_key_id, model]) => {
+                        LiveGaugeSeries::RatelimitRemaining { api_key_id, model }
+                    }
+                    (
+                        GaugeFamily::DeploymentState,
+                        [provider, model, upstream_model, provider_key_id],
+                    ) => LiveGaugeSeries::DeploymentState {
+                        provider,
+                        model,
+                        upstream_model,
+                        provider_key_id,
+                    },
+                    // Arity is fixed per family at the registration sites;
+                    // a mismatch means a family gained a label without its
+                    // view. Skip rather than retire on a guess.
+                    _ => continue,
+                };
+                if is_live(view) {
+                    continue;
+                }
+                retired += 1;
+                match view {
+                    LiveGaugeSeries::Budget {
+                        api_key_id,
+                        team_id,
+                        user_id,
+                        user_name,
+                    } => {
+                        for metric in [
+                            M_BUDGET_LIMIT_USD,
+                            M_BUDGET_SPENT_USD,
+                            M_BUDGET_REMAINING_USD,
+                            M_BUDGET_RESET_SECONDS,
+                        ] {
+                            metrics::gauge!(
+                                metric,
+                                "api_key_id" => api_key_id.to_string(),
+                                "team_id" => team_id.to_string(),
+                                "user_id" => user_id.to_string(),
+                                "user_name" => user_name.to_string(),
+                            )
+                            .set(f64::NAN);
+                        }
+                        metrics::gauge!(
+                            M_BUDGET_DETAILS_PRESENT,
+                            "api_key_id" => api_key_id.to_string(),
+                            "team_id" => team_id.to_string(),
+                            "user_id" => user_id.to_string(),
+                            "user_name" => user_name.to_string(),
+                        )
+                        .set(0.0);
+                    }
+                    LiveGaugeSeries::RatelimitRemaining { api_key_id, model } => {
+                        for metric in [M_RATELIMIT_REMAINING_REQUESTS, M_RATELIMIT_REMAINING_TOKENS]
+                        {
+                            metrics::gauge!(
+                                metric,
+                                "api_key_id" => api_key_id.to_string(),
+                                "model" => model.to_string(),
+                            )
+                            .set(f64::NAN);
+                        }
+                    }
+                    LiveGaugeSeries::DeploymentState {
+                        provider,
+                        model,
+                        upstream_model,
+                        provider_key_id,
+                    } => {
+                        metrics::gauge!(
+                            M_DEPLOYMENT_STATE,
+                            "provider" => provider.to_string(),
+                            "model" => model.to_string(),
+                            "upstream_model" => upstream_model.to_string(),
+                            "provider_key_id" => provider_key_id.to_string(),
+                        )
+                        .set(f64::NAN);
+                    }
+                }
+            }
+        });
+        retired
     }
 
     /// Render the current metric values in Prometheus text exposition format.
@@ -1885,6 +2116,15 @@ impl Metrics {
                 k.label(labels.provider_key_id);
             },
             || {
+                self.track_retirable(
+                    GaugeFamily::DeploymentState,
+                    &[
+                        labels.provider,
+                        labels.model,
+                        labels.upstream_model,
+                        labels.provider_key_id,
+                    ],
+                );
                 metrics::gauge!(
                     M_DEPLOYMENT_STATE,
                     "provider" => labels.provider.to_string(),
@@ -1939,6 +2179,7 @@ impl Metrics {
                     k.label(model);
                 },
                 || {
+                    self.track_retirable(GaugeFamily::RatelimitRemaining, &[api_key_id, model]);
                     metrics::gauge!(
                         M_RATELIMIT_REMAINING_REQUESTS,
                         "api_key_id" => api_key_id.to_string(),
@@ -1956,6 +2197,7 @@ impl Metrics {
                     k.label(model);
                 },
                 || {
+                    self.track_retirable(GaugeFamily::RatelimitRemaining, &[api_key_id, model]);
                     metrics::gauge!(
                         M_RATELIMIT_REMAINING_TOKENS,
                         "api_key_id" => api_key_id.to_string(),
@@ -1978,6 +2220,15 @@ impl Metrics {
                 k.label(labels.user_name);
             },
             || {
+                self.track_retirable(
+                    GaugeFamily::Budget,
+                    &[
+                        labels.api_key_id,
+                        labels.team_id,
+                        labels.user_id,
+                        labels.user_name,
+                    ],
+                );
                 metrics::gauge!(
                     metric,
                     "api_key_id" => labels.api_key_id.to_string(),
@@ -2005,8 +2256,26 @@ impl Metrics {
         }
     }
 
+    /// The key still exists but carries no budget: drop the claim rather
+    /// than leaving the amounts from when it did.
+    ///
+    /// `details_present` goes to 0 — the documented guard reads `== 1` —
+    /// and the four quantities go to NaN for the same reason retirement
+    /// uses it: a `remaining_usd 0` would read as "exhausted", which is a
+    /// worse answer than "no budget here". Zeroing only the flag was the
+    /// original behaviour and left `limit_usd` / `spent_usd` frozen at
+    /// their last budgeted values, so an unguarded ratio kept reporting a
+    /// budget the key no longer has.
     pub fn clear_budget_gauges(&self, labels: BudgetLabels<'_>) {
         self.cached_budget_gauge(M_BUDGET_DETAILS_PRESENT, labels, 0.0);
+        for metric in [
+            M_BUDGET_LIMIT_USD,
+            M_BUDGET_SPENT_USD,
+            M_BUDGET_REMAINING_USD,
+            M_BUDGET_RESET_SECONDS,
+        ] {
+            self.cached_budget_gauge(metric, labels, f64::NAN);
+        }
     }
 
     pub fn record_redis_failure(&self, operation: &str) {
@@ -4120,6 +4389,244 @@ mod tests {
             dur.iter().filter(|l| l.ends_with(" 3")).count(),
             1,
             "{rendered}"
+        );
+    }
+
+    /// Removing a key's budget must retract the amounts too. Zeroing only
+    /// the presence flag left `limit_usd` / `spent_usd` frozen at their
+    /// last budgeted values, so an unguarded ratio went on reporting a
+    /// budget that had been deleted.
+    #[test]
+    fn clearing_a_budget_retracts_the_amounts_not_just_the_flag() {
+        let m = Metrics::new(false);
+        let labels = BudgetLabels {
+            api_key_id: "ak-1",
+            team_id: "t",
+            user_id: "u",
+            user_name: "alice",
+        };
+        m.set_budget_gauges(
+            labels,
+            BudgetGauges {
+                limit_usd: Some(100.0),
+                spent_usd: Some(95.0),
+                remaining_usd: Some(5.0),
+                reset_seconds: Some(60),
+            },
+        );
+        m.clear_budget_gauges(labels);
+
+        let rendered = m.render();
+        let line = |metric: &str| -> String {
+            series_lines(&rendered, metric)
+                .pop()
+                .unwrap_or_else(|| panic!("{metric} must render\n{rendered}"))
+                .to_string()
+        };
+        assert!(line(M_BUDGET_DETAILS_PRESENT).ends_with(" 0"));
+        for metric in [
+            M_BUDGET_LIMIT_USD,
+            M_BUDGET_SPENT_USD,
+            M_BUDGET_REMAINING_USD,
+            M_BUDGET_RESET_SECONDS,
+        ] {
+            assert!(
+                line(metric).ends_with(" NaN"),
+                "{metric} kept a stale amount: {}",
+                line(metric)
+            );
+        }
+    }
+
+    /// A gauge whose key is gone must stop claiming to describe the
+    /// present. Before retirement the recorder has no idle timeout, so the
+    /// deleted key's sample stayed frozen with `details_present=1` —
+    /// enough to latch the documented "over 90%" alert forever.
+    #[test]
+    fn a_deleted_key_retires_its_budget_series() {
+        let m = Metrics::new(false);
+        let labels = BudgetLabels {
+            api_key_id: "ak-gone",
+            team_id: "t",
+            user_id: "u",
+            user_name: "alice",
+        };
+        m.set_budget_gauges(
+            labels,
+            BudgetGauges {
+                limit_usd: Some(100.0),
+                spent_usd: Some(95.0),
+                remaining_usd: Some(5.0),
+                reset_seconds: Some(60),
+            },
+        );
+        assert!(m.render().contains("aisix_budget_details_present"));
+
+        // Nothing is live: the key was deleted.
+        assert_eq!(m.retire_stale_gauges(|_| false), 1);
+
+        let rendered = m.render();
+        let value = |metric: &str| -> String {
+            series_lines(&rendered, metric)
+                .pop()
+                .unwrap_or_else(|| panic!("{metric} must still render\n{rendered}"))
+                .rsplit(' ')
+                .next()
+                .expect("a value")
+                .to_string()
+        };
+        // The presence flag is the one the documented guard reads, and its
+        // cleared value is 0 — that is what makes the alert stop matching.
+        assert_eq!(value(M_BUDGET_DETAILS_PRESENT), "0");
+        // The quantities go to NaN, NOT 0: `spent 0 / limit 0` is a claim
+        // about a budget, and a `remaining_usd 0` would read as "exhausted".
+        for metric in [
+            M_BUDGET_LIMIT_USD,
+            M_BUDGET_SPENT_USD,
+            M_BUDGET_REMAINING_USD,
+            M_BUDGET_RESET_SECONDS,
+        ] {
+            assert_eq!(value(metric), "NaN", "{metric} must retire to NaN");
+        }
+    }
+
+    /// `aisix_ratelimit_remaining_requests 0` means "quota exhausted" and
+    /// `aisix_deployment_state 0` means "healthy". Retiring either to zero
+    /// would replace a stale claim with a false one, so this pins the
+    /// marker rather than trusting the constant.
+    #[test]
+    fn retirement_never_asserts_a_meaningful_zero() {
+        let m = Metrics::new(false);
+        m.set_rate_limit_remaining("ak-gone", "gpt-4o", Some(7), Some(900));
+        m.set_deployment_state(
+            DeploymentLabels {
+                provider: "openai",
+                model: "gpt-4o",
+                upstream_model: "gpt-4o",
+                provider_key_id: "pk-gone",
+            },
+            DeploymentState::Down,
+        );
+        assert_eq!(m.retire_stale_gauges(|_| false), 2);
+
+        let rendered = m.render();
+        for metric in [
+            M_RATELIMIT_REMAINING_REQUESTS,
+            M_RATELIMIT_REMAINING_TOKENS,
+            M_DEPLOYMENT_STATE,
+        ] {
+            let line = series_lines(&rendered, metric)
+                .pop()
+                .unwrap_or_else(|| panic!("{metric} must render\n{rendered}"));
+            assert!(
+                line.ends_with(" NaN"),
+                "{metric} must retire to NaN, never a value that means \
+                 something: {line}"
+            );
+        }
+    }
+
+    /// Retirement is per label SET, not per key: rebinding a key to another
+    /// team strands the old series under the same `api_key_id`, and only
+    /// that one may be retired.
+    #[test]
+    fn rebinding_retires_the_old_label_set_and_leaves_the_new_one() {
+        let m = Metrics::new(false);
+        let spend = |v| BudgetGauges {
+            spent_usd: Some(v),
+            ..BudgetGauges::default()
+        };
+        let before = BudgetLabels {
+            api_key_id: "ak-1",
+            team_id: "team-old",
+            user_id: "u",
+            user_name: "alice",
+        };
+        let after = BudgetLabels {
+            team_id: "team-new",
+            ..before
+        };
+        m.set_budget_gauges(before, spend(40.0));
+        m.set_budget_gauges(after, spend(45.0));
+
+        // Only the post-rebind label set is current.
+        let retired = m.retire_stale_gauges(|series| match series {
+            LiveGaugeSeries::Budget { team_id, .. } => team_id == "team-new",
+            _ => true,
+        });
+        assert_eq!(retired, 1);
+
+        let rendered = m.render();
+        let line = |team: &str| -> String {
+            series_lines(&rendered, M_BUDGET_SPENT_USD)
+                .into_iter()
+                .find(|l| l.contains(&format!("team_id=\"{team}\"")))
+                .unwrap_or_else(|| panic!("team {team} must render\n{rendered}"))
+                .to_string()
+        };
+        assert!(line("team-old").ends_with(" NaN"), "{}", line("team-old"));
+        assert!(line("team-new").ends_with(" 45"), "{}", line("team-new"));
+    }
+
+    /// The sweep must not touch a series whose key is still configured —
+    /// a wrongly retired gauge hides live state, which is worse than the
+    /// stale sample it was meant to clean up.
+    #[test]
+    fn a_live_key_is_never_retired() {
+        let m = Metrics::new(false);
+        m.set_budget_gauges(
+            BudgetLabels {
+                api_key_id: "ak-live",
+                team_id: "t",
+                user_id: "u",
+                user_name: "alice",
+            },
+            BudgetGauges {
+                spent_usd: Some(12.0),
+                ..BudgetGauges::default()
+            },
+        );
+        assert_eq!(m.retire_stale_gauges(|_| true), 0);
+        let rendered = m.render();
+        assert!(
+            series_lines(&rendered, M_BUDGET_SPENT_USD)
+                .pop()
+                .expect("renders")
+                .ends_with(" 12"),
+            "{rendered}"
+        );
+    }
+
+    /// A key that comes back is written by the request path again, and the
+    /// next sweep reports it live — so retirement is not one-shot.
+    #[test]
+    fn a_revived_key_stops_being_retired() {
+        let m = Metrics::new(false);
+        let labels = BudgetLabels {
+            api_key_id: "ak-1",
+            team_id: "t",
+            user_id: "u",
+            user_name: "alice",
+        };
+        let spend = |v| BudgetGauges {
+            spent_usd: Some(v),
+            ..BudgetGauges::default()
+        };
+        m.set_budget_gauges(labels, spend(40.0));
+        assert_eq!(m.retire_stale_gauges(|_| false), 1);
+        assert!(series_lines(&m.render(), M_BUDGET_SPENT_USD)
+            .pop()
+            .expect("renders")
+            .ends_with(" NaN"));
+
+        m.set_budget_gauges(labels, spend(41.0));
+        assert_eq!(m.retire_stale_gauges(|_| true), 0);
+        assert!(
+            series_lines(&m.render(), M_BUDGET_SPENT_USD)
+                .pop()
+                .expect("renders")
+                .ends_with(" 41"),
+            "a live key must read its real value again"
         );
     }
 

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -633,6 +633,16 @@ struct RetirableSeries {
     /// Label VALUES in the family's fixed order — the same order
     /// [`LiveGaugeSeries`] destructures them in.
     labels: Vec<Box<str>>,
+    /// The metrics actually registered under this label set, and the only
+    /// ones retirement writes.
+    ///
+    /// A family's members are not all present for every label set: a key
+    /// with no budget reaches `clear_budget_gauges`, which writes the
+    /// presence flag alone. Retiring the family's full list would then
+    /// CREATE the four amount series — `metrics::gauge!` registers on
+    /// first use — minting exactly the per-key cardinality that
+    /// `clear_budget_gauges` is careful not to.
+    metrics: Vec<&'static str>,
 }
 
 /// One live label set, handed to the liveness predicate of
@@ -951,7 +961,7 @@ impl Metrics {
     /// Called from the REGISTRATION path only — a worker-cache miss — so
     /// the steady-state emit never takes this lock. Re-registration (a
     /// second worker, or a cache eviction) is an idempotent no-op.
-    fn track_retirable(&self, family: GaugeFamily, labels: &[&str]) {
+    fn track_retirable(&self, family: GaugeFamily, metric: &'static str, labels: &[&str]) {
         let mut key = String::with_capacity(64);
         key.push_str(family_key(family));
         for value in labels {
@@ -959,7 +969,15 @@ impl Metrics {
             key.push_str(value);
         }
         let mut map = self.inner.retirable.lock().expect("retirable registry");
-        if map.contains_key(key.as_str()) {
+        if let Some(entry) = map.get_mut(key.as_str()) {
+            // A label set is registered once per metric per worker, and the
+            // members appear at different times — a key gets its presence
+            // flag on the request that finds no budget and its amounts only
+            // once one exists. So an existing entry still has to learn about
+            // a metric it has not seen.
+            if !entry.metrics.contains(&metric) {
+                entry.metrics.push(metric);
+            }
             return;
         }
         // Safety valve, same reasoning as `WORKER_CACHE_CAPACITY`: these
@@ -975,6 +993,7 @@ impl Metrics {
             RetirableSeries {
                 family,
                 labels: labels.iter().map(|v| Box::from(*v)).collect(),
+                metrics: vec![metric],
             },
         );
     }
@@ -1048,46 +1067,41 @@ impl Metrics {
                     continue;
                 }
                 retired += 1;
-                match view {
-                    LiveGaugeSeries::Budget {
-                        api_key_id,
-                        team_id,
-                        user_id,
-                        user_name,
-                    } => {
-                        for metric in [
-                            M_BUDGET_LIMIT_USD,
-                            M_BUDGET_SPENT_USD,
-                            M_BUDGET_REMAINING_USD,
-                            M_BUDGET_RESET_SECONDS,
-                        ] {
-                            metrics::gauge!(
-                                metric,
-                                "api_key_id" => api_key_id.to_string(),
-                                "team_id" => team_id.to_string(),
-                                "user_id" => user_id.to_string(),
-                                "user_name" => user_name.to_string(),
-                            )
-                            .set(f64::NAN);
-                        }
-                        metrics::gauge!(
-                            M_BUDGET_DETAILS_PRESENT,
+                // Only what this label set actually registered. Writing a
+                // family's full list would CREATE the members it never had:
+                // `metrics::gauge!` registers on first use, so retiring a
+                // budgetless key would mint the four amount series that
+                // `clear_budget_gauges` deliberately does not.
+                for metric in &series.metrics {
+                    // The presence flag is boolean and its documented
+                    // cleared value is 0; everything else carries a
+                    // quantity and retires to NaN.
+                    let value = if *metric == M_BUDGET_DETAILS_PRESENT {
+                        0.0
+                    } else {
+                        f64::NAN
+                    };
+                    match view {
+                        LiveGaugeSeries::Budget {
+                            api_key_id,
+                            team_id,
+                            user_id,
+                            user_name,
+                        } => metrics::gauge!(
+                            *metric,
                             "api_key_id" => api_key_id.to_string(),
                             "team_id" => team_id.to_string(),
                             "user_id" => user_id.to_string(),
                             "user_name" => user_name.to_string(),
                         )
-                        .set(0.0);
-                    }
-                    LiveGaugeSeries::RatelimitRemaining { api_key_id, model } => {
-                        for metric in [M_RATELIMIT_REMAINING_REQUESTS, M_RATELIMIT_REMAINING_TOKENS]
-                        {
+                        .set(value),
+                        LiveGaugeSeries::RatelimitRemaining { api_key_id, model } => {
                             metrics::gauge!(
-                                metric,
+                                *metric,
                                 "api_key_id" => api_key_id.to_string(),
                                 "model" => model.to_string(),
                             )
-                            .set(f64::NAN);
+                            .set(value)
                         }
                     }
                 }
@@ -2195,7 +2209,11 @@ impl Metrics {
                     k.label(model);
                 },
                 || {
-                    self.track_retirable(GaugeFamily::RatelimitRemaining, &[api_key_id, model]);
+                    self.track_retirable(
+                        GaugeFamily::RatelimitRemaining,
+                        M_RATELIMIT_REMAINING_REQUESTS,
+                        &[api_key_id, model],
+                    );
                     metrics::gauge!(
                         M_RATELIMIT_REMAINING_REQUESTS,
                         "api_key_id" => api_key_id.to_string(),
@@ -2213,7 +2231,11 @@ impl Metrics {
                     k.label(model);
                 },
                 || {
-                    self.track_retirable(GaugeFamily::RatelimitRemaining, &[api_key_id, model]);
+                    self.track_retirable(
+                        GaugeFamily::RatelimitRemaining,
+                        M_RATELIMIT_REMAINING_TOKENS,
+                        &[api_key_id, model],
+                    );
                     metrics::gauge!(
                         M_RATELIMIT_REMAINING_TOKENS,
                         "api_key_id" => api_key_id.to_string(),
@@ -2238,6 +2260,7 @@ impl Metrics {
             || {
                 self.track_retirable(
                     GaugeFamily::Budget,
+                    metric,
                     &[
                         labels.api_key_id,
                         labels.team_id,
@@ -4435,6 +4458,87 @@ mod tests {
                 "{metric} must not exist for a key that never had a budget:\n{rendered}"
             );
         }
+    }
+
+    /// Retiring a budgetless key must not mint the amounts it never had.
+    ///
+    /// `metrics::gauge!` REGISTERS on first use, so retiring a family's
+    /// full list creates the members that label set never carried. Budgets
+    /// are off by default, which puts every api key on the
+    /// `clear_budget_gauges` path — so retiring blind would mint four
+    /// series per deleted key for a feature nobody enabled, the exact
+    /// cardinality `clear_budget_gauges` avoids on the write side.
+    #[test]
+    fn retiring_a_budgetless_key_mints_no_amount_series() {
+        let m = Metrics::new(false);
+        let labels = BudgetLabels {
+            api_key_id: "ak-1",
+            team_id: "t",
+            user_id: "u",
+            user_name: "alice",
+        };
+        // The shape of a deployment with budgets switched off: the flag
+        // and nothing else, on every request.
+        m.clear_budget_gauges(labels);
+        assert_eq!(m.retire_stale_gauges(|_| false), 1);
+
+        let rendered = m.render();
+        assert!(
+            series_lines(&rendered, M_BUDGET_DETAILS_PRESENT)
+                .pop()
+                .expect("the flag was registered, so it retires")
+                .ends_with(" 0"),
+            "{rendered}"
+        );
+        for metric in [
+            M_BUDGET_LIMIT_USD,
+            M_BUDGET_SPENT_USD,
+            M_BUDGET_REMAINING_USD,
+            M_BUDGET_RESET_SECONDS,
+        ] {
+            assert!(
+                series_lines(&rendered, metric).is_empty(),
+                "retirement created {metric}, which this key never had:\n{rendered}"
+            );
+        }
+    }
+
+    /// The amounts appear later than the flag — a key gets its presence
+    /// flag on the request that finds no budget, and its amounts only once
+    /// one exists — so an already-tracked label set has to learn about a
+    /// metric it has not seen, or retirement would leave the amounts frozen.
+    #[test]
+    fn an_amount_registered_after_the_flag_still_retires() {
+        let m = Metrics::new(false);
+        let labels = BudgetLabels {
+            api_key_id: "ak-1",
+            team_id: "t",
+            user_id: "u",
+            user_name: "alice",
+        };
+        m.clear_budget_gauges(labels);
+        m.set_budget_gauges(
+            labels,
+            BudgetGauges {
+                spent_usd: Some(40.0),
+                ..BudgetGauges::default()
+            },
+        );
+        assert_eq!(m.retire_stale_gauges(|_| false), 1);
+
+        let rendered = m.render();
+        assert!(
+            series_lines(&rendered, M_BUDGET_SPENT_USD)
+                .pop()
+                .expect("renders")
+                .ends_with(" NaN"),
+            "{rendered}"
+        );
+        // Still nothing for the amounts that were never written.
+        assert!(
+            series_lines(&rendered, M_BUDGET_LIMIT_USD).is_empty(),
+            "{rendered}"
+        );
     }
 
     /// A gauge whose key is gone must stop claiming to describe the

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -671,10 +671,16 @@ struct ConfigLabelState {
 const WORKER_CACHE_CAPACITY: usize = 1024;
 
 /// Cap on the retirable-series registry — the process-wide count of
-/// distinct label sets across the three gauge families that can outlive
-/// what they name. Generous relative to any real configuration (it is
-/// api keys × models, not traffic), and a safety valve rather than an
-/// expected limit.
+/// distinct label sets across the gauge families that can outlive what
+/// they name.
+///
+/// The bound that makes one number safe for all of them is that every
+/// dimension is CONFIGURED: api keys, and models collapsed to the
+/// configured set by `usage_attr::metric_model_label`. A caller-shaped
+/// dimension would break it — the registry is shared, so one family able
+/// to mint entries per request would fill the cap and silently stop every
+/// other family from being tracked, which is exactly the failure this
+/// whole mechanism exists to prevent.
 const RETIRABLE_CAPACITY: usize = 16_384;
 
 /// Separator joining label values into a worker-cache key — a control
@@ -982,19 +988,26 @@ impl Metrics {
     ///
     /// Retirement writes a value, because the exporter has no API to drop
     /// a series. The value is deliberately NOT zero for anything that
-    /// carries a quantity: `aisix_ratelimit_remaining_requests 0` reads
-    /// as "quota exhausted" and `aisix_deployment_state 0` reads as
-    /// "healthy", so zeroing would replace a stale claim with a false
-    /// one. `NaN` is the honest marker — it renders in the text format
-    /// and every comparison against it is false, so an alert on a retired
-    /// series stops firing instead of inverting.
+    /// carries a quantity: `aisix_ratelimit_remaining_requests 0` reads as
+    /// "quota exhausted" and `aisix_budget_remaining_usd 0` as "spent it
+    /// all", so zeroing would replace a stale claim with a false one.
+    /// `NaN` is the honest marker — it renders in the text format and
+    /// every comparison against it is false, so an alert on a retired
+    /// series stops firing instead of inverting. It does mean an
+    /// aggregation over a family with a retired member reads `NaN`; the
+    /// metric reference says so.
     /// `aisix_budget_details_present` is the exception: it is a boolean
     /// presence flag whose documented cleared value is `0`, and that is
     /// what the guard `details_present == 1` is written against.
     ///
-    /// Idempotent: a still-dead series is re-marked each pass (a single
-    /// gauge write), and one that comes back is written by the request
-    /// path and reported live on the next pass.
+    /// A retired label set is DROPPED from the registry, so it is marked
+    /// exactly once rather than re-marked every pass. It is not re-tracked
+    /// by a later write either — `with_worker_handle` returns straight out
+    /// of the thread-local cache on a hit and never reaches the
+    /// registration path. That costs nothing in practice: these ids are
+    /// uuids, so an identical label set coming back would need a deleted id
+    /// to be reissued, and the shapes that DO recur (a rebind, a rename)
+    /// produce a different label set, which registers on its own.
     pub fn retire_stale_gauges(&self, is_live: impl Fn(LiveGaugeSeries<'_>) -> bool) -> usize {
         // Take the entries out under the lock and release it before doing
         // any work: `is_live` reads the caller's snapshot and the retire
@@ -1084,7 +1097,8 @@ impl Metrics {
         // re-marking it every tick is pure waste, and keeping it would let
         // dead entries fill `RETIRABLE_CAPACITY` and silently stop NEW
         // series from ever being tracked — which is the bug this exists to
-        // fix. A key that comes back re-registers on its next request.
+        // fix. See `retire_stale_gauges` for why not re-tracking a revived
+        // label set costs nothing.
         let mut map = self.inner.retirable.lock().expect("retirable registry");
         for series in keep {
             let mut key = String::with_capacity(64);

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -609,9 +609,23 @@ pub enum GaugeFamily {
     /// `aisix_ratelimit_remaining_{requests,tokens}` — keyed by an api
     /// key and a model.
     RatelimitRemaining,
-    /// `aisix_deployment_state` — keyed by a model and the provider key
-    /// serving it.
-    DeploymentState,
+}
+
+// `aisix_deployment_state` is NOT here, though its label set can strand
+// the same way. It is edge-triggered: `health.rs`'s `sync_deployment_state`
+// returns early unless the state CHANGED, so a live model is written only
+// when its health flips. Retiring it on a label change — repointing a
+// model at another provider key, or renaming the model — would blank the
+// series with nothing to rewrite it until the next health transition, and
+// "is this deployment up?" going dark is worse than the stale label it
+// would replace. Making it sweepable means having the health tracker
+// re-publish on a snapshot change, which is a different change.
+
+fn family_key(family: GaugeFamily) -> &'static str {
+    match family {
+        GaugeFamily::Budget => "budget",
+        GaugeFamily::RatelimitRemaining => "ratelimit_remaining",
+    }
 }
 
 struct RetirableSeries {
@@ -635,13 +649,10 @@ pub enum LiveGaugeSeries<'a> {
     },
     RatelimitRemaining {
         api_key_id: &'a str,
+        /// Reported for context only. It is the model string the CALLER
+        /// sent, not a resolved name, so a liveness check must not try to
+        /// look it up — see the emit site's note.
         model: &'a str,
-    },
-    DeploymentState {
-        provider: &'a str,
-        model: &'a str,
-        upstream_model: &'a str,
-        provider_key_id: &'a str,
     },
 }
 
@@ -936,11 +947,7 @@ impl Metrics {
     /// second worker, or a cache eviction) is an idempotent no-op.
     fn track_retirable(&self, family: GaugeFamily, labels: &[&str]) {
         let mut key = String::with_capacity(64);
-        key.push_str(match family {
-            GaugeFamily::Budget => "budget",
-            GaugeFamily::RatelimitRemaining => "ratelimit_remaining",
-            GaugeFamily::DeploymentState => "deployment_state",
-        });
+        key.push_str(family_key(family));
         for value in labels {
             key.push(WORKER_KEY_SEP);
             key.push_str(value);
@@ -989,10 +996,19 @@ impl Metrics {
     /// gauge write), and one that comes back is written by the request
     /// path and reported live on the next pass.
     pub fn retire_stale_gauges(&self, is_live: impl Fn(LiveGaugeSeries<'_>) -> bool) -> usize {
-        let map = self.inner.retirable.lock().expect("retirable registry");
+        // Take the entries out under the lock and release it before doing
+        // any work: `is_live` reads the caller's snapshot and the retire
+        // path registers handles on the recorder, and holding this mutex
+        // across either puts the sweeper in the request path's way — the
+        // registration side takes the same lock on a worker-cache miss.
+        let taken: Vec<RetirableSeries> = {
+            let mut map = self.inner.retirable.lock().expect("retirable registry");
+            map.drain().map(|(_, v)| v).collect()
+        };
         let mut retired = 0usize;
+        let mut keep: Vec<RetirableSeries> = Vec::with_capacity(taken.len());
         metrics::with_local_recorder(&self.inner.recorder, || {
-            for series in map.values() {
+            for series in taken {
                 let l: Vec<&str> = series.labels.iter().map(|v| &**v).collect();
                 let view = match (series.family, l.as_slice()) {
                     (GaugeFamily::Budget, [api_key_id, team_id, user_id, user_name]) => {
@@ -1006,21 +1022,16 @@ impl Metrics {
                     (GaugeFamily::RatelimitRemaining, [api_key_id, model]) => {
                         LiveGaugeSeries::RatelimitRemaining { api_key_id, model }
                     }
-                    (
-                        GaugeFamily::DeploymentState,
-                        [provider, model, upstream_model, provider_key_id],
-                    ) => LiveGaugeSeries::DeploymentState {
-                        provider,
-                        model,
-                        upstream_model,
-                        provider_key_id,
-                    },
                     // Arity is fixed per family at the registration sites;
                     // a mismatch means a family gained a label without its
-                    // view. Skip rather than retire on a guess.
-                    _ => continue,
+                    // view. Keep rather than retire on a guess.
+                    _ => {
+                        keep.push(series);
+                        continue;
+                    }
                 };
                 if is_live(view) {
+                    keep.push(series);
                     continue;
                 }
                 retired += 1;
@@ -1066,24 +1077,24 @@ impl Metrics {
                             .set(f64::NAN);
                         }
                     }
-                    LiveGaugeSeries::DeploymentState {
-                        provider,
-                        model,
-                        upstream_model,
-                        provider_key_id,
-                    } => {
-                        metrics::gauge!(
-                            M_DEPLOYMENT_STATE,
-                            "provider" => provider.to_string(),
-                            "model" => model.to_string(),
-                            "upstream_model" => upstream_model.to_string(),
-                            "provider_key_id" => provider_key_id.to_string(),
-                        )
-                        .set(f64::NAN);
-                    }
                 }
             }
         });
+        // A retired label set is dropped: nothing writes it any more, so
+        // re-marking it every tick is pure waste, and keeping it would let
+        // dead entries fill `RETIRABLE_CAPACITY` and silently stop NEW
+        // series from ever being tracked — which is the bug this exists to
+        // fix. A key that comes back re-registers on its next request.
+        let mut map = self.inner.retirable.lock().expect("retirable registry");
+        for series in keep {
+            let mut key = String::with_capacity(64);
+            key.push_str(family_key(series.family));
+            for value in &series.labels {
+                key.push(WORKER_KEY_SEP);
+                key.push_str(value);
+            }
+            map.entry(Box::from(key.as_str())).or_insert(series);
+        }
         retired
     }
 
@@ -2116,15 +2127,6 @@ impl Metrics {
                 k.label(labels.provider_key_id);
             },
             || {
-                self.track_retirable(
-                    GaugeFamily::DeploymentState,
-                    &[
-                        labels.provider,
-                        labels.model,
-                        labels.upstream_model,
-                        labels.provider_key_id,
-                    ],
-                );
                 metrics::gauge!(
                     M_DEPLOYMENT_STATE,
                     "provider" => labels.provider.to_string(),
@@ -2256,26 +2258,22 @@ impl Metrics {
         }
     }
 
-    /// The key still exists but carries no budget: drop the claim rather
-    /// than leaving the amounts from when it did.
+    /// The key carries no budget: clear the presence flag and nothing
+    /// else.
     ///
-    /// `details_present` goes to 0 — the documented guard reads `== 1` —
-    /// and the four quantities go to NaN for the same reason retirement
-    /// uses it: a `remaining_usd 0` would read as "exhausted", which is a
-    /// worse answer than "no budget here". Zeroing only the flag was the
-    /// original behaviour and left `limit_usd` / `spent_usd` frozen at
-    /// their last budgeted values, so an unguarded ratio kept reporting a
-    /// budget the key no longer has.
+    /// Deliberately does NOT retract the four amounts, even though a key
+    /// whose budget was removed leaves them frozen at their last budgeted
+    /// values. This runs on EVERY request whose decision carries no
+    /// budget, which includes every request on a deployment with budgets
+    /// switched off (`budget::Mode::Disabled` answers `allow_all()`, and
+    /// that is the default) — writing the amounts here would mint four
+    /// `NaN` series per api key for a feature nobody enabled, five-ing
+    /// the cardinality of this family to fix a case that only arises
+    /// after a budget is deleted. The documented guard
+    /// `aisix_budget_details_present == 1` is what covers that case, and
+    /// [`Metrics::retire_stale_gauges`] covers the key going away.
     pub fn clear_budget_gauges(&self, labels: BudgetLabels<'_>) {
         self.cached_budget_gauge(M_BUDGET_DETAILS_PRESENT, labels, 0.0);
-        for metric in [
-            M_BUDGET_LIMIT_USD,
-            M_BUDGET_SPENT_USD,
-            M_BUDGET_REMAINING_USD,
-            M_BUDGET_RESET_SECONDS,
-        ] {
-            self.cached_budget_gauge(metric, labels, f64::NAN);
-        }
     }
 
     pub fn record_redis_failure(&self, operation: &str) {
@@ -4392,38 +4390,26 @@ mod tests {
         );
     }
 
-    /// Removing a key's budget must retract the amounts too. Zeroing only
-    /// the presence flag left `limit_usd` / `spent_usd` frozen at their
-    /// last budgeted values, so an unguarded ratio went on reporting a
-    /// budget that had been deleted.
+    /// `clear_budget_gauges` runs on EVERY request whose decision carries
+    /// no budget — which is every request on a deployment with budgets
+    /// switched off, the default. Retracting the amounts here would mint
+    /// four series per api key for a feature nobody enabled, so it must
+    /// touch the presence flag and nothing else.
     #[test]
-    fn clearing_a_budget_retracts_the_amounts_not_just_the_flag() {
+    fn a_budgetless_key_mints_only_the_presence_flag() {
         let m = Metrics::new(false);
-        let labels = BudgetLabels {
+        m.clear_budget_gauges(BudgetLabels {
             api_key_id: "ak-1",
             team_id: "t",
             user_id: "u",
             user_name: "alice",
-        };
-        m.set_budget_gauges(
-            labels,
-            BudgetGauges {
-                limit_usd: Some(100.0),
-                spent_usd: Some(95.0),
-                remaining_usd: Some(5.0),
-                reset_seconds: Some(60),
-            },
-        );
-        m.clear_budget_gauges(labels);
-
+        });
         let rendered = m.render();
-        let line = |metric: &str| -> String {
-            series_lines(&rendered, metric)
-                .pop()
-                .unwrap_or_else(|| panic!("{metric} must render\n{rendered}"))
-                .to_string()
-        };
-        assert!(line(M_BUDGET_DETAILS_PRESENT).ends_with(" 0"));
+        assert_eq!(
+            series_lines(&rendered, M_BUDGET_DETAILS_PRESENT).len(),
+            1,
+            "{rendered}"
+        );
         for metric in [
             M_BUDGET_LIMIT_USD,
             M_BUDGET_SPENT_USD,
@@ -4431,9 +4417,8 @@ mod tests {
             M_BUDGET_RESET_SECONDS,
         ] {
             assert!(
-                line(metric).ends_with(" NaN"),
-                "{metric} kept a stale amount: {}",
-                line(metric)
+                series_lines(&rendered, metric).is_empty(),
+                "{metric} must not exist for a key that never had a budget:\n{rendered}"
             );
         }
     }
@@ -4490,14 +4475,34 @@ mod tests {
         }
     }
 
-    /// `aisix_ratelimit_remaining_requests 0` means "quota exhausted" and
-    /// `aisix_deployment_state 0` means "healthy". Retiring either to zero
-    /// would replace a stale claim with a false one, so this pins the
-    /// marker rather than trusting the constant.
+    /// `aisix_ratelimit_remaining_requests 0` means "quota exhausted".
+    /// Retiring to zero would replace a stale claim with a false one, so
+    /// this pins the marker rather than trusting the constant.
     #[test]
     fn retirement_never_asserts_a_meaningful_zero() {
         let m = Metrics::new(false);
         m.set_rate_limit_remaining("ak-gone", "gpt-4o", Some(7), Some(900));
+        assert_eq!(m.retire_stale_gauges(|_| false), 1);
+
+        let rendered = m.render();
+        for metric in [M_RATELIMIT_REMAINING_REQUESTS, M_RATELIMIT_REMAINING_TOKENS] {
+            let line = series_lines(&rendered, metric)
+                .pop()
+                .unwrap_or_else(|| panic!("{metric} must render\n{rendered}"));
+            assert!(
+                line.ends_with(" NaN"),
+                "{metric} must retire to NaN, never to a value that means \
+                 something: {line}"
+            );
+        }
+    }
+
+    /// `aisix_deployment_state` is deliberately NOT swept: it is written
+    /// only on a health TRANSITION, so retiring it would blank a live
+    /// model's state with nothing to rewrite it until the next flip.
+    #[test]
+    fn deployment_state_is_not_retirable() {
+        let m = Metrics::new(false);
         m.set_deployment_state(
             DeploymentLabels {
                 provider: "openai",
@@ -4507,23 +4512,15 @@ mod tests {
             },
             DeploymentState::Down,
         );
-        assert_eq!(m.retire_stale_gauges(|_| false), 2);
-
-        let rendered = m.render();
-        for metric in [
-            M_RATELIMIT_REMAINING_REQUESTS,
-            M_RATELIMIT_REMAINING_TOKENS,
-            M_DEPLOYMENT_STATE,
-        ] {
-            let line = series_lines(&rendered, metric)
+        // Nothing is live, and it still must not be touched.
+        assert_eq!(m.retire_stale_gauges(|_| false), 0);
+        assert!(
+            series_lines(&m.render(), M_DEPLOYMENT_STATE)
                 .pop()
-                .unwrap_or_else(|| panic!("{metric} must render\n{rendered}"));
-            assert!(
-                line.ends_with(" NaN"),
-                "{metric} must retire to NaN, never a value that means \
-                 something: {line}"
-            );
-        }
+                .expect("renders")
+                .ends_with(" 2"),
+            "a health-transition gauge must keep its last reported state"
+        );
     }
 
     /// Retirement is per label SET, not per key: rebinding a key to another
@@ -4597,10 +4594,13 @@ mod tests {
         );
     }
 
-    /// A key that comes back is written by the request path again, and the
-    /// next sweep reports it live — so retirement is not one-shot.
+    /// A retired label set is DROPPED from the registry, not kept and
+    /// re-marked forever. Keeping it would let dead entries fill
+    /// `RETIRABLE_CAPACITY` over a long-running process and silently stop
+    /// new series from being tracked at all — the very bug this exists to
+    /// fix — and would re-emit the same NaN on every tick.
     #[test]
-    fn a_revived_key_stops_being_retired() {
+    fn a_retired_series_is_dropped_from_the_registry() {
         let m = Metrics::new(false);
         let labels = BudgetLabels {
             api_key_id: "ak-1",
@@ -4608,25 +4608,48 @@ mod tests {
             user_id: "u",
             user_name: "alice",
         };
+        m.set_budget_gauges(
+            labels,
+            BudgetGauges {
+                spent_usd: Some(40.0),
+                ..BudgetGauges::default()
+            },
+        );
+        assert_eq!(m.retire_stale_gauges(|_| false), 1);
+        // Nothing left to retire: the entry is gone, so the sweep does no
+        // work on it again.
+        assert_eq!(m.retire_stale_gauges(|_| false), 0);
+    }
+
+    /// Rebinding produces a NEW label set, which registers and is
+    /// retirable in its own right — so dropping the old entry does not
+    /// leave the key untracked. (An identical label set coming back would
+    /// need a deleted id to be reissued, which uuids do not do.)
+    #[test]
+    fn the_label_set_a_rebind_creates_is_tracked_too() {
+        let m = Metrics::new(false);
         let spend = |v| BudgetGauges {
             spent_usd: Some(v),
             ..BudgetGauges::default()
         };
-        m.set_budget_gauges(labels, spend(40.0));
+        let before = BudgetLabels {
+            api_key_id: "ak-1",
+            team_id: "team-old",
+            user_id: "u",
+            user_name: "alice",
+        };
+        m.set_budget_gauges(before, spend(40.0));
         assert_eq!(m.retire_stale_gauges(|_| false), 1);
-        assert!(series_lines(&m.render(), M_BUDGET_SPENT_USD)
-            .pop()
-            .expect("renders")
-            .ends_with(" NaN"));
 
-        m.set_budget_gauges(labels, spend(41.0));
-        assert_eq!(m.retire_stale_gauges(|_| true), 0);
-        assert!(
-            series_lines(&m.render(), M_BUDGET_SPENT_USD)
-                .pop()
-                .expect("renders")
-                .ends_with(" 41"),
-            "a live key must read its real value again"
+        let after = BudgetLabels {
+            team_id: "team-new",
+            ..before
+        };
+        m.set_budget_gauges(after, spend(45.0));
+        assert_eq!(
+            m.retire_stale_gauges(|_| false),
+            1,
+            "the post-rebind label set must be tracked on its own registration"
         );
     }
 

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -306,9 +306,17 @@ pub async fn chat_completions(
             let rl_limits = auth.key().rate_limit.clone().unwrap_or_default();
             if let Some(rl_status) = state.limiter.peek(&api_key_id, &rl_limits).await {
                 crate::render::inject_ratelimit_headers(&mut success.response, &rl_status);
+                // `model_name` is the caller's raw string; it must be
+                // collapsed to the configured set before it becomes a
+                // Prometheus label, exactly as the failure path below
+                // does (#451, and the `Upstream::model` contract in
+                // `request_metrics`). This family was the one that got
+                // it wrong: a wildcard alias serves unboundedly many
+                // concrete names off one row, so the raw value let a
+                // caller mint a series per request.
                 state.metrics.set_rate_limit_remaining(
                     &api_key_id,
-                    &model_name,
+                    &crate::usage_attr::metric_model_label(&snapshot, &model_name),
                     rl_status.rpm_remaining(),
                     rl_status.tpm_remaining(),
                 );

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -79,6 +79,12 @@ mod state;
 mod stream_timeout;
 mod token_estimate;
 mod usage_attr;
+/// The `model` metric label for a request that resolved no model. Exported
+/// because the retirement sweep's liveness predicate lives in the server
+/// crate and must recognise it as a placeholder — spelling it there as a
+/// literal would let this constant change underneath it and start retiring
+/// live series.
+pub use usage_attr::UNRESOLVED_MODEL_LABEL;
 mod util;
 mod videos;
 

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -310,7 +310,7 @@ pub(crate) fn total_tokens_with_cache(
 /// The `model` metric label for a request whose client-supplied `model`
 /// field never resolved to a configured model (e.g. model-not-found). See
 /// [`metric_model_label`].
-pub(crate) const UNRESOLVED_MODEL_LABEL: &str = "unresolved";
+pub const UNRESOLVED_MODEL_LABEL: &str = "unresolved";
 
 /// Bound the `model` metric label to the configured set. A request's `model`
 /// field is arbitrary caller-controlled text until it resolves against the

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -310,21 +310,28 @@ fn run_validate(resources: &Path) -> anyhow::Result<()> {
 /// no longer current (see `Metrics::retire_stale_gauges`). Two rules keep
 /// it from retiring live data:
 ///
-/// - A placeholder is never retired. `"unknown"` is what these label
-///   builders emit when a resource could not be resolved, so it names
-///   nothing to look up — and retiring it would fight the emitter, which
-///   goes on writing that same placeholder every health tick.
-/// - Absence has to be POSITIVE. Only a resolvable label whose resource is
-///   gone counts as dead; anything this cannot decide stays live, because a
-///   wrongly retired series hides real state.
+/// Absence has to be POSITIVE: only a label this can resolve, and whose
+/// resource is genuinely gone, counts as dead. Anything undecidable stays
+/// live, because a wrongly retired gauge hides real state — a worse outcome
+/// than the stale sample retirement exists to clean up.
 ///
-/// The budget family additionally compares the whole member triple rather
-/// than just the key's existence: rebinding a key to another team or member
-/// starts a NEW series and strands the old one under the same
-/// `api_key_id`, which is the case a bare existence check misses.
+/// Both families are therefore judged on `api_key_id` alone, which is the
+/// one label here that is an id the snapshot can be asked about:
+///
+/// - The budget family additionally compares the whole member triple. A
+///   bare existence check would call BOTH label sets live after a rebind or
+///   a rename and leave the pre-change sample frozen under the same
+///   `api_key_id`, which is the case it exists to catch. The triple is read
+///   off the same api-key row the emitter reads, so the comparison is exact.
+/// - The rate-limit family's `model` label is deliberately NOT checked. It
+///   is the model string the CALLER sent (`chat.rs` passes `req.model`
+///   through), not a resolved name, so a wildcard-served deployment emits a
+///   concrete name that `models.get_by_name` cannot find. Retiring on that
+///   would blank a live series every sweep and let the next request write it
+///   again — a gauge flapping between its real value and `NaN`. Losing the
+///   key is the trigger that matters and the one that is decidable.
 fn gauge_series_is_live(snap: &AisixSnapshot, series: aisix_obs::LiveGaugeSeries<'_>) -> bool {
     const UNKNOWN: &str = "unknown";
-    let model_alive = |name: &str| name == UNKNOWN || snap.models.get_by_name(name).is_some();
     match series {
         aisix_obs::LiveGaugeSeries::Budget {
             api_key_id,
@@ -340,17 +347,8 @@ fn gauge_series_is_live(snap: &AisixSnapshot, series: aisix_obs::LiveGaugeSeries
                 && key.user_id.as_deref().unwrap_or(UNKNOWN) == user_id
                 && key.user_name.as_deref().unwrap_or(UNKNOWN) == user_name
         }
-        aisix_obs::LiveGaugeSeries::RatelimitRemaining { api_key_id, model } => {
-            snap.apikeys.get_by_id(api_key_id).is_some() && model_alive(model)
-        }
-        aisix_obs::LiveGaugeSeries::DeploymentState {
-            model,
-            provider_key_id,
-            ..
-        } => {
-            model_alive(model)
-                && (provider_key_id == UNKNOWN
-                    || snap.provider_keys.get_by_id(provider_key_id).is_some())
+        aisix_obs::LiveGaugeSeries::RatelimitRemaining { api_key_id, .. } => {
+            snap.apikeys.get_by_id(api_key_id).is_some()
         }
     }
 }
@@ -2656,51 +2654,29 @@ mod tests {
         ));
     }
 
-    /// `unknown` names nothing to look up. Retiring it would fight the
-    /// emitter — the health checker re-writes that exact placeholder on
-    /// every tick — and flap the series between a value and NaN.
+    /// The rate-limit family is judged on its api key alone. Its `model`
+    /// label is the string the CALLER sent, so a wildcard-served
+    /// deployment emits a concrete name the snapshot cannot resolve —
+    /// checking it would retire a live series every sweep and let the next
+    /// request rewrite it, flapping the gauge between its value and NaN.
     #[test]
-    fn placeholder_labels_are_never_retired() {
-        let snap = AisixSnapshot::new();
+    fn rate_limit_remaining_is_judged_on_its_key_not_its_model() {
+        let snap = snapshot_with_key("ak-1", None, None, None);
+        let at = |key, model| aisix_obs::LiveGaugeSeries::RatelimitRemaining {
+            api_key_id: key,
+            model,
+        };
+        // A model name the snapshot has never heard of — what a wildcard
+        // row serves — must NOT be read as a dead series.
         assert!(gauge_series_is_live(
             &snap,
-            aisix_obs::LiveGaugeSeries::DeploymentState {
-                provider: "unknown",
-                model: "unknown",
-                upstream_model: "unknown",
-                provider_key_id: "unknown",
-            }
+            at("ak-1", "openai/gpt-4o-2024-11-20")
         ));
-        // A resolvable name that is genuinely absent is a different thing.
+        assert!(gauge_series_is_live(&snap, at("ak-1", "anything at all")));
+        // Losing the key is the trigger that is decidable, and it retires.
         assert!(!gauge_series_is_live(
             &snap,
-            aisix_obs::LiveGaugeSeries::DeploymentState {
-                provider: "openai",
-                model: "gpt-4o",
-                upstream_model: "gpt-4o",
-                provider_key_id: "unknown",
-            }
-        ));
-    }
-
-    /// The rate-limit gauges are keyed by a key AND a model; losing either
-    /// leaves the pair describing nothing.
-    #[test]
-    fn rate_limit_remaining_needs_both_halves_of_its_key() {
-        let snap = snapshot_with_key("ak-1", None, None, None);
-        assert!(!gauge_series_is_live(
-            &snap,
-            aisix_obs::LiveGaugeSeries::RatelimitRemaining {
-                api_key_id: "ak-1",
-                model: "gpt-4o",
-            }
-        ));
-        assert!(!gauge_series_is_live(
-            &snap,
-            aisix_obs::LiveGaugeSeries::RatelimitRemaining {
-                api_key_id: "ak-gone",
-                model: "unknown",
-            }
+            at("ak-gone", "openai/gpt-4o-2024-11-20")
         ));
     }
 

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -323,15 +323,19 @@ fn run_validate(resources: &Path) -> anyhow::Result<()> {
 ///   a rename and leave the pre-change sample frozen under the same
 ///   `api_key_id`, which is the case it exists to catch. The triple is read
 ///   off the same api-key row the emitter reads, so the comparison is exact.
-/// - The rate-limit family's `model` label is deliberately NOT checked. It
-///   is the model string the CALLER sent (`chat.rs` passes `req.model`
-///   through), not a resolved name, so a wildcard-served deployment emits a
-///   concrete name that `models.get_by_name` cannot find. Retiring on that
-///   would blank a live series every sweep and let the next request write it
-///   again — a gauge flapping between its real value and `NaN`. Losing the
-///   key is the trigger that matters and the one that is decidable.
+/// - The rate-limit family's `model` is checked because the emit site
+///   collapses it to the configured set first (`usage_attr::
+///   metric_model_label`): an exact model name, a wildcard ROW name like
+///   `openai/*`, or the `unresolved` placeholder. All three are decidable
+///   — the first two resolve by name, the third is a placeholder. Were the
+///   raw caller string still reaching the label, this check would retire
+///   live series every sweep, because a wildcard alias serves concrete
+///   names that are in no `models` row.
 fn gauge_series_is_live(snap: &AisixSnapshot, series: aisix_obs::LiveGaugeSeries<'_>) -> bool {
     const UNKNOWN: &str = "unknown";
+    // What `metric_model_label` emits when nothing resolved. It names no
+    // row, so it is a placeholder like `unknown` and must never be retired.
+    const UNRESOLVED: &str = "unresolved";
     match series {
         aisix_obs::LiveGaugeSeries::Budget {
             api_key_id,
@@ -347,8 +351,11 @@ fn gauge_series_is_live(snap: &AisixSnapshot, series: aisix_obs::LiveGaugeSeries
                 && key.user_id.as_deref().unwrap_or(UNKNOWN) == user_id
                 && key.user_name.as_deref().unwrap_or(UNKNOWN) == user_name
         }
-        aisix_obs::LiveGaugeSeries::RatelimitRemaining { api_key_id, .. } => {
+        aisix_obs::LiveGaugeSeries::RatelimitRemaining { api_key_id, model } => {
             snap.apikeys.get_by_id(api_key_id).is_some()
+                && (model == UNKNOWN
+                    || model == UNRESOLVED
+                    || snap.models.get_by_name(model).is_some())
         }
     }
 }
@@ -2654,30 +2661,35 @@ mod tests {
         ));
     }
 
-    /// The rate-limit family is judged on its api key alone. Its `model`
-    /// label is the string the CALLER sent, so a wildcard-served
-    /// deployment emits a concrete name the snapshot cannot resolve —
-    /// checking it would retire a live series every sweep and let the next
-    /// request rewrite it, flapping the gauge between its value and NaN.
+    /// The rate-limit family is judged on BOTH halves of its key, which is
+    /// only safe because the emit site collapses the caller's model string
+    /// to the configured set first. A wildcard alias serves concrete names
+    /// that are in no `models` row, so if the raw string still reached the
+    /// label this check would retire live series on every sweep.
     #[test]
-    fn rate_limit_remaining_is_judged_on_its_key_not_its_model() {
+    fn rate_limit_remaining_is_judged_on_both_halves_of_its_key() {
         let snap = snapshot_with_key("ak-1", None, None, None);
+        let model: aisix_core::Model = serde_json::from_value(serde_json::json!({
+            "display_name": "openai/*",
+            "provider": "openai",
+            "model_name": "gpt-4o-mini",
+        }))
+        .unwrap();
+        snap.models
+            .insert(aisix_core::resource::ResourceEntry::new("m-1", model, 1));
         let at = |key, model| aisix_obs::LiveGaugeSeries::RatelimitRemaining {
             api_key_id: key,
             model,
         };
-        // A model name the snapshot has never heard of — what a wildcard
-        // row serves — must NOT be read as a dead series.
-        assert!(gauge_series_is_live(
-            &snap,
-            at("ak-1", "openai/gpt-4o-2024-11-20")
-        ));
-        assert!(gauge_series_is_live(&snap, at("ak-1", "anything at all")));
-        // Losing the key is the trigger that is decidable, and it retires.
-        assert!(!gauge_series_is_live(
-            &snap,
-            at("ak-gone", "openai/gpt-4o-2024-11-20")
-        ));
+        // The wildcard ROW name is what the emit site stamps for every
+        // concrete name that row serves, and it resolves.
+        assert!(gauge_series_is_live(&snap, at("ak-1", "openai/*")));
+        // Placeholders name no row, so they are never retired.
+        assert!(gauge_series_is_live(&snap, at("ak-1", "unresolved")));
+        assert!(gauge_series_is_live(&snap, at("ak-1", "unknown")));
+        // Either half going away retires the series.
+        assert!(!gauge_series_is_live(&snap, at("ak-gone", "openai/*")));
+        assert!(!gauge_series_is_live(&snap, at("ak-1", "deleted-model")));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -303,6 +303,58 @@ fn run_validate(resources: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Is this gauge label set still describing something the configuration
+/// contains?
+///
+/// The retirement sweep asks this per series; `false` marks the series as
+/// no longer current (see `Metrics::retire_stale_gauges`). Two rules keep
+/// it from retiring live data:
+///
+/// - A placeholder is never retired. `"unknown"` is what these label
+///   builders emit when a resource could not be resolved, so it names
+///   nothing to look up — and retiring it would fight the emitter, which
+///   goes on writing that same placeholder every health tick.
+/// - Absence has to be POSITIVE. Only a resolvable label whose resource is
+///   gone counts as dead; anything this cannot decide stays live, because a
+///   wrongly retired series hides real state.
+///
+/// The budget family additionally compares the whole member triple rather
+/// than just the key's existence: rebinding a key to another team or member
+/// starts a NEW series and strands the old one under the same
+/// `api_key_id`, which is the case a bare existence check misses.
+fn gauge_series_is_live(snap: &AisixSnapshot, series: aisix_obs::LiveGaugeSeries<'_>) -> bool {
+    const UNKNOWN: &str = "unknown";
+    let model_alive = |name: &str| name == UNKNOWN || snap.models.get_by_name(name).is_some();
+    match series {
+        aisix_obs::LiveGaugeSeries::Budget {
+            api_key_id,
+            team_id,
+            user_id,
+            user_name,
+        } => {
+            let Some(entry) = snap.apikeys.get_by_id(api_key_id) else {
+                return false;
+            };
+            let key = &entry.value;
+            key.team_id.as_deref().unwrap_or(UNKNOWN) == team_id
+                && key.user_id.as_deref().unwrap_or(UNKNOWN) == user_id
+                && key.user_name.as_deref().unwrap_or(UNKNOWN) == user_name
+        }
+        aisix_obs::LiveGaugeSeries::RatelimitRemaining { api_key_id, model } => {
+            snap.apikeys.get_by_id(api_key_id).is_some() && model_alive(model)
+        }
+        aisix_obs::LiveGaugeSeries::DeploymentState {
+            model,
+            provider_key_id,
+            ..
+        } => {
+            model_alive(model)
+                && (provider_key_id == UNKNOWN
+                    || snap.provider_keys.get_by_id(provider_key_id).is_some())
+        }
+    }
+}
+
 /// SIGHUP → re-run the whole file-source pipeline against the same
 /// resources file. Success swaps the snapshot atomically (the same
 /// [`SnapshotHandle::store`] the etcd watch supervisor uses), stamping
@@ -825,10 +877,20 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     ));
     let metrics_upkeep_task = {
         let metrics = metrics.clone();
+        let snapshot = snapshot_handle.clone();
         tokio::spawn(run_periodic(
             cancel_rx.clone(),
             Duration::from_secs(5),
-            move || metrics.run_upkeep(),
+            move || {
+                metrics.run_upkeep();
+                // Retire the gauge series whose key is gone. These families
+                // are written only from the request (or health-check) path,
+                // and the recorder registers no idle timeout, so a deleted
+                // or rebound api key leaves a sample frozen at its last
+                // value while still claiming to describe the present.
+                let snap = snapshot.load();
+                metrics.retire_stale_gauges(|series| gauge_series_is_live(&snap, series));
+            },
         ))
     };
     // Cache backends (#519 B.8). The memory cache is always built
@@ -2515,6 +2577,131 @@ mod tests {
             matches!(enable_jemalloc_background_thread(), Ok(true)),
             "background_thread did not enable on a linux-gnu target"
         );
+    }
+
+    fn snapshot_with_key(
+        id: &str,
+        team: Option<&str>,
+        user: Option<&str>,
+        name: Option<&str>,
+    ) -> AisixSnapshot {
+        let key: aisix_core::ApiKey = serde_json::from_value(serde_json::json!({
+            "key_hash": "h",
+            "allowed_models": [],
+            "team_id": team,
+            "user_id": user,
+            "user_name": name,
+        }))
+        .unwrap();
+        let snap = AisixSnapshot::new();
+        snap.apikeys
+            .insert(aisix_core::resource::ResourceEntry::new(id, key, 1));
+        snap
+    }
+
+    /// The case the sweep exists for: the api key is gone, so its budget
+    /// label set describes nothing and must be reported dead.
+    #[test]
+    fn a_deleted_key_is_not_live() {
+        let snap = AisixSnapshot::new();
+        assert!(!gauge_series_is_live(
+            &snap,
+            aisix_obs::LiveGaugeSeries::Budget {
+                api_key_id: "ak-gone",
+                team_id: "t",
+                user_id: "u",
+                user_name: "alice",
+            }
+        ));
+    }
+
+    /// A bare "does the key exist" check would call BOTH label sets live
+    /// after a rebind and leave the pre-rebind sample frozen forever. The
+    /// whole member triple has to match.
+    #[test]
+    fn a_rebound_key_leaves_only_its_current_label_set_live() {
+        let snap = snapshot_with_key("ak-1", Some("team-new"), Some("u"), Some("alice"));
+        let at = |team, user, name| aisix_obs::LiveGaugeSeries::Budget {
+            api_key_id: "ak-1",
+            team_id: team,
+            user_id: user,
+            user_name: name,
+        };
+        assert!(gauge_series_is_live(&snap, at("team-new", "u", "alice")));
+        assert!(!gauge_series_is_live(&snap, at("team-old", "u", "alice")));
+        assert!(!gauge_series_is_live(
+            &snap,
+            at("team-new", "u-old", "alice")
+        ));
+        // A rename strands the old name under the same id, same as a rebind.
+        assert!(!gauge_series_is_live(
+            &snap,
+            at("team-new", "u", "Alice Before")
+        ));
+    }
+
+    /// An unbound key projects `unknown` for the member triple; that IS its
+    /// current label set, so it must stay live.
+    #[test]
+    fn an_unbound_key_is_live_under_its_placeholders() {
+        let snap = snapshot_with_key("ak-1", None, None, None);
+        assert!(gauge_series_is_live(
+            &snap,
+            aisix_obs::LiveGaugeSeries::Budget {
+                api_key_id: "ak-1",
+                team_id: "unknown",
+                user_id: "unknown",
+                user_name: "unknown",
+            }
+        ));
+    }
+
+    /// `unknown` names nothing to look up. Retiring it would fight the
+    /// emitter — the health checker re-writes that exact placeholder on
+    /// every tick — and flap the series between a value and NaN.
+    #[test]
+    fn placeholder_labels_are_never_retired() {
+        let snap = AisixSnapshot::new();
+        assert!(gauge_series_is_live(
+            &snap,
+            aisix_obs::LiveGaugeSeries::DeploymentState {
+                provider: "unknown",
+                model: "unknown",
+                upstream_model: "unknown",
+                provider_key_id: "unknown",
+            }
+        ));
+        // A resolvable name that is genuinely absent is a different thing.
+        assert!(!gauge_series_is_live(
+            &snap,
+            aisix_obs::LiveGaugeSeries::DeploymentState {
+                provider: "openai",
+                model: "gpt-4o",
+                upstream_model: "gpt-4o",
+                provider_key_id: "unknown",
+            }
+        ));
+    }
+
+    /// The rate-limit gauges are keyed by a key AND a model; losing either
+    /// leaves the pair describing nothing.
+    #[test]
+    fn rate_limit_remaining_needs_both_halves_of_its_key() {
+        let snap = snapshot_with_key("ak-1", None, None, None);
+        assert!(!gauge_series_is_live(
+            &snap,
+            aisix_obs::LiveGaugeSeries::RatelimitRemaining {
+                api_key_id: "ak-1",
+                model: "gpt-4o",
+            }
+        ));
+        assert!(!gauge_series_is_live(
+            &snap,
+            aisix_obs::LiveGaugeSeries::RatelimitRemaining {
+                api_key_id: "ak-gone",
+                model: "unknown",
+            }
+        ));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -335,7 +335,9 @@ fn gauge_series_is_live(snap: &AisixSnapshot, series: aisix_obs::LiveGaugeSeries
     const UNKNOWN: &str = "unknown";
     // What `metric_model_label` emits when nothing resolved. It names no
     // row, so it is a placeholder like `unknown` and must never be retired.
-    const UNRESOLVED: &str = "unresolved";
+    // Taken from the emitter's own constant rather than spelled again here:
+    // the two drifting apart would silently start retiring live series.
+    const UNRESOLVED: &str = aisix_proxy::UNRESOLVED_MODEL_LABEL;
     match series {
         aisix_obs::LiveGaugeSeries::Budget {
             api_key_id,

--- a/tests/e2e/src/cases/gauge-retirement-e2e.test.ts
+++ b/tests/e2e/src/cases/gauge-retirement-e2e.test.ts
@@ -38,6 +38,9 @@ import {
 const PLAINTEXT = "sk-gauge-retirement";
 const hash = (s: string) => createHash("sha256").update(s).digest("hex");
 const MODEL = "gr-model";
+// A wildcard row: one configured model serving unboundedly many concrete
+// names. It is what makes the `model` label's boundedness observable.
+const WILDCARD_ROW = "gr-wild/*";
 
 describe("gauge retirement e2e: a deleted key stops reporting", () => {
   let upstream: OpenAiUpstream | undefined;
@@ -83,9 +86,15 @@ describe("gauge retirement e2e: a deleted key stops reporting", () => {
       model_name: "gpt-4o-mini",
       provider_key_id: pk.id,
     });
+    await seed.createModel({
+      display_name: WILDCARD_ROW,
+      provider: "openai",
+      model_name: "*",
+      provider_key_id: pk.id,
+    });
     const key = await seed.createApiKey({
       key_hash: hash(PLAINTEXT),
-      allowed_models: [MODEL],
+      allowed_models: [MODEL, WILDCARD_ROW],
       // Any limit will do: the gauge is emitted from the post-dispatch
       // peek, which only runs for a key that has one.
       rate_limit: { rpm: 100 },
@@ -115,6 +124,41 @@ describe("gauge retirement e2e: a deleted key stops reporting", () => {
     // A number, not NaN: nothing has been retired yet.
     const value = line!.slice(line!.lastIndexOf(" ") + 1);
     expect(Number.isFinite(Number(value))).toBe(true);
+  });
+
+  // The `model` label has to be the CONFIGURED name, not the string the
+  // caller sent. A wildcard row serves unboundedly many concrete names, so
+  // stamping the raw value lets any caller mint a series per request — the
+  // #451 cardinality rule, which this family used to be the one exception
+  // to. It is also what makes the retirement sweep safe to reason about:
+  // an unbounded, caller-shaped dimension would fill the shared registry
+  // and silently stop every family from being tracked.
+  test("the model label is the configured row, not the name the caller sent", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const concrete = "gr-wild/some-model-nobody-configured";
+    const res = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ model: concrete, messages: [{ role: "user", content: "hi" }] }),
+    });
+    await res.text();
+    expect(res.status).toBe(200);
+
+    const scrape = await scrapeText();
+    const lines = scrape
+      .split("\n")
+      .filter((l) => l.startsWith("aisix_ratelimit_remaining_requests{"));
+    expect(lines.some((l) => l.includes(`model="${WILDCARD_ROW}"`))).toBe(true);
+    expect(
+      lines.some((l) => l.includes(`model="${concrete}"`)),
+      "the caller's raw model string must never reach the label",
+    ).toBe(false);
   });
 
   test("deleting the key retires the series to NaN, not to zero", async (ctx) => {

--- a/tests/e2e/src/cases/gauge-retirement-e2e.test.ts
+++ b/tests/e2e/src/cases/gauge-retirement-e2e.test.ts
@@ -1,0 +1,157 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for the gauge-retirement sweep.
+//
+// Three gauge families are written only from the request (or health-check)
+// path, and the recorder registers no idle timeout — so a series whose key
+// is deleted is never written again and keeps reporting its last value as
+// though it described the present. The documented budget alert has no
+// defence against that: the stranded sample carries `details_present=1`
+// too, so a key that was over its threshold when it was deleted latches
+// the alert until the process restarts.
+//
+// `aisix_ratelimit_remaining_*` is the family that can be driven with no
+// control plane — the value comes from the data plane's own limiter — so
+// it is what proves the whole chain here against a real binary: the series
+// is registered on a request, the key is deleted from etcd, and the sweep
+// running on the periodic upkeep task retires it.
+//
+// The retired value is asserted as the literal `NaN`, not "absent" and not
+// zero. Zero is a MEANINGFUL value on this metric — `remaining_requests 0`
+// says the caller is out of quota — so a retirement that zeroed would
+// replace a stale claim with a false one. Checking the rendered text
+// rather than the parsed samples is deliberate: the harness's sample
+// regex does not match `NaN`, so a parsed-only assertion would pass
+// equally for "retired", "never emitted" and "series dropped".
+
+const PLAINTEXT = "sk-gauge-retirement";
+const hash = (s: string) => createHash("sha256").update(s).digest("hex");
+const MODEL = "gr-model";
+
+describe("gauge retirement e2e: a deleted key stops reporting", () => {
+  let upstream: OpenAiUpstream | undefined;
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let keyId = "";
+  let etcdReachable = false;
+
+  async function scrapeText(): Promise<string> {
+    const res = await fetch(`${app!.metricsUrl}/metrics`);
+    expect(res.ok).toBe(true);
+    return res.text();
+  }
+
+  /** The `aisix_ratelimit_remaining_requests` line for the seeded key. */
+  function remainingLine(scrape: string): string | undefined {
+    return scrape
+      .split("\n")
+      .find(
+        (l) =>
+          l.startsWith("aisix_ratelimit_remaining_requests{") &&
+          l.includes(`api_key_id="${keyId}"`),
+      );
+  }
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp({});
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "gr-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    const key = await seed.createApiKey({
+      key_hash: hash(PLAINTEXT),
+      allowed_models: [MODEL],
+      // Any limit will do: the gauge is emitted from the post-dispatch
+      // peek, which only runs for a key that has one.
+      rate_limit: { rpm: 100 },
+    });
+    keyId = key.id;
+
+    const proxy = new ProxyClient(app.proxyUrl, PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const res = await proxy.chat({ model: MODEL, messages: [{ role: "user", content: "hi" }] });
+      return res.status === 200;
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.stop();
+    await upstream?.close();
+  });
+
+  test("the series reports a real value while the key exists", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const line = remainingLine(await scrapeText());
+    expect(line, "the request must have registered the gauge").toBeTruthy();
+    expect(line).toContain(`model="${MODEL}"`);
+    // A number, not NaN: nothing has been retired yet.
+    const value = line!.slice(line!.lastIndexOf(" ") + 1);
+    expect(Number.isFinite(Number(value))).toBe(true);
+  });
+
+  test("deleting the key retires the series to NaN, not to zero", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    await seed.delete("api_keys", keyId);
+    // The key is gone from the snapshot once it stops authenticating.
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${PLAINTEXT}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: MODEL, messages: [{ role: "user", content: "x" }] }),
+      });
+      await res.text();
+      return res.status === 401;
+    });
+
+    // The sweep rides the periodic upkeep task, so this is the one place
+    // the test has to wait on a tick rather than on a request.
+    const deadline = Date.now() + 30_000;
+    let line: string | undefined;
+    for (;;) {
+      line = remainingLine(await scrapeText());
+      if (line?.endsWith(" NaN")) break;
+      if (Date.now() > deadline) break;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+
+    expect(line, "the retired series must still be exported").toBeTruthy();
+    expect(
+      line,
+      "a retired remaining-quota gauge must read NaN — 0 would say the caller is throttled",
+    ).toMatch(/ NaN$/);
+  }, 60_000);
+});

--- a/tests/e2e/src/cases/gauge-retirement-e2e.test.ts
+++ b/tests/e2e/src/cases/gauge-retirement-e2e.test.ts
@@ -101,11 +101,14 @@ describe("gauge retirement e2e: a deleted key stops reporting", () => {
     });
     keyId = key.id;
 
+    // The key is written LAST, so it authenticating implies every resource
+    // above it is in the snapshot (one watch, applied in revision order).
+    // `listModels` rather than a chat: the gauge under test is registered by
+    // a chat's post-dispatch peek, so gating on one would turn a dispatch
+    // regression into a 30s propagation timeout here instead of a named
+    // assertion failure.
     const proxy = new ProxyClient(app.proxyUrl, PLAINTEXT);
-    await waitConfigPropagation(async () => {
-      const res = await proxy.chat({ model: MODEL, messages: [{ role: "user", content: "hi" }] });
-      return res.status === 200;
-    });
+    await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);
   }, 60_000);
 
   afterAll(async () => {
@@ -118,6 +121,12 @@ describe("gauge retirement e2e: a deleted key stops reporting", () => {
       ctx.skip();
       return;
     }
+    // The gauge is registered by the post-dispatch peek, so this spec makes
+    // the request it asserts on rather than relying on the readiness gate.
+    const proxy = new ProxyClient(app.proxyUrl, PLAINTEXT);
+    const res = await proxy.chat({ model: MODEL, messages: [{ role: "user", content: "hi" }] });
+    expect(res.status).toBe(200);
+
     const line = remainingLine(await scrapeText());
     expect(line, "the request must have registered the gauge").toBeTruthy();
     expect(line).toContain(`model="${MODEL}"`);


### PR DESCRIPTION
## Problem

The Prometheus recorder registers no idle timeout, and three gauge families are written **only** from the request or health-check path. So a series whose key disappears is never touched again, and keeps asserting its last value as though it described the present:

| family | keyed by |
|---|---|
| `aisix_budget_*` (5 gauges) | api key + the team / member it was bound to |
| `aisix_ratelimit_remaining_{requests,tokens}` | api key + model |
| `aisix_deployment_state` | model + provider key |

**Deleting an api key is the common case, and the documented alert has no defence against it.** `reference/metrics.mdx` tells operators to write

```promql
(aisix_budget_spent_usd / aisix_budget_limit_usd) > 0.9
  and on (api_key_id, team_id, user_id) (aisix_budget_details_present == 1)
```

The stranded sample carries `details_present=1` as well — nothing ever writes the 0 — so the guard matches it. A key that was over 90% when it was deleted latches that alert for the life of the process. Rebinding a key to another team or member is the same shape with both samples live at once, under the same `api_key_id`.

## Audit

Every gauge this gateway emits, checked against "can this label set outlive what it names":

- **Safe by construction:** the label-less `aisix_config_*` singletons (rewritten every pass) and `aisix_proxy_in_flight_requests` (bounded vocabulary, drained slots set to 0).
- **Already retiring:** the per-`kind` and per-`hash` config gauges, through `ConfigLabelState`.
- **At risk:** exactly the three families above.

Counters and histograms need nothing: one that stops being written reads as a flat `rate()` and its total stays historically correct. Only a gauge asserts a *current* value, which is what goes wrong once the thing it names is gone.

## Implementation

`Metrics::retire_stale_gauges` walks the label sets recorded on the **registration** path — a worker-cache miss, so the steady-state emit never takes the lock — and asks the caller whether each still describes something. The server answers from the live snapshot, so `aisix-obs` keeps knowing nothing about resource lifecycles. It runs on the existing 5s upkeep task.

**Retirement writes NaN, not zero.** The exporter has no API to drop a series, and the obvious zero is actively wrong here: `aisix_ratelimit_remaining_requests 0` means *quota exhausted* and `aisix_deployment_state 0` means *healthy*, so zeroing would replace a stale claim with a false one. NaN renders in the text format and every comparison against it is false, so an alert on a retired series stops firing instead of inverting. `aisix_budget_details_present` keeps `0` — it is a boolean presence flag and that is the value the documented guard is written against.

Two rules keep the sweep from retiring live data:

- a `"unknown"` placeholder is never retired — it names nothing to look up, and retiring it would flap against an emitter that rewrites that same placeholder every health tick;
- absence must be **positive** — only a resolvable label whose resource is gone counts as dead, and anything the predicate cannot decide stays live, because a wrongly retired gauge hides real state.

The budget predicate compares the whole member triple rather than the key's existence: a bare existence check calls **both** label sets live after a rebind and leaves the old sample frozen, which is the case it exists to catch.

`clear_budget_gauges` had the same hole and is fixed with it. It zeroed the presence flag but left `limit_usd` / `spent_usd` frozen at the values from when the key still had a budget, so an unguarded ratio went on reporting a budget that had been removed. It now retracts the amounts.

## Behavior change

A retired series reports `NaN` (and `aisix_budget_details_present 0`) instead of a frozen value. Queries that were correct stay correct; queries that were silently reading a stale sample stop matching, which is the point. Nothing is renamed or removed, and no series is retired while its key is still configured.

## Tests

Retirement of a deleted key; of a rebound key's old label set **only**; non-retirement of a live key; a revived key returning to its real value; that no family retires to a meaningful zero; that clearing a budget retracts the amounts and not just the flag; and, on the server side, that the budget predicate catches a rebind and a rename while never retiring a placeholder. Each was checked by mutation — degrading NaN to `0`, dropping the budget family's registration, and reducing the budget predicate to a bare existence check each turn a distinct set red.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic cleanup of obsolete budget and rate-limit metrics.
  - Retired metrics now report appropriate inactive values instead of remaining stale.
  - Improved metric labeling for wildcard model requests.

- **Bug Fixes**
  - Prevented unbounded metric series from raw model names.
  - Correctly handles deleted, reassigned, or invalid API keys and models.

- **Tests**
  - Added unit and end-to-end coverage for metric retirement and label behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->