### PR TITLE
feat(ratelimit): report the standard rate-limit headers on a gateway 429

### DIFF
--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1659,9 +1659,11 @@ async fn dispatch(
                                 dispatched: false,
                             },
                         );
-                        // Keep the limiter's own Retry-After hint on the wire:
-                        // when every target is exhausted this error becomes the
-                        // client's 429, and SDKs back off on that header.
+                        // Fallback only: `last_reserve_reject` below carries
+                        // the same refusal un-flattened and takes precedence
+                        // at exhaustion. This stays so the loop still has a
+                        // 429-shaped `last_err` if a later target clears the
+                        // reject without recording one of its own.
                         last_err = Some(BridgeError::upstream_status_with_retry_after(
                             429,
                             format!(
@@ -2782,9 +2784,11 @@ async fn dispatch(
                             dispatched: false,
                         },
                     );
-                    // Keep the limiter's own Retry-After hint on the wire:
-                    // when every target is exhausted this error becomes the
-                    // client's 429, and SDKs back off on that header.
+                    // Fallback only: `last_reserve_reject` below carries the
+                    // same refusal un-flattened and takes precedence at
+                    // exhaustion. This stays so the loop still has a
+                    // 429-shaped `last_err` if a later target clears the
+                    // reject without recording one of its own.
                     last_err = Some(BridgeError::upstream_status_with_retry_after(
                         429,
                         format!(

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1670,12 +1670,15 @@ async fn dispatch(
                             ),
                             crate::quota::retry_after_of(&e).map(Duration::from_secs),
                         ));
-                        // Only the policy-layer rejection is worth
-                        // surfacing un-flattened (it carries the
-                        // `error.policy` attribution); the inline model
-                        // layer keeps the established flattened shape.
-                        last_reserve_reject =
-                            matches!(e, ProxyError::PolicyRateLimit { .. }).then_some(e);
+                        // Surface the quota rejection un-flattened. A
+                        // `Bridge` error reads as the PROVIDER's 429 — it
+                        // carries no `error.policy` attribution and no
+                        // `x-ratelimit-*` headers, so a caller refused by this
+                        // gateway's own limiter would see the wire shape of
+                        // somebody else's refusal. `/v1/messages` and
+                        // `/v1/responses` keep theirs too; this arm used to keep
+                        // only the policy layer's.
+                        last_reserve_reject = Some(e);
                         continue 'targets;
                     }
                 };
@@ -2790,12 +2793,15 @@ async fn dispatch(
                         ),
                         crate::quota::retry_after_of(&e).map(Duration::from_secs),
                     ));
-                    // Only the policy-layer rejection is worth surfacing
-                    // un-flattened (it carries the `error.policy`
-                    // attribution); the inline model layer keeps the
-                    // established flattened shape.
-                    last_reserve_reject =
-                        matches!(e, ProxyError::PolicyRateLimit { .. }).then_some(e);
+                    // Surface the quota rejection un-flattened. A
+                    // `Bridge` error reads as the PROVIDER's 429 — it
+                    // carries no `error.policy` attribution and no
+                    // `x-ratelimit-*` headers, so a caller refused by this
+                    // gateway's own limiter would see the wire shape of
+                    // somebody else's refusal. `/v1/messages` and
+                    // `/v1/responses` keep theirs too; this arm used to keep
+                    // only the policy layer's.
+                    last_reserve_reject = Some(e);
                     continue 'targets;
                 }
             };

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -727,19 +727,72 @@ impl ProxyError {
     }
 }
 
