### PR TITLE
fix(anthropic): carry the reasoning-effort tier across protocol translation

### DIFF
--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -491,10 +491,17 @@ fn translate_reasoning_effort_to_anthropic(
     let Some(effort) = effort.as_str() else {
         return;
     };
+    let has_native_effort = extras
+        .get("output_config")
+        .and_then(|config| config.as_object())
+        .is_some_and(|config| config.contains_key("effort"));
     // `none` has no Anthropic tier — it asks for no reasoning at all,
-    // which is the `disabled` thinking mode.
+    // which is the `disabled` thinking mode. An effort the caller set
+    // natively is their statement about depth, and disabling thinking
+    // beside it would contradict it; Anthropic also rejects `disabled`
+    // above the `high` tier, so the pair can 400 outright.
     if effort == "none" {
-        if !extras.contains_key("thinking") {
+        if !has_native_effort && !extras.contains_key("thinking") {
             extras.insert(
                 "thinking".to_string(),
                 serde_json::json!({"type": "disabled"}),
@@ -4123,6 +4130,63 @@ mod tests {
             Some(&serde_json::json!("nonsense"))
         );
         assert!(!built.extra.contains_key("reasoning_effort"));
+    }
+
+    #[test]
+    fn build_request_none_yields_to_a_native_effort_tier() {
+        // `reasoning_effort: none` beside a caller-set tier is a
+        // contradiction the caller wrote. The native field wins, so no
+        // `thinking: disabled` is injected next to it — Anthropic
+        // rejects `disabled` above `high` anyway.
+        let req = ChatFormat {
+            extra: {
+                let mut m = serde_json::Map::new();
+                m.insert("reasoning_effort".to_string(), "none".into());
+                m.insert(
+                    "output_config".to_string(),
+                    serde_json::json!({"effort": "max"}),
+                );
+                m
+            },
+            ..ChatFormat::new("c", vec![ChatMessage::user("hi")])
+        };
+        let (_system, messages) = split_system(&req).unwrap();
+        let built = build_request(&req, "c-name", None, messages, false);
+        assert_eq!(
+            built.extra.get("output_config"),
+            Some(&serde_json::json!({"effort": "max"}))
+        );
+        assert!(!built.extra.contains_key("thinking"));
+        assert!(!built.extra.contains_key("reasoning_effort"));
+    }
+
+    #[test]
+    fn build_request_tier_joins_a_caller_supplied_thinking_mode() {
+        // `thinking` is the mode and `output_config.effort` the depth:
+        // Anthropic treats them as complementary, so a caller who set a
+        // mode natively still gets the tier they asked for.
+        let req = ChatFormat {
+            extra: {
+                let mut m = serde_json::Map::new();
+                m.insert("reasoning_effort".to_string(), "high".into());
+                m.insert(
+                    "thinking".to_string(),
+                    serde_json::json!({"type": "adaptive", "display": "summarized"}),
+                );
+                m
+            },
+            ..ChatFormat::new("c", vec![ChatMessage::user("hi")])
+        };
+        let (_system, messages) = split_system(&req).unwrap();
+        let built = build_request(&req, "c-name", None, messages, false);
+        assert_eq!(
+            built.extra.get("thinking"),
+            Some(&serde_json::json!({"type": "adaptive", "display": "summarized"}))
+        );
+        assert_eq!(
+            built.extra.get("output_config"),
+            Some(&serde_json::json!({"effort": "high"}))
+        );
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -491,6 +491,19 @@ fn translate_reasoning_effort_to_anthropic(
     let Some(effort) = effort.as_str() else {
         return;
     };
+    // A caller who natively turned thinking off has already stated the
+    // depth, so the alias adds nothing — and pairing a tier with it
+    // would build a request Anthropic rejects above `high`, naming an
+    // `output_config` the caller never sent. `reasoning_effort_for`
+    // resolves the same pair the same way in the other direction.
+    if extras
+        .get("thinking")
+        .and_then(|t| t.get("type"))
+        .and_then(|t| t.as_str())
+        == Some("disabled")
+    {
+        return;
+    }
     let has_native_effort = extras
         .get("output_config")
         .and_then(|config| config.as_object())
@@ -4187,6 +4200,40 @@ mod tests {
             built.extra.get("output_config"),
             Some(&serde_json::json!({"effort": "high"}))
         );
+    }
+
+    #[test]
+    fn build_request_native_disabled_thinking_suppresses_the_tier() {
+        // Anthropic accepts `disabled` only at `high` or below, so
+        // attaching a tier here would make the gateway construct a
+        // request the upstream rejects — over a field the caller never
+        // sent. Mirrors `disabled` outranking a tier inbound.
+        for effort in ["max", "high"] {
+            let req = ChatFormat {
+                extra: {
+                    let mut m = serde_json::Map::new();
+                    m.insert("reasoning_effort".to_string(), effort.into());
+                    m.insert(
+                        "thinking".to_string(),
+                        serde_json::json!({"type": "disabled"}),
+                    );
+                    m
+                },
+                ..ChatFormat::new("c", vec![ChatMessage::user("hi")])
+            };
+            let (_system, messages) = split_system(&req).unwrap();
+            let built = build_request(&req, "c-name", None, messages, false);
+            assert_eq!(
+                built.extra.get("thinking"),
+                Some(&serde_json::json!({"type": "disabled"})),
+                "reasoning_effort = {effort}"
+            );
+            assert!(
+                !built.extra.contains_key("output_config"),
+                "tier attached to disabled thinking for reasoning_effort = {effort}"
+            );
+            assert!(!built.extra.contains_key("reasoning_effort"));
+        }
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -477,8 +477,11 @@ pub fn build_request<'a>(
 /// tier has said nothing about which thinking mode it wants, and on
 /// Opus 4.6 and later the model applies its own.
 ///
-/// A native field the caller supplied itself always wins, being the more
-/// specific expression of the same setting.
+/// An effort the caller expressed natively always wins, being the more
+/// specific statement of the same setting. That means `output_config.effort`
+/// specifically, not the presence of an `output_config`: the object also
+/// carries `format` and `task_budget`, and treating it as an effort
+/// declaration would drop the tier of any request that sent one of those.
 fn translate_reasoning_effort_to_anthropic(
     extras: &mut serde_json::Map<String, serde_json::Value>,
 ) {
@@ -514,11 +517,23 @@ fn translate_reasoning_effort_to_anthropic(
             return;
         }
     };
-    if !extras.contains_key("output_config") {
-        extras.insert(
-            "output_config".to_string(),
-            serde_json::json!({"effort": tier}),
-        );
+    match extras.get_mut("output_config") {
+        // `output_config` is a carrier: a caller who sent one for
+        // `format` or `task_budget` has said nothing about effort, so
+        // the tier merges in beside them. Only an `effort` they set
+        // themselves outranks it.
+        Some(serde_json::Value::Object(config)) => {
+            config.entry("effort").or_insert_with(|| tier.into());
+        }
+        // Not an object: whatever the caller meant, replacing it would
+        // lose it. Anthropic rejects the shape either way.
+        Some(_) => {}
+        None => {
+            extras.insert(
+                "output_config".to_string(),
+                serde_json::json!({"effort": tier}),
+            );
+        }
     }
 }
 
@@ -4055,6 +4070,57 @@ mod tests {
         assert_eq!(
             built.extra.get("output_config"),
             Some(&serde_json::json!({"effort": "max"}))
+        );
+        assert!(!built.extra.contains_key("reasoning_effort"));
+    }
+
+    #[test]
+    fn build_request_merges_the_tier_into_a_carrier_output_config() {
+        // `output_config` also carries `format` and `task_budget`. A
+        // request that sent one of those has said nothing about effort,
+        // so treating the object's presence as a native override drops
+        // the caller's tier — the same silent loss this change fixes on
+        // the other side.
+        let req = ChatFormat {
+            extra: {
+                let mut m = serde_json::Map::new();
+                m.insert("reasoning_effort".to_string(), "high".into());
+                m.insert(
+                    "output_config".to_string(),
+                    serde_json::json!({"task_budget": {"type": "tokens", "total": 64000}}),
+                );
+                m
+            },
+            ..ChatFormat::new("c", vec![ChatMessage::user("hi")])
+        };
+        let (_system, messages) = split_system(&req).unwrap();
+        let built = build_request(&req, "c-name", None, messages, false);
+        assert_eq!(
+            built.extra.get("output_config"),
+            Some(&serde_json::json!({
+                "task_budget": {"type": "tokens", "total": 64000},
+                "effort": "high",
+            }))
+        );
+        assert!(!built.extra.contains_key("reasoning_effort"));
+    }
+
+    #[test]
+    fn build_request_leaves_a_non_object_output_config_alone() {
+        let req = ChatFormat {
+            extra: {
+                let mut m = serde_json::Map::new();
+                m.insert("reasoning_effort".to_string(), "high".into());
+                m.insert("output_config".to_string(), serde_json::json!("nonsense"));
+                m
+            },
+            ..ChatFormat::new("c", vec![ChatMessage::user("hi")])
+        };
+        let (_system, messages) = split_system(&req).unwrap();
+        let built = build_request(&req, "c-name", None, messages, false);
+        assert_eq!(
+            built.extra.get("output_config"),
+            Some(&serde_json::json!("nonsense"))
         );
         assert!(!built.extra.contains_key("reasoning_effort"));
     }

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -447,6 +447,7 @@ pub fn build_request<'a>(
     let tool_choice = extras
         .remove("tool_choice")
         .and_then(translate_openai_tool_choice_to_anthropic);
+    translate_reasoning_effort_to_anthropic(&mut extras);
     AnthropicRequest {
         model: upstream_model,
         messages,
@@ -458,6 +459,66 @@ pub fn build_request<'a>(
         tools,
         tool_choice,
         extra: extras,
+    }
+}
+
+/// Rewrite an OpenAI-shape `reasoning_effort` into Anthropic's effort
+/// control, the mirror of [`reasoning_effort_for`]. The field is always
+/// consumed: forwarding it verbatim reaches `/v1/messages` as an unknown
+/// top-level parameter (AISIX-Cloud#1474).
+///
+/// `output_config.effort` is the target rather than a
+/// `thinking.budget_tokens` block, because a budget is rejected outright
+/// from Opus 4.7 onwards while effort is accepted across the whole
+/// current family. LiteLLM picks between the two using its model
+/// capability map; the gateway has no equivalent — it holds only the
+/// operator-supplied upstream model name — so it emits the shape current
+/// models take. `thinking` is left alone: a caller asking for a depth
+/// tier has said nothing about which thinking mode it wants, and on
+/// Opus 4.6 and later the model applies its own.
+///
+/// A native field the caller supplied itself always wins, being the more
+/// specific expression of the same setting.
+fn translate_reasoning_effort_to_anthropic(
+    extras: &mut serde_json::Map<String, serde_json::Value>,
+) {
+    let Some(effort) = extras.remove("reasoning_effort") else {
+        return;
+    };
+    let Some(effort) = effort.as_str() else {
+        return;
+    };
+    // `none` has no Anthropic tier — it asks for no reasoning at all,
+    // which is the `disabled` thinking mode.
+    if effort == "none" {
+        if !extras.contains_key("thinking") {
+            extras.insert(
+                "thinking".to_string(),
+                serde_json::json!({"type": "disabled"}),
+            );
+        }
+        return;
+    }
+    // Anthropic's vocabulary has no `minimal`; `low` is its floor.
+    let tier = match effort {
+        "minimal" | "low" => "low",
+        "medium" => "medium",
+        "high" => "high",
+        "xhigh" => "xhigh",
+        "max" => "max",
+        other => {
+            tracing::debug!(
+                reasoning_effort = %other,
+                "dropping unrecognised reasoning_effort on Anthropic dispatch"
+            );
+            return;
+        }
+    };
+    if !extras.contains_key("output_config") {
+        extras.insert(
+            "output_config".to_string(),
+            serde_json::json!({"effort": tier}),
+        );
     }
 }
 
@@ -721,12 +782,20 @@ pub fn translate_anthropic_tool_choice_to_openai(
 /// whitelist-and-drop policy (#825) in the opposite direction.
 ///
 /// Translations (matching LiteLLM's Anthropic→OpenAI adapter):
-///   tools / tool_choice   → OpenAI shapes (existing helpers)
-///   stop_sequences        → stop
-///   metadata.user_id      → user
-///   thinking              → reasoning_effort
+///   tools / tool_choice                → OpenAI shapes (existing helpers)
+///   stop_sequences                     → stop
+///   metadata.user_id                   → user
+///   thinking / output_config.effort    → reasoning_effort
+///   output_format / output_config.format → response_format
+///
+/// `thinking` and `output_config` are resolved together after the loop:
+/// both encode the same OpenAI knob, so neither can be translated by
+/// looking at one key in isolation (AISIX-Cloud#1474).
 pub fn translate_extras_to_openai_shape(extra: &mut serde_json::Map<String, serde_json::Value>) {
     let anthropic = std::mem::take(extra);
+    let mut thinking = None;
+    let mut output_config = None;
+    let mut output_format = None;
     for (key, value) in anthropic {
         match key.as_str() {
             "tools" => {
@@ -747,11 +816,9 @@ pub fn translate_extras_to_openai_shape(extra: &mut serde_json::Map<String, serd
                     extra.insert("user".to_string(), user_id.into());
                 }
             }
-            "thinking" => {
-                if let Some(effort) = reasoning_effort_from_thinking(&value) {
-                    extra.insert("reasoning_effort".to_string(), effort.into());
-                }
-            }
+            "thinking" => thinking = Some(value),
+            "output_config" => output_config = Some(value),
+            "output_format" => output_format = Some(value),
             _ => {
                 tracing::debug!(
                     field = %key,
@@ -760,12 +827,68 @@ pub fn translate_extras_to_openai_shape(extra: &mut serde_json::Map<String, serd
             }
         }
     }
+
+    if let Some(effort) = reasoning_effort_for(thinking.as_ref(), output_config.as_ref()) {
+        extra.insert("reasoning_effort".to_string(), effort);
+    }
+
+    // Anthropic carries a structured-output schema either at the legacy
+    // top-level `output_format` or, since Structured Outputs, at
+    // `output_config.format`. The legacy field wins when both are set,
+    // matching LiteLLM.
+    let format = output_format
+        .or_else(|| output_config.and_then(|c| c.get("format").cloned()))
+        .and_then(anthropic_output_format_to_response_format);
+    if let Some(response_format) = format {
+        extra.insert("response_format".to_string(), response_format);
+    }
 }
 
-/// Bucket Anthropic `thinking` into an OpenAI `reasoning_effort` label.
-/// Thresholds match LiteLLM's `reasoning_effort_from_thinking_budget`
-/// (budget_tokens ≥ 4096 → high, ≥ 2048 → medium, ≥ 1024 → low, below →
-/// minimal; `adaptive` → medium; `disabled`/unrecognised → None).
+/// Resolve the OpenAI `reasoning_effort` a request's Anthropic thinking
+/// controls ask for. Precedence, highest first:
+///
+/// 1. `thinking.type = "disabled"` → `none`. An explicit opt-out is a
+///    stronger instruction than a depth tier, so a stray
+///    `output_config.effort` does not override it (LiteLLM resolves
+///    this pair the same way).
+/// 2. `output_config.effort` → forwarded verbatim. This is Anthropic's
+///    current effort control and the only one Opus 4.7 and later accept.
+/// 3. `thinking.type = "enabled"` → bucketed from `budget_tokens`.
+///    Deprecated on Opus 4.6 and rejected outright from 4.7, kept for
+///    clients still sending it.
+/// 4. `thinking.type = "adaptive"` with no effort → `high`, which is
+///    what Anthropic itself applies when `output_config.effort` is
+///    omitted.
+///
+/// Tiers are forwarded as written: `max` and `xhigh` reach an upstream
+/// that may not accept them and are rejected there, which is the
+/// intended outcome — silently degrading a tier the caller chose is the
+/// failure this resolution order exists to prevent.
+fn reasoning_effort_for(
+    thinking: Option<&serde_json::Value>,
+    output_config: Option<&serde_json::Value>,
+) -> Option<serde_json::Value> {
+    let thinking_type = thinking
+        .and_then(|t| t.get("type"))
+        .and_then(|t| t.as_str());
+    if thinking_type == Some("disabled") {
+        return Some("none".into());
+    }
+    let declared = output_config
+        .and_then(|c| c.get("effort"))
+        .and_then(|e| e.as_str());
+    if let Some(effort) = declared {
+        return Some(effort.into());
+    }
+    reasoning_effort_from_thinking(thinking?).map(Into::into)
+}
+
+/// Bucket an Anthropic `thinking` block into an OpenAI `reasoning_effort`
+/// label. `budget_tokens` thresholds match LiteLLM's
+/// `reasoning_effort_from_thinking_budget` (≥ 4096 → high, ≥ 2048 →
+/// medium, ≥ 1024 → low, below → minimal). `adaptive` carries no budget;
+/// it resolves to Anthropic's own default tier, and callers who want a
+/// different one send `output_config.effort` (see [`reasoning_effort_for`]).
 fn reasoning_effort_from_thinking(thinking: &serde_json::Value) -> Option<&'static str> {
     match thinking.get("type").and_then(|t| t.as_str())? {
         "enabled" => {
@@ -780,8 +903,79 @@ fn reasoning_effort_from_thinking(thinking: &serde_json::Value) -> Option<&'stat
                 _ => "minimal",
             })
         }
-        "adaptive" => Some("medium"),
+        "adaptive" => Some(ANTHROPIC_DEFAULT_EFFORT),
         _ => None,
+    }
+}
+
+/// The tier Anthropic applies when a request omits `output_config.effort`.
+const ANTHROPIC_DEFAULT_EFFORT: &str = "high";
+
+/// Translate an Anthropic structured-output block —
+/// `{"type": "json_schema", "schema": {…}}` — into the OpenAI
+/// `response_format` shape. Anthropic's structured outputs are
+/// constrained-decoded, so the OpenAI side is emitted with
+/// `strict: true` to keep that guarantee rather than degrading it to a
+/// best-effort hint; strict mode in turn requires every object schema to
+/// close over its properties (LiteLLM normalises the schema the same
+/// way). Returns `None` for any other shape, which is then dropped.
+fn anthropic_output_format_to_response_format(
+    output_format: serde_json::Value,
+) -> Option<serde_json::Value> {
+    if output_format.get("type").and_then(|t| t.as_str())? != "json_schema" {
+        return None;
+    }
+    let mut schema = output_format.get("schema")?.clone();
+    if schema.is_null() {
+        return None;
+    }
+    close_object_schemas(&mut schema);
+    Some(serde_json::json!({
+        "type": "json_schema",
+        "json_schema": {
+            "name": "structured_output",
+            "schema": schema,
+            "strict": true,
+        }
+    }))
+}
+
+/// Recursively make every object schema satisfy OpenAI strict mode:
+/// `additionalProperties: false`, and every declared property listed in
+/// `required`.
+fn close_object_schemas(schema: &mut serde_json::Value) {
+    let Some(obj) = schema.as_object_mut() else {
+        return;
+    };
+    if obj.get("type").and_then(|t| t.as_str()) == Some("object") {
+        if let Some(properties) = obj.get("properties").and_then(|p| p.as_object()) {
+            let required: Vec<serde_json::Value> =
+                properties.keys().map(|k| k.as_str().into()).collect();
+            obj.insert("additionalProperties".to_string(), false.into());
+            obj.insert("required".to_string(), required.into());
+        }
+        if let Some(properties) = obj.get_mut("properties").and_then(|p| p.as_object_mut()) {
+            for property in properties.values_mut() {
+                close_object_schemas(property);
+            }
+        }
+    }
+    if let Some(items) = obj.get_mut("items") {
+        close_object_schemas(items);
+    }
+    for key in ["anyOf", "oneOf", "allOf"] {
+        if let Some(branches) = obj.get_mut(key).and_then(|b| b.as_array_mut()) {
+            for branch in branches {
+                close_object_schemas(branch);
+            }
+        }
+    }
+    for key in ["$defs", "definitions"] {
+        if let Some(defs) = obj.get_mut(key).and_then(|d| d.as_object_mut()) {
+            for def in defs.values_mut() {
+                close_object_schemas(def);
+            }
+        }
     }
 }
 
@@ -3573,8 +3767,12 @@ mod tests {
                 serde_json::json!({"type": "enabled", "budget_tokens": 100}),
                 Some("minimal"),
             ),
-            (serde_json::json!({"type": "adaptive"}), Some("medium")),
-            (serde_json::json!({"type": "disabled"}), None),
+            // `adaptive` carries no budget: it resolves to the tier
+            // Anthropic itself applies when effort is omitted.
+            (serde_json::json!({"type": "adaptive"}), Some("high")),
+            // An explicit opt-out survives as OpenAI's own `none`
+            // rather than being dropped into "upstream decides".
+            (serde_json::json!({"type": "disabled"}), Some("none")),
         ] {
             let mut extra = serde_json::Map::new();
             extra.insert("thinking".to_string(), thinking.clone());
@@ -3585,6 +3783,301 @@ mod tests {
                 "thinking = {thinking}"
             );
             assert!(!extra.contains_key("thinking"));
+        }
+    }
+
+    // ─── output_config.effort / format (AISIX-Cloud#1474) ─────────
+
+    #[test]
+    fn extras_shape_effort_outranks_thinking() {
+        // The pairing Opus 4.6+ clients actually send: adaptive thinking
+        // for the mode, output_config.effort for the depth. Resolving
+        // `thinking` alone pinned every such request to one tier.
+        for (thinking, expected) in [
+            (serde_json::json!({"type": "adaptive"}), "max"),
+            // Even against the legacy budget shape the newer field wins;
+            // a client sending both means the budget as boilerplate.
+            (
+                serde_json::json!({"type": "enabled", "budget_tokens": 8000}),
+                "max",
+            ),
+        ] {
+            let mut extra = serde_json::json!({
+                "thinking": thinking,
+                "output_config": {"effort": "max"},
+            })
+            .as_object()
+            .unwrap()
+            .clone();
+            translate_extras_to_openai_shape(&mut extra);
+            assert_eq!(
+                extra.get("reasoning_effort").and_then(|v| v.as_str()),
+                Some(expected),
+                "thinking = {thinking}"
+            );
+            assert!(!extra.contains_key("output_config"));
+            assert!(!extra.contains_key("thinking"));
+        }
+    }
+
+    #[test]
+    fn extras_shape_effort_without_thinking_still_maps() {
+        // Thinking is on by default from Opus 5, so omitting `thinking`
+        // and sending only the tier is the current idiomatic request.
+        let mut extra = serde_json::json!({"output_config": {"effort": "xhigh"}})
+            .as_object()
+            .unwrap()
+            .clone();
+        translate_extras_to_openai_shape(&mut extra);
+        assert_eq!(
+            extra.get("reasoning_effort"),
+            Some(&serde_json::json!("xhigh"))
+        );
+    }
+
+    #[test]
+    fn extras_shape_forwards_effort_tiers_verbatim() {
+        // No tier is remapped down to one an arbitrary upstream is more
+        // likely to accept: an upstream rejection is visible, a silent
+        // downgrade is not.
+        for tier in ["low", "medium", "high", "xhigh", "max"] {
+            let mut extra = serde_json::json!({"output_config": {"effort": tier}})
+                .as_object()
+                .unwrap()
+                .clone();
+            translate_extras_to_openai_shape(&mut extra);
+            assert_eq!(
+                extra.get("reasoning_effort").and_then(|v| v.as_str()),
+                Some(tier)
+            );
+        }
+    }
+
+    #[test]
+    fn extras_shape_disabled_thinking_outranks_effort() {
+        // "Do not reason" is a stronger instruction than a depth tier.
+        let mut extra = serde_json::json!({
+            "thinking": {"type": "disabled"},
+            "output_config": {"effort": "max"},
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        translate_extras_to_openai_shape(&mut extra);
+        assert_eq!(
+            extra.get("reasoning_effort"),
+            Some(&serde_json::json!("none"))
+        );
+    }
+
+    #[test]
+    fn extras_shape_non_string_effort_falls_back_to_thinking() {
+        let mut extra = serde_json::json!({
+            "thinking": {"type": "enabled", "budget_tokens": 8000},
+            "output_config": {"effort": 3},
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        translate_extras_to_openai_shape(&mut extra);
+        assert_eq!(
+            extra.get("reasoning_effort"),
+            Some(&serde_json::json!("high"))
+        );
+    }
+
+    #[test]
+    fn extras_shape_output_config_without_effort_or_format_is_dropped() {
+        // `output_config` is consumed whatever it holds — the OpenAI
+        // wire has no equivalent for its other sub-keys and the whole
+        // object 400s if forwarded.
+        let mut extra = serde_json::json!({
+            "output_config": {"task_budget": {"type": "tokens", "total": 64000}},
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        translate_extras_to_openai_shape(&mut extra);
+        assert!(extra.is_empty(), "expected all dropped, got: {extra:?}");
+    }
+
+    #[test]
+    fn extras_shape_output_config_format_becomes_response_format() {
+        let mut extra = serde_json::json!({
+            "output_config": {
+                "format": {
+                    "type": "json_schema",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                            "days": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {"high": {"type": "number"}},
+                                },
+                            },
+                        },
+                    },
+                }
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        translate_extras_to_openai_shape(&mut extra);
+
+        let rf = extra.get("response_format").expect("response_format set");
+        assert_eq!(rf["type"], serde_json::json!("json_schema"));
+        assert_eq!(rf["json_schema"]["strict"], serde_json::json!(true));
+        let schema = &rf["json_schema"]["schema"];
+        // Strict mode closes every object level, not just the root.
+        assert_eq!(schema["additionalProperties"], serde_json::json!(false));
+        assert_eq!(schema["required"], serde_json::json!(["city", "days"]));
+        let item = &schema["properties"]["days"]["items"];
+        assert_eq!(item["additionalProperties"], serde_json::json!(false));
+        assert_eq!(item["required"], serde_json::json!(["high"]));
+        assert!(!extra.contains_key("output_config"));
+    }
+
+    #[test]
+    fn extras_shape_legacy_output_format_outranks_output_config_format() {
+        let mut extra = serde_json::json!({
+            "output_format": {
+                "type": "json_schema",
+                "schema": {"type": "object", "properties": {"legacy": {"type": "string"}}},
+            },
+            "output_config": {
+                "format": {
+                    "type": "json_schema",
+                    "schema": {"type": "object", "properties": {"newer": {"type": "string"}}},
+                }
+            },
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        translate_extras_to_openai_shape(&mut extra);
+        assert_eq!(
+            extra["response_format"]["json_schema"]["schema"]["required"],
+            serde_json::json!(["legacy"])
+        );
+        assert!(!extra.contains_key("output_format"));
+    }
+
+    #[test]
+    fn extras_shape_unrecognised_output_format_is_dropped() {
+        // Neither shape reaches the upstream as an unknown parameter.
+        for output_format in [
+            serde_json::json!({"type": "json_object"}),
+            serde_json::json!({"type": "json_schema"}),
+            serde_json::json!("json"),
+        ] {
+            let mut extra = serde_json::Map::new();
+            extra.insert("output_format".to_string(), output_format.clone());
+            translate_extras_to_openai_shape(&mut extra);
+            assert!(extra.is_empty(), "output_format = {output_format}");
+        }
+    }
+
+    // ─── reasoning_effort → Anthropic (AISIX-Cloud#1474) ──────────
+
+    #[test]
+    fn build_request_maps_reasoning_effort_to_output_config() {
+        for (effort, tier) in [
+            ("minimal", "low"),
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "high"),
+            ("xhigh", "xhigh"),
+            ("max", "max"),
+        ] {
+            let req = ChatFormat {
+                extra: {
+                    let mut m = serde_json::Map::new();
+                    m.insert("reasoning_effort".to_string(), effort.into());
+                    m
+                },
+                ..ChatFormat::new("c", vec![ChatMessage::user("hi")])
+            };
+            let (_system, messages) = split_system(&req).unwrap();
+            let built = build_request(&req, "c-name", None, messages, false);
+            assert_eq!(
+                built.extra.get("output_config"),
+                Some(&serde_json::json!({"effort": tier})),
+                "reasoning_effort = {effort}"
+            );
+            // Never forwarded verbatim: `/v1/messages` 400s on it.
+            assert!(!built.extra.contains_key("reasoning_effort"));
+            // No thinking mode is invented on the caller's behalf.
+            assert!(!built.extra.contains_key("thinking"));
+        }
+    }
+
+    #[test]
+    fn build_request_maps_reasoning_effort_none_to_disabled_thinking() {
+        // Anthropic has no `none` tier; the equivalent is not thinking.
+        let req = ChatFormat {
+            extra: {
+                let mut m = serde_json::Map::new();
+                m.insert("reasoning_effort".to_string(), "none".into());
+                m
+            },
+            ..ChatFormat::new("c", vec![ChatMessage::user("hi")])
+        };
+        let (_system, messages) = split_system(&req).unwrap();
+        let built = build_request(&req, "c-name", None, messages, false);
+        assert_eq!(
+            built.extra.get("thinking"),
+            Some(&serde_json::json!({"type": "disabled"}))
+        );
+        assert!(!built.extra.contains_key("output_config"));
+        assert!(!built.extra.contains_key("reasoning_effort"));
+    }
+
+    #[test]
+    fn build_request_reasoning_effort_yields_to_caller_supplied_native_fields() {
+        let req = ChatFormat {
+            extra: {
+                let mut m = serde_json::Map::new();
+                m.insert("reasoning_effort".to_string(), "low".into());
+                m.insert(
+                    "output_config".to_string(),
+                    serde_json::json!({"effort": "max"}),
+                );
+                m
+            },
+            ..ChatFormat::new("c", vec![ChatMessage::user("hi")])
+        };
+        let (_system, messages) = split_system(&req).unwrap();
+        let built = build_request(&req, "c-name", None, messages, false);
+        assert_eq!(
+            built.extra.get("output_config"),
+            Some(&serde_json::json!({"effort": "max"}))
+        );
+        assert!(!built.extra.contains_key("reasoning_effort"));
+    }
+
+    #[test]
+    fn build_request_drops_unrecognised_reasoning_effort() {
+        for value in [serde_json::json!("turbo"), serde_json::json!(5)] {
+            let req = ChatFormat {
+                extra: {
+                    let mut m = serde_json::Map::new();
+                    m.insert("reasoning_effort".to_string(), value.clone());
+                    m
+                },
+                ..ChatFormat::new("c", vec![ChatMessage::user("hi")])
+            };
+            let (_system, messages) = split_system(&req).unwrap();
+            let built = build_request(&req, "c-name", None, messages, false);
+            assert!(
+                !built.extra.contains_key("reasoning_effort"),
+                "reasoning_effort = {value} leaked upstream"
+            );
+            assert!(!built.extra.contains_key("output_config"));
+            assert!(!built.extra.contains_key("thinking"));
         }
     }
 

--- a/tests/e2e/src/cases/reasoning-effort-translation-e2e.test.ts
+++ b/tests/e2e/src/cases/reasoning-effort-translation-e2e.test.ts
@@ -277,6 +277,7 @@ describe("OpenAI Chat → Anthropic upstream: reasoning_effort becomes output_co
 
   async function upstreamBodyFor(
     extra: Record<string, unknown>,
+    stream = false,
   ): Promise<Record<string, unknown>> {
     const baseline = upstream!.receivedRequests.length;
     const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
@@ -288,6 +289,7 @@ describe("OpenAI Chat → Anthropic upstream: reasoning_effort becomes output_co
       body: JSON.stringify({
         model: "effort-anth",
         messages: [{ role: "user", content: "probe" }],
+        ...(stream ? { stream: true } : {}),
         ...extra,
       }),
     });
@@ -323,5 +325,34 @@ describe("OpenAI Chat → Anthropic upstream: reasoning_effort becomes output_co
     const none = await upstreamBodyFor({ reasoning_effort: "none" });
     expect(none.output_config).toBeUndefined();
     expect(none.thinking).toEqual({ type: "disabled" });
+  });
+
+  test("the streaming call site takes the same translation", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    // The Anthropic bridge calls `build_request` from two places, one
+    // per streaming mode. They share the translation today; this keeps
+    // the streaming one from drifting out of it.
+    const body = await upstreamBodyFor({ reasoning_effort: "xhigh" }, true);
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.output_config).toEqual({ effort: "xhigh" });
+    expect(body.stream).toBe(true);
+  });
+
+  test("a carrier output_config keeps its other keys and gains the tier", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    const body = await upstreamBodyFor({
+      reasoning_effort: "high",
+      output_config: { task_budget: { type: "tokens", total: 64000 } },
+    });
+    expect(body.output_config).toEqual({
+      task_budget: { type: "tokens", total: 64000 },
+      effort: "high",
+    });
   });
 });

--- a/tests/e2e/src/cases/reasoning-effort-translation-e2e.test.ts
+++ b/tests/e2e/src/cases/reasoning-effort-translation-e2e.test.ts
@@ -1,0 +1,327 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the reasoning-effort knob survives cross-protocol translation in
+// both directions (AISIX-Cloud#1474).
+//
+// Anthropic moved the control off `thinking.budget_tokens` and onto
+// `output_config.effort`: the budget is deprecated on Opus 4.6 and
+// rejected outright from 4.7, so a current client sends adaptive
+// thinking plus an effort tier, or an effort tier alone. The gateway
+// translated only `thinking`, so `output_config` fell into the
+// drop-everything-else branch and the caller's tier never reached the
+// upstream — an adaptive request arrived byte-identical whichever tier
+// it asked for.
+//
+// These assert on what the mock upstream actually received, which is
+// the only place the bug was visible: SLS `content_mode = full` records
+// the client-side body from before translation, so an `output_config`
+// there proves nothing about what went upstream.
+
+const ANTHROPIC_IN_PLAINTEXT = "sk-effort-anthropic-in";
+const ANTHROPIC_IN_KEY_HASH = createHash("sha256")
+  .update(ANTHROPIC_IN_PLAINTEXT)
+  .digest("hex");
+
+describe("Anthropic Messages → OpenAI upstream: effort tier reaches the upstream (#1474)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "chatcmpl-effort-01",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "hello" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      },
+    });
+
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "effort-xprov-pk",
+      secret: "sk-openai-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "effort-xprov",
+      provider: "openai",
+      model_name: "gpt-4o",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: ANTHROPIC_IN_KEY_HASH,
+      allowed_models: ["effort-xprov"],
+    });
+
+    // The caller key is seeded last, so it authenticating implies the
+    // whole seed set is in the snapshot. Gating on a `/v1/messages`
+    // call instead would fail by timeout rather than by assertion when
+    // the translation under test breaks.
+    const proxy = new ProxyClient(app.proxyUrl, ANTHROPIC_IN_PLAINTEXT);
+    await waitConfigPropagation(
+      async () => (await proxy.listModels()).status === 200,
+    );
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  /** Send an Anthropic body and return the body the upstream received. */
+  async function upstreamBodyFor(
+    extra: Record<string, unknown>,
+    stream = false,
+  ): Promise<Record<string, unknown>> {
+    const baseline = upstream!.receivedRequests.length;
+    const res = await fetch(`${app!.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": ANTHROPIC_IN_PLAINTEXT,
+      },
+      body: JSON.stringify({
+        model: "effort-xprov",
+        max_tokens: 16000,
+        messages: [{ role: "user", content: "probe" }],
+        ...(stream ? { stream: true } : {}),
+        ...extra,
+      }),
+    });
+    expect(res.ok).toBe(true);
+    // Drain a streaming body so the upstream request is complete before
+    // the assertions read it.
+    await res.text();
+    const req = upstream!.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/chat/completions");
+    expect(req).toBeDefined();
+    return JSON.parse(req!.body) as Record<string, unknown>;
+  }
+
+  test("output_config.effort becomes reasoning_effort, and outranks thinking", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // The reported request: adaptive thinking + an explicit tier. The
+    // tier is what the caller chose, so the tier is what goes upstream.
+    const withThinking = await upstreamBodyFor({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "max" },
+    });
+    expect(withThinking.reasoning_effort).toBe("max");
+    expect(withThinking.output_config).toBeUndefined();
+    expect(withThinking.thinking).toBeUndefined();
+
+    // The reported variant: a tier with no `thinking` at all, which is
+    // how a current client asks, since thinking is on by default.
+    const effortOnly = await upstreamBodyFor({
+      output_config: { effort: "xhigh" },
+    });
+    expect(effortOnly.reasoning_effort).toBe("xhigh");
+    expect(effortOnly.output_config).toBeUndefined();
+
+    // Adaptive with no tier takes Anthropic's own default, not a
+    // middle tier the caller never asked for.
+    const adaptiveOnly = await upstreamBodyFor({
+      thinking: { type: "adaptive" },
+    });
+    expect(adaptiveOnly.reasoning_effort).toBe("high");
+
+    // The legacy budget shape still maps, for clients that predate the
+    // effort field.
+    const legacyBudget = await upstreamBodyFor({
+      thinking: { type: "enabled", budget_tokens: 8000 },
+    });
+    expect(legacyBudget.reasoning_effort).toBe("high");
+  });
+
+  test("streaming takes the same translation as non-streaming", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    const body = await upstreamBodyFor(
+      { thinking: { type: "adaptive" }, output_config: { effort: "max" } },
+      true,
+    );
+    expect(body.reasoning_effort).toBe("max");
+    expect(body.output_config).toBeUndefined();
+  });
+
+  test("output_config.format becomes a strict response_format", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+    const body = await upstreamBodyFor({
+      output_config: {
+        format: {
+          type: "json_schema",
+          schema: {
+            type: "object",
+            properties: { city: { type: "string" } },
+          },
+        },
+      },
+    });
+    expect(body.output_config).toBeUndefined();
+    expect(body.response_format).toEqual({
+      type: "json_schema",
+      json_schema: {
+        name: "structured_output",
+        strict: true,
+        schema: {
+          type: "object",
+          properties: { city: { type: "string" } },
+          additionalProperties: false,
+          required: ["city"],
+        },
+      },
+    });
+  });
+});
+
+// ─── Reverse direction ──────────────────────────────────────────────
+
+const OPENAI_IN_PLAINTEXT = "sk-effort-openai-in";
+const OPENAI_IN_KEY_HASH = createHash("sha256")
+  .update(OPENAI_IN_PLAINTEXT)
+  .digest("hex");
+
+describe("OpenAI Chat → Anthropic upstream: reasoning_effort becomes output_config (#1474)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "msg_effort_01",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "hello" }],
+        model: "claude-opus-4-6",
+        stop_reason: "end_turn",
+        usage: { input_tokens: 5, output_tokens: 4 },
+      },
+    });
+
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    // The Anthropic bridge appends `/v1/messages` itself, so api_base
+    // is the bare host — the opposite of the OpenAI bridge convention.
+    const pk = await seed.createProviderKey({
+      display_name: "effort-anth-pk",
+      provider: "anthropic",
+      adapter: "anthropic",
+      secret: "sk-ant-mock",
+      api_base: upstream.baseUrl,
+    });
+    await seed.createModel({
+      display_name: "effort-anth",
+      provider: "anthropic",
+      model_name: "claude-opus-4-6",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: OPENAI_IN_KEY_HASH,
+      allowed_models: ["effort-anth"],
+    });
+
+    const proxy = new ProxyClient(app.proxyUrl, OPENAI_IN_PLAINTEXT);
+    await waitConfigPropagation(
+      async () => (await proxy.listModels()).status === 200,
+    );
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  async function upstreamBodyFor(
+    extra: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const baseline = upstream!.receivedRequests.length;
+    const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${OPENAI_IN_PLAINTEXT}`,
+      },
+      body: JSON.stringify({
+        model: "effort-anth",
+        messages: [{ role: "user", content: "probe" }],
+        ...extra,
+      }),
+    });
+    expect(res.ok).toBe(true);
+    await res.text();
+    const req = upstream!.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path.endsWith("/v1/messages"));
+    expect(req).toBeDefined();
+    return JSON.parse(req!.body) as Record<string, unknown>;
+  }
+
+  test("reasoning_effort is translated, never forwarded verbatim", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // `reasoning_effort` is not an Anthropic field: forwarding it
+    // verbatim reaches `/v1/messages` as an unknown parameter.
+    const tiered = await upstreamBodyFor({ reasoning_effort: "xhigh" });
+    expect(tiered.reasoning_effort).toBeUndefined();
+    expect(tiered.output_config).toEqual({ effort: "xhigh" });
+    // The caller asked for a depth, not a thinking mode — the model
+    // applies its own.
+    expect(tiered.thinking).toBeUndefined();
+
+    // Anthropic's vocabulary has no `minimal`; `low` is its floor.
+    const minimal = await upstreamBodyFor({ reasoning_effort: "minimal" });
+    expect(minimal.output_config).toEqual({ effort: "low" });
+
+    // ...and no `none`: asking for no reasoning is the disabled mode.
+    const none = await upstreamBodyFor({ reasoning_effort: "none" });
+    expect(none.output_config).toBeUndefined();
+    expect(none.thinking).toEqual({ type: "disabled" });
+  });
+});


