### PR TITLE
fix(proxy): echo the caller's model name on the native passthrough paths

### DIFF
--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -562,9 +562,8 @@ async fn dispatch(
 
             // Echo the model name the caller addressed. The request half
             // already translates the alias to the upstream id
-            // (`aisix-provider-openai::bridge::completions`); without this the
-            // response half was the only endpoint-shaped answer that handed
-            // the upstream's own id back.
+            // (`aisix-provider-openai::bridge::completions`), so without this
+            // the response half handed the upstream's own id straight back.
             crate::model_echo::restamp_body(&mut resp_json, model_name);
 
             // #932: mask-action PII rules rewrite the reply text AFTER the

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -560,6 +560,13 @@ async fn dispatch(
                 }
             }
 
+            // Echo the model name the caller addressed. The request half
+            // already translates the alias to the upstream id
+            // (`aisix-provider-openai::bridge::completions`); without this the
+            // response half was the only endpoint-shaped answer that handed
+            // the upstream's own id back.
+            crate::model_echo::restamp_body(&mut resp_json, model_name);
+
             // #932: mask-action PII rules rewrite the reply text AFTER the
             // block check passes.
             crate::redact::merge_counts(

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -421,6 +421,10 @@ async fn dispatch(
     );
     let captured_prompt = content_cap.map(|_| serde_json::to_string(&body).unwrap_or_default());
 
+    // The name the caller addressed, kept before `body` is consumed below —
+    // the response echoes it rather than the id the provider reports (the
+    // `model_echo` contract).
+    let client_facing_model = body.model.clone();
     let model_rl =
         crate::quota::ModelRateLimit::from_model(&body.model, &model_entry.id, &model_entry.value);
     let reservation = crate::quota::enforce(state, snapshot, auth, Some(&model_rl)).await?;
@@ -469,7 +473,11 @@ async fn dispatch(
     })
     .await
     {
-        Ok(embed_resp) => {
+        Ok(mut embed_resp) => {
+            // The provider bridge fills `model` from the upstream's own
+            // document (or echoes the upstream id it was sent); the client
+            // asked for an alias and gets the alias back.
+            embed_resp.model = client_facing_model;
             // #701: clear any cooldown/unhealthy mark now the upstream
             // answered — same recovery signal as rerank/audio/chat.
             state.health.record_success(&model_entry.value.display_name);

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -58,6 +58,7 @@ mod jwt;
 mod mcp;
 mod mcp_auth;
 mod messages;
+mod model_echo;
 mod model_resolve;
 mod models;
 mod operation;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -7,7 +7,9 @@
 //!   gateway-internal `ChatFormat` can't lossily round-trip (cache_control,
 //!   thinking blocks, tool_use, image blocks). Adds `x-api-key` +
 //!   `anthropic-version` headers, rewrites the `model` field to the
-//!   upstream id, and streams the SSE response verbatim.
+//!   upstream id, and relays the SSE response frame-by-frame — every byte
+//!   as the provider wrote it except the caller-facing `model` name, which
+//!   is restamped on `message_start` (see [`crate::model_echo`]).
 //!
 //! - **Non-Anthropic upstream** (`Model.provider == openai|gemini|deepseek`)
 //!   — translates the Anthropic-shape body to the gateway's internal
@@ -1101,8 +1103,9 @@ async fn dispatch_to_target(
 
 /// Anthropic-protocol input -> Anthropic upstream: byte-for-byte
 /// passthrough to `{api_base}/v1/messages`. Adds the `x-api-key` +
-/// `anthropic-version` headers, rewrites the `model` field to the
-/// upstream id, and streams the SSE response verbatim.
+/// `anthropic-version` headers, rewrites the request `model` to the
+/// upstream id, and relays the SSE response frame-by-frame, restamping the
+/// caller-facing `model` on `message_start` (see [`crate::model_echo`]).
 #[allow(clippy::too_many_arguments)]
 async fn anthropic_passthrough_dispatch(
     state: &ProxyState,
@@ -3128,7 +3131,8 @@ fn emit_anthropic_usage_event(
 // ─── Anthropic streaming usage parser (#245) ───────────────────────
 //
 // The Anthropic `/v1/messages` passthrough forwards the upstream SSE
-// byte stream verbatim. To recover token counts for telemetry without
+// byte stream unchanged apart from the caller-facing `model` name. To
+// recover token counts for telemetry without
 // altering the bytes the client sees, `build_anthropic_passthrough_stream`
 // wraps the byte stream: it appends each chunk to a frame buffer,
 // extracts complete SSE events (delimited by a blank line), and parses
@@ -3543,7 +3547,9 @@ impl<T> Stream for AnthropicDeliveryCounter<T> {
 /// Wrap an Anthropic upstream byte stream so token usage is parsed
 /// in-flight and `on_complete` fires once at end-of-stream (or
 /// client-disconnect) with the accumulated counts. Bytes are forwarded
-/// verbatim — the client sees the exact upstream SSE wire shape.
+/// unchanged apart from the caller-facing `model` on `message_start`: the
+/// client sees the upstream's own SSE wire shape, byte for byte, with that
+/// one value spliced (see [`crate::model_echo`]).
 #[allow(clippy::too_many_arguments)]
 fn build_anthropic_passthrough_stream<S, F>(
     upstream: S,
@@ -3673,12 +3679,28 @@ where
         }
         // A non-conformant upstream can end without terminating its last
         // frame. Those bytes were never forwarded (they are still the
-        // partial tail), so release them now rather than truncating the
-        // response.
+        // partial tail).
+        //
+        // On the live-forward path, release them: the client is no worse off
+        // than it was before this relay became frame-aligned, and truncating
+        // a response over a missing terminator would be a regression.
+        //
+        // Under a hold-back policy, DROP them. Only complete frames reach
+        // `drain_anthropic_sse_frames`, so an unterminated tail never fed
+        // `response_text` and was therefore never scanned — releasing it
+        // after the output check is exactly the bypass hold-back exists to
+        // prevent, and a client cannot parse a frame with no terminator
+        // anyway. Fail closed.
         if !buf.is_empty() {
             let tail = std::mem::take(&mut buf);
             if hold_policy.is_some() {
-                held.extend_from_slice(&tail);
+                tracing::warn!(
+                    guardrail_hook = "output",
+                    dropped = tail.len(),
+                    "streaming /v1/messages passthrough ended on an unterminated SSE \
+                     frame; dropping it unscanned rather than releasing it past the \
+                     output guardrail",
+                );
             } else {
                 if guard.usage().downstream_latency_ms == 0 {
                     guard.usage().downstream_latency_ms =
@@ -5228,7 +5250,8 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
     /// realistic Anthropic SSE response (input_tokens in
     /// `message_start`, running output_tokens in `message_delta`) and
     /// asserts the emitted UsageEvent carries the real counts, plus
-    /// the response bytes still pass through verbatim.
+    /// the response bytes still pass through unchanged apart from the
+    /// caller-facing `model` name.
     #[tokio::test]
     async fn anthropic_passthrough_streaming_records_usage_from_sse_frames() {
         use aisix_obs::UsageSink;
@@ -5280,7 +5303,8 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         let resp = app.oneshot(make_req(body)).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        // Bytes pass through verbatim — the client still sees the exact
+        // Bytes pass through unchanged apart from the caller-facing
+        // `model` name — the client still sees the exact
         // Anthropic SSE wire shape.
         let streamed =
             String::from_utf8(to_bytes(resp.into_body(), 65536).await.unwrap().to_vec()).unwrap();
@@ -5384,6 +5408,81 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
         assert_eq!(event.cache_read_tokens, 9);
         assert_eq!(event.provider_request_id, "gen_01REPRO952");
         assert_eq!(event.provider_model_version, "mco-5");
+    }
+
+    /// `extract_sse_data_range` is what the model restamp splices into, so
+    /// an off-by-one in its arithmetic would rewrite the wrong bytes. The
+    /// range is checked against the payload it must select on every framing
+    /// variant a provider is allowed to emit. The `extract_sse_data_line`
+    /// assertion beside it is a cheap guard for the day someone gives that
+    /// accessor its own implementation again — today it delegates here, so
+    /// only the `want` table can actually catch a regression.
+    #[test]
+    fn extract_sse_data_range_selects_exactly_the_payload() {
+        use super::{extract_sse_data_line, extract_sse_data_range};
+
+        for (frame, want) in [
+            // Canonical: labelled event, LF terminators, one space after the colon.
+            (
+                &b"event: message_start\ndata: {\"a\":1}\n\n"[..],
+                Some(&b"{\"a\":1}"[..]),
+            ),
+            // CRLF: the `\r` belongs to the framing, not the payload.
+            (
+                &b"event: x\r\ndata: {\"a\":1}\r\n\r\n"[..],
+                Some(&b"{\"a\":1}"[..]),
+            ),
+            // No space after the colon — the spec makes it optional.
+            (&b"data:{\"a\":1}\n\n"[..], Some(&b"{\"a\":1}"[..])),
+            // A comment/keepalive line ahead of the data line.
+            (&b": ping\ndata: {\"a\":1}\n\n"[..], Some(&b"{\"a\":1}"[..])),
+            // Terminal sentinel.
+            (&b"data: [DONE]\n\n"[..], Some(&b"[DONE]"[..])),
+            // Empty payload: a zero-width range, not a panic and not the tail.
+            (&b"data:\n\n"[..], Some(&b""[..])),
+            // No data line at all.
+            (&b"event: ping\n\n"[..], None),
+            // A value containing the delimiter bytes must not confuse the scan.
+            (
+                &b"event: e\ndata: {\"t\":\"a: b\"}\n\n"[..],
+                Some(&b"{\"t\":\"a: b\"}"[..]),
+            ),
+        ] {
+            let range = extract_sse_data_range(frame);
+            assert_eq!(
+                range.clone().map(|r| &frame[r]),
+                want,
+                "range selects the payload for {:?}",
+                String::from_utf8_lossy(frame),
+            );
+            assert_eq!(
+                extract_sse_data_line(frame),
+                want,
+                "the line accessor stays equivalent for {:?}",
+                String::from_utf8_lossy(frame),
+            );
+        }
+    }
+
+    /// A frame whose data line is not splice-able JSON forwards verbatim
+    /// rather than being corrupted or dropped — the restamp is best-effort
+    /// by design, and losing one frame's model name beats mangling a stream.
+    #[test]
+    fn restamp_leaves_unparseable_frames_alone() {
+        use crate::model_echo::{anthropic_message_model, restamp_sse_frame};
+
+        for frame in [
+            &b"data: not json at all\n\n"[..],
+            &b"data: {\"message\":{\"model\":\n\n"[..],
+            &b"data:\n\n"[..],
+            &b"event: ping\n\n"[..],
+        ] {
+            assert!(
+                restamp_sse_frame(frame, "gw-alias", anthropic_message_model).is_none(),
+                "no rewrite for {:?}",
+                String::from_utf8_lossy(frame),
+            );
+        }
     }
 
     /// Issue #245: the SSE frame parser must reassemble events that

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3625,11 +3625,32 @@ where
                 // would otherwise grow `buf` unboundedly (per-request
                 // memory exhaustion). Real Anthropic SSE frames are
                 // well under a few KB, so a 1 MiB ceiling can only be
-                // hit by a non-conformant stream; release the
-                // un-terminated remainder downstream rather than OOM.
-                // Delivery is preserved — only this frame's usage parse
-                // and model restamp are lost.
+                // hit by a non-conformant stream.
+                //
+                // Under a hold-back policy those bytes fail closed, for the
+                // same reason the EOF tail below does: an unterminated frame
+                // never reached `drain_anthropic_sse_frames`, so it never fed
+                // `response_text` and the output guardrail never saw it.
+                // Releasing it with `held` after the scan would be a bypass,
+                // and its size is not what makes it one.
+                //
+                // On the live-forward path there is no scan to bypass, so the
+                // remainder goes downstream rather than being dropped or held
+                // until OOM. Delivery is preserved — only that frame's usage
+                // parse and model restamp are lost.
                 if buf.len() > MAX_SSE_FRAME_BUF_BYTES {
+                    if hold_policy.is_some() {
+                        tracing::warn!(
+                            guardrail_hook = "output",
+                            buffered = buf.len(),
+                            "streaming /v1/messages passthrough buffered an unterminated \
+                             SSE frame past the cap; failing closed rather than releasing \
+                             it unscanned",
+                        );
+                        guard.usage().guardrail_blocked = true;
+                        yield Ok(Bytes::from(guardrail_block_frame(None, Some(crate::error::TAG_OUTPUT_BUFFER_EXCEEDED))));
+                        return;
+                    }
                     tracing::warn!(
                         buffered = buf.len(),
                         "anthropic stream: SSE frame buffer exceeded cap without a \

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3550,6 +3550,11 @@ impl<T> Stream for AnthropicDeliveryCounter<T> {
 /// unchanged apart from the caller-facing `model` on `message_start`: the
 /// client sees the upstream's own SSE wire shape, byte for byte, with that
 /// one value spliced (see [`crate::model_echo`]).
+///
+/// Under a hold-back output policy the relay additionally WITHHOLDS bytes it
+/// could not scan — an unterminated frame at EOF, or one that ran past the
+/// frame cap. See the two arms below; on the live-forward path neither
+/// applies and every byte is delivered.
 #[allow(clippy::too_many_arguments)]
 fn build_anthropic_passthrough_stream<S, F>(
     upstream: S,
@@ -3648,7 +3653,11 @@ where
                              it unscanned",
                         );
                         guard.usage().guardrail_blocked = true;
-                        yield Ok(Bytes::from(guardrail_block_frame(None, Some(crate::error::TAG_OUTPUT_BUFFER_EXCEEDED))));
+                        // `unscannable_body`, not `output_buffer_exceeded`:
+                        // the frame is refused because it never reached the
+                        // scan, not because of its size. The hold-back cap
+                        // below keeps the size-based tag.
+                        yield Ok(Bytes::from(guardrail_block_frame(None, Some(crate::error::TAG_UNSCANNABLE_BODY))));
                         return;
                     }
                     tracing::warn!(
@@ -3722,6 +3731,21 @@ where
                      frame; dropping it unscanned rather than releasing it past the \
                      output guardrail",
                 );
+                // When the tail was the ENTIRE response, dropping it silently
+                // would hand the caller an empty 200 and no signal at all —
+                // and the guardrail scan is skipped too, since nothing ever
+                // reached `response_text`. Refuse explicitly instead, the same
+                // shape the frame-cap arm above uses. A stream that delivered
+                // real frames and merely lost a trailing fragment is NOT
+                // turned into a refusal.
+                if held.is_empty() {
+                    guard.usage().guardrail_blocked = true;
+                    yield Ok(Bytes::from(guardrail_block_frame(
+                        None,
+                        Some(crate::error::TAG_UNSCANNABLE_BODY),
+                    )));
+                    return;
+                }
             } else {
                 if guard.usage().downstream_latency_ms == 0 {
                     guard.usage().downstream_latency_ms =
@@ -6305,6 +6329,112 @@ event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n"
         assert_eq!(
             event.status_code, 200,
             "a fail-closed refusal is not a client abandonment"
+        );
+    }
+
+    /// The two other ways an unscanned byte could reach a client under a
+    /// hold-back policy, both deterministic here rather than only in e2e.
+    ///
+    /// `case` is the upstream's SSE body; `expect_released` is text that must
+    /// reach the caller, `expect_withheld` text that must not.
+    async fn holdback_case(sse: String) -> String {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(4);
+        let snap = new_snap_anthropic(&upstream.uri());
+        snap.models.insert(anthropic_model("my-claude"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        // Block-capable, so the stream is held back; the literal never
+        // appears, so only the unscannable-bytes arms can refuse.
+        let row: aisix_core::models::Guardrail = serde_json::from_str(
+            r#"{"name":"out-block","enabled":true,"kind":"keyword","hook_point":"output","fail_open":false,"patterns":[{"kind":"literal","value":"NEVERAPPEARS"}]}"#,
+        )
+        .unwrap();
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-out", row, 1));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        let state = crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+
+        let resp = crate::build_router(state)
+            .oneshot(make_req(serde_json::json!({
+                "model": "my-claude",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "stream": true,
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        String::from_utf8(to_bytes(resp.into_body(), 1 << 21).await.unwrap().to_vec()).unwrap()
+    }
+
+    /// A stream that ends mid-frame: the scanned frames are delivered, the
+    /// unterminated remainder is not. It never reached the frame drain, so it
+    /// never fed the text the output guardrail scans — releasing it after the
+    /// scan cleared would be a way around the check.
+    #[tokio::test]
+    async fn holdback_withholds_an_unterminated_tail_but_delivers_what_was_scanned() {
+        let sse = concat!(
+            r#"event: message_start
+data: {"type":"message_start","message":{"id":"msg_t","role":"assistant","content":[],"model":"claude-3-5-haiku-20241022","stop_reason":null,"usage":{"input_tokens":4,"output_tokens":1}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"SCANNEDTEXT"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"UNSCANNEDTAIL""#,
+        );
+        let streamed = holdback_case(sse.to_string()).await;
+        assert!(
+            streamed.contains("SCANNEDTEXT"),
+            "frames that were scanned still reach the caller: {streamed}"
+        );
+        assert!(
+            !streamed.contains("UNSCANNEDTAIL"),
+            "the unterminated tail must not be released: {streamed}"
+        );
+        // The caller's alias, not the upstream id, on the way past.
+        assert!(streamed.contains(r#""model":"my-claude""#));
+        assert!(!streamed.contains("claude-3-5-haiku-20241022"));
+    }
+
+    /// A single frame that never terminates and runs past the 1 MiB frame
+    /// cap. Same bypass as the tail, reached by size instead of by EOF, so it
+    /// takes the same refusal — and `unscannable_body` rather than a
+    /// size-shaped tag, because the scan is what it missed.
+    #[tokio::test]
+    async fn holdback_refuses_a_frame_that_overruns_the_cap_without_terminating() {
+        let huge = "y".repeat(super::MAX_SSE_FRAME_BUF_BYTES + 1024);
+        let sse = format!(
+            concat!(
+                "event: content_block_delta\n",
+                r#"data: {{"type":"content_block_delta","index":0,"delta":{{"type":"text_delta","text":"{huge}""#,
+            ),
+            huge = huge
+        );
+        let streamed = holdback_case(sse).await;
+        assert!(
+            streamed.contains(crate::error::TAG_UNSCANNABLE_BODY),
+            "an unterminated oversized frame is refused, not released: {}",
+            &streamed[..streamed.len().min(400)]
+        );
+        assert!(
+            !streamed.contains(&huge),
+            "unscannable content must not be released"
         );
     }
 }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3749,6 +3749,17 @@ where
                     return;
                 }
             } else {
+                // Restamp on the way out, for the same reason the `/v1/responses`
+                // relay does: the upstream has ended, so this is a final frame it
+                // never terminated rather than one still arriving. Anthropic's last
+                // frame is `message_stop`, which carries no model, so this is inert
+                // today — it is here so the two relays cannot answer differently.
+                let tail = crate::model_echo::restamp_sse_frame(
+                    &tail,
+                    &model_label,
+                    crate::model_echo::anthropic_message_model,
+                )
+                .unwrap_or(tail);
                 if guard.usage().downstream_latency_ms == 0 {
                     guard.usage().downstream_latency_ms =
                         started.elapsed().as_millis().min(u32::MAX as u128) as u32;
@@ -3756,9 +3767,10 @@ where
                 yield Ok(Bytes::from(tail));
             }
         }
-        // Upstream stream over — the response was forwarded in full. Record
-        // it before the scan below, which awaits a remote provider and is a
-        // routine drop point for clients that close on the terminal event.
+        // Upstream stream over. Record it before the scan below, which awaits
+        // a remote provider and is a routine drop point for clients that close
+        // on the terminal event. NOT the same as "all of it was forwarded":
+        // under a hold-back policy an unscannable frame may have been withheld.
         guard.usage().reached_end = true;
         // End-of-stream output guardrail (#448): scan the accumulated
         // assistant text. On a block, emit a terminal Anthropic `error`
@@ -6334,12 +6346,14 @@ event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n"
         );
     }
 
-    /// The two other ways an unscanned byte could reach a client under a
-    /// hold-back policy, both deterministic here rather than only in e2e.
+    /// Drive one streamed `/v1/messages` request through a block-capable
+    /// output guardrail (so the hold-back path is in force) and return the
+    /// body the CALLER received. `sse` is the upstream's raw SSE response.
     ///
-    /// `case` is the upstream's SSE body; `expect_released` is text that must
-    /// reach the caller, `expect_withheld` text that must not.
-    async fn holdback_case(sse: String) -> String {
+    /// The guardrail's literal never appears in any case below, so a refusal
+    /// can only come from bytes the scan could not see — which is what these
+    /// tests are about.
+    async fn holdback_case(sse: String) -> (String, aisix_obs::UsageEvent) {
         use aisix_obs::UsageSink;
 
         let upstream = MockServer::start().await;
@@ -6353,7 +6367,7 @@ event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n"
             .mount(&upstream)
             .await;
 
-        let (tx, _rx) = tokio::sync::mpsc::channel(4);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
         let snap = new_snap_anthropic(&upstream.uri());
         snap.models.insert(anthropic_model("my-claude"));
         snap.apikeys.insert(apikey_entry(&["*"]));
@@ -6381,7 +6395,26 @@ event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n"
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        String::from_utf8(to_bytes(resp.into_body(), 1 << 21).await.unwrap().to_vec()).unwrap()
+        let body =
+            String::from_utf8(to_bytes(resp.into_body(), 1 << 21).await.unwrap().to_vec()).unwrap();
+        let event = tokio::time::timeout(std::time::Duration::from_millis(1000), rx.recv())
+            .await
+            .expect("usage event was never emitted")
+            .expect("usage event sender dropped");
+        (body, event)
+    }
+
+    /// Every fail-closed arm reports the same way: the gateway ended this, so
+    /// it is a 200 carrying `guardrail_blocked`, not the 499 a client
+    /// abandonment would produce (AISIX-Cloud#1428). Asserted per arm because
+    /// each sets the flag itself — drop `guardrail_blocked = true` from any one
+    /// of them and only its own test can notice.
+    fn assert_refused_not_abandoned(event: &aisix_obs::UsageEvent) {
+        assert!(event.guardrail_blocked, "a refusal is a guardrail block");
+        assert_eq!(
+            event.status_code, 200,
+            "a fail-closed refusal is not a client abandonment"
+        );
     }
 
     /// A stream that ends mid-frame: the scanned frames are delivered, the
@@ -6398,7 +6431,13 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
 
 event: content_block_delta
 data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"UNSCANNEDTAIL""#;
-        let streamed = holdback_case(sse.to_string()).await;
+        let (streamed, event) = holdback_case(sse.to_string()).await;
+        // Frames WERE delivered, so this is not a refusal — the tail is simply
+        // withheld and the stream reports normally.
+        assert!(
+            !event.guardrail_blocked,
+            "withholding a tail is not a block"
+        );
         assert!(
             streamed.contains("SCANNEDTEXT"),
             "frames that were scanned still reach the caller: {streamed}"
@@ -6426,7 +6465,7 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
             ),
             huge = huge
         );
-        let streamed = holdback_case(sse).await;
+        let (streamed, event) = holdback_case(sse).await;
         assert!(
             streamed.contains(crate::error::TAG_UNSCANNABLE_BODY),
             "an unterminated oversized frame is refused, not released: {}",
@@ -6436,5 +6475,27 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
             !streamed.contains(&huge),
             "unscannable content must not be released"
         );
+        assert_refused_not_abandoned(&event);
+    }
+
+    /// The third arm: the unterminated frame is the WHOLE response, and small
+    /// enough that the frame cap never fires. Nothing was ever drained, so
+    /// nothing was scanned and there is nothing to deliver — dropping it
+    /// silently would hand the caller an empty 200 with no signal at all, so
+    /// it is refused explicitly instead.
+    #[tokio::test]
+    async fn holdback_refuses_when_the_unterminated_frame_is_the_whole_response() {
+        let sse = r#"event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ONLYEVERFRAGMENT""#;
+        let (streamed, event) = holdback_case(sse.to_string()).await;
+        assert!(
+            streamed.contains(crate::error::TAG_UNSCANNABLE_BODY),
+            "an all-fragment response is refused, not silently emptied: {streamed}"
+        );
+        assert!(
+            !streamed.contains("ONLYEVERFRAGMENT"),
+            "unscanned content must not be released: {streamed}"
+        );
+        assert_refused_not_abandoned(&event);
     }
 }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -6390,16 +6390,14 @@ event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n"
     /// scan cleared would be a way around the check.
     #[tokio::test]
     async fn holdback_withholds_an_unterminated_tail_but_delivers_what_was_scanned() {
-        let sse = concat!(
-            r#"event: message_start
+        let sse = r#"event: message_start
 data: {"type":"message_start","message":{"id":"msg_t","role":"assistant","content":[],"model":"claude-3-5-haiku-20241022","stop_reason":null,"usage":{"input_tokens":4,"output_tokens":1}}}
 
 event: content_block_delta
 data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"SCANNEDTEXT"}}
 
 event: content_block_delta
-data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"UNSCANNEDTAIL""#,
-        );
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"UNSCANNEDTAIL""#;
         let streamed = holdback_case(sse.to_string()).await;
         assert!(
             streamed.contains("SCANNEDTEXT"),

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3725,21 +3725,47 @@ where
         // anyway. Fail closed.
         if !buf.is_empty() {
             let tail = std::mem::take(&mut buf);
-            if hold_policy.is_some() {
+            // The upstream has ended, so this fragment is a final frame it
+            // never terminated — complete, just missing its blank line. Parse
+            // it like any other frame BEFORE the scan below runs, so its text
+            // reaches `response_text` and the output guardrail actually sees
+            // it. Then it is scanned content like everything else and can be
+            // released, which is what keeps a provider that omits the last
+            // terminator from losing its `message_stop` behind a guardrail.
+            //
+            // `scannable` is false only when the fragment is not parseable —
+            // truncated mid-JSON. Nothing can extract its text, so releasing
+            // it WOULD be the bypass, and that case alone fails closed.
+            let scannable = match extract_sse_data_line(&tail) {
+                Some(data) => match serde_json::from_slice::<Value>(data) {
+                    Ok(json) => {
+                        update_anthropic_usage(
+                            guard.usage(),
+                            &json,
+                            attempt_started,
+                            &mut first_token_seen,
+                        );
+                        true
+                    }
+                    Err(_) => false,
+                },
+                // No `data:` line at all (a comment / keepalive): nothing to
+                // scan, so nothing to withhold.
+                None => true,
+            };
+            if hold_policy.is_some() && !scannable {
                 tracing::warn!(
                     guardrail_hook = "output",
                     dropped = tail.len(),
-                    "streaming /v1/messages passthrough ended on an unterminated SSE \
-                     frame; dropping it unscanned rather than releasing it past the \
-                     output guardrail",
+                    "streaming /v1/messages passthrough ended on an SSE frame that \
+                     could not be parsed; dropping it rather than releasing it past \
+                     the output guardrail",
                 );
-                // When the tail was the ENTIRE response, dropping it silently
-                // would hand the caller an empty 200 and no signal at all —
-                // and the guardrail scan is skipped too, since nothing ever
+                // When that fragment was the ENTIRE response, dropping it
+                // silently would hand the caller an empty 200 and no signal at
+                // all — and the scan is skipped too, since nothing ever
                 // reached `response_text`. Refuse explicitly instead, the same
-                // shape the frame-cap arm above uses. A stream that delivered
-                // real frames and merely lost a trailing fragment is NOT
-                // turned into a refusal.
+                // shape the frame-cap arm above uses.
                 if held.is_empty() {
                     guard.usage().guardrail_blocked = true;
                     yield Ok(Bytes::from(guardrail_block_frame(
@@ -3748,12 +3774,25 @@ where
                     )));
                     return;
                 }
+            } else if hold_policy.is_some() {
+                // Scanned like every other frame — hold it with them.
+                let tail = crate::model_echo::restamp_sse_frame(
+                    &tail,
+                    &model_label,
+                    crate::model_echo::anthropic_message_model,
+                )
+                .unwrap_or(tail);
+                held.extend_from_slice(&tail);
             } else {
                 // Restamp on the way out, for the same reason the `/v1/responses`
                 // relay does: the upstream has ended, so this is a final frame it
-                // never terminated rather than one still arriving. Anthropic's last
-                // frame is `message_stop`, which carries no model, so this is inert
-                // today — it is here so the two relays cannot answer differently.
+                // never terminated rather than one still arriving.
+                //
+                // Note this is NOT the same as Anthropic's terminal frame. That
+                // one is `message_stop` and carries no model — but an upstream
+                // that dies part-way through leaves whatever frame it was
+                // writing, and if that is `message_start` this restamp is the
+                // only thing standing between the caller and the upstream id.
                 let tail = crate::model_echo::restamp_sse_frame(
                     &tail,
                     &model_label,
@@ -6339,16 +6378,14 @@ event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n"
             .await
             .expect("usage event was never emitted")
             .expect("usage event sender dropped");
-        assert!(event.guardrail_blocked);
-        assert_eq!(
-            event.status_code, 200,
-            "a fail-closed refusal is not a client abandonment"
-        );
+        assert_refused_not_abandoned(&event);
     }
 
     /// Drive one streamed `/v1/messages` request through a block-capable
-    /// output guardrail (so the hold-back path is in force) and return the
-    /// body the CALLER received. `sse` is the upstream's raw SSE response.
+    /// output guardrail (so the hold-back path is in force). `sse` is the
+    /// upstream's raw SSE response; the pair returned is the body the CALLER
+    /// received and the UsageEvent the request emitted — both halves matter,
+    /// since a refusal has to look right on the wire AND in telemetry.
     ///
     /// The guardrail's literal never appears in any case below, so a refusal
     /// can only come from bytes the scan could not see — which is what these
@@ -6417,12 +6454,13 @@ event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n"
         );
     }
 
-    /// A stream that ends mid-frame: the scanned frames are delivered, the
-    /// unterminated remainder is not. It never reached the frame drain, so it
-    /// never fed the text the output guardrail scans — releasing it after the
-    /// scan cleared would be a way around the check.
+    /// A stream that dies mid-JSON: the scanned frames are delivered, the
+    /// unparseable remainder is not. Nothing can extract that fragment's text,
+    /// so it cannot reach the output scan, and releasing it afterwards would
+    /// be a way around the check. Contrast the test below, where the tail is
+    /// complete JSON and merely lacks its blank line — that one IS delivered.
     #[tokio::test]
-    async fn holdback_withholds_an_unterminated_tail_but_delivers_what_was_scanned() {
+    async fn holdback_withholds_an_unparseable_tail_but_delivers_what_was_scanned() {
         let sse = r#"event: message_start
 data: {"type":"message_start","message":{"id":"msg_t","role":"assistant","content":[],"model":"claude-3-5-haiku-20241022","stop_reason":null,"usage":{"input_tokens":4,"output_tokens":1}}}
 
@@ -6478,7 +6516,31 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
         assert_refused_not_abandoned(&event);
     }
 
-    /// The third arm: the unterminated frame is the WHOLE response, and small
+    /// A provider that omits only the FINAL blank line. The frame is complete
+    /// JSON, so at EOF it can be parsed like any other, which puts its text in
+    /// front of the output guardrail — and once scanned there is no reason to
+    /// withhold it. Dropping it here was a regression: `message_stop` carries
+    /// no text, so withholding it protected nothing while breaking every
+    /// Anthropic SDK client that waits for it (`get_final_message`).
+    #[tokio::test]
+    async fn holdback_delivers_a_complete_tail_that_merely_lacks_its_terminator() {
+        let sse = "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ok\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-3-5-haiku-20241022\",\"stop_reason\":null,\"usage\":{\"input_tokens\":4,\"output_tokens\":1}}}\n\n\
+event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n\
+event: message_stop\ndata: {\"type\":\"message_stop\"}";
+        let (streamed, event) = holdback_case(sse.to_string()).await;
+        assert!(
+            streamed.contains("message_stop"),
+            "a complete final frame is delivered even without its blank line: {streamed}"
+        );
+        assert!(streamed.contains("hello"));
+        assert!(
+            !event.guardrail_blocked,
+            "a scannable tail is not a refusal: {streamed}"
+        );
+        assert!(!streamed.contains(crate::error::TAG_UNSCANNABLE_BODY));
+    }
+
+    /// The third arm: the unparseable frame is the WHOLE response, and small
     /// enough that the frame cap never fires. Nothing was ever drained, so
     /// nothing was scanned and there is nothing to deliver — dropping it
     /// silently would hand the caller an empty 200 with no signal at all, so

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1709,13 +1709,11 @@ async fn anthropic_passthrough_dispatch(
             }
         }
 
-        // Restore the gateway-facing model name so callers see what they asked for.
-        if let Some(m) = json_body.get_mut("model") {
-            // If the upstream echoes the model name, rewrite to the gateway name.
-            if m.as_str().map(|s| s == upstream_model).unwrap_or(false) {
-                *m = Value::String(model_name.to_string());
-            }
-        }
+        // Restore the gateway-facing model name so callers see what they asked
+        // for. Unconditional: the upstream is free to answer with an id other
+        // than the one it was asked for (a dated snapshot, a server-side
+        // remap), and the caller still addressed the alias.
+        crate::model_echo::restamp_body(&mut json_body, model_name);
 
         // #932: mask-action PII rules rewrite the passthrough response body
         // (text blocks + tool_use input) AFTER the block check passes.
@@ -3358,15 +3356,26 @@ fn update_anthropic_usage(
     }
 }
 
-/// Drain every complete SSE frame from `buf`, updating `acc`. A frame
-/// ends at the first blank line (`\n\n`). Incomplete trailing bytes are
-/// left in `buf` for the next chunk. The `data:` payload is parsed as
-/// JSON; non-JSON or non-`data` frames are skipped.
+/// Drain every complete SSE frame from `buf`, updating `acc` and
+/// appending the frame to `out` with the client-facing `model` restamped
+/// onto `message_start`. A frame ends at the first blank line (`\n\n`);
+/// incomplete trailing bytes are left in `buf` for the next chunk. The
+/// `data:` payload is parsed as JSON for the usage side; non-JSON or
+/// non-`data` frames are skipped there and forwarded untouched.
+///
+/// `out` is what the client receives, so the relay forwards whole frames
+/// rather than raw chunks: a value can only be spliced once the frame
+/// carrying it has arrived in full. A frame is the SSE protocol's atomic
+/// unit — every conforming parser buffers to the blank-line terminator
+/// anyway — so holding a partial one back is not observable to a client,
+/// and `buf` retains only that partial tail.
 fn drain_anthropic_sse_frames(
     buf: &mut Vec<u8>,
     acc: &mut AnthropicStreamUsage,
     attempt_started: Instant,
     first_token_seen: &mut bool,
+    client_facing_model: &str,
+    out: &mut Vec<u8>,
 ) {
     // SSE event delimiter is a blank line. Anthropic emits `\n\n`;
     // tolerate `\r\n\r\n` defensively by normalising the search.
@@ -3376,6 +3385,14 @@ fn drain_anthropic_sse_frames(
             if let Ok(json) = serde_json::from_slice::<Value>(data) {
                 update_anthropic_usage(acc, &json, attempt_started, first_token_seen);
             }
+        }
+        match crate::model_echo::restamp_sse_frame(
+            &frame,
+            client_facing_model,
+            crate::model_echo::anthropic_message_model,
+        ) {
+            Some(rewritten) => out.extend_from_slice(&rewritten),
+            None => out.extend_from_slice(&frame),
         }
     }
 }
@@ -3409,11 +3426,25 @@ pub(crate) fn find_frame_end(buf: &[u8]) -> Option<usize> {
 /// Anthropic emits single-line data for the frames we care about.
 /// Shared with the `/v1/responses` streaming usage parser (#808).
 pub(crate) fn extract_sse_data_line(frame: &[u8]) -> Option<&[u8]> {
+    extract_sse_data_range(frame).map(|r| &frame[r])
+}
+
+/// The same payload as [`extract_sse_data_line`], as a range into
+/// `frame`. The restamp path needs the offsets so it can splice a value
+/// back into the frame without rebuilding the bytes around it
+/// (`model_echo::restamp_sse_frame`).
+pub(crate) fn extract_sse_data_range(frame: &[u8]) -> Option<std::ops::Range<usize>> {
+    let mut offset = 0usize;
     for line in frame.split(|&b| b == b'\n') {
+        let start = offset;
+        offset += line.len() + 1; // the split consumed one `\n`
         let line = line.strip_suffix(b"\r").unwrap_or(line);
-        if let Some(rest) = line.strip_prefix(b"data:") {
-            let rest = rest.strip_prefix(b" ").unwrap_or(rest);
-            return Some(rest);
+        if line.starts_with(b"data:") {
+            let mut from = start + b"data:".len();
+            if frame.get(from) == Some(&b' ') {
+                from += 1;
+            }
+            return Some(from..start + line.len());
         }
     }
     None
@@ -3566,15 +3597,19 @@ where
         let mut held: Vec<u8> = Vec::new();
         while let Some(item) = upstream.next().await {
             if let Ok(bytes) = &item {
-                // Side-channel parse: copy into the frame buffer (the
-                // original `bytes` is yielded unchanged below) and drain
-                // any complete SSE frames into the accumulator.
+                // Accumulate, then drain every COMPLETE frame — restamped
+                // with the caller's model name — into `forward`. The client
+                // receives whole frames, never a partial one; `buf` keeps the
+                // trailing remainder until its terminator arrives.
                 buf.extend_from_slice(bytes);
+                let mut forward: Vec<u8> = Vec::new();
                 drain_anthropic_sse_frames(
                     &mut buf,
                     guard.usage(),
                     attempt_started,
                     &mut first_token_seen,
+                    &model_label,
+                    &mut forward,
                 );
                 // Bound the frame buffer (PR #436 audit MEDIUM-2). The
                 // happy path drains complete frames above, so `buf`
@@ -3584,26 +3619,25 @@ where
                 // would otherwise grow `buf` unboundedly (per-request
                 // memory exhaustion). Real Anthropic SSE frames are
                 // well under a few KB, so a 1 MiB ceiling can only be
-                // hit by a non-conformant stream; drop the buffer
-                // (losing usage parsing for that pathological case)
-                // rather than OOM. The bytes themselves still forward
-                // to the client verbatim — only telemetry parsing is
-                // affected.
+                // hit by a non-conformant stream; release the
+                // un-terminated remainder downstream rather than OOM.
+                // Delivery is preserved — only this frame's usage parse
+                // and model restamp are lost.
                 if buf.len() > MAX_SSE_FRAME_BUF_BYTES {
                     tracing::warn!(
                         buffered = buf.len(),
                         "anthropic stream: SSE frame buffer exceeded cap without a \
-                         terminator; dropping buffer (usage parsing skipped for the \
-                         oversized frame)"
+                         terminator; releasing it unparsed (usage parsing and model \
+                         restamp skipped for the oversized frame)"
                     );
-                    buf.clear();
+                    forward.append(&mut buf);
                 }
                 if let Some(max_hold) = hold_policy {
                     // Hold-back: withhold the bytes until the end-of-stream
                     // scan clears (and masks) them. Overflow fails closed —
                     // content that can't be fully buffered to scan must not
                     // be released (mirrors /v1/responses).
-                    if held.len() + bytes.len() > max_hold {
+                    if held.len() + forward.len() > max_hold {
                         tracing::warn!(
                             guardrail_hook = "output",
                             max_buffer_bytes = max_hold,
@@ -3613,23 +3647,44 @@ where
                         yield Ok(Bytes::from(guardrail_block_frame(None, Some(crate::error::TAG_OUTPUT_BUFFER_EXCEEDED))));
                         return;
                     }
-                    held.extend_from_slice(bytes);
+                    held.extend_from_slice(&forward);
                     continue;
                 }
+                // Nothing completed yet — keep reading rather than yielding
+                // an empty chunk.
+                if forward.is_empty() {
+                    continue;
+                }
+                if guard.usage().downstream_latency_ms == 0 {
+                    guard.usage().downstream_latency_ms =
+                        started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+                }
+                yield Ok(Bytes::from(forward));
+                continue;
             }
-            // Forward the original item verbatim (Ok bytes OR Err — an
-            // upstream error mid-stream is passed through; the
-            // accumulator keeps whatever was captured before it). In
+            // An upstream error mid-stream is passed through; the
+            // accumulator keeps whatever was captured before it. In
             // hold-back mode an Err lands here too: it is forwarded and
             // the held (unscanned) content is dropped — fail closed.
-            let errored = item.is_err();
-            if !errored && guard.usage().downstream_latency_ms == 0 {
-                guard.usage().downstream_latency_ms =
-                    started.elapsed().as_millis().min(u32::MAX as u128) as u32;
-            }
             yield item;
-            if errored && hold_policy.is_some() {
+            if hold_policy.is_some() {
                 return;
+            }
+        }
+        // A non-conformant upstream can end without terminating its last
+        // frame. Those bytes were never forwarded (they are still the
+        // partial tail), so release them now rather than truncating the
+        // response.
+        if !buf.is_empty() {
+            let tail = std::mem::take(&mut buf);
+            if hold_policy.is_some() {
+                held.extend_from_slice(&tail);
+            } else {
+                if guard.usage().downstream_latency_ms == 0 {
+                    guard.usage().downstream_latency_ms =
+                        started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+                }
+                yield Ok(Bytes::from(tail));
             }
         }
         // Upstream stream over — the response was forwarded in full. Record
@@ -5352,7 +5407,15 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
             b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"m1\",\"model\":\"claude-x\",\"usage\":{\"input_tokens\":11}}}\n\n\
 event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":2",
         );
-        drain_anthropic_sse_frames(&mut buf, &mut acc, started, &mut first_token_seen);
+        let mut out: Vec<u8> = Vec::new();
+        drain_anthropic_sse_frames(
+            &mut buf,
+            &mut acc,
+            started,
+            &mut first_token_seen,
+            "gw-alias",
+            &mut out,
+        );
         // Only the complete first frame is consumed.
         assert_eq!(acc.prompt_tokens, 11, "input_tokens parsed from frame 1");
         assert_eq!(acc.provider_request_id, "m1");
@@ -5360,15 +5423,40 @@ event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_toke
             acc.completion_tokens, 0,
             "partial frame 2 must NOT be parsed until its terminator arrives",
         );
+        // The completed frame is forwarded with the caller's model name
+        // restamped; the partial one is withheld, so no half-frame reaches
+        // the client and no upstream id leaks on the way past.
+        let emitted = String::from_utf8(std::mem::take(&mut out)).unwrap();
+        assert!(
+            emitted.contains("\"model\":\"gw-alias\"") && !emitted.contains("claude-x"),
+            "message_start forwards with the caller's name: {emitted}",
+        );
+        assert!(
+            emitted.ends_with("}}}\n\n") && !emitted.contains("message_delta"),
+            "the partial second frame is withheld: {emitted}",
+        );
 
         // Second "chunk": the remainder of the message_delta frame.
         buf.extend_from_slice(b"3}}\n\n");
-        drain_anthropic_sse_frames(&mut buf, &mut acc, started, &mut first_token_seen);
+        drain_anthropic_sse_frames(
+            &mut buf,
+            &mut acc,
+            started,
+            &mut first_token_seen,
+            "gw-alias",
+            &mut out,
+        );
         assert_eq!(
             acc.completion_tokens, 23,
             "output_tokens parsed once the split frame is reassembled",
         );
         assert!(buf.is_empty(), "buffer fully drained after both frames");
+        let emitted = String::from_utf8(out).unwrap();
+        assert!(
+            emitted.starts_with("event: message_delta\n")
+                && emitted.contains("\"output_tokens\":23"),
+            "the reassembled frame forwards whole and unaltered: {emitted}",
+        );
     }
 
     /// Issue #245 (audit angle 8c): a stream that carries NO usage
@@ -5391,7 +5479,20 @@ event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_toke
             b"event: ping\ndata: {\"type\":\"ping\"}\n\n\
 event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"overloaded\"}}\n\n",
         );
-        drain_anthropic_sse_frames(&mut buf, &mut acc, started, &mut first_token_seen);
+        let mut out: Vec<u8> = Vec::new();
+        let expected = buf.clone();
+        drain_anthropic_sse_frames(
+            &mut buf,
+            &mut acc,
+            started,
+            &mut first_token_seen,
+            "gw-alias",
+            &mut out,
+        );
+        assert_eq!(
+            out, expected,
+            "frames with no model reach the client byte-for-byte",
+        );
 
         assert_eq!(acc.prompt_tokens, 0, "no usage → prompt_tokens stays zero");
         assert_eq!(acc.completion_tokens, 0, "no usage → completion stays zero");

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3155,8 +3155,10 @@ pub(crate) const MAX_SSE_FRAME_BUF_BYTES: usize = 1 << 20; // 1 MiB
 /// corresponding frame.
 #[derive(Default)]
 struct AnthropicStreamUsage {
-    /// `true` once the upstream stream reached its end, i.e. the response
-    /// was forwarded in full. Stays `false` when the consumer went away
+    /// `true` once the UPSTREAM stream reached its end. Not the same as
+    /// "the response was forwarded in full": under a hold-back policy the
+    /// relay may have withheld an unterminated frame it could not scan.
+    /// Stays `false` when the consumer went away
     /// first — the generator is dropped at a suspension point and the tail
     /// never runs — which the telemetry closure reports as `499`.
     reached_end: bool,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3774,14 +3774,31 @@ where
                     )));
                     return;
                 }
-            } else if hold_policy.is_some() {
-                // Scanned like every other frame — hold it with them.
+            } else if let Some(max_hold) = hold_policy {
+                // Scanned like every other frame — hold it with them, but
+                // under the same size policy: this path reaches `held`
+                // outside the loop, so without this the last frame could
+                // carry the buffer past the cap the loop refuses at.
                 let tail = crate::model_echo::restamp_sse_frame(
                     &tail,
                     &model_label,
                     crate::model_echo::anthropic_message_model,
                 )
                 .unwrap_or(tail);
+                if held.len() + tail.len() > max_hold {
+                    tracing::warn!(
+                        guardrail_hook = "output",
+                        max_buffer_bytes = max_hold,
+                        "streaming /v1/messages passthrough exceeded hold-back cap on its \
+                         final frame; failing closed",
+                    );
+                    guard.usage().guardrail_blocked = true;
+                    yield Ok(Bytes::from(guardrail_block_frame(
+                        None,
+                        Some(crate::error::TAG_OUTPUT_BUFFER_EXCEEDED),
+                    )));
+                    return;
+                }
                 held.extend_from_slice(&tail);
             } else {
                 // Restamp on the way out, for the same reason the `/v1/responses`

--- a/crates/aisix-proxy/src/model_echo.rs
+++ b/crates/aisix-proxy/src/model_echo.rs
@@ -10,8 +10,15 @@
 //! The bridged dispatch paths satisfy that by construction: they build the
 //! client-facing body themselves and stamp the caller's name into it. The
 //! NATIVE passthrough paths do not — they forward the upstream's own document,
-//! which carries the upstream's own id. This module is the one place that
-//! difference is repaired, so the family cannot drift again.
+//! which carries the upstream's own id. This module is where that difference
+//! is repaired, so the paths that use it cannot drift apart again.
+//!
+//! It is NOT yet the whole family. `/v1/rerank` (a Jina response carries a
+//! top-level `model`) and `/v1/realtime` (`session.created` / `session.updated`
+//! carry `session.model`) still hand the upstream id back — tracked as #1087
+//! and #1088. `/v1/fine_tuning/jobs` is deliberately outside it: its request
+//! half forwards the caller's `model` to the provider verbatim, so naming the
+//! upstream base model on both halves is the symmetric answer there (#1089).
 //!
 //! Two shapes, because a native path answers in two:
 //!
@@ -101,9 +108,18 @@ pub(crate) fn restamp_sse_buffer(
         }
         rest = tail;
     }
-    // A trailing fragment with no terminator is forwarded as-is: it carries
-    // no frame to splice.
-    out.extend_from_slice(rest);
+    // The document is COMPLETE, so a trailing fragment is not a frame still
+    // arriving — it is a final frame the upstream never terminated, and it is
+    // the one carrying `response.completed` when a provider omits the last
+    // blank line. Splice it too. (The streaming relays are the opposite case
+    // and must keep holding their tail: more bytes may still come.) The other
+    // readers of this same buffer parse it line-by-line, so they already see
+    // this frame; skipping it here would make the echo the only thing that
+    // misses it.
+    match restamp_sse_frame(rest, client_facing_model, selects_model) {
+        Some(rewritten) => out.extend_from_slice(&rewritten),
+        None => out.extend_from_slice(rest),
+    }
     out
 }
 
@@ -204,7 +220,7 @@ mod tests {
             &b""[..],
             &b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n"[..],
             &b"event: ping\ndata: {}\n\ndata: [DONE]\n\n"[..],
-            // No terminator at all — the whole buffer is a fragment.
+            // No terminator at all, and nothing to match inside it.
             &b"data: {\"type\":\"response.created\""[..],
             // A complete frame followed by an unterminated remainder.
             &b"data: {\"a\":1}\n\ndata: {\"b\":2"[..],
@@ -218,6 +234,29 @@ mod tests {
                 String::from_utf8_lossy(buf),
             );
         }
+    }
+
+    /// A provider that omits the final blank line still gets its last frame
+    /// restamped. That frame is `response.completed` — the one an SDK builds
+    /// its final Response object from — so skipping it would leak the
+    /// upstream id on exactly the event that matters most, and only when a
+    /// buffering guardrail is attached.
+    #[test]
+    fn restamp_sse_buffer_splices_a_final_frame_that_was_never_terminated() {
+        let buf = concat!(
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"model\":\"up-1\"}}\n\n",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"model\":\"up-1\"}}",
+        )
+        .as_bytes();
+        let out =
+            String::from_utf8(restamp_sse_buffer(buf, "alias", responses_snapshot_model)).unwrap();
+        assert_eq!(out.matches("\"model\":\"alias\"").count(), 2);
+        assert!(
+            !out.contains("up-1"),
+            "the unterminated final frame too: {out}"
+        );
+        // Still no terminator invented for it.
+        assert!(out.ends_with("}}"));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/model_echo.rs
+++ b/crates/aisix-proxy/src/model_echo.rs
@@ -1,0 +1,164 @@
+//! Restamp the client-facing `model` field onto a native passthrough response.
+//!
+//! The wire contract is stated once, in [`crate::render`]: `response.model`
+//! carries the model name the CALLER addressed — the alias they put on the
+//! request — never the upstream provider's own id. That is what makes an
+//! alias an alias: the caller names one thing, and every answer they get back
+//! names the same thing, whichever provider or routing target actually served
+//! it.
+//!
+//! The bridged dispatch paths satisfy that by construction: they build the
+//! client-facing body themselves and stamp the caller's name into it. The
+//! NATIVE passthrough paths do not — they forward the upstream's own document,
+//! which carries the upstream's own id. This module is the one place that
+//! difference is repaired, so the family cannot drift again.
+//!
+//! Two shapes, because a native path answers in two:
+//!
+//! - [`restamp_body`] for a parsed JSON response.
+//! - [`restamp_sse_frame`] for one frame of a streamed response. It splices
+//!   the value through [`crate::json_splice`] rather than re-serialising the
+//!   frame, so every byte the gateway is not deliberately changing — key
+//!   order, whitespace, number spellings, escape choices — reaches the client
+//!   exactly as the provider wrote it.
+//!
+//! Both are deliberately no-ops when the document carries no `model` at the
+//! selected path. A response that never had the field does not acquire one.
+
+use serde_json::Value;
+
+use crate::json_splice::{self, PathSeg};
+
+/// Restamp the top-level `model` of a parsed response body.
+///
+/// Unconditional: whatever the upstream reported is replaced. It must NOT be
+/// conditioned on the upstream having echoed the configured `model_name` —
+/// that guard is what let the alias leak whenever a provider answered with a
+/// different id than the one it was asked for, which is the common case
+/// (a dated snapshot id, or a name the provider remaps server-side).
+pub(crate) fn restamp_body(body: &mut Value, client_facing_model: &str) {
+    if let Some(m) = body.get_mut("model") {
+        *m = Value::String(client_facing_model.to_string());
+    }
+}
+
+/// Restamp the `model` value inside one SSE frame's `data:` payload.
+///
+/// Returns the rewritten frame, or `None` when the frame carries no value at
+/// the selected path (the common case — most frames in a stream have no
+/// `model` at all) or when its payload is not splice-able JSON. A `None`
+/// caller forwards the original bytes.
+pub(crate) fn restamp_sse_frame(
+    frame: &[u8],
+    client_facing_model: &str,
+    selects_model: fn(&[PathSeg]) -> bool,
+) -> Option<Vec<u8>> {
+    let range = crate::messages::extract_sse_data_range(frame)?;
+    let payload = &frame[range.clone()];
+    // The terminal `[DONE]` sentinel is not JSON.
+    if payload == b"[DONE]" {
+        return None;
+    }
+    let spliced = match json_splice::rewrite_string_values(payload, selects_model, |_| {
+        Some(client_facing_model.to_string())
+    }) {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => return None,
+        Err(error) => {
+            // The scanner fails whole rather than half-rewriting. A frame it
+            // cannot read forwards verbatim: leaking the upstream id on one
+            // frame is a smaller harm than corrupting the stream.
+            tracing::debug!(%error, "sse frame model restamp skipped; forwarding verbatim");
+            return None;
+        }
+    };
+    let mut out = Vec::with_capacity(frame.len() - payload.len() + spliced.len());
+    out.extend_from_slice(&frame[..range.start]);
+    out.extend_from_slice(&spliced);
+    out.extend_from_slice(&frame[range.end..]);
+    Some(out)
+}
+
+/// `message.model` on an Anthropic `message_start` frame.
+///
+/// The path alone identifies the frame: `message_start` is the only Anthropic
+/// event whose payload nests a `message` object, so no type check is needed.
+pub(crate) fn anthropic_message_model(path: &[PathSeg]) -> bool {
+    path.len() == 2 && path[0].is_key("message") && path[1].is_key("model")
+}
+
+/// `response.model` on a Responses-API snapshot frame.
+///
+/// Exact-depth, so it selects the six events that carry a whole `response`
+/// object — `response.created` / `.in_progress` / `.completed` /
+/// `.incomplete` / `.failed` / `.queued` — and nothing nested deeper inside
+/// one (an output item, a tool definition).
+pub(crate) fn responses_snapshot_model(path: &[PathSeg]) -> bool {
+    path.len() == 2 && path[0].is_key("response") && path[1].is_key("model")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restamp_body_replaces_whatever_the_upstream_reported() {
+        // The upstream answered with a dated snapshot id, not the name it was
+        // asked for. The caller still addressed `ds-native`.
+        let mut body = serde_json::json!({"id": "msg_1", "model": "deepseek-v4-flash"});
+        restamp_body(&mut body, "ds-native");
+        assert_eq!(body["model"], "ds-native");
+    }
+
+    #[test]
+    fn restamp_body_does_not_invent_the_field() {
+        let mut body = serde_json::json!({"input_tokens": 7});
+        restamp_body(&mut body, "ds-native");
+        assert!(body.get("model").is_none());
+    }
+
+    #[test]
+    fn restamp_sse_frame_rewrites_message_start_and_leaves_the_rest_byte_identical() {
+        let frame = b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-x-20250101\",\"usage\":{\"input_tokens\":1e2}}}\n\n";
+        let out = restamp_sse_frame(frame, "my-claude", anthropic_message_model)
+            .expect("message_start carries message.model");
+        let out = String::from_utf8(out).unwrap();
+        assert!(out.contains("\"model\":\"my-claude\""));
+        // Everything outside the spliced value survives as written — the
+        // event line, the key order, and the number spelling a
+        // `serde_json` round-trip would have canonicalised to `100.0`.
+        assert!(out.starts_with("event: message_start\ndata: {\"type\":\"message_start\""));
+        assert!(out.contains("\"input_tokens\":1e2"));
+        assert!(out.ends_with("}}}\n\n"));
+    }
+
+    #[test]
+    fn restamp_sse_frame_skips_frames_without_the_path() {
+        // `message_delta` has no `message` object; `content_block_delta` has
+        // no model anywhere. Both forward verbatim.
+        for frame in [
+            &b"event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":9}}\n\n"[..],
+            &b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"hi\"}}\n\n"[..],
+            &b"data: [DONE]\n\n"[..],
+        ] {
+            assert!(restamp_sse_frame(frame, "my-claude", anthropic_message_model).is_none());
+        }
+    }
+
+    #[test]
+    fn responses_predicate_selects_the_snapshot_frames_only() {
+        let snapshot = b"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-4o-mini-2024-07-18\"}}\n\n";
+        let out = restamp_sse_frame(snapshot, "gpt4o-mini", responses_snapshot_model)
+            .expect("response.completed carries response.model");
+        assert!(String::from_utf8(out)
+            .unwrap()
+            .contains("\"model\":\"gpt4o-mini\""));
+
+        // A model named deeper inside the response object is NOT the
+        // caller-facing field and must not be touched.
+        let nested = b"data: {\"type\":\"response.output_item.done\",\"item\":{\"model\":\"whisper-1\"}}\n\n";
+        assert!(restamp_sse_frame(nested, "gpt4o-mini", responses_snapshot_model).is_none());
+        let deep = b"data: {\"type\":\"response.completed\",\"response\":{\"tools\":[{\"model\":\"aux\"}]}}\n\n";
+        assert!(restamp_sse_frame(deep, "gpt4o-mini", responses_snapshot_model).is_none());
+    }
+}

--- a/crates/aisix-proxy/src/model_echo.rs
+++ b/crates/aisix-proxy/src/model_echo.rs
@@ -79,6 +79,34 @@ pub(crate) fn restamp_sse_frame(
     Some(out)
 }
 
+/// Restamp every frame of a COMPLETE, already-buffered SSE document.
+///
+/// The streaming relays splice frame-by-frame as they drain, but a
+/// block-capable output guardrail buffers the whole response and returns it
+/// as one body without ever reaching the relay — so that branch needs the
+/// same pass applied in one go, or the identical request answers with the
+/// upstream id whenever such a guardrail is attached.
+pub(crate) fn restamp_sse_buffer(
+    buf: &[u8],
+    client_facing_model: &str,
+    selects_model: fn(&[PathSeg]) -> bool,
+) -> Vec<u8> {
+    let mut out = Vec::with_capacity(buf.len());
+    let mut rest = buf;
+    while let Some(end) = crate::messages::find_frame_end(rest) {
+        let (frame, tail) = rest.split_at(end);
+        match restamp_sse_frame(frame, client_facing_model, selects_model) {
+            Some(rewritten) => out.extend_from_slice(&rewritten),
+            None => out.extend_from_slice(frame),
+        }
+        rest = tail;
+    }
+    // A trailing fragment with no terminator is forwarded as-is: it carries
+    // no frame to splice.
+    out.extend_from_slice(rest);
+    out
+}
+
 /// `message.model` on an Anthropic `message_start` frame.
 ///
 /// The path alone identifies the frame: `message_start` is the only Anthropic
@@ -143,6 +171,26 @@ mod tests {
         ] {
             assert!(restamp_sse_frame(frame, "my-claude", anthropic_message_model).is_none());
         }
+    }
+
+    #[test]
+    fn restamp_sse_buffer_rewrites_every_snapshot_frame_and_preserves_the_rest() {
+        let buf = concat!(
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"model\":\"up-1\"}}\n\n",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"model\":\"up-1\",\"usage\":{\"input_tokens\":1}}}\n\n",
+            "data: [DONE]\n\n",
+        )
+        .as_bytes();
+        let out =
+            String::from_utf8(restamp_sse_buffer(buf, "alias", responses_snapshot_model)).unwrap();
+        assert_eq!(out.matches("\"model\":\"alias\"").count(), 2);
+        assert!(!out.contains("up-1"));
+        // Untouched frames survive byte-for-byte, terminator included.
+        assert!(
+            out.contains("data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n")
+        );
+        assert!(out.ends_with("data: [DONE]\n\n"));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/model_echo.rs
+++ b/crates/aisix-proxy/src/model_echo.rs
@@ -193,6 +193,33 @@ mod tests {
         assert!(out.ends_with("data: [DONE]\n\n"));
     }
 
+    /// The no-match path must be an identity function on bytes: this runs
+    /// over a whole buffered response, so anything it perturbs reaches the
+    /// client. Includes shapes the frame walk could mishandle — an empty
+    /// buffer, a lone unterminated fragment, and a final frame whose
+    /// terminator is missing.
+    #[test]
+    fn restamp_sse_buffer_is_byte_identity_when_nothing_matches() {
+        for buf in [
+            &b""[..],
+            &b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n"[..],
+            &b"event: ping\ndata: {}\n\ndata: [DONE]\n\n"[..],
+            // No terminator at all — the whole buffer is a fragment.
+            &b"data: {\"type\":\"response.created\""[..],
+            // A complete frame followed by an unterminated remainder.
+            &b"data: {\"a\":1}\n\ndata: {\"b\":2"[..],
+            // CRLF framing.
+            &b"event: x\r\ndata: {\"a\":1}\r\n\r\n"[..],
+        ] {
+            assert_eq!(
+                restamp_sse_buffer(buf, "alias", responses_snapshot_model),
+                buf.to_vec(),
+                "no match must not perturb a byte: {:?}",
+                String::from_utf8_lossy(buf),
+            );
+        }
+    }
+
     #[test]
     fn responses_predicate_selects_the_snapshot_frames_only() {
         let snapshot = b"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-4o-mini-2024-07-18\"}}\n\n";

--- a/crates/aisix-proxy/src/model_resolve.rs
+++ b/crates/aisix-proxy/src/model_resolve.rs
@@ -76,6 +76,17 @@ fn best_wildcard_row(
     best.map(|(_, entry, upstream)| (entry, upstream))
 }
 
+/// Whether `model` is a row that would actually serve the caller-facing
+/// name `requested` — an exact `display_name`, or a wildcard glob covering
+/// it. Used where a name arrives from somewhere other than a live request
+/// body (a client-supplied video id) and must not be echoed back as though
+/// the gateway had attested it.
+pub(crate) fn row_serves_name(model: &Model, requested: &str) -> bool {
+    model.display_name == requested
+        || (model.display_name.contains('*')
+            && wildcard_capture(&model.display_name, requested).is_some())
+}
+
 /// The `display_name` of the wildcard row that would serve `requested`,
 /// for metric-label bounding: successful wildcard traffic must label as
 /// the configured row (`openai/*`), never as the caller-minted concrete
@@ -130,6 +141,29 @@ mod tests {
             "provider_key_id": "pk-1",
         }))
         .unwrap()
+    }
+
+    /// `row_serves_name` gates a name that did NOT arrive on a live request
+    /// body — it decides whether the gateway will echo a caller-supplied
+    /// string back as its own `model`. A row must accept every name it
+    /// really serves and refuse everything else.
+    #[test]
+    fn row_serves_name_accepts_only_names_the_row_would_serve() {
+        let exact = direct_model("wan-turbo", Some("wan-upstream"));
+        assert!(row_serves_name(&exact, "wan-turbo"));
+        assert!(!row_serves_name(&exact, "wan-turbo-forged"));
+        assert!(!row_serves_name(&exact, "anything-at-all"));
+
+        let wildcard = direct_model("wan/*", Some("wan-*"));
+        // Every name the glob covers — the whole reason the poll echoes the
+        // caller's string rather than the row's own.
+        assert!(row_serves_name(&wildcard, "wan/turbo"));
+        assert!(row_serves_name(&wildcard, "wan/plus"));
+        // The row's own pattern is not a name a caller addressed.
+        assert!(!row_serves_name(&wildcard, "wan"));
+        // Outside the glob: a forged id must not get its string echoed.
+        assert!(!row_serves_name(&wildcard, "other/turbo"));
+        assert!(!row_serves_name(&wildcard, "anything-at-all"));
     }
 
     fn snapshot_with(models: Vec<(&str, Model)>) -> AisixSnapshot {

--- a/crates/aisix-proxy/src/model_resolve.rs
+++ b/crates/aisix-proxy/src/model_resolve.rs
@@ -90,6 +90,11 @@ pub(crate) fn row_serves_name(model: &Model, requested: &str) -> bool {
     if model.is_routing() || model.is_ensemble() || model.is_semantic() {
         return false;
     }
+    // Exact equality FIRST, and for wildcard rows too. `resolve_model` starts
+    // with `get_by_name(requested)`, so a caller can address `wan/*`
+    // literally and be served by that row — which makes the pattern a name
+    // the row serves, however odd it looks. Narrowing this to the glob would
+    // make the two functions disagree about the same request.
     model.display_name == requested
         || (model.display_name.contains('*')
             && wildcard_capture(&model.display_name, requested).is_some())
@@ -167,7 +172,12 @@ mod tests {
         // caller's string rather than the row's own.
         assert!(row_serves_name(&wildcard, "wan/turbo"));
         assert!(row_serves_name(&wildcard, "wan/plus"));
-        // The row's own pattern is not a name a caller addressed.
+        // The pattern itself IS accepted, and deliberately so: `resolve_model`
+        // resolves `wan/*` by exact name lookup before it ever tries globbing,
+        // so that string is a name this row really serves. Narrowing it here
+        // would make the echo refuse a name the dispatcher accepts.
+        assert!(row_serves_name(&wildcard, "wan/*"));
+        // A bare prefix is not covered by the glob.
         assert!(!row_serves_name(&wildcard, "wan"));
         // Outside the glob: a forged id must not get its string echoed.
         assert!(!row_serves_name(&wildcard, "other/turbo"));

--- a/crates/aisix-proxy/src/model_resolve.rs
+++ b/crates/aisix-proxy/src/model_resolve.rs
@@ -82,6 +82,14 @@ fn best_wildcard_row(
 /// body (a client-supplied video id) and must not be echoed back as though
 /// the gateway had attested it.
 pub(crate) fn row_serves_name(model: &Model, requested: &str) -> bool {
+    // The same kind gate `best_wildcard_row` applies: only a direct row can
+    // serve a caller-minted alias. Unreachable today on the one surface that
+    // calls this — `dispatch::require_provider` rejects those kinds first —
+    // but this sits beside the function it mirrors, and it judges an entry
+    // the CLIENT named, so the two answer alike rather than by coincidence.
+    if model.is_routing() || model.is_ensemble() || model.is_semantic() {
+        return false;
+    }
     model.display_name == requested
         || (model.display_name.contains('*')
             && wildcard_capture(&model.display_name, requested).is_some())

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -7,7 +7,9 @@
 //! 1. Authenticate and authorise the API key + model.
 //! 2. Validate the model is an OpenAI provider.
 //! 3. Rewrite the `model` field to the upstream model name.
-//! 4. Forward verbatim — streaming SSE and non-streaming JSON both work.
+//! 4. Relay the reply — streaming SSE and non-streaming JSON both work.
+//!    The body is the upstream's own, byte for byte, except the
+//!    caller-facing `model` name (see [`crate::model_echo`]).
 //!
 //! Only OpenAI models support this endpoint. Non-OpenAI models receive a
 //! 400 with an explanatory message.
@@ -1410,6 +1412,17 @@ async fn responses_to_target(
                 }
                 None => buf,
             };
+            // A block-capable output guardrail buffers the whole response and
+            // returns it here, never reaching the live relay that splices
+            // frame-by-frame — so the same pass runs once over the buffer.
+            // Without it, attaching such a guardrail would silently change
+            // which model name the caller is told (after masking, so a mask
+            // cannot reintroduce the upstream id).
+            let buf = crate::model_echo::restamp_sse_buffer(
+                &buf,
+                requested_model,
+                crate::model_echo::responses_snapshot_model,
+            );
             // #808: the whole SSE response is buffered here, so parse its
             // terminal event for usage and let the handler emit (the body is
             // a single complete chunk now, not a live stream).
@@ -2723,7 +2736,8 @@ impl<F: FnOnce(ResponseUsage, String, Vec<aisix_core::GuardrailMonitorHit>)> Dro
 /// client-disconnect) with the accumulated counts (#808) plus the captured
 /// output text (AISIX-Cloud#947, empty when `content_cap` is `None`) and the
 /// end-of-stream scan's monitor hits (AISIX-Cloud#1010, empty without
-/// `eos_scan`). Bytes forward verbatim — the client sees the exact upstream
+/// `eos_scan`). Bytes forward unchanged apart from the caller-facing
+/// `model` on the snapshot frames — the client sees the exact upstream
 /// SSE wire shape.
 fn build_responses_passthrough_stream<S, F>(
     upstream: S,

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -2818,6 +2818,15 @@ where
                 // un-terminated remainder downstream rather than OOM. Delivery is
                 // preserved — only this frame's usage parse and model restamp
                 // are lost.
+                //
+                // The restamp cannot be recovered here, and not for want of
+                // trying: at the cap the frame is genuinely still arriving, so
+                // its JSON is incomplete, so `json_splice` refuses it and falls
+                // back to verbatim by design. Reaching this needs a single SSE
+                // frame over 1 MiB — on this surface `response.completed`
+                // carries the whole Response object, so a caller with a very
+                // large `tools[]` can get there. Named in the PR description as
+                // a known limit rather than papered over.
                 if buf.len() > crate::messages::MAX_SSE_FRAME_BUF_BYTES {
                     tracing::warn!(
                         buffered = buf.len(),
@@ -2856,13 +2865,32 @@ where
         // object from. Same reasoning as `model_echo::restamp_sse_buffer`,
         // and this path reaches it without any guardrail attached.
         if !buf.is_empty() {
-            let tail = std::mem::take(&mut buf);
-            let tail = crate::model_echo::restamp_sse_frame(
-                &tail,
+            // Parse it before releasing it. On this surface the unterminated
+            // final frame is `response.completed`, which carries the
+            // authoritative token counts and `response.id`: forwarding it to
+            // the caller while never reading it handed them real usage in the
+            // body and recorded estimated counts, with no provider request id,
+            // in the UsageEvent. Appending the terminator the upstream omitted
+            // lets the normal drain read it; the drain consumes `buf`, and
+            // what it hands back is the restamped frame plus that terminator,
+            // so the client gets its own bytes back.
+            buf.extend_from_slice(b"\n\n");
+            let mut drained: Vec<u8> = Vec::new();
+            let (usage_acc, capture) = guard.parts();
+            drain_responses_sse_frames(
+                &mut buf,
+                usage_acc,
+                capture,
+                attempt_started,
+                &mut first_frame_seen,
                 &client_facing_model,
-                crate::model_echo::responses_snapshot_model,
-            )
-            .unwrap_or(tail);
+                &mut drained,
+            );
+            let tail = match drained.len().checked_sub(2) {
+                // Drop only the terminator this branch appended.
+                Some(n) if drained.ends_with(b"\n\n") => drained[..n].to_vec(),
+                _ => drained,
+            };
             let (usage_acc, _) = guard.parts();
             let acc = usage_acc.get_or_insert_with(Default::default);
             if acc.downstream_latency_ms == 0 {
@@ -3687,6 +3715,71 @@ mod tests {
                 assert_eq!(event.requested_model, model);
             }
         }
+    }
+
+    /// A provider that omits the blank line after its terminal
+    /// `response.completed` used to cost the gateway that whole frame: it was
+    /// forwarded to the caller but never parsed, so the body carried the real
+    /// token counts while the UsageEvent carried estimates and no provider
+    /// request id. At EOF the frame is complete, so it is parsed like any
+    /// other — the caller's alias is stamped on it AND its usage is recorded.
+    #[tokio::test]
+    async fn streamed_unterminated_terminal_frame_is_still_parsed_for_usage() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        // Note the absent trailing blank line on the last frame.
+        let sse = "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_eof\",\"model\":\"gpt-4o-2024-11-20\"}}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_eof\",\"model\":\"gpt-4o-2024-11-20\",\"usage\":{\"input_tokens\":31,\"output_tokens\":17,\"total_tokens\":48}}}";
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let state = crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+
+        let resp = crate::build_router(state)
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": "hi",
+                "stream": true,
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let streamed =
+            String::from_utf8(to_bytes(resp.into_body(), 1 << 20).await.unwrap().to_vec()).unwrap();
+
+        // Delivered, restamped, and NOT given a terminator it never had.
+        assert!(streamed.contains(r#""model":"gpt-4o-resp""#), "{streamed}");
+        assert!(!streamed.contains("gpt-4o-2024-11-20"), "{streamed}");
+        assert!(
+            streamed.ends_with("}}}"),
+            "no invented terminator: {streamed}"
+        );
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(1000), rx.recv())
+            .await
+            .expect("usage event must be emitted")
+            .expect("usage_sink sender dropped");
+        // The authoritative counts off that frame, not a local estimate.
+        assert_eq!(event.prompt_tokens, 31, "{streamed}");
+        assert_eq!(event.completion_tokens, 17, "{streamed}");
+        assert!(!event.usage_estimated, "the frame was read, not guessed");
+        assert_eq!(event.provider_request_id, "resp_eof");
     }
 
     /// #719: the Responses `input` array form (message items with typed

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1536,8 +1536,9 @@ async fn responses_to_target(
         // #808: wrap the verbatim byte stream so the terminal
         // `response.completed` SSE event's `usage` block is parsed in-flight
         // and a UsageEvent is emitted from the stream's Drop guard at
-        // end-of-stream (or client-disconnect). Bytes forward unchanged — the
-        // client still sees the exact upstream SSE wire shape. Pre-#808 this
+        // end-of-stream (or client-disconnect). Bytes forward unchanged apart
+        // from the caller-facing `model` on the snapshot frames — see
+        // [`crate::model_echo`]. Pre-#808 this
         // path dropped the event entirely, so every streaming /v1/responses
         // call (e.g. all Codex traffic, which always streams) was invisible
         // to the dashboard Logs and the budget ledger.

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -2848,14 +2848,28 @@ where
         // A non-conformant upstream can end without terminating its last
         // frame. Those bytes were never forwarded (they are still the partial
         // tail), so release them now rather than truncating the response.
+        //
+        // Restamp it on the way out. Mid-stream a fragment is a frame still
+        // arriving and must be held, but the upstream has now ended: this is
+        // a final frame it never terminated, and on this surface that is
+        // `response.completed` — the event an SDK builds its final Response
+        // object from. Same reasoning as `model_echo::restamp_sse_buffer`,
+        // and this path reaches it without any guardrail attached.
         if !buf.is_empty() {
+            let tail = std::mem::take(&mut buf);
+            let tail = crate::model_echo::restamp_sse_frame(
+                &tail,
+                &client_facing_model,
+                crate::model_echo::responses_snapshot_model,
+            )
+            .unwrap_or(tail);
             let (usage_acc, _) = guard.parts();
             let acc = usage_acc.get_or_insert_with(Default::default);
             if acc.downstream_latency_ms == 0 {
                 acc.downstream_latency_ms =
                     started.elapsed().as_millis().min(u32::MAX as u128) as u32;
             }
-            yield Ok(bytes::Bytes::from(std::mem::take(&mut buf)));
+            yield Ok(bytes::Bytes::from(tail));
         }
         // Upstream EOF — the response was delivered in full. Record that
         // before the scan below, which awaits a remote provider and is a

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -2870,11 +2870,17 @@ where
             // authoritative token counts and `response.id`: forwarding it to
             // the caller while never reading it handed them real usage in the
             // body and recorded estimated counts, with no provider request id,
-            // in the UsageEvent. Appending the terminator the upstream omitted
-            // lets the normal drain read it; the drain consumes `buf`, and
-            // what it hands back is the restamped frame plus that terminator,
-            // so the client gets its own bytes back.
-            buf.extend_from_slice(b"\n\n");
+            // in the UsageEvent. Completing the terminator the upstream left
+            // off lets the normal drain read it; the drain consumes `buf`, and
+            // stripping back exactly what was added hands the client its own
+            // bytes.
+            //
+            // Pad by what is MISSING, not a fixed `\n\n`: a tail already
+            // ending in one `\n` needs one more, and padding two would make
+            // `find_frame_end` end the frame one byte early, so the strip
+            // below would eat the newline the upstream actually sent.
+            let pad: &[u8] = if buf.ends_with(b"\n") { b"\n" } else { b"\n\n" };
+            buf.extend_from_slice(pad);
             let mut drained: Vec<u8> = Vec::new();
             let (usage_acc, capture) = guard.parts();
             drain_responses_sse_frames(
@@ -2886,9 +2892,9 @@ where
                 &client_facing_model,
                 &mut drained,
             );
-            let tail = match drained.len().checked_sub(2) {
-                // Drop only the terminator this branch appended.
-                Some(n) if drained.ends_with(b"\n\n") => drained[..n].to_vec(),
+            let tail = match drained.len().checked_sub(pad.len()) {
+                // Drop only the bytes this branch appended.
+                Some(n) if drained.ends_with(pad) => drained[..n].to_vec(),
                 _ => drained,
             };
             let (usage_acc, _) = guard.parts();
@@ -3780,6 +3786,59 @@ mod tests {
         assert_eq!(event.completion_tokens, 17, "{streamed}");
         assert!(!event.usage_estimated, "the frame was read, not guessed");
         assert_eq!(event.provider_request_id, "resp_eof");
+    }
+
+    /// The same tail, but ending in ONE newline — a provider that wrote half
+    /// its terminator. The EOF branch completes the terminator so the drain
+    /// can read the frame, then strips back exactly what it added; padding a
+    /// fixed `\n\n` here would end the frame a byte early and eat the newline
+    /// the upstream really sent.
+    #[tokio::test]
+    async fn streamed_terminal_frame_with_a_half_terminator_keeps_its_own_bytes() {
+        let upstream = MockServer::start().await;
+        let sse = "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_half\",\"model\":\"gpt-4o-2024-11-20\"}}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_half\",\"model\":\"gpt-4o-2024-11-20\",\"usage\":{\"input_tokens\":5,\"output_tokens\":3,\"total_tokens\":8}}}\n";
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_openai(&upstream.uri());
+        snap.models.insert(openai_model("gpt-4o-resp"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(OpenAiBridge::new()));
+        let state = crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg()).without_cache();
+
+        let resp = crate::build_router(state)
+            .oneshot(make_req(serde_json::json!({
+                "model": "gpt-4o-resp",
+                "input": "hi",
+                "stream": true,
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let streamed =
+            String::from_utf8(to_bytes(resp.into_body(), 1 << 20).await.unwrap().to_vec()).unwrap();
+
+        assert!(
+            streamed.contains(r#""model":"gpt-4o-resp""#),
+            "{streamed:?}"
+        );
+        // The upstream's own single trailing newline survives — not stripped,
+        // and not promoted to a full terminator it never sent.
+        assert!(
+            streamed.ends_with("}}}\n"),
+            "the provider's own trailing newline must survive: {:?}",
+            &streamed[streamed.len().saturating_sub(40)..]
+        );
+        assert!(!streamed.ends_with("}}}\n\n"), "no terminator invented");
     }
 
     /// #719: the Responses `input` array form (message items with typed

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1581,6 +1581,7 @@ async fn responses_to_target(
             attempt_started,
             content_cap,
             eos_scan,
+            requested_model.to_string(),
             move |mut usage, out_text, output_hits| {
                 // Streams that reach here are committed 200s — the
                 // `!status.is_success()` guard above returned early on errors.
@@ -1830,6 +1831,12 @@ async fn responses_to_target(
                 });
             }
         }
+
+        // Echo the model name the caller addressed, not the id the upstream
+        // answered with — the same contract the bridged half of this endpoint
+        // already honours, so `/v1/responses` stops answering differently
+        // depending on which provider happens to be behind the alias.
+        crate::model_echo::restamp_body(&mut json_body, requested_model);
 
         // #932: mask-action PII rules rewrite the response body AFTER the
         // block check passes.
@@ -2513,16 +2520,36 @@ fn responses_sse_provider_request_id(bytes: &[u8]) -> String {
 /// content capture (AISIX-Cloud#947). A frame ends at the first blank line;
 /// an incomplete trailing frame is left in `buf` for the next chunk. Reuses
 /// the shared SSE framing helpers from the `/v1/messages` passthrough so the
-/// two surfaces parse identically.
+/// two surfaces parse identically. Each frame is also appended to `out` with
+/// the client-facing `model` restamped onto the snapshot frames that carry
+/// one.
+///
+/// `out` is what the client receives, so the relay forwards whole frames
+/// rather than raw chunks — a value can only be spliced once the frame
+/// carrying it has arrived in full, and the Responses snapshot events are
+/// spread across the whole stream (`response.created` first,
+/// `response.completed` last). A frame is the SSE protocol's atomic unit, so
+/// holding a partial one back is not observable to a conforming client;
+/// `buf` retains only that partial tail.
 fn drain_responses_sse_frames(
     buf: &mut Vec<u8>,
     acc: &mut Option<ResponseUsage>,
     mut capture: Option<&mut SseTextCapture>,
     attempt_started: Instant,
     first_frame_seen: &mut bool,
+    client_facing_model: &str,
+    out: &mut Vec<u8>,
 ) {
     while let Some(end) = crate::messages::find_frame_end(buf) {
         let frame: Vec<u8> = buf.drain(..end).collect();
+        match crate::model_echo::restamp_sse_frame(
+            &frame,
+            client_facing_model,
+            crate::model_echo::responses_snapshot_model,
+        ) {
+            Some(rewritten) => out.extend_from_slice(&rewritten),
+            None => out.extend_from_slice(&frame),
+        }
         if let Some(data) = crate::messages::extract_sse_data_line(&frame) {
             if data == b"[DONE]" {
                 continue;
@@ -2706,6 +2733,9 @@ fn build_responses_passthrough_stream<S, F>(
     attempt_started: Instant,
     content_cap: Option<u32>,
     eos_scan: Option<EosOutputScan>,
+    // The model name the caller addressed, restamped onto the snapshot
+    // frames so a streamed response echoes the alias like a buffered one.
+    client_facing_model: String,
     on_complete: F,
 ) -> impl futures::Stream<Item = reqwest::Result<bytes::Bytes>>
 where
@@ -2750,9 +2780,12 @@ where
         let mut first_frame_seen = false;
         while let Some(item) = upstream.next().await {
             if let Ok(bytes) = &item {
-                // Side-channel parse: copy into the frame buffer (the original
-                // `bytes` is yielded unchanged below) and drain complete frames.
+                // Accumulate, then drain every COMPLETE frame — restamped with
+                // the caller's model name — into `forward`. The client receives
+                // whole frames, never a partial one; `buf` keeps the trailing
+                // remainder until its terminator arrives.
                 buf.extend_from_slice(bytes);
+                let mut forward: Vec<u8> = Vec::new();
                 let (usage_acc, capture) = guard.parts();
                 drain_responses_sse_frames(
                     &mut buf,
@@ -2760,33 +2793,54 @@ where
                     capture,
                     attempt_started,
                     &mut first_frame_seen,
+                    &client_facing_model,
+                    &mut forward,
                 );
                 // Bound the frame buffer: the happy path drains complete frames
                 // above so `buf` only holds a partial trailing frame. A
                 // non-conformant upstream streaming bytes without a blank-line
-                // terminator would otherwise grow `buf` unboundedly; drop it
-                // (losing usage parsing for that pathological case) rather than
-                // OOM. Bytes still forward verbatim — only telemetry is affected.
+                // terminator would otherwise grow `buf` unboundedly; release the
+                // un-terminated remainder downstream rather than OOM. Delivery is
+                // preserved — only this frame's usage parse and model restamp
+                // are lost.
                 if buf.len() > crate::messages::MAX_SSE_FRAME_BUF_BYTES {
                     tracing::warn!(
                         buffered = buf.len(),
                         "responses stream: SSE frame buffer exceeded cap without a \
-                         terminator; dropping buffer (usage parsing skipped)"
+                         terminator; releasing it unparsed (usage parsing and model \
+                         restamp skipped)"
                     );
-                    buf.clear();
+                    forward.append(&mut buf);
                 }
-            }
-            // Forward the original item verbatim (Ok bytes OR a mid-stream Err).
-            // The first successful forward is what the caller waited for.
-            if item.is_ok() {
+                // Nothing completed yet — keep reading rather than yielding an
+                // empty chunk.
+                if forward.is_empty() {
+                    continue;
+                }
+                // The first forward is what the caller waited for.
                 let (usage_acc, _) = guard.parts();
                 let acc = usage_acc.get_or_insert_with(Default::default);
                 if acc.downstream_latency_ms == 0 {
                     acc.downstream_latency_ms =
                         started.elapsed().as_millis().min(u32::MAX as u128) as u32;
                 }
+                yield Ok(bytes::Bytes::from(forward));
+                continue;
             }
+            // A mid-stream Err is forwarded as-is.
             yield item;
+        }
+        // A non-conformant upstream can end without terminating its last
+        // frame. Those bytes were never forwarded (they are still the partial
+        // tail), so release them now rather than truncating the response.
+        if !buf.is_empty() {
+            let (usage_acc, _) = guard.parts();
+            let acc = usage_acc.get_or_insert_with(Default::default);
+            if acc.downstream_latency_ms == 0 {
+                acc.downstream_latency_ms =
+                    started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+            }
+            yield Ok(bytes::Bytes::from(std::mem::take(&mut buf)));
         }
         // Upstream EOF — the response was delivered in full. Record that
         // before the scan below, which awaits a remote provider and is a

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -1844,8 +1844,18 @@ pub async fn get_video(
         let poll = result?;
         // Echo the name the caller submitted under, not the row's own — the
         // two differ for a wildcard row, and the submit response already
-        // echoed the caller's (`model_echo`).
-        let video = video_object_from_poll(&video_id, &requested_alias, &poll);
+        // echoed the caller's (`model_echo`). But that name is decoded from a
+        // CLIENT-SUPPLIED id, so echo it only when this row would actually
+        // serve it: a forged id, or one left behind by a row renamed since
+        // submit, falls back to the row's own name rather than being handed
+        // back as though the gateway had attested it.
+        let echoed =
+            if crate::model_resolve::row_serves_name(&target.model_entry.value, &requested_alias) {
+                requested_alias.as_str()
+            } else {
+                target.display_name()
+            };
+        let video = video_object_from_poll(&video_id, echoed, &poll);
         Ok((
             Json(video).into_response(),
             target.provider_label.clone(),

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -1785,12 +1785,18 @@ async fn dispatch_create(
 /// crafted ids. The submit path keeps its distinct 403/501 — there the
 /// caller already knows the model name they asked for, so there is
 /// nothing to disclose.
+///
+/// Returns the resolved target, the provider-side task id, and the model
+/// name the CALLER addressed at submit time. That last one is NOT the row's
+/// `display_name`: a wildcard row serves many caller-minted names, and the
+/// client-facing `model` echoes the one the caller used. Telemetry labels
+/// keep using `display_name` — see `usage_attr`.
 fn resolve_get_target(
     snapshot: &aisix_core::AisixSnapshot,
     auth: &AuthenticatedKey,
     video_id: &str,
     client_ctx: &ClientContext,
-) -> Result<(VideoTarget, String), ProxyError> {
+) -> Result<(VideoTarget, String, String), ProxyError> {
     let (entry_id, alias, task_id) =
         decode_video_id(video_id).ok_or_else(|| ProxyError::VideoNotFound(video_id.to_string()))?;
     let model_entry = snapshot
@@ -1798,7 +1804,7 @@ fn resolve_get_target(
         .get_by_id(&entry_id)
         .ok_or_else(|| ProxyError::VideoNotFound(video_id.to_string()))?;
     match resolve_video_target(snapshot, auth, model_entry, &alias, client_ctx) {
-        Ok(Ok(target)) => Ok((target, task_id)),
+        Ok(Ok(target)) => Ok((target, task_id, alias)),
         // Unsupported provider → uniform 404 (oracle fold, see above).
         Ok(Err(_)) => Err(ProxyError::VideoNotFound(video_id.to_string())),
         // ACL denial → uniform 404 (oracle fold, see above).
@@ -1826,7 +1832,8 @@ pub async fn get_video(
     let snapshot = state.snapshot.load();
 
     let result: Result<(Response, String, String), ProxyError> = async {
-        let (target, task_id) = resolve_get_target(&snapshot, &auth, &video_id, &client)?;
+        let (target, task_id, requested_alias) =
+            resolve_get_target(&snapshot, &auth, &video_id, &client)?;
         // Poll traffic is exempt from model-level limits BY DESIGN
         // (AISIX-Cloud#1118 decision 3): a client polling a task it
         // already paid an RPM slot to submit must not starve itself.
@@ -1835,7 +1842,10 @@ pub async fn get_video(
         let result = poll_task(&state, &target, &task_id, &client.request_id).await;
         reservation.commit_tokens(0).await;
         let poll = result?;
-        let video = video_object_from_poll(&video_id, target.display_name(), &poll);
+        // Echo the name the caller submitted under, not the row's own — the
+        // two differ for a wildcard row, and the submit response already
+        // echoed the caller's (`model_echo`).
+        let video = video_object_from_poll(&video_id, &requested_alias, &poll);
         Ok((
             Json(video).into_response(),
             target.provider_label.clone(),
@@ -1882,7 +1892,7 @@ pub async fn video_content(
     let snapshot = state.snapshot.load();
 
     let result: Result<(Response, String, String), ProxyError> = async {
-        let (target, task_id) = resolve_get_target(&snapshot, &auth, &video_id, &client)?;
+        let (target, task_id, _) = resolve_get_target(&snapshot, &auth, &video_id, &client)?;
         // Same model-layer exemption as the poll route (see get_video).
         let reservation = crate::quota::enforce(&state, &snapshot, &auth, None).await?;
         let result = poll_task(&state, &target, &task_id, &client.request_id).await;

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -430,6 +430,19 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
     if (!etcdReachable) return;
     app = await spawnApp();
     seed = new SeedClient(etcd, app.etcdPrefix);
+    // BOTH tests here need the hold-back policy in force, so it is seeded
+    // once for the app rather than by whichever test happens to run first.
+    // `keyword` on the output hook is block-capable, which is what makes the
+    // gateway buffer a streamed response instead of forwarding it live. The
+    // pattern deliberately never matches: the point is the buffered delivery
+    // path, not a block.
+    await seed.createGuardrail({
+      name: "gr-model-echo-holdback",
+      enabled: true,
+      hook_point: "output",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: "ABSOLUTELYFORBIDDENWORD" }],
+    });
   });
 
   afterAll(async () => {
@@ -451,17 +464,6 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
       ],
     });
     upstreams.push(upstream);
-
-    // `keyword` on the output hook is block-capable, so it holds the whole
-    // stream back. The reply deliberately does not match, so the response is
-    // delivered — the point is the buffered delivery path, not a block.
-    await seed.createGuardrail({
-      name: "gr-model-echo-holdback",
-      enabled: true,
-      hook_point: "output",
-      kind: "keyword",
-      patterns: [{ kind: "literal", value: "ABSOLUTELYFORBIDDENWORD" }],
-    });
 
     const pk = await seed.createProviderKey({
       display_name: "pk-echo-guarded",

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -1,0 +1,396 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the client-facing `model` field echoes the alias the CALLER
+// addressed, on every endpoint that answers with one.
+//
+// The scenario every case here is built on is the one a gateway alias
+// exists for: the operator configures `model_name` (what to ask the
+// provider for) and the provider answers with a DIFFERENT id — a dated
+// snapshot, or a name it remaps server-side. That is the ordinary case,
+// not an edge: ask OpenAI for `gpt-4o-mini` and it answers
+// `gpt-4o-mini-2024-07-18`.
+//
+// Every upstream below therefore reports `UPSTREAM_REPORTED_MODEL`,
+// which matches NEITHER the caller's alias NOR the configured
+// `model_name`. A gateway that echoes the upstream's document, or that
+// only restamps when the upstream happened to repeat the configured
+// name back, fails these assertions; one that echoes the alias passes.
+//
+// Coverage is per endpoint AND per response form, because the two are
+// produced by different code on the native passthrough paths: a
+// buffered JSON body is restamped once, while a streamed one carries
+// the field inside SSE frames that are relayed as bytes.
+
+const CALLER_PLAINTEXT = "sk-model-echo-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+/** What the operator configured as the upstream model id. */
+const CONFIGURED_MODEL_NAME = "provider-model-v1";
+/** What the provider actually answers with — deliberately neither of the other two. */
+const UPSTREAM_REPORTED_MODEL = "provider-model-v1-20260101";
+
+const HEADERS = {
+  authorization: `Bearer ${CALLER_PLAINTEXT}`,
+  "content-type": "application/json",
+};
+
+/**
+ * Assert on the whole payload, not just the `model` field: a stream that
+ * silently dropped or reordered frames while restamping would otherwise
+ * pass. `text` is the concatenated response body.
+ */
+function expectAliasNotUpstreamId(text: string, alias: string): void {
+  expect(text).toContain(`"model":"${alias}"`);
+  expect(text).not.toContain(UPSTREAM_REPORTED_MODEL);
+  expect(text).not.toContain(`"model":"${CONFIGURED_MODEL_NAME}"`);
+}
+
+describe("client-facing model echo e2e: the response names what the caller asked for", () => {
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  /**
+   * Seed a provider key + model, then the caller key LAST and gate on it
+   * authenticating — that single condition implies the whole seed set is
+   * in the snapshot (see this directory's AGENTS.md).
+   */
+  async function seedAlias(
+    alias: string,
+    upstream: OpenAiUpstream,
+    opts: { provider?: string; adapter?: string; modelName?: string } = {},
+  ): Promise<void> {
+    const pk = await seed!.createProviderKey({
+      display_name: `pk-${alias}`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+      provider: opts.provider ?? "openai",
+      adapter: opts.adapter ?? "openai",
+    });
+    await seed!.createModel({
+      display_name: alias,
+      provider: opts.provider ?? "openai",
+      model_name: opts.modelName ?? CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed!.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+      });
+      const ok = r.status === 200;
+      const body = ok ? ((await r.json()) as { data?: Array<{ id?: string }> }) : undefined;
+      if (!ok) await r.text();
+      return !!body?.data?.some((m) => m.id === alias);
+    });
+  }
+
+  test("/v1/messages native passthrough: buffered response echoes the alias", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "msg_echo_01",
+        type: "message",
+        role: "assistant",
+        model: UPSTREAM_REPORTED_MODEL,
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 4, output_tokens: 2 },
+      },
+    });
+    upstreams.push(upstream);
+    await seedAlias("echo-messages", upstream, {
+      provider: "anthropic",
+      adapter: "anthropic",
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-messages",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "say ok" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    expectAliasNotUpstreamId(await res.text(), "echo-messages");
+  });
+
+  test("/v1/messages native passthrough: streamed message_start echoes the alias", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    // Written as verbatim frames so the assertion is against the real
+    // Anthropic wire shape: `model` is nested under `message`, and it
+    // appears on `message_start` only.
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: message_start\ndata: {"type":"message_start","message":{"id":"msg_echo_02","type":"message","role":"assistant","model":"${UPSTREAM_REPORTED_MODEL}","content":[],"usage":{"input_tokens":4,"output_tokens":0}}}\n\n`,
+        `event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`,
+        `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n`,
+        `event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n`,
+        `event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}\n\n`,
+        `event: message_stop\ndata: {"type":"message_stop"}\n\n`,
+      ],
+      eventDelayMs: 5,
+    });
+    upstreams.push(upstream);
+    await seedAlias("echo-messages-stream", upstream, {
+      provider: "anthropic",
+      adapter: "anthropic",
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-messages-stream",
+        max_tokens: 16,
+        stream: true,
+        messages: [{ role: "user", content: "say ok" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expectAliasNotUpstreamId(text, "echo-messages-stream");
+    // The rest of the stream is relayed intact: every frame the upstream
+    // wrote is still there, in order, and the deltas are untouched.
+    const positions = [
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ].map((t) => text.indexOf(`"type":"${t}"`));
+    expect(positions.every((p) => p >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    expect(text).toContain('"text":"ok"');
+    expect(text).toContain('"output_tokens":2');
+  });
+
+  test("/v1/responses native passthrough: buffered response echoes the alias", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "resp_echo_01",
+        object: "response",
+        created_at: Math.floor(Date.now() / 1000),
+        status: "completed",
+        model: UPSTREAM_REPORTED_MODEL,
+        output: [
+          {
+            id: "msg_echo_r1",
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "ok" }],
+          },
+        ],
+        usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+      },
+    });
+    upstreams.push(upstream);
+    await seedAlias("echo-responses", upstream);
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({ model: "echo-responses", input: "say ok" }),
+    });
+    expect(res.status).toBe(200);
+    expectAliasNotUpstreamId(await res.text(), "echo-responses");
+  });
+
+  test("/v1/responses native passthrough: every streamed snapshot frame echoes the alias", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    // The Responses stream names the model on each snapshot event, not
+    // just the first: a restamp that only fixed `response.created` would
+    // still hand the upstream id back on `response.completed`, which is
+    // the event SDKs build their final Response object from.
+    const snapshot = (status: string) =>
+      `"id":"resp_echo_02","object":"response","status":"${status}","model":"${UPSTREAM_REPORTED_MODEL}"`;
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: response.created\ndata: {"type":"response.created","response":{${snapshot("in_progress")}}}\n\n`,
+        `event: response.in_progress\ndata: {"type":"response.in_progress","response":{${snapshot("in_progress")}}}\n\n`,
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"ok"}\n\n`,
+        `event: response.completed\ndata: {"type":"response.completed","response":{${snapshot("completed")},"usage":{"input_tokens":4,"output_tokens":2,"total_tokens":6}}}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+      eventDelayMs: 5,
+    });
+    upstreams.push(upstream);
+    await seedAlias("echo-responses-stream", upstream);
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-responses-stream",
+        input: "say ok",
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expectAliasNotUpstreamId(text, "echo-responses-stream");
+    // All THREE snapshot frames, not just the first.
+    expect(text.split(`"model":"echo-responses-stream"`).length - 1).toBe(3);
+    // Relay integrity: the delta and the terminal sentinel survive.
+    expect(text).toContain('"delta":"ok"');
+    expect(text).toContain('"total_tokens":6');
+    expect(text.trimEnd().endsWith("data: [DONE]")).toBe(true);
+  });
+
+  test("/v1/completions echoes the alias", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl_echo_01",
+        object: "text_completion",
+        created: Math.floor(Date.now() / 1000),
+        model: UPSTREAM_REPORTED_MODEL,
+        choices: [{ index: 0, text: "ok", finish_reason: "stop" }],
+        usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+      },
+    });
+    upstreams.push(upstream);
+    await seedAlias("echo-completions", upstream);
+
+    const res = await fetch(`${app.proxyUrl}/v1/completions`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({ model: "echo-completions", prompt: "say ok" }),
+    });
+    expect(res.status).toBe(200);
+    expectAliasNotUpstreamId(await res.text(), "echo-completions");
+  });
+
+  test("/v1/videos: the poll echoes the name the caller submitted under, not the wildcard row's", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    // A wildcard row serves many caller-minted names, so the row's own
+    // `display_name` (`wan-echo/*`) is NOT what the caller addressed. The
+    // submit response already echoed the caller's name; the poll answers
+    // about the same job and must not rename it mid-flight.
+    // Static (not scripted): submit and poll parse the same DashScope
+    // envelope, and the readiness probe would otherwise consume a step.
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        output: { task_id: "task-echo-01", task_status: "RUNNING" },
+        request_id: "req-echo-01",
+      },
+    });
+    upstreams.push(upstream);
+
+    const pk = await seed.createProviderKey({
+      display_name: "pk-echo-videos",
+      secret: "sk-mock-dashscope",
+      api_base: upstream.baseUrl,
+      provider: "alibaba",
+    });
+    await seed.createModel({
+      display_name: "wan-echo/*",
+      provider: "alibaba",
+      model_name: "wan-echo-upstream",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    // A wildcard row is deliberately absent from `/v1/models`, so gate on
+    // the caller key authenticating there instead (see this directory's
+    // AGENTS.md) and then on the submit route accepting the minted name.
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/videos`, {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({ model: "wan-echo/turbo", prompt: "ready-probe" }),
+      });
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { object?: unknown };
+      return j.object === "video";
+    });
+
+    const created = await fetch(`${app.proxyUrl}/v1/videos`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({ model: "wan-echo/turbo", prompt: "a cardboard city" }),
+    });
+    expect(created.status).toBe(200);
+    const video = (await created.json()) as { id?: string; model?: unknown };
+    expect(video.model).toBe("wan-echo/turbo");
+
+    const polled = await fetch(`${app.proxyUrl}/v1/videos/${video.id}`, {
+      method: "GET",
+      headers: { authorization: HEADERS.authorization },
+      redirect: "manual",
+    });
+    expect(polled.status).toBe(200);
+    const job = (await polled.json()) as { model?: unknown; id?: unknown };
+    expect(job.id).toBe(video.id);
+    // The failure this pins: the poll used to answer with the row's
+    // `display_name`, renaming the caller's job to `wan-echo/*`.
+    expect(job.model).toBe("wan-echo/turbo");
+  });
+
+  test("/v1/embeddings echoes the alias", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        object: "list",
+        model: UPSTREAM_REPORTED_MODEL,
+        data: [{ object: "embedding", index: 0, embedding: [0.1, 0.2] }],
+        usage: { prompt_tokens: 4, total_tokens: 4 },
+      },
+    });
+    upstreams.push(upstream);
+    await seedAlias("echo-embeddings", upstream);
+
+    const res = await fetch(`${app.proxyUrl}/v1/embeddings`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({ model: "echo-embeddings", input: "say ok" }),
+    });
+    expect(res.status).toBe(200);
+    expectAliasNotUpstreamId(await res.text(), "echo-embeddings");
+  });
+});

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -282,6 +282,12 @@ describe("client-facing model echo e2e: the response names what the caller asked
     // is `response.completed`, the event an SDK builds its final Response
     // object from. No guardrail here: this is the ordinary configuration, so
     // it is the likelier way to meet the bug, not the exotic one.
+    //
+    // That the LIVE relay serves this is a property of the suite, not of the
+    // assertions — the buffered branch would satisfy them too. It holds
+    // because this describe seeds no guardrail and `seedAlias` creates only a
+    // provider key, a model and a caller key, so `runs_on_output` is false.
+    // Adding a guardrail to this describe would silently move the coverage.
     const upstream = await startOpenAiUpstream({
       rawStreamFrames: [
         `event: response.created\ndata: {"type":"response.created","response":{"id":"resp_eof","object":"response","status":"in_progress","model":"${UPSTREAM_REPORTED_MODEL}"}}\n\n`,

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -274,6 +274,44 @@ describe("client-facing model echo e2e: the response names what the caller asked
     expect(text.trimEnd().endsWith("data: [DONE]")).toBe(true);
   });
 
+  test("/v1/responses streamed: a final frame the upstream never terminated still echoes the alias", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    // Mid-stream a fragment is a frame still arriving and must be held. At
+    // EOF it is a frame the upstream never closed — and on this surface that
+    // is `response.completed`, the event an SDK builds its final Response
+    // object from. No guardrail here: this is the ordinary configuration, so
+    // it is the likelier way to meet the bug, not the exotic one.
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: response.created\ndata: {"type":"response.created","response":{"id":"resp_eof","object":"response","status":"in_progress","model":"${UPSTREAM_REPORTED_MODEL}"}}\n\n`,
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"ok"}\n\n`,
+        // Deliberately no trailing blank line on the last frame.
+        `event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_eof","object":"response","status":"completed","model":"${UPSTREAM_REPORTED_MODEL}","usage":{"input_tokens":4,"output_tokens":2,"total_tokens":6}}}`,
+      ],
+    });
+    upstreams.push(upstream);
+    await seedAlias("echo-eof-tail", upstream);
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-eof-tail",
+        input: "say ok",
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expectAliasNotUpstreamId(text, "echo-eof-tail");
+    // Both snapshot frames, the unterminated one included.
+    expect(text.split('"model":"echo-eof-tail"').length - 1).toBe(2);
+    // The tail is delivered, not withheld: there is no scan to bypass here.
+    expect(text).toContain('"total_tokens":6');
+    expect(text).toContain('"delta":"ok"');
+  });
+
   test("/v1/completions echoes the alias", async (ctx) => {
     if (!etcdReachable || !app || !seed) return void ctx.skip();
 

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -332,21 +332,18 @@ describe("client-facing model echo e2e: the response names what the caller asked
       key_hash: CALLER_KEY_HASH,
       allowed_models: ["*"],
     });
-    // A wildcard row is deliberately absent from `/v1/models`, so gate on
-    // the caller key authenticating there instead (see this directory's
-    // AGENTS.md) and then on the submit route accepting the minted name.
+    // A wildcard row is deliberately absent from `/v1/models`, so the gate
+    // is the caller key authenticating there — seeded last, so that single
+    // condition implies the model and provider key landed too (see this
+    // directory's AGENTS.md). It must NOT be a submit, which is behavior
+    // this test asserts: a broken submit would then surface as a 30s
+    // propagation timeout instead of the assertion that names the defect.
     await waitConfigPropagation(async () => {
-      const r = await fetch(`${app!.proxyUrl}/v1/videos`, {
-        method: "POST",
-        headers: HEADERS,
-        body: JSON.stringify({ model: "wan-echo/turbo", prompt: "ready-probe" }),
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
       });
-      if (r.status !== 200) {
-        await r.text();
-        return false;
-      }
-      const j = (await r.json()) as { object?: unknown };
-      return j.object === "video";
+      await r.text();
+      return r.status === 200;
     });
 
     const created = await fetch(`${app.proxyUrl}/v1/videos`, {
@@ -369,6 +366,25 @@ describe("client-facing model echo e2e: the response names what the caller asked
     // The failure this pins: the poll used to answer with the row's
     // `display_name`, renaming the caller's job to `wan-echo/*`.
     expect(job.model).toBe("wan-echo/turbo");
+
+    // The alias is decoded from the id the CLIENT holds, so a forged one
+    // must not be echoed back as though the gateway had attested it. Mint an
+    // id for the same row carrying a name the row does not serve: the poll
+    // falls back to the row's own name instead of parroting the forgery.
+    const [entryId] = Buffer.from(video.id!, "base64url")
+      .toString("utf8")
+      .split(":");
+    const forged = Buffer.from(
+      `${entryId}:${Buffer.from("not-a-name-this-row-serves").toString("base64url")}:task-echo-01`,
+    ).toString("base64url");
+    const forgedPoll = await fetch(`${app.proxyUrl}/v1/videos/${forged}`, {
+      method: "GET",
+      headers: { authorization: HEADERS.authorization },
+      redirect: "manual",
+    });
+    expect(forgedPoll.status).toBe(200);
+    const forgedJob = (await forgedPoll.json()) as { model?: unknown };
+    expect(forgedJob.model).toBe("wan-echo/*");
   });
 
   test("/v1/embeddings echoes the alias", async (ctx) => {
@@ -392,5 +408,161 @@ describe("client-facing model echo e2e: the response names what the caller asked
     });
     expect(res.status).toBe(200);
     expectAliasNotUpstreamId(await res.text(), "echo-embeddings");
+  });
+});
+
+// A block-capable output guardrail must see the whole response before any of
+// it reaches the caller, so a streamed `/v1/responses` request with one
+// attached is BUFFERED and returned as a single body — never touching the
+// live relay that splices frame-by-frame. That branch needs the same restamp,
+// or attaching a guardrail silently changes which model name the caller is
+// told. Its own app: an env-scoped attachment applies to every request, so it
+// cannot share the suite above.
+describe("client-facing model echo e2e: a buffering output guardrail keeps the alias", () => {
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("/v1/responses streamed behind a block-capable output guardrail still echoes the alias", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const snapshot = (status: string) =>
+      `"id":"resp_guarded","object":"response","status":"${status}","model":"${UPSTREAM_REPORTED_MODEL}"`;
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: response.created\ndata: {"type":"response.created","response":{${snapshot("in_progress")}}}\n\n`,
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"perfectly fine text"}\n\n`,
+        `event: response.completed\ndata: {"type":"response.completed","response":{${snapshot("completed")},"usage":{"input_tokens":4,"output_tokens":3,"total_tokens":7}}}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+    });
+    upstreams.push(upstream);
+
+    // `keyword` on the output hook is block-capable, so it holds the whole
+    // stream back. The reply deliberately does not match, so the response is
+    // delivered — the point is the buffered delivery path, not a block.
+    await seed.createGuardrail({
+      name: "gr-model-echo-holdback",
+      enabled: true,
+      hook_point: "output",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: "ABSOLUTELYFORBIDDENWORD" }],
+    });
+
+    const pk = await seed.createProviderKey({
+      display_name: "pk-echo-guarded",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "echo-guarded",
+      provider: "openai",
+      model_name: CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      await r.text();
+      return r.status === 200;
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-guarded",
+        input: "say something fine",
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expectAliasNotUpstreamId(text, "echo-guarded");
+    // Both snapshot frames, and the held stream released intact.
+    expect(text.split('"model":"echo-guarded"').length - 1).toBe(2);
+    expect(text).toContain('"delta":"perfectly fine text"');
+    expect(text.trimEnd().endsWith("data: [DONE]")).toBe(true);
+  });
+
+  // The same hold-back policy on `/v1/messages`. Only COMPLETE frames feed
+  // the text the output guardrail scans, so an upstream that dies mid-frame
+  // leaves a tail nothing ever inspected. Releasing it after the scan would
+  // be a way around the very check hold-back exists to apply, so it is
+  // dropped — the client could not have parsed an unterminated frame anyway.
+  test("/v1/messages hold-back drops an unterminated tail instead of releasing it unscanned", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: message_start\ndata: {"type":"message_start","message":{"id":"msg_tail","type":"message","role":"assistant","model":"${UPSTREAM_REPORTED_MODEL}","content":[],"usage":{"input_tokens":4,"output_tokens":0}}}\n\n`,
+        `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"delivered text"}}\n\n`,
+        // No terminator: the stream ends mid-frame.
+        `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"NEVERSCANNEDTAIL"`,
+      ],
+    });
+    upstreams.push(upstream);
+
+    const pk = await seed.createProviderKey({
+      display_name: "pk-echo-tail",
+      secret: "sk-mock",
+      api_base: upstream.baseUrl,
+      provider: "anthropic",
+      adapter: "anthropic",
+    });
+    await seed.createModel({
+      display_name: "echo-tail",
+      provider: "anthropic",
+      model_name: CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      await r.text();
+      return r.status === 200;
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-tail",
+        max_tokens: 16,
+        stream: true,
+        messages: [{ role: "user", content: "say ok" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // The scanned frames are delivered, with the alias restamped...
+    expect(text).toContain('"model":"echo-tail"');
+    expect(text).toContain('"text":"delivered text"');
+    // ...and the unterminated, never-scanned tail is not.
+    expect(text).not.toContain("NEVERSCANNEDTAIL");
   });
 });

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -328,22 +328,35 @@ describe("client-facing model echo e2e: the response names what the caller asked
       model_name: "wan-echo-upstream",
       provider_key_id: pk.id,
     });
+    // A wildcard row is deliberately absent from `/v1/models`, so it cannot
+    // be the gate — and neither can the caller key, which earlier tests in
+    // this suite already seeded under the same hash, leaving that condition
+    // true before this test writes anything. Seed a sentinel row AFTER the
+    // wildcard one instead: etcd applies in revision order, so the sentinel
+    // showing up implies the provider key and the wildcard row landed too.
+    // The gate must not be a submit — that is behavior this test asserts, and
+    // a broken submit would surface as a propagation timeout rather than as
+    // the assertion naming the defect.
+    await seed.createModel({
+      display_name: "wan-echo-ready",
+      provider: "alibaba",
+      model_name: "wan-echo-upstream",
+      provider_key_id: pk.id,
+    });
     await seed.createApiKey({
       key_hash: CALLER_KEY_HASH,
       allowed_models: ["*"],
     });
-    // A wildcard row is deliberately absent from `/v1/models`, so the gate
-    // is the caller key authenticating there — seeded last, so that single
-    // condition implies the model and provider key landed too (see this
-    // directory's AGENTS.md). It must NOT be a submit, which is behavior
-    // this test asserts: a broken submit would then surface as a 30s
-    // propagation timeout instead of the assertion that names the defect.
     await waitConfigPropagation(async () => {
       const r = await fetch(`${app!.proxyUrl}/v1/models`, {
         headers: { authorization: HEADERS.authorization },
       });
-      await r.text();
-      return r.status === 200;
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === "wan-echo-ready");
     });
 
     const created = await fetch(`${app.proxyUrl}/v1/videos`, {
@@ -484,8 +497,12 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
       const r = await fetch(`${app!.proxyUrl}/v1/models`, {
         headers: { authorization: HEADERS.authorization },
       });
-      await r.text();
-      return r.status === 200;
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === "echo-guarded");
     });
 
     const res = await fetch(`${app.proxyUrl}/v1/responses`, {
@@ -541,12 +558,19 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
       key_hash: CALLER_KEY_HASH,
       allowed_models: ["*"],
     });
+    // Gate on THIS test's row, not on the key: the preceding test in this
+    // suite already seeded the same key hash, so key-authenticates-200 is
+    // true before this test writes anything and would not wait at all.
     await waitConfigPropagation(async () => {
       const r = await fetch(`${app!.proxyUrl}/v1/models`, {
         headers: { authorization: HEADERS.authorization },
       });
-      await r.text();
-      return r.status === 200;
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === "echo-tail");
     });
 
     const res = await fetch(`${app.proxyUrl}/v1/messages`, {


### PR DESCRIPTION
## Problem

`response.model` is supposed to name the model the **caller** addressed — the alias they put on the request — not the id the upstream answered with. That is the contract `crates/aisix-proxy/src/render.rs` states, and `/v1/chat/completions` has always honoured it. The bridged dispatch paths satisfy it by construction, because they build the client-facing body themselves.

The **native passthrough** paths forward the upstream's own document, and were not repairing it:

| Endpoint | Buffered | Streamed |
| --- | --- | --- |
| `/v1/messages` (Anthropic upstream) | restamped **only** when the upstream echoed the configured `model_name` back verbatim | never restamped |
| `/v1/responses` (OpenAI upstream) | never restamped | never restamped |
| `/v1/completions` | never restamped | n/a |
| `/v1/embeddings` | never restamped | n/a |
| `/v1/videos` poll | answered with the row's `display_name` | n/a |

The `/v1/messages` guard is the interesting one: a provider is free to answer with an id other than the one it was asked for — a dated snapshot, or a name it remaps server-side — and every such provider slipped straight through. Asking for `deepseek-chat` and being answered `deepseek-v4-flash` is enough.

`/v1/responses` is worse in a different way: the same endpoint answered with the alias (bridged provider) or the upstream id (OpenAI), depending only on which provider sat behind the alias — which a caller cannot see. `responses-cross-provider-e2e` already pinned the bridged half with the comment "Operator-facing model name, not the upstream id."

`/v1/videos` only diverges for a **wildcard** row: the submit echoes the caller's minted name (`wan/turbo`) and the poll answered with the row's own (`wan/*`), renaming a job halfway through its lifecycle.

## Change

The restamp now lives in one place — `crates/aisix-proxy/src/model_echo.rs` — so the family cannot drift again.

- **Buffered** responses go through `restamp_body`, unconditionally.
- **Streamed** responses carry the field inside SSE frames, so the two native relays now drain **whole frames** and splice the value through the existing `json_splice` walker. Every byte outside the replaced value reaches the client exactly as the provider wrote it — key order, whitespace, number spellings, escape choices — which a `serde_json` round-trip would not preserve.
- Frame selection is by exact JSON path, which is precise on both protocols: `message.model` exists only on Anthropic's `message_start`, and a depth-2 `response.model` selects exactly the six Responses snapshot events (`created` / `in_progress` / `completed` / `incomplete` / `failed` / `queued`) without reaching a model named deeper inside an output item or a tool definition.

Forwarding whole frames rather than raw chunks is not observable to a client: a frame is the SSE protocol's atomic unit and every conforming parser buffers to the blank-line terminator anyway.

On the **live-forward** path delivery is never truncated — an unterminated frame is released once it passes the existing 1 MiB buffer cap, and again at end of stream. (The previous behaviour on cap overflow was to *drop* the buffer, a telemetry-only loss since bytes were forwarded separately; it now releases them downstream, so that path is delivery-neutral.)

Under a **hold-back** output policy those same bytes are withheld instead, which review surfaced as a guardrail bypass and is described under Behavior change below.

`/v1/videos` gets the caller's minted alias plumbed out of `resolve_get_target`, which already decodes it from the video id. Telemetry labels deliberately keep using `display_name` — see `usage_attr`.

### Not in scope

`/passthrough/*` is untouched. Not rewriting the alias is a documented promise there, not an oversight.

Three siblings that share the shape are filed separately rather than folded in:

- #1087 — `/v1/rerank`: Jina responses carry a top-level `model`; Cohere and OpenAI-compatible shapes do not. This one is **small** — `rerank.rs` already parses the whole body for usage before relaying it, so `json_splice` closes it in a few lines. It is out of scope here because the scope was agreed before that was understood, not because it is expensive.
- #1088 — `/v1/realtime`: `session.created` / `session.updated` carry `session.model`. Genuinely more work: a bidirectional WebSocket relay with no equivalent of the SSE drain point this PR restructured, and it currently parses only the event types it needs.
- #1089 — `/v1/fine_tuning/jobs` is symmetric by design: its request half forwards the caller's `model` to the provider verbatim (pinned by its own test), so a caller names the upstream base model on both sides. Making only the response echo an alias would break that symmetry, so the posture is a decision rather than a fix.

`/v1/images/*` and `/v1/audio/*` are not in the family: the OpenAI image response object carries no `model`, and the audio responses relayed today carry none either. Whether some non-OpenAI STT backend returns one is unverified — worth a look when #1087 is picked up.

**One known limit that cannot be closed by splicing.** On `/v1/responses`, a single SSE frame that runs past the 1 MiB buffer cap without terminating is released un-restamped, so the caller sees the upstream id. This is not an oversight: at the cap the frame is genuinely still arriving, so its JSON is incomplete, so `json_splice` refuses it and falls back to verbatim — which is the safe behaviour. Reaching it needs one frame over 1 MiB, and on this surface `response.completed` carries the whole Response object, so a caller with a very large `tools[]` can get there. Said so at the code site rather than left for a reader to find. (`/v1/messages` cannot reach it: `message_start` is the only frame carrying a model and it is a few hundred bytes.)

One adjacent defect this PR does **not** fix, filed as #1091: buffered `/v1/responses` can release an unterminated final frame past the output guardrail, the same bypass this PR closes on `/v1/messages`. It is pre-existing, but closing one side and not the other leaves the siblings disagreeing, so it is named here rather than left silent. It changes what a guardrail delivers, which is a wider decision than this PR's scope.

## Behavior change

A client reading `model` off a `/v1/messages`, `/v1/responses`, `/v1/completions` or `/v1/embeddings` response — or off a `/v1/videos` poll — now sees the gateway model name it asked for, where it previously saw the provider's own id. This is not a regression introduced in this cycle; both halves reproduce on the previous release.

Review surfaced two further changes.

**On the `/v1/messages` hold-back path** — a streamed request with a block- or mask-capable output guardrail attached — an unterminated SSE frame is no longer released. Only complete frames feed the text the output guardrail scans, so such a frame was never scanned, and releasing it after the check was a way around it. Three shapes, all now closed:

| Shape | Before | Now |
| --- | --- | --- |
| Stream ends mid-frame, earlier frames delivered | tail released unscanned | tail dropped, earlier frames still delivered |
| Stream ends mid-frame, that frame is the whole response | released unscanned | refused, `unscannable_body` |
| One frame runs past the 1 MiB frame cap without terminating | released unscanned | refused, `unscannable_body` |

The refusal tag is deliberately **not** the hold-back cap's `output_buffer_exceeded`: that one is about size, whereas these refuse because the bytes never reached the scan. The hold-back cap keeps its own tag. The live-forward path (no such guardrail) is unchanged and still delivers these bytes — there is no scan to bypass there, and truncating on a missing terminator would be the regression.

**On `/v1/videos`**, polls echo the submitted alias only when the row would actually serve it — an exact `display_name`, or a wildcard glob covering it. That name is decoded from a client-supplied id, so echoing it unconditionally would hand a forged string back as though the gateway had attested it; a forgery, or a row renamed since submit, falls back to the row's own name.

## Tests

`tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts` — 7 cases, every one of them built on the scenario a gateway alias exists for: the mock upstream reports an id matching **neither** the caller's alias **nor** the configured `model_name`, so a gateway that echoes the upstream document, or that only restamps on an exact match, fails.

Coverage is per endpoint *and* per response form, because the two are produced by different code on the native paths. The streaming cases also assert relay integrity — frame order, deltas, the terminal `[DONE]` — so a restamp that dropped or reordered frames would not pass by fixing `model` alone.

Mutation-checked locally: all 7 fail with the fix reverted and pass with it. The `/v1/videos` case was additionally mutated on its own (reverting just that line yields `'wan-echo/*'` where `'wan-echo/turbo'` is expected).

Unit coverage in `model_echo` pins the splice's byte preservation (a `1e2` in the same frame survives un-canonicalised) and the path predicates' precision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Responses now preserve the model alias requested by the client across completions, embeddings, messages, responses, Anthropic streaming, and video status endpoints.
  - Streaming responses restamp model names even when final events are incomplete or missing terminators.
  - Video status responses fall back safely to the provider model name when an alias is invalid or no longer applies.
- **Bug Fixes**
  - Improved handling of incomplete or oversized streamed data.
  - Guardrail-protected streams now block unscannable content instead of releasing it unchecked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->