+impl ProxyError {
+    /// The gateway limit that refused this request, when the gateway's
+    /// OWN limiter is what refused it.
+    ///
+    /// `None` for every other 429: a budget rejection caps spend in
+    /// dollars, not requests or tokens, and an upstream 429 reports the
+    /// provider's quota, which the gateway does not know. Both would
+    /// have to invent the numbers. That makes the presence of the
+    /// `x-ratelimit-*` trio on a 429 the caller's signal that AISIX
+    /// itself rejected the request rather than relaying somebody else's
+    /// rejection.
+    fn rate_limit_detail(&self) -> Option<aisix_ratelimit::LimitDetail> {
+        match self {
+            ProxyError::RateLimit(e) => Some(e.detail()),
+            ProxyError::PolicyRateLimit { source, .. } => Some(source.detail()),
+            _ => None,
+        }
+    }
+}
+
+/// Write the retry / rate-limit headers both envelopes owe a rejection.
+///
+/// Shared so the OpenAI-shape and Anthropic-shape renderers cannot
+/// drift: `/v1/messages` answering a 429 without the headers
+/// `/v1/chat/completions` carries would be the same class of bug #336
+/// fixed for the body.
+///
+/// `X-RateLimit-Reset` is delta-seconds, deliberately the same number
+/// as `Retry-After` for a windowed dimension — a caller may read either
+/// one and back off identically, with no clock sync against the
+/// gateway. `X-RateLimit-Scope` is an AISIX extension naming which
+/// dimension fired; without it `x-ratelimit-limit: 100` cannot be told
+/// apart between an rpm, a tpm and a concurrency cap, whose units all
+/// differ.
+fn apply_retry_headers(
+    response: &mut Response,
+    retry_after_secs: Option<u64>,
+    detail: Option<aisix_ratelimit::LimitDetail>,
+) {
+    let headers = response.headers_mut();
+    let mut set = |name: &'static str, value: String| {
+        if let Ok(v) = HeaderValue::from_str(&value) {
+            headers.insert(name, v);
+        }
+    };
+    if let Some(secs) = retry_after_secs {
+        set("retry-after", secs.to_string());
+    }
+    if let Some(d) = detail {
+        set("x-ratelimit-limit", d.limit.to_string());
+        set("x-ratelimit-remaining", d.remaining.to_string());
+        set("x-ratelimit-reset", d.reset_secs.to_string());
+        set("x-ratelimit-scope", d.dimension.to_string());
+    }
+}
+
 impl IntoResponse for ProxyError {
     fn into_response(self) -> Response {
         let challenge = self.auth_challenge();
         let status = self.status();
         let retry_after = self.retry_after_secs();
+        let rate_limit_detail = self.rate_limit_detail();
         let upgrade_reject = matches!(self, ProxyError::WebSocketUpgradeRequired { .. });
         let body = self.envelope();
         let mut response = (status, Json(body)).into_response();
-        if let Some(secs) = retry_after {
-            if let Ok(value) = HeaderValue::from_str(&secs.to_string()) {
-                response.headers_mut().insert("retry-after", value);
-            }
-        }
+        apply_retry_headers(&mut response, retry_after, rate_limit_detail);
         if let Some(challenge) = challenge {
             response.extensions_mut().insert(challenge);
         }
@@ -849,6 +902,7 @@ impl ProxyError {
     pub fn into_anthropic_response(self) -> Response {
         let status = self.status();
         let retry_after = self.retry_after_secs();
+        let rate_limit_detail = self.rate_limit_detail();
         let kind = anthropic_kind_from_status(status).to_string();
         // Reuse OpenAI envelope only for the SAFE-MESSAGE logic
         // (5xx body redaction, 4xx upstream-message pass-through).
@@ -863,11 +917,7 @@ impl ProxyError {
             },
         };
         let mut response = (status, Json(anth_body)).into_response();
-        if let Some(secs) = retry_after {
-            if let Ok(value) = HeaderValue::from_str(&secs.to_string()) {
-                response.headers_mut().insert("retry-after", value);
-            }
-        }
+        apply_retry_headers(&mut response, retry_after, rate_limit_detail);
         response
     }
 }
@@ -1455,6 +1505,146 @@ mod tests {
             msg.contains("503"),
             "redacted message must still surface the upstream status, got: {msg}",
         );
+    }
+
+    /// The four headers a gateway-produced 429 owes the caller, on the
+    /// OpenAI-shape envelope. `x-ratelimit-reset` is delta-seconds and
+    /// equals `retry-after` for a windowed dimension, so a client may
+    /// back off on either without a clock shared with the gateway.
+    #[tokio::test]
+    async fn gateway_429_carries_the_standard_rate_limit_headers() {
+        let err = ProxyError::RateLimit(aisix_ratelimit::RateLimitError::Requests {
+            scope: aisix_core::RateLimitScope::Requests,
+            detail: aisix_ratelimit::LimitDetail {
+                dimension: "rpm",
+                limit: 100,
+                remaining: 0,
+                reset_secs: 43,
+            },
+        });
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let h = resp.headers();
+        assert_eq!(h.get("retry-after").unwrap(), "43");
+        assert_eq!(h.get("x-ratelimit-limit").unwrap(), "100");
+        assert_eq!(h.get("x-ratelimit-remaining").unwrap(), "0");
+        assert_eq!(h.get("x-ratelimit-reset").unwrap(), "43");
+        assert_eq!(h.get("x-ratelimit-scope").unwrap(), "rpm");
+    }
+
+    /// `/v1/messages` answers in the Anthropic envelope but owes the
+    /// same headers — the renderers share one writer precisely so this
+    /// cannot drift per endpoint.
+    #[tokio::test]
+    async fn anthropic_envelope_429_carries_the_same_rate_limit_headers() {
+        let err = ProxyError::RateLimit(aisix_ratelimit::RateLimitError::Tokens {
+            scope: aisix_core::RateLimitScope::Tokens,
+            detail: aisix_ratelimit::LimitDetail {
+                dimension: "tpm",
+                limit: 50_000,
+                remaining: 0,
+                reset_secs: 12,
+            },
+        });
+        let resp = err.into_anthropic_response();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let h = resp.headers();
+        assert_eq!(h.get("retry-after").unwrap(), "12");
+        assert_eq!(h.get("x-ratelimit-limit").unwrap(), "50000");
+        assert_eq!(h.get("x-ratelimit-remaining").unwrap(), "0");
+        assert_eq!(h.get("x-ratelimit-reset").unwrap(), "12");
+        assert_eq!(h.get("x-ratelimit-scope").unwrap(), "tpm");
+    }
+
+    /// A policy-layer rejection is the same rejection with an attributed
+    /// policy — it reports the policy's own limit, not a blank.
+    #[tokio::test]
+    async fn policy_429_reports_the_policy_layer_limit() {
+        let err = ProxyError::PolicyRateLimit {
+            source: aisix_ratelimit::RateLimitError::Requests {
+                scope: aisix_core::RateLimitScope::Requests,
+                detail: aisix_ratelimit::LimitDetail {
+                    dimension: "rpd",
+                    limit: 5_000,
+                    remaining: 0,
+                    reset_secs: 3_600,
+                },
+            },
+            policy_id: "pol-1".into(),
+            policy_name: "team-daily".into(),
+        };
+        let resp = err.into_response();
+        let h = resp.headers();
+        assert_eq!(h.get("x-ratelimit-limit").unwrap(), "5000");
+        assert_eq!(h.get("x-ratelimit-scope").unwrap(), "rpd");
+        assert_eq!(h.get("x-ratelimit-reset").unwrap(), "3600");
+    }
+
+    /// A concurrency cap has no window, so it reports a fixed hint —
+    /// but it DOES report all four headers. Before this contract a
+    /// concurrency 429 carried no retry hint at all, leaving a client
+    /// with nothing to back off on.
+    #[tokio::test]
+    async fn concurrency_429_carries_all_four_headers() {
+        let err = ProxyError::RateLimit(aisix_ratelimit::RateLimitError::Concurrency {
+            detail: aisix_ratelimit::LimitDetail {
+                dimension: aisix_ratelimit::CONCURRENCY_DIMENSION,
+                limit: 8,
+                remaining: 0,
+                reset_secs: aisix_ratelimit::CONCURRENCY_RETRY_AFTER_SECS,
+            },
+        });
+        let resp = err.into_response();
+        let h = resp.headers();
+        assert_eq!(h.get("retry-after").unwrap(), "60");
+        assert_eq!(h.get("x-ratelimit-limit").unwrap(), "8");
+        assert_eq!(h.get("x-ratelimit-remaining").unwrap(), "0");
+        assert_eq!(h.get("x-ratelimit-reset").unwrap(), "60");
+        assert_eq!(h.get("x-ratelimit-scope").unwrap(), "concurrency");
+    }
+
+    /// An upstream 429 is the provider's rejection, not the gateway's.
+    /// Its `Retry-After` is forwarded, but the gateway must NOT invent
+    /// `x-ratelimit-*` values for a quota it does not know — their
+    /// absence is how a caller tells the two 429s apart.
+    #[tokio::test]
+    async fn upstream_429_forwards_retry_after_but_no_gateway_ratelimit_headers() {
+        let err = ProxyError::Bridge(BridgeError::upstream_status_with_retry_after(
+            429,
+            "rate limited by provider",
+            Some(std::time::Duration::from_secs(30)),
+        ));
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let h = resp.headers();
+        assert_eq!(h.get("retry-after").unwrap(), "30");
+        assert!(h.get("x-ratelimit-limit").is_none());
+        assert!(h.get("x-ratelimit-remaining").is_none());
+        assert!(h.get("x-ratelimit-reset").is_none());
+        assert!(h.get("x-ratelimit-scope").is_none());
+    }
+
+    /// A budget rejection caps spend in dollars. It shares the 429
+    /// status but has no request/token dimension, so the trio must stay
+    /// absent rather than carry a number in the wrong unit.
+    #[tokio::test]
+    async fn budget_429_keeps_retry_after_without_rate_limit_headers() {
+        let err = ProxyError::BudgetExceeded(Box::new(crate::budget::BudgetReason {
+            message: "budget exceeded".into(),
+            scope: None,
+            scope_ref: None,
+            limit_usd: Some("1.00".into()),
+            spent_usd: Some("2.00".into()),
+            period: None,
+            period_resets_at: None,
+            retry_after_seconds: Some(600),
+        }));
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let h = resp.headers();
+        assert_eq!(h.get("retry-after").unwrap(), "600");
+        assert!(h.get("x-ratelimit-limit").is_none());
+        assert!(h.get("x-ratelimit-scope").is_none());
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -5493,6 +5493,23 @@ data: [DONE]\n\n";
     /// can mount multiple Models in one snapshot. `pk_id` lets each
     /// model point at its own ProviderKey row — useful for routing
     /// tests that use multiple upstream MockServers.
+    fn model_entry_with_limits(
+        id: &str,
+        name: &str,
+        pk_id: &str,
+        rate_limit: serde_json::Value,
+    ) -> ResourceEntry<Model> {
+        let cfg = serde_json::json!({
+            "display_name": name,
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": pk_id,
+            "rate_limit": rate_limit,
+        });
+        let model: Model = serde_json::from_value(cfg).unwrap();
+        ResourceEntry::new(id, model, 1)
+    }
+
     fn model_entry_with_id(id: &str, name: &str, pk_id: &str) -> ResourceEntry<Model> {
         let cfg = format!(
             r#"{{
@@ -5516,6 +5533,105 @@ data: [DONE]\n\n";
 
     /// Build a virtual routing Model that points at `targets` (other
     /// Model.display_name values) using the given strategy.
+    /// A routing group whose every target is over its own model limit
+    /// is still THIS gateway refusing the request, so its 429 must carry
+    /// the same headers a direct model's refusal does.
+    ///
+    /// The dispatch loop turns a per-target quota rejection into a
+    /// failed attempt and keeps going; when nothing is left, whatever
+    /// the loop kept is what the caller sees. Wrapping that in a
+    /// `Bridge` error — the shape an UPSTREAM 429 takes — would strip
+    /// the headers and tell the caller the provider refused them.
+    #[tokio::test]
+    async fn exhausted_routing_group_429_still_carries_the_rate_limit_headers() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(pk_entry_with_id("pk-1", &upstream.uri()));
+        // The group's only target carries an INLINE model limit — the
+        // layer that used to be flattened away. A policy-layer rejection
+        // was already surfaced un-flattened.
+        snap.models.insert(model_entry_with_limits(
+            "m-1",
+            "primary",
+            "pk-1",
+            serde_json::json!({"rpm": 1}),
+        ));
+        snap.models.insert(routing_entry(
+            "smart",
+            "failover",
+            &["primary"],
+            None,
+            None,
+            None,
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
+
+        let app = build_router(build_state(snap, hub));
+        let call = || {
+            let app = app.clone();
+            async move {
+                let body = serde_json::json!({
+                    "model": "smart",
+                    "messages": [{"role": "user", "content": "hi"}]
+                });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("authorization", "Bearer sk-caller")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap();
+                run(app, req).await
+            }
+        };
+
+        assert_eq!(call().await.status(), StatusCode::OK);
+
+        let resp = call().await;
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let headers = resp.headers();
+        assert_eq!(
+            headers
+                .get("x-ratelimit-scope")
+                .and_then(|v| v.to_str().ok()),
+            Some("rpm"),
+            "an exhausted group must report the target limit that refused it",
+        );
+        assert_eq!(
+            headers
+                .get("x-ratelimit-limit")
+                .and_then(|v| v.to_str().ok()),
+            Some("1"),
+        );
+        assert_eq!(
+            headers
+                .get("x-ratelimit-remaining")
+                .and_then(|v| v.to_str().ok()),
+            Some("0"),
+        );
+        assert!(headers.contains_key("x-ratelimit-reset"));
+        assert!(headers.contains_key("retry-after"));
+    }
+
     fn routing_entry(
         name: &str,
         strategy: &str,

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -7161,6 +7161,99 @@ data: [DONE]\n\n";
         );
     }
 
+    /// The 429 the customer's client actually receives, through the
+    /// whole router rather than the renderer alone: the quota gate's
+    /// rejection has to reach `IntoResponse` with its dimension intact.
+    /// A unit test on the renderer would still pass if the gate lost
+    /// the detail on the way out.
+    #[tokio::test]
+    async fn ratelimit_429_carries_the_standard_headers_end_to_end() {
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-up",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = seed_snapshot_with_limits(
+            "my-gpt4",
+            &["my-gpt4"],
+            &upstream.uri(),
+            serde_json::json!({"rpm": 1}),
+        );
+        let app = build_router(build_state(snap, hub));
+
+        let call = || {
+            let app = app.clone();
+            async move {
+                let body = serde_json::json!({
+                    "model": "my-gpt4",
+                    "messages": [{"role": "user", "content": "hi"}]
+                });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("authorization", "Bearer sk-caller")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap();
+                run(app, req).await
+            }
+        };
+
+        assert_eq!(call().await.status(), StatusCode::OK);
+
+        let resp = call().await;
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let headers = resp.headers();
+        assert_eq!(
+            headers
+                .get("x-ratelimit-limit")
+                .and_then(|v| v.to_str().ok()),
+            Some("1"),
+        );
+        assert_eq!(
+            headers
+                .get("x-ratelimit-remaining")
+                .and_then(|v| v.to_str().ok()),
+            Some("0"),
+        );
+        assert_eq!(
+            headers
+                .get("x-ratelimit-scope")
+                .and_then(|v| v.to_str().ok()),
+            Some("rpm"),
+        );
+        // Reset and Retry-After are the same delta-seconds count down to
+        // the minute boundary, so a client may read either one.
+        let reset = headers
+            .get("x-ratelimit-reset")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok())
+            .expect("x-ratelimit-reset present and numeric");
+        let retry_after = headers
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok())
+            .expect("retry-after present and numeric");
+        assert_eq!(reset, retry_after);
+        assert!(
+            (1..=60).contains(&reset),
+            "an rpm window resets within the minute, got {reset}",
+        );
+    }
+
     #[tokio::test]
     async fn input_guardrail_block_returns_422_and_skips_upstream() {
         // wiremock that fails the test if it's hit at all.

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -5586,12 +5586,16 @@ data: [DONE]\n\n";
         snap.apikeys.insert(apikey_entry("sk-caller", &["smart"]));
 
         let app = build_router(build_state(snap, hub));
-        let call = || {
+        // The streaming and non-streaming dispatch loops are separate
+        // copies of the same logic and drifted apart once already, so
+        // both are exercised here against the one shared bucket.
+        let call = |stream: bool| {
             let app = app.clone();
             async move {
                 let body = serde_json::json!({
                     "model": "smart",
-                    "messages": [{"role": "user", "content": "hi"}]
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": stream,
                 });
                 let req = Request::builder()
                     .method("POST")
@@ -5604,32 +5608,41 @@ data: [DONE]\n\n";
             }
         };
 
-        assert_eq!(call().await.status(), StatusCode::OK);
+        fn assert_headers(resp: axum::http::Response<Body>, which: &str) {
+            assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS, "{which}");
+            let headers = resp.headers();
+            assert_eq!(
+                headers
+                    .get("x-ratelimit-scope")
+                    .and_then(|v| v.to_str().ok()),
+                Some("rpm"),
+                "{which}: an exhausted group must report the target limit that refused it",
+            );
+            assert_eq!(
+                headers
+                    .get("x-ratelimit-limit")
+                    .and_then(|v| v.to_str().ok()),
+                Some("1"),
+                "{which}",
+            );
+            assert_eq!(
+                headers
+                    .get("x-ratelimit-remaining")
+                    .and_then(|v| v.to_str().ok()),
+                Some("0"),
+                "{which}",
+            );
+            assert!(headers.contains_key("x-ratelimit-reset"), "{which}");
+            assert!(headers.contains_key("retry-after"), "{which}");
+        }
 
-        let resp = call().await;
-        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
-        let headers = resp.headers();
-        assert_eq!(
-            headers
-                .get("x-ratelimit-scope")
-                .and_then(|v| v.to_str().ok()),
-            Some("rpm"),
-            "an exhausted group must report the target limit that refused it",
-        );
-        assert_eq!(
-            headers
-                .get("x-ratelimit-limit")
-                .and_then(|v| v.to_str().ok()),
-            Some("1"),
-        );
-        assert_eq!(
-            headers
-                .get("x-ratelimit-remaining")
-                .and_then(|v| v.to_str().ok()),
-            Some("0"),
-        );
-        assert!(headers.contains_key("x-ratelimit-reset"));
-        assert!(headers.contains_key("retry-after"));
+        // Non-streaming: the first call burns the target's only slot.
+        assert_eq!(call(false).await.status(), StatusCode::OK);
+        assert_headers(call(false).await, "non-streaming");
+
+        // Streaming runs the second copy of the loop against the same,
+        // now-exhausted bucket.
+        assert_headers(call(true).await, "streaming");
     }
 
     fn routing_entry(

--- a/crates/aisix-ratelimit/src/error.rs
+++ b/crates/aisix-ratelimit/src/error.rs
@@ -39,8 +39,11 @@ pub struct LimitDetail {
     /// tokens for `tp*`, in-flight slots for `concurrency` — the unit
     /// follows the dimension, which is why the wire reports both.
     pub limit: u64,
-    /// Headroom left under `limit`. Zero on every rejection except a
-    /// concurrency one racing a slot release.
+    /// Headroom left under `limit`, saturating at zero. Every rejection
+    /// reports zero — a windowed dimension refuses at or past its cap,
+    /// and the concurrency gauge refuses at or past its slot count — so
+    /// the subtraction exists to keep the value derived from the two
+    /// numbers beside it rather than hardcoded per call site.
     pub remaining: u64,
     /// Seconds until the caller may retry: to the window boundary for a
     /// windowed dimension, [`CONCURRENCY_RETRY_AFTER_SECS`] otherwise.

--- a/crates/aisix-ratelimit/src/error.rs
+++ b/crates/aisix-ratelimit/src/error.rs
@@ -5,20 +5,87 @@
 
 use aisix_core::RateLimitScope;
 
+/// Retry hint reported for a concurrency rejection.
+///
+/// A concurrency slot frees when some in-flight request finishes, which
+/// the gateway cannot predict — unlike a windowed dimension there is no
+/// reset instant to report. One minute is the hint the established
+/// ecosystem's proxy limiters emit for the same rejection, so clients
+/// tuned against those back off identically here. It is an interop
+/// choice, not a measurement: do not "tune" it without redoing that
+/// comparison.
+pub const CONCURRENCY_RETRY_AFTER_SECS: u64 = 60;
+
+/// Dimension name reported for a concurrency rejection. The windowed
+/// dimensions report the `Dim::name` the store already keys them by
+/// (`rps` / `rpm` / `rph` / `rpd` / `tpm` / `tpd`).
+pub const CONCURRENCY_DIMENSION: &str = "concurrency";
+
+/// The single limit that produced a rejection, and its state at that
+/// moment. Carries what the caller-facing `x-ratelimit-*` headers on a
+/// 429 report, so the response layer never has to re-derive which of a
+/// key's limits actually fired.
+///
+/// `dimension` is finer-grained than [`RateLimitScope`]: the scope only
+/// separates request-counting from token-counting (it labels the
+/// rejection metric), while this names the exact window — `rpm` and
+/// `rpd` share a scope but are different limits with different reset
+/// instants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LimitDetail {
+    /// `rps` | `rpm` | `rph` | `rpd` | `tpm` | `tpd` | `concurrency`.
+    pub dimension: &'static str,
+    /// The configured cap for that dimension. Requests for `rp*`,
+    /// tokens for `tp*`, in-flight slots for `concurrency` — the unit
+    /// follows the dimension, which is why the wire reports both.
+    pub limit: u64,
+    /// Headroom left under `limit`. Zero on every rejection except a
+    /// concurrency one racing a slot release.
+    pub remaining: u64,
+    /// Seconds until the caller may retry: to the window boundary for a
+    /// windowed dimension, [`CONCURRENCY_RETRY_AFTER_SECS`] otherwise.
+    pub reset_secs: u64,
+}
+
+impl LimitDetail {
+    /// Detail for a windowed dimension that has just refused a request.
+    /// `used` is the counter's value *before* the refused request, so
+    /// `remaining` saturates to zero exactly when the cap is met or
+    /// overrun.
+    pub(crate) fn window(dimension: &'static str, limit: u64, used: u64, reset_secs: u64) -> Self {
+        Self {
+            dimension,
+            limit,
+            remaining: limit.saturating_sub(used),
+            reset_secs,
+        }
+    }
+
+    /// Detail for a concurrency gate that has just refused a request.
+    pub(crate) fn concurrency(limit: u64, in_flight: u64) -> Self {
+        Self {
+            dimension: CONCURRENCY_DIMENSION,
+            limit,
+            remaining: limit.saturating_sub(in_flight),
+            reset_secs: CONCURRENCY_RETRY_AFTER_SECS,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RateLimitError {
     #[error("request limit exceeded ({scope})")]
     Requests {
         scope: RateLimitScope,
-        retry_after_secs: u64,
+        detail: LimitDetail,
     },
     #[error("token limit exceeded ({scope})")]
     Tokens {
         scope: RateLimitScope,
-        retry_after_secs: u64,
+        detail: LimitDetail,
     },
     #[error("concurrency limit exceeded")]
-    Concurrency,
+    Concurrency { detail: LimitDetail },
 }
 
 impl RateLimitError {
@@ -26,20 +93,21 @@ impl RateLimitError {
         match self {
             RateLimitError::Requests { scope, .. } => *scope,
             RateLimitError::Tokens { scope, .. } => *scope,
-            RateLimitError::Concurrency => RateLimitScope::Requests,
+            RateLimitError::Concurrency { .. } => RateLimitScope::Requests,
+        }
+    }
+
+    /// The limit that fired, for the `x-ratelimit-*` headers on the 429.
+    pub fn detail(&self) -> LimitDetail {
+        match self {
+            RateLimitError::Requests { detail, .. }
+            | RateLimitError::Tokens { detail, .. }
+            | RateLimitError::Concurrency { detail } => *detail,
         }
     }
 
     pub fn retry_after_secs(&self) -> Option<u64> {
-        match self {
-            RateLimitError::Requests {
-                retry_after_secs, ..
-            }
-            | RateLimitError::Tokens {
-                retry_after_secs, ..
-            } => Some(*retry_after_secs),
-            RateLimitError::Concurrency => None,
-        }
+        Some(self.detail().reset_secs)
     }
 }
 
@@ -51,16 +119,41 @@ mod tests {
     fn requests_scope_preserved_on_access() {
         let e = RateLimitError::Requests {
             scope: RateLimitScope::Requests,
-            retry_after_secs: 42,
+            detail: LimitDetail::window("rpm", 10, 10, 42),
         };
         assert_eq!(e.scope(), RateLimitScope::Requests);
         assert_eq!(e.retry_after_secs(), Some(42));
+        assert_eq!(e.detail().dimension, "rpm");
+        assert_eq!(e.detail().limit, 10);
+        assert_eq!(e.detail().remaining, 0);
     }
 
     #[test]
-    fn concurrency_has_no_retry_after_hint() {
-        let e = RateLimitError::Concurrency;
+    fn concurrency_reports_a_fixed_retry_hint() {
+        // A concurrency slot has no window, so there is nothing to
+        // compute — but a 429 with no retry hint at all leaves a client
+        // with only "retry immediately", which is the behaviour the
+        // hint exists to prevent.
+        let e = RateLimitError::Concurrency {
+            detail: LimitDetail::concurrency(8, 8),
+        };
+        assert_eq!(e.retry_after_secs(), Some(CONCURRENCY_RETRY_AFTER_SECS));
+        assert_eq!(e.detail().dimension, "concurrency");
+        assert_eq!(e.detail().limit, 8);
+        assert_eq!(e.detail().remaining, 0);
+        // Concurrency rejections still label the rejection metric with
+        // the request scope — the metric's label set is unchanged.
         assert_eq!(e.scope(), RateLimitScope::Requests);
-        assert!(e.retry_after_secs().is_none());
+    }
+
+    #[test]
+    fn window_remaining_saturates_when_the_counter_overran_the_cap() {
+        // Token windows are checked-but-not-incremented, so a commit can
+        // push the counter past the cap; `remaining` must floor at zero
+        // rather than wrap.
+        let d = LimitDetail::window("tpm", 1_000, 1_750, 17);
+        assert_eq!(d.remaining, 0);
+        assert_eq!(d.limit, 1_000);
+        assert_eq!(d.reset_secs, 17);
     }
 }

--- a/crates/aisix-ratelimit/src/lib.rs
+++ b/crates/aisix-ratelimit/src/lib.rs
@@ -20,7 +20,7 @@ pub mod store;
 mod window;
 
 pub use clock::{Clock, SystemClock, TestClock};
-pub use error::RateLimitError;
+pub use error::{LimitDetail, RateLimitError, CONCURRENCY_DIMENSION, CONCURRENCY_RETRY_AFTER_SECS};
 pub use limiter::{
     Limiter, MultiReservation, RateLimitStatus, Reservation, StreamConcurrencyGuard,
 };

--- a/crates/aisix-ratelimit/src/limiter.rs
+++ b/crates/aisix-ratelimit/src/limiter.rs
@@ -324,13 +324,113 @@ mod tests {
         let _r2 = limiter.pre_commit("k1", &l).await.unwrap();
         let err = limiter.pre_commit("k1", &l).await.unwrap_err();
         match err {
-            RateLimitError::Requests {
-                retry_after_secs, ..
-            } => {
-                assert!(retry_after_secs > 0);
+            RateLimitError::Requests { detail, .. } => {
+                assert!(detail.reset_secs > 0);
+                // The refusal names the exact window that fired, not
+                // just "some request limit" — the 429's headers report
+                // this dimension.
+                assert_eq!(detail.dimension, "rpm");
+                assert_eq!(detail.limit, 2);
+                assert_eq!(detail.remaining, 0);
             }
             other => panic!("expected Requests, got {other:?}"),
         }
+    }
+
+    /// The 429's `x-ratelimit-*` headers name ONE dimension, so which
+    /// one a multi-dimension key reports has to be pinned: it is the
+    /// dimension that actually refused, which is the first one the
+    /// acquire order reaches. rps is tighter than rpm here, so a burst
+    /// must be attributed to rps even though rpm is also configured.
+    #[tokio::test]
+    async fn refusal_names_the_dimension_that_actually_fired() {
+        let clock = TestClock::new(100);
+        let limiter = Limiter::local_with_clock(clock.clone());
+        let l = limits_full(Some(1), Some(100), None, None);
+
+        let _r1 = limiter.pre_commit("k", &l).await.unwrap();
+        let detail = limiter.pre_commit("k", &l).await.unwrap_err().detail();
+        assert_eq!(detail.dimension, "rps");
+        assert_eq!(detail.limit, 1);
+        assert_eq!(detail.remaining, 0);
+
+        // Move past the second but stay inside the minute, and exhaust
+        // rpm instead: the same key now reports the other dimension.
+        let l = limits_full(Some(100), Some(1), None, None);
+        clock.advance(1);
+        let _r2 = limiter.pre_commit("k2", &l).await.unwrap();
+        let detail = limiter.pre_commit("k2", &l).await.unwrap_err().detail();
+        assert_eq!(detail.dimension, "rpm");
+        assert_eq!(detail.limit, 1);
+    }
+
+    /// A token refusal reports the token window and its cap, not the
+    /// request one — the two carry different units, which is why the
+    /// wire names the dimension alongside the number.
+    #[tokio::test]
+    async fn token_refusal_reports_the_token_window() {
+        let clock = TestClock::new(100);
+        let limiter = Limiter::local_with_clock(clock.clone());
+        let l = limits(Some(100), Some(50), None);
+
+        // Overrun tpm: checked-but-not-incremented means the refusal
+        // lands on the NEXT request after the commit.
+        let r = limiter.pre_commit("k", &l).await.unwrap();
+        r.commit_tokens(1_000).await;
+
+        let detail = limiter.pre_commit("k", &l).await.unwrap_err().detail();
+        assert_eq!(detail.dimension, "tpm");
+        assert_eq!(detail.limit, 50);
+        // The counter overran the cap; remaining floors at zero.
+        assert_eq!(detail.remaining, 0);
+    }
+
+    /// `x-ratelimit-reset` is delta-seconds to the window boundary, and
+    /// it must never reach zero — a client that reads `0` and retries
+    /// immediately is exactly the retry storm the header exists to
+    /// prevent. Walks the whole minute rather than sampling one point.
+    #[tokio::test]
+    async fn reset_counts_down_to_the_window_boundary_and_never_hits_zero() {
+        // Window [60, 120): the counter is exhausted at t=60 and every
+        // later second inside it must report the remaining distance.
+        let clock = TestClock::new(60);
+        let limiter = Limiter::local_with_clock(clock.clone());
+        let l = limits(Some(1), None, None);
+        let _r = limiter.pre_commit("k", &l).await.unwrap();
+
+        for offset in 0..60u64 {
+            let detail = limiter.pre_commit("k", &l).await.unwrap_err().detail();
+            assert_eq!(
+                detail.reset_secs,
+                60 - offset,
+                "at t=60+{offset} the minute window has {} s left",
+                60 - offset
+            );
+            assert!(detail.reset_secs >= 1, "reset must never be zero");
+            clock.advance(1);
+        }
+
+        // t=120 rolls the window: the request is admitted again, which
+        // is what the last reported reset (1 s) promised.
+        assert!(limiter.pre_commit("k", &l).await.is_ok());
+    }
+
+    /// A concurrency refusal has no window to count down, so it reports
+    /// the fixed hint plus the gauge's own state.
+    #[tokio::test]
+    async fn concurrency_refusal_reports_the_gauge_and_the_fixed_hint() {
+        let clock = TestClock::new(0);
+        let limiter = Limiter::local_with_clock(clock.clone());
+        let l = limits(None, None, Some(2));
+
+        let _r1 = limiter.pre_commit("k", &l).await.unwrap();
+        let _r2 = limiter.pre_commit("k", &l).await.unwrap();
+        let detail = limiter.pre_commit("k", &l).await.unwrap_err().detail();
+
+        assert_eq!(detail.dimension, "concurrency");
+        assert_eq!(detail.limit, 2);
+        assert_eq!(detail.remaining, 0);
+        assert_eq!(detail.reset_secs, 60);
     }
 
     #[tokio::test]
@@ -357,7 +457,7 @@ mod tests {
         let r2 = limiter.pre_commit("k1", &l).await.unwrap();
         assert!(matches!(
             limiter.pre_commit("k1", &l).await.unwrap_err(),
-            RateLimitError::Concurrency,
+            RateLimitError::Concurrency { .. },
         ));
 
         // Drop r1 — concurrency should free up.
@@ -656,7 +756,7 @@ mod tests {
         // request is rejected.
         assert!(matches!(
             limiter.pre_commit("k", &l).await.unwrap_err(),
-            RateLimitError::Concurrency
+            RateLimitError::Concurrency { .. }
         ));
 
         // Stream completes/cancels → guard drops → slot released.

--- a/crates/aisix-ratelimit/src/store/local.rs
+++ b/crates/aisix-ratelimit/src/store/local.rs
@@ -13,9 +13,12 @@ use dashmap::DashMap;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
-use super::{RateStore, DAY_SECS, HOUR_SECS, MINUTE_SECS, SECOND_SECS};
+use super::{
+    RateStore, DAY_SECS, DIM_RPD, DIM_RPH, DIM_RPM, DIM_RPS, DIM_TPD, DIM_TPM, HOUR_SECS,
+    MINUTE_SECS, SECOND_SECS,
+};
 use crate::clock::{Clock, SystemClock};
-use crate::error::RateLimitError;
+use crate::error::{LimitDetail, RateLimitError};
 use crate::limiter::RateLimitStatus;
 use crate::window::{FixedWindowCounter, WindowCheck};
 
@@ -98,7 +101,9 @@ impl<C: Clock> RateStore for LocalStore<C> {
         // Concurrency first — cheapest and never consumes a window slot.
         if let Some(max) = limits.concurrency {
             if s.in_flight >= max {
-                return Err(RateLimitError::Concurrency);
+                return Err(RateLimitError::Concurrency {
+                    detail: LimitDetail::concurrency(u64::from(max), u64::from(s.in_flight)),
+                });
             }
         }
 
@@ -108,7 +113,7 @@ impl<C: Clock> RateStore for LocalStore<C> {
             if let Some(retry) = s.tpm.is_exceeded(now, max) {
                 return Err(RateLimitError::Tokens {
                     scope: RateLimitScope::Tokens,
-                    retry_after_secs: retry,
+                    detail: LimitDetail::window(DIM_TPM, max, s.tpm.current(now), retry),
                 });
             }
         }
@@ -116,7 +121,7 @@ impl<C: Clock> RateStore for LocalStore<C> {
             if let Some(retry) = s.tpd.is_exceeded(now, max) {
                 return Err(RateLimitError::Tokens {
                     scope: RateLimitScope::Tokens,
-                    retry_after_secs: retry,
+                    detail: LimitDetail::window(DIM_TPD, max, s.tpd.current(now), retry),
                 });
             }
         }
@@ -127,32 +132,47 @@ impl<C: Clock> RateStore for LocalStore<C> {
         // rejects, every earlier-incremented counter is rolled back by
         // exactly the delta this call contributed — concurrent sibling
         // requests' increments survive.
+        //
+        // Each rejection first reads the refused window's own state for
+        // the 429's `x-ratelimit-*` headers. The read has to happen
+        // before the roll-backs below, and the result must be bound out
+        // of the `if let` scrutinee — an `if let` over the call itself
+        // would hold the counter borrowed across the body.
         let mut rps_incremented = false;
         if let Some(max) = limits.rps {
-            if let WindowCheck::Full { retry_after_secs } = s.rps.check_and_increment(now, 1, max) {
+            let check = s.rps.check_and_increment(now, 1, max);
+            if let WindowCheck::Full { retry_after_secs } = check {
+                let detail =
+                    LimitDetail::window(DIM_RPS, max, s.rps.current(now), retry_after_secs);
                 return Err(RateLimitError::Requests {
                     scope: RateLimitScope::Requests,
-                    retry_after_secs,
+                    detail,
                 });
             }
             rps_incremented = true;
         }
         let mut rpm_incremented = false;
         if let Some(max) = limits.rpm {
-            if let WindowCheck::Full { retry_after_secs } = s.rpm.check_and_increment(now, 1, max) {
+            let check = s.rpm.check_and_increment(now, 1, max);
+            if let WindowCheck::Full { retry_after_secs } = check {
+                let detail =
+                    LimitDetail::window(DIM_RPM, max, s.rpm.current(now), retry_after_secs);
                 if rps_incremented {
                     s.rps.decrement(now, 1);
                 }
                 return Err(RateLimitError::Requests {
                     scope: RateLimitScope::Requests,
-                    retry_after_secs,
+                    detail,
                 });
             }
             rpm_incremented = true;
         }
         let mut rph_incremented = false;
         if let Some(max) = limits.rph {
-            if let WindowCheck::Full { retry_after_secs } = s.rph.check_and_increment(now, 1, max) {
+            let check = s.rph.check_and_increment(now, 1, max);
+            if let WindowCheck::Full { retry_after_secs } = check {
+                let detail =
+                    LimitDetail::window(DIM_RPH, max, s.rph.current(now), retry_after_secs);
                 if rpm_incremented {
                     s.rpm.decrement(now, 1);
                 }
@@ -161,13 +181,16 @@ impl<C: Clock> RateStore for LocalStore<C> {
                 }
                 return Err(RateLimitError::Requests {
                     scope: RateLimitScope::Requests,
-                    retry_after_secs,
+                    detail,
                 });
             }
             rph_incremented = true;
         }
         if let Some(max) = limits.rpd {
-            if let WindowCheck::Full { retry_after_secs } = s.rpd.check_and_increment(now, 1, max) {
+            let check = s.rpd.check_and_increment(now, 1, max);
+            if let WindowCheck::Full { retry_after_secs } = check {
+                let detail =
+                    LimitDetail::window(DIM_RPD, max, s.rpd.current(now), retry_after_secs);
                 if rph_incremented {
                     s.rph.decrement(now, 1);
                 }
@@ -179,7 +202,7 @@ impl<C: Clock> RateStore for LocalStore<C> {
                 }
                 return Err(RateLimitError::Requests {
                     scope: RateLimitScope::Requests,
-                    retry_after_secs,
+                    detail,
                 });
             }
         }

--- a/crates/aisix-ratelimit/src/store/mod.rs
+++ b/crates/aisix-ratelimit/src/store/mod.rs
@@ -34,6 +34,17 @@ pub(crate) const MINUTE_SECS: u64 = 60;
 pub(crate) const HOUR_SECS: u64 = 60 * 60;
 pub(crate) const DAY_SECS: u64 = 24 * 60 * 60;
 
+/// Dimension names. Both stores name the same window identically —
+/// they are the Redis key segment AND the `x-ratelimit-scope` value a
+/// 429 reports, so a client cannot be told `rpm` by one backend and
+/// `RPM` by the other.
+pub(crate) const DIM_RPS: &str = "rps";
+pub(crate) const DIM_RPM: &str = "rpm";
+pub(crate) const DIM_RPH: &str = "rph";
+pub(crate) const DIM_RPD: &str = "rpd";
+pub(crate) const DIM_TPM: &str = "tpm";
+pub(crate) const DIM_TPD: &str = "tpd";
+
 /// A windowed request/token dimension active on a [`RateLimit`]:
 /// `(name, window_secs, limit)`. Shared by both stores so the Redis key
 /// layout and the local counter set never drift.
@@ -46,10 +57,10 @@ pub(crate) struct Dim {
 /// Request-count dimensions (rps/rpm/rph/rpd) that carry a limit.
 pub(crate) fn request_dims(limits: &RateLimit) -> Vec<Dim> {
     [
-        ("rps", SECOND_SECS, limits.rps),
-        ("rpm", MINUTE_SECS, limits.rpm),
-        ("rph", HOUR_SECS, limits.rph),
-        ("rpd", DAY_SECS, limits.rpd),
+        (DIM_RPS, SECOND_SECS, limits.rps),
+        (DIM_RPM, MINUTE_SECS, limits.rpm),
+        (DIM_RPH, HOUR_SECS, limits.rph),
+        (DIM_RPD, DAY_SECS, limits.rpd),
     ]
     .into_iter()
     .filter_map(|(name, window_secs, limit)| {
@@ -65,8 +76,8 @@ pub(crate) fn request_dims(limits: &RateLimit) -> Vec<Dim> {
 /// Token-count dimensions (tpm/tpd) that carry a limit.
 pub(crate) fn token_dims(limits: &RateLimit) -> Vec<Dim> {
     [
-        ("tpm", MINUTE_SECS, limits.tpm),
-        ("tpd", DAY_SECS, limits.tpd),
+        (DIM_TPM, MINUTE_SECS, limits.tpm),
+        (DIM_TPD, DAY_SECS, limits.tpd),
     ]
     .into_iter()
     .filter_map(|(name, window_secs, limit)| {

--- a/crates/aisix-ratelimit/src/store/redis.rs
+++ b/crates/aisix-ratelimit/src/store/redis.rs
@@ -45,7 +45,7 @@ use async_trait::async_trait;
 use redis::Script;
 
 use super::{local::LocalStore, token_dims, Dim, RateStore};
-use crate::error::RateLimitError;
+use crate::error::{LimitDetail, RateLimitError};
 use crate::limiter::RateLimitStatus;
 
 /// Default key namespace, kept distinct from `aisix:cache` so the same
@@ -60,6 +60,12 @@ pub const DEFAULT_CONC_TTL_SECS: u64 = 300;
 pub const DEFAULT_GRACE_SECS: u64 = 5;
 
 // Result codes returned by the acquire script's first element.
+/// Dimension name reported when the script names an index this build
+/// no longer knows — only reachable if the script and the caller ever
+/// disagree on the dimension list, which they cannot today (both come
+/// from the same `request_dims` / `token_dims` call).
+const UNKNOWN_DIMENSION: &str = "unknown";
+
 const CODE_OK: i64 = 0;
 const CODE_CONCURRENCY: i64 = 1;
 const CODE_TOKENS: i64 = 2;
@@ -80,8 +86,9 @@ local now = tonumber(t[1])
 local conc_key = prefix .. ':conc'
 if conc_max >= 0 then
   redis.call('ZREMRANGEBYSCORE', conc_key, 0, now - conc_ttl)
-  if redis.call('ZCARD', conc_key) >= conc_max then
-    return {1, 0}
+  local in_flight = redis.call('ZCARD', conc_key)
+  if in_flight >= conc_max then
+    return {1, 0, 0, conc_max, in_flight}
   end
 end
 
@@ -105,7 +112,7 @@ for i = 1, ntok do
   local cur = tonumber(redis.call('GET', prefix .. ':' .. name .. ':' .. ws) or '0')
   if cur > limit then
     local retry = window - (now - ws); if retry < 1 then retry = 1 end
-    return {2, retry}
+    return {2, retry, i, limit, cur}
   end
 end
 
@@ -115,7 +122,7 @@ for i = 1, nreq do
   local cur = tonumber(redis.call('GET', prefix .. ':' .. name .. ':' .. ws) or '0')
   if cur + 1 > limit then
     local retry = window - (now - ws); if retry < 1 then retry = 1 end
-    return {3, retry}
+    return {3, retry, i, limit, cur}
   end
 end
 
@@ -131,7 +138,7 @@ if conc_max >= 0 then
   redis.call('ZADD', conc_key, now, member)
   redis.call('EXPIRE', conc_key, conc_ttl)
 end
-return {0, 0}
+return {0, 0, 0, 0, 0}
 "#;
 
 /// Post-deduct: add `tokens` to the tpm/tpd windows AND release the
@@ -325,16 +332,38 @@ impl RateStore for RedisStore {
                 self.mark_ok();
                 let code = reply.first().copied().unwrap_or(CODE_OK);
                 let retry = reply.get(1).copied().unwrap_or(0).max(0) as u64;
+                // The script reports which dimension refused as its
+                // 1-based index into the same `request_dims` /
+                // `token_dims` vectors this call pushed into ARGV, so
+                // the name never has to cross the wire.
+                let refused = |dims: &[super::Dim]| {
+                    let idx = reply.get(2).copied().unwrap_or(0);
+                    let name = usize::try_from(idx)
+                        .ok()
+                        .and_then(|i| i.checked_sub(1))
+                        .and_then(|i| dims.get(i))
+                        .map(|d| d.name)
+                        .unwrap_or(UNKNOWN_DIMENSION);
+                    let limit = reply.get(3).copied().unwrap_or(0).max(0) as u64;
+                    let used = reply.get(4).copied().unwrap_or(0).max(0) as u64;
+                    LimitDetail::window(name, limit, used, retry)
+                };
                 match code {
                     CODE_OK => Ok(()),
-                    CODE_CONCURRENCY => Err(RateLimitError::Concurrency),
+                    CODE_CONCURRENCY => {
+                        let limit = reply.get(3).copied().unwrap_or(0).max(0) as u64;
+                        let in_flight = reply.get(4).copied().unwrap_or(0).max(0) as u64;
+                        Err(RateLimitError::Concurrency {
+                            detail: LimitDetail::concurrency(limit, in_flight),
+                        })
+                    }
                     CODE_TOKENS => Err(RateLimitError::Tokens {
                         scope: aisix_core::RateLimitScope::Tokens,
-                        retry_after_secs: retry,
+                        detail: refused(&token_dims(limits)),
                     }),
                     CODE_REQUESTS => Err(RateLimitError::Requests {
                         scope: aisix_core::RateLimitScope::Requests,
-                        retry_after_secs: retry,
+                        detail: refused(&super::request_dims(limits)),
                     }),
                     _ => Ok(()),
                 }

--- a/crates/aisix-ratelimit/tests/redis_integration.rs
+++ b/crates/aisix-ratelimit/tests/redis_integration.rs
@@ -104,6 +104,88 @@ async fn rpm_counter_is_shared_across_replicas() {
     );
 }
 
+/// The shared backend must describe a refusal exactly as the local one
+/// does: the 429's `x-ratelimit-*` headers are the same contract on a
+/// clustered deployment as on a single node.
+///
+/// The Lua script reports the refused dimension as an INDEX into the
+/// same `request_dims` / `token_dims` list the caller pushed into ARGV,
+/// so the name is reconstructed on the Rust side. A key carrying several
+/// windows is what makes that mapping observable — with a single window
+/// any index would decode to the same name.
+#[tokio::test]
+async fn refusal_detail_survives_the_shared_backend() {
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: RATELIMIT_TEST_REDIS_URL not set");
+        return;
+    };
+    let a = store(&url).await;
+    let b = store(&url).await;
+    let key = unique_key("detail");
+    // rps is looser than rpm here, so the SECOND dimension in the
+    // request list is the one that refuses — an off-by-one in the index
+    // mapping would report `rps`.
+    let limits = RateLimit {
+        rps: Some(10),
+        rpm: Some(1),
+        ..rl()
+    };
+
+    a.acquire(&key, &limits, "a-1")
+        .await
+        .expect("first allowed");
+    let err = b
+        .acquire(&key, &limits, "b-1")
+        .await
+        .expect_err("shared counter must refuse the second replica");
+
+    let detail = err.detail();
+    assert_eq!(detail.dimension, "rpm", "got {err:?}");
+    assert_eq!(detail.limit, 1);
+    assert_eq!(detail.remaining, 0);
+    assert!(
+        (1..=60).contains(&detail.reset_secs),
+        "a minute window resets within the minute, got {}",
+        detail.reset_secs
+    );
+}
+
+/// A concurrency refusal from the shared backend carries the gauge's
+/// own state plus the fixed hint — the same shape the local store
+/// produces, so a client cannot tell the backends apart.
+#[tokio::test]
+async fn concurrency_refusal_detail_survives_the_shared_backend() {
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: RATELIMIT_TEST_REDIS_URL not set");
+        return;
+    };
+    let a = store(&url).await;
+    let b = store(&url).await;
+    let key = unique_key("conc-detail");
+    let limits = RateLimit {
+        concurrency: Some(1),
+        ..rl()
+    };
+
+    a.acquire(&key, &limits, "a-1")
+        .await
+        .expect("first allowed");
+    let err = b
+        .acquire(&key, &limits, "b-1")
+        .await
+        .expect_err("shared concurrency gauge must refuse");
+
+    let detail = err.detail();
+    assert_eq!(detail.dimension, "concurrency", "got {err:?}");
+    assert_eq!(detail.limit, 1);
+    assert_eq!(detail.remaining, 0);
+    assert_eq!(
+        detail.reset_secs,
+        aisix_ratelimit::CONCURRENCY_RETRY_AFTER_SECS
+    );
+    assert_eq!(detail.reset_secs, 60);
+}
+
 /// Sleep until the next whole second starts.
 ///
 /// The rps counter buckets server-side: the Lua script reads `now` from
@@ -218,7 +300,7 @@ async fn concurrency_slot_is_shared_and_released_across_replicas() {
     assert!(
         matches!(
             b.acquire(&key, &limits, "b-1").await,
-            Err(aisix_ratelimit::RateLimitError::Concurrency)
+            Err(aisix_ratelimit::RateLimitError::Concurrency { .. })
         ),
         "concurrency slot must be shared across replicas"
     );

--- a/tests/e2e/src/cases/model-group-member-ratelimit-e2e.test.ts
+++ b/tests/e2e/src/cases/model-group-member-ratelimit-e2e.test.ts
@@ -272,9 +272,13 @@ describe("model group member rate limit e2e (AISIX-Cloud#1087)", () => {
     expect(servedContent(await callGroup("mgrl-both-limited"))).toBe("served-by-c2");
 
     // Both members exhausted → the request fails with 429, not a 5xx, and
-    // carries the limiter's `Retry-After` so SDK back-off still works. The
-    // hint is the load-bearing half: a bare 429 makes clients retry
-    // immediately against a window that has not reopened.
+    // describes the limit that refused it. The refusal is reported as the
+    // gateway's own — it used to be flattened into an upstream-shaped
+    // error, which carries neither the taxonomy nor the `x-ratelimit-*`
+    // headers, so a caller could not tell it from the provider throttling
+    // them. `Retry-After` is the load-bearing half of that: a bare 429
+    // makes clients retry immediately against a window that has not
+    // reopened.
     const third = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
       method: "POST",
       headers: {
@@ -287,11 +291,23 @@ describe("model group member rate limit e2e (AISIX-Cloud#1087)", () => {
       }),
     });
     expect(third.status).toBe(429);
-    const body = (await third.json()) as { error?: { message?: string } };
-    expect(body.error?.message ?? "").toContain("rate limit");
+    const body = (await third.json()) as {
+      error?: { message?: string; type?: string };
+    };
+    // The stable taxonomy rather than a substring of the prose: the
+    // message is the limiter's own now (`request limit exceeded
+    // (requests)`), matching what /v1/messages and /v1/responses have
+    // always returned for the same exhaustion.
+    expect(body.error?.type).toBe("rate_limit_exceeded");
+    expect(third.headers.get("x-ratelimit-scope")).toBe("rpm");
+    expect(third.headers.get("x-ratelimit-limit")).toBe("1");
+    expect(third.headers.get("x-ratelimit-remaining")).toBe("0");
     const retryAfter = Number.parseInt(third.headers.get("retry-after") ?? "", 10);
     expect(retryAfter).toBeGreaterThan(0);
     expect(retryAfter).toBeLessThanOrEqual(60);
+    expect(Number.parseInt(third.headers.get("x-ratelimit-reset") ?? "", 10)).toBe(
+      retryAfter,
+    );
   });
 
   test("winning member's TPM bucket is committed, throttling the next call", async (ctx) => {

--- a/tests/e2e/src/cases/ratelimit-standard-headers-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-standard-headers-e2e.test.ts
@@ -222,7 +222,9 @@ describe("rate limit e2e: standard 429 headers", () => {
     const probe = new ProxyClient(app.proxyUrl, TPM_PLAINTEXT);
     await waitConfigPropagation(async () => {
       const res = await probe.listModels();
-      return res.status === 200;
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === FAST_MODEL);
     });
     await awaitWindowHeadroom();
 

--- a/tests/e2e/src/cases/ratelimit-standard-headers-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-standard-headers-e2e.test.ts
@@ -1,0 +1,264 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  ProxyClient,
+  spawnApp,
+  startOpenAiUpstream,
+  awaitWindowHeadroom,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { harnessRequest } from "../harness/http.js";
+
+// E2E: the standard rate-limit headers on a gateway-produced 429.
+//
+// A caller that hits a limit needs to learn, from the response alone,
+// what the cap was, that it has nothing left, and when to come back.
+// This spec reads the RAW response rather than going through an SDK:
+// an SDK normalises header access and silently retries, so an
+// SDK-level assertion cannot show what is actually on the wire — which
+// is the artifact being pinned here.
+//
+// Contract, per dimension that refused:
+//   x-ratelimit-limit      the cap of the dimension that refused
+//   x-ratelimit-remaining  headroom left under it (0 on a refusal)
+//   x-ratelimit-reset      delta-seconds until it lets the caller back
+//   retry-after            same wait, so either header can drive back-off
+//   x-ratelimit-scope      AISIX extension: WHICH dimension refused —
+//                          `x-ratelimit-limit: 1` is otherwise
+//                          indistinguishable between a request cap, a
+//                          token cap and a concurrency cap, whose units
+//                          all differ
+//
+// The trio is emitted ONLY when the gateway's own limiter refused. A
+// 200, an upstream 429 and a budget rejection all leave it absent, so
+// its presence is what tells a caller whose limit it hit. The 200 half
+// of that is asserted here; the other two are pinned on the renderer
+// (`crates/aisix-proxy/src/error.rs`), which is where the decision
+// lives.
+
+const RPM_PLAINTEXT = "sk-rlh-rpm";
+const TPM_PLAINTEXT = "sk-rlh-tpm";
+const CONC_PLAINTEXT = "sk-rlh-conc";
+const hash = (s: string) => createHash("sha256").update(s).digest("hex");
+
+const FAST_MODEL = "rlh-fast";
+const SLOW_MODEL = "rlh-slow";
+
+/** Upstream stall for the concurrency case, in ms. */
+const SLOW_UPSTREAM_MS = 2_000;
+
+interface RawResponse {
+  status: number;
+  headers: Record<string, string>;
+}
+
+async function rawChat(
+  proxyUrl: string,
+  apiKey: string,
+  model: string,
+): Promise<RawResponse> {
+  const res = await harnessRequest(`${proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: "hi" }],
+    }),
+  });
+  // Drain so the connection is not left half-read between calls.
+  await res.body.text();
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(res.headers)) {
+    headers[k.toLowerCase()] = Array.isArray(v) ? v.join(", ") : String(v ?? "");
+  }
+  return { status: res.statusCode, headers };
+}
+
+/**
+ * Assert the four contracted headers plus the scope extension, and
+ * return the parsed reset so a caller can bound it against the window
+ * the refusing dimension actually has.
+ */
+function expectStandardHeaders(
+  res: RawResponse,
+  expected: { limit: number; scope: string },
+): number {
+  expect(res.status).toBe(429);
+  expect(res.headers["x-ratelimit-limit"]).toBe(String(expected.limit));
+  expect(res.headers["x-ratelimit-remaining"]).toBe("0");
+  expect(res.headers["x-ratelimit-scope"]).toBe(expected.scope);
+
+  const reset = Number.parseInt(res.headers["x-ratelimit-reset"] ?? "", 10);
+  const retryAfter = Number.parseInt(res.headers["retry-after"] ?? "", 10);
+  expect(Number.isNaN(reset)).toBe(false);
+  expect(Number.isNaN(retryAfter)).toBe(false);
+  // Both headers answer "when may I retry", so they must agree — a
+  // client is free to read whichever one it already supports.
+  expect(reset).toBe(retryAfter);
+  // Zero would tell the client to retry immediately, which is the
+  // retry storm the hint exists to prevent.
+  expect(reset).toBeGreaterThanOrEqual(1);
+  return reset;
+}
+
+describe("rate limit e2e: standard 429 headers", () => {
+  let app: SpawnedApp | undefined;
+  let fastUpstream: OpenAiUpstream | undefined;
+  let slowUpstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    fastUpstream = await startOpenAiUpstream();
+    // The concurrency cap can only be observed while a request is still
+    // in flight, so that dimension needs an upstream that holds the
+    // gateway's slot open long enough for a second call to arrive.
+    slowUpstream = await startOpenAiUpstream({
+      responseDelayMs: SLOW_UPSTREAM_MS,
+    });
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const fastPk = await seed.createProviderKey({
+      display_name: "rlh-fast-pk",
+      secret: "sk-mock",
+      api_base: `${fastUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: FAST_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: fastPk.id,
+    });
+    const slowPk = await seed.createProviderKey({
+      display_name: "rlh-slow-pk",
+      secret: "sk-mock",
+      api_base: `${slowUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: SLOW_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: slowPk.id,
+    });
+
+    // One key per dimension, each carrying ONLY that dimension, so a
+    // refusal cannot be attributed to the wrong one.
+    await seed.createApiKey({
+      key_hash: hash(RPM_PLAINTEXT),
+      allowed_models: [FAST_MODEL],
+      rate_limit: { rpm: 1 },
+    });
+    // tpm is checked-but-not-incremented before dispatch: the first
+    // call is admitted and commits the mock's usage, which overruns
+    // this cap, so the SECOND call is the one refused.
+    await seed.createApiKey({
+      key_hash: hash(TPM_PLAINTEXT),
+      allowed_models: [FAST_MODEL],
+      rate_limit: { tpm: 1 },
+    });
+    await seed.createApiKey({
+      key_hash: hash(CONC_PLAINTEXT),
+      allowed_models: [SLOW_MODEL],
+      rate_limit: { concurrency: 1 },
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await fastUpstream?.close();
+    await slowUpstream?.close();
+  });
+
+  test("a request-cap 429 carries the four headers on the raw response", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    // listModels does not consume the rpm=1 slot, so it is a readiness
+    // probe the test can afford.
+    const probe = new ProxyClient(app.proxyUrl, RPM_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      if (res.status !== 200) return false;
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return data.some((m) => m.id === FAST_MODEL);
+    });
+
+    // The limiter buckets on fixed wall-clock minutes; a burst that
+    // straddles a boundary would get a fresh allowance.
+    await awaitWindowHeadroom();
+
+    const first = await rawChat(app.proxyUrl, RPM_PLAINTEXT, FAST_MODEL);
+    expect(first.status).toBe(200);
+    // A 200 reports the per-dimension `x-ratelimit-*-requests` family
+    // and NOT the unsuffixed trio: the trio's presence is what marks a
+    // response as the gateway's own rate-limit refusal.
+    expect(first.headers["x-ratelimit-limit-requests"]).toBe("1");
+    expect(first.headers["x-ratelimit-limit"]).toBeUndefined();
+    expect(first.headers["x-ratelimit-scope"]).toBeUndefined();
+
+    const refused = await rawChat(app.proxyUrl, RPM_PLAINTEXT, FAST_MODEL);
+    const reset = expectStandardHeaders(refused, { limit: 1, scope: "rpm" });
+    // rpm is a minute window, so the wait cannot exceed one.
+    expect(reset).toBeLessThanOrEqual(60);
+  });
+
+  test("a token-cap 429 reports the token dimension, not the request one", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const probe = new ProxyClient(app.proxyUrl, TPM_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      return res.status === 200;
+    });
+    await awaitWindowHeadroom();
+
+    const first = await rawChat(app.proxyUrl, TPM_PLAINTEXT, FAST_MODEL);
+    expect(first.status).toBe(200);
+
+    const refused = await rawChat(app.proxyUrl, TPM_PLAINTEXT, FAST_MODEL);
+    const reset = expectStandardHeaders(refused, { limit: 1, scope: "tpm" });
+    expect(reset).toBeLessThanOrEqual(60);
+  });
+
+  test("a concurrency 429 carries all four headers and a fixed hint", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const probe = new ProxyClient(app.proxyUrl, CONC_PLAINTEXT);
+    await waitConfigPropagation(async () => {
+      const res = await probe.listModels();
+      const data = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return res.status === 200 && data.some((m) => m.id === SLOW_MODEL);
+    });
+
+    // Hold the only slot with a call the upstream stalls, then race a
+    // second one into it.
+    const held = rawChat(app.proxyUrl, CONC_PLAINTEXT, SLOW_MODEL);
+    await new Promise((r) => setTimeout(r, 300));
+    const refused = await rawChat(app.proxyUrl, CONC_PLAINTEXT, SLOW_MODEL);
+
+    // A concurrency slot frees when some in-flight request finishes,
+    // which the gateway cannot predict — so unlike a window this
+    // reports a fixed hint rather than a countdown. Before this
+    // contract the same 429 carried no retry hint at all.
+    const reset = expectStandardHeaders(refused, { limit: 1, scope: "concurrency" });
+    expect(reset).toBe(60);
+
+    expect((await held).status).toBe(200);
+  }, 30_000);
+});


### PR DESCRIPTION
## Problem

A caller refused by the gateway's own rate limiter cannot learn, from the response, what the cap was or when to come back.

- `Retry-After` is emitted only for windowed dimensions. A **concurrency** rejection carries no retry hint at all, so a client has nothing to back off on and retries immediately.
- The `x-ratelimit-*` family is emitted **only on successful `/v1/chat/completions` responses**. A 429 carries none of it, and the names it uses on a 200 are the per-dimension `…-requests` / `…-tokens` / `…-concurrent` ones, not the conventional unsuffixed set.

## What changes

Every rejection the limiter produces now describes the single limit that refused it. Captured from a running gateway against a real provider:

```http
HTTP/1.1 429 Too Many Requests
content-type: application/json
retry-after: 18
x-ratelimit-limit: 1
x-ratelimit-remaining: 0
x-ratelimit-reset: 18
x-ratelimit-scope: rpm
server: AISIX/0.3.0
x-aisix-request-id: 61156a89-cb20-49c6-bbdb-20f71fc88431

{"error":{"message":"request limit exceeded (requests)","type":"rate_limit_exceeded"}}
```

`x-ratelimit-reset` is a **duration in seconds**, not a timestamp, so a client needs no clock shared with the gateway. For a windowed dimension it is the same number as `retry-after`, so either header can drive back-off, and it never reaches `0` — the smallest value is `1`.

`x-ratelimit-scope` is an AISIX extension naming which of `rps` / `rpm` / `rph` / `rpd` / `tpm` / `tpd` / `concurrency` refused. Without it the numbers are ambiguous, because the units differ per dimension: `x-ratelimit-limit: 1000` could be requests, tokens, or in-flight slots.

A concurrency slot frees when some in-flight request finishes, which the gateway cannot predict, so that dimension reports a fixed `60` rather than nothing — matching what comparable proxy limiters emit for the same rejection.

## Implementation

`RateLimitError` gains a `LimitDetail { dimension, limit, remaining, reset_secs }`. It previously kept only a requests-vs-tokens scope and a retry hint, dropping which window it was and what its cap was — the information the headers report.

Both stores populate it. The Redis script reports the refused dimension as a **1-based index** into the same `request_dims` / `token_dims` list the caller pushed into ARGV, so no dimension name crosses the wire and the two backends cannot disagree on one. The dimension names are now shared constants used by both the Redis key layout and the header value.

The headers are written by **one helper shared by both response renderers** (`into_response` for the OpenAI shape, `into_anthropic_response` for the Anthropic shape), which every endpoint funnels through — `/v1/chat/completions`, `/v1/messages`, `/v1/responses`, `/v1/embeddings`, `/v1/rerank`, audio, images, videos, jobs, realtime, MCP, A2A and passthrough routes. No handler builds a 429 of its own.

### Routing dispatch had to be fixed to honour this

Both dispatch loops in `chat.rs` flattened a per-target quota rejection into `BridgeError::upstream_status_with_retry_after(429, …)` — the shape an *upstream* 429 takes — and kept the un-flattened `ProxyError` only for a policy-layer rejection. A routing group whose every target was over its own **inline model limit** therefore produced a 429 with no `error.policy` attribution and none of the new headers, i.e. the wire shape of somebody else's refusal. `/v1/messages` and `/v1/responses` already keep theirs, so the family was out of lockstep on the very contract being introduced. Both loops now keep the rejection un-flattened; `reserve_routing_target` only ever returns quota errors, so nothing else changes shape.

## Scope: only the gateway's own rejections

The `x-ratelimit-*` trio is emitted **only** when the AISIX limiter refused. It is absent from successful responses (which keep the per-dimension family), from upstream 429s (the provider's `Retry-After` is still forwarded, but its quota state is not something the gateway knows), and from budget rejections (a budget caps spend in currency). Their presence is how a caller tells whose limit it hit.

Ensemble panel members and the judge are a known exception: they flatten their own quota rejections into a bare upstream-shaped 429 and carry neither the trio nor `Retry-After`. That is an existing ensemble parity gap, deliberately left for the ensemble design pass rather than patched here; the documentation names it explicitly.

## Behavior changes

- A **concurrency-cap 429 now carries `Retry-After: 60`** where it previously carried no retry hint. Clients that treated the absent header as "retry immediately" will now back off.
- When a routing group is exhausted by inline model limits, the terminal **`error_class` / access-log `error_kind` changes from `upstream_error` to `rate_limit_exceeded`**. This corrects an attribution — the gateway's own throttling was being recorded as an upstream fault — but a dashboard query filtering on the old label will stop matching.
- The same 429's **body message shortens**, from `routing target "primary" is over its model rate limit: request limit exceeded (requests)` to `request limit exceeded (requests)`, matching `/v1/messages` and `/v1/responses`. The target name stays in the attempt record's `error_message`.

## Tests

- **Limiter unit** — which dimension is attributed when several are configured, token refusals reporting the token window and cap, `remaining` saturating at zero when a committed token count overran the cap, and a boundary test that walks a whole minute asserting `reset` counts down exactly and never reaches `0`.
- **Renderer unit** — all five headers on both envelopes; the policy layer reporting its own limit; a concurrency 429 carrying all four; upstream 429 and budget 429 carrying `Retry-After` and **no** trio.
- **Router integration** — a real 429 through `/v1/chat/completions` asserting the quota gate's rejection reaches the renderer with its dimension intact and that `reset == retry-after`; plus an exhausted routing group through **both** the streaming and non-streaming dispatch loops.
- **Shared-store integration** — a refusal through Redis reporting the same detail as the local store, on a key with two request windows so an off-by-one in the index mapping is observable; plus the concurrency gauge's own state.
- **E2E** (`tests/e2e/src/cases/ratelimit-standard-headers-e2e.test.ts`) — reads the **raw** HTTP response rather than going through an SDK, for the request-cap, token-cap and concurrency dimensions, and asserts a 200 does **not** carry the trio.

Every assertion was mutation-checked: suppressing the header writes reds 5 Rust tests and all 3 e2e cases; changing the concurrency constant reds the two tests that pin its value; mislabelling the token dimension reds the token test; an off-by-one in the Lua index mapping reds the Redis test; and re-flattening either dispatch loop reds its half of the routing test.

Verified end to end outside the test suites as well: a standalone gateway against a real provider, driven with `curl -i`, produces the response above for `rpm`, and the equivalent for `tpm` (`x-ratelimit-scope: tpm`) and `concurrency` (`retry-after: 60`, `x-ratelimit-scope: concurrency`).

## Docs

Paired PRs: api7/docs#2253 and api7/docs.apiseven.com#540.

Fixes api7/AISIX-Cloud#1464