### PR DESCRIPTION
Anthropic moved the reasoning depth control off `thinking.budget_tokens` and onto `output_config.effort`. The budget is deprecated on Claude Opus 4.6 and rejected outright from 4.7, so a current client sends adaptive thinking plus an effort tier, or an effort tier alone. Neither reached the upstream.

## Anthropic in, OpenAI out

`translate_extras_to_openai_shape` whitelisted `thinking` and dropped every other top-level field, so `output_config` fell into the drop branch. Two consequences, both silent:

- `thinking: {type: adaptive}` + `output_config: {effort: max}` reached the upstream as `reasoning_effort: medium` — `adaptive` was pinned to `medium` regardless of the tier, so an adaptive request arrived byte-identical whichever effort it asked for.
- `output_config: {effort: max}` with no `thinking` — the idiomatic shape now that thinking is on by default — produced no `reasoning_effort` at all.

`thinking` and `output_config` are now resolved together, since both encode the same OpenAI knob and neither can be translated by looking at one key in isolation:

| Request | `reasoning_effort` |
| --- | --- |
| `thinking.type: disabled` | `none` |
| `output_config.effort` | forwarded verbatim |
| `thinking.type: enabled` | bucketed from `budget_tokens` (unchanged: ≥4096 high, ≥2048 medium, ≥1024 low, below minimal) |
| `thinking.type: adaptive`, no tier | `high` |

An explicit opt-out outranks a tier, and `adaptive` with no tier resolves to the tier Anthropic itself applies when a request omits one, rather than to a middle tier the caller never asked for.

Tiers are forwarded as written. `max` and `xhigh` reach an upstream that may reject them, which is the intended outcome: substituting a tier the upstream happens to accept would quietly change the reasoning depth the application asked for, and that is harder to notice than an error. No capability table is consulted.

## The same whitelist also dropped the structured-output schema

`output_format` and `output_config.format` took the same drop branch, so an Anthropic structured-output request lost its schema on this path. Both now become an OpenAI `response_format` in `json_schema` form with strict mode enabled, which requires every object schema to close over its properties (`additionalProperties: false`, all declared properties in `required`, at each nesting level). `output_format` wins when a request carries both.

## OpenAI in, Anthropic out

`build_request` forwarded `ChatFormat::extra` verbatim apart from tools, so an OpenAI-shape `reasoning_effort` reached `/v1/messages` as an unknown top-level field. It now becomes `output_config.effort` — `minimal` maps to Anthropic's `low` floor, and `none` becomes `thinking: {"type": "disabled"}` since Anthropic has no `none` tier.

`thinking` is otherwise left alone: the caller asked for a depth, not a thinking mode, and current Anthropic models apply their own. `output_config.effort` rather than a `budget_tokens` block, because a budget is rejected from Opus 4.7 onwards while effort is accepted across the whole current family, and the gateway holds only the operator-supplied upstream model name — there is no capability map to choose between the two shapes with. A native field the request supplied itself takes precedence, and an unrecognised value is dropped rather than forwarded.

## Behavior changes

- `thinking: {type: adaptive}` with no effort now yields `reasoning_effort: high` instead of `medium` on the translated path.
- `thinking: {type: disabled}` now yields `reasoning_effort: none` instead of omitting the field.
- An OpenAI-shape request with `reasoning_effort` against an Anthropic upstream previously failed with an unknown-parameter error; it now succeeds.

## Tests

Unit coverage in `wire.rs` for each precedence branch, the verbatim tier forwarding, strict-mode schema closing, and each reverse-direction mapping. Every one was mutation-checked: reverting `adaptive` to `medium`, dropping the `disabled` arm, un-capturing `output_config`, removing the format translation, removing the reverse call, skipping the schema closing, and flipping either precedence order each fail at least one test, and none survived.

`tests/e2e/reasoning-effort-translation-e2e.test.ts` asserts on the body a mock upstream actually received, in both directions and for streaming as well as non-streaming — the only place the bug was visible, since SLS `content_mode = full` records the client-side body from before translation. All four cases fail against a pre-fix binary with the reported symptoms (`expected 'medium' to be 'max'`, and `reasoning_effort` present in the Anthropic-bound body).

Docs ship separately, per repo policy: api7/docs and api7/docs.apiseven.com.

Fixes api7/AISIX-Cloud#1474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved translation of reasoning-effort settings between OpenAI and Anthropic requests.
  - Added support for converting Anthropic structured-output formats into compatible response formats.
  - Preserved existing output configuration and reasoning settings during streaming and cross-provider requests.

- **Bug Fixes**
  - Corrected handling of disabled and adaptive reasoning modes.
  - Ensured provider-specific fields are translated or omitted appropriately.
  - Applied stricter handling to structured object schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->