### PR TITLE
fix(metrics): align protocol coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust
 /target
+/target-anon
 # PGO phase target dirs (native runs of the three-phase release recipe)
 /target-pgo-gen
 /target-pgo

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -206,13 +206,13 @@ pub const M_BUDGET_DETAILS_PRESENT: &str = "aisix_budget_details_present";
 pub const M_REDIS_FAILURES_TOTAL: &str = "aisix_redis_failures_total";
 pub const M_USAGE_EVENT_DROPS_TOTAL: &str = "aisix_usage_event_drops_total";
 /// Guardrail outcomes (#379 observability). `aisix_guardrail_blocks_total`
-/// counts guardrail executions that rejected a request (input or output hook;
-/// policy or fail-closed combined). `aisix_guardrail_bypasses_total` counts
-/// fail-open executions — a remote-API guardrail's upstream was unreachable
-/// but `fail_open` let the request through — sliced by the bounded DP-internal
+/// counts requests rejected by guardrail enforcement, including fail-closed
+/// paths such as a streaming buffer overflow that happen before a guardrail
+/// member executes. `aisix_guardrail_bypasses_total` counts fail-open
+/// executions — a remote-API guardrail's upstream was unreachable but
+/// `fail_open` let the request through — sliced by the bounded DP-internal
 /// `reason` (e.g. `bedrock_5xx` / `bedrock_timeout` /
-/// `bedrock_throttled`). Both counters share the all-endpoint execution
-/// chokepoint with `aisix_guardrail_latency_seconds`.
+/// `bedrock_throttled`).
 pub const M_GUARDRAIL_BLOCKS_TOTAL: &str = "aisix_guardrail_blocks_total";
 pub const M_GUARDRAIL_BYPASSES_TOTAL: &str = "aisix_guardrail_bypasses_total";
 
@@ -1323,31 +1323,31 @@ impl Metrics {
         );
     }
 
-    /// Record the aggregate counters that accompany one timed guardrail
-    /// execution. Keeping this beside the per-guardrail histogram makes the
-    /// three families share the same all-endpoint coverage.
-    fn record_guardrail_outcome(&self, result: &str, error_type: Option<&str>) {
-        if result == "blocked" {
-            self.cached_counter(
-                M_GUARDRAIL_BLOCKS_TOTAL,
-                1,
-                |_| {},
-                || metrics::counter!(M_GUARDRAIL_BLOCKS_TOTAL),
-            );
-        }
-        if let ("bypassed", Some(reason)) = (result, error_type) {
-            self.cached_counter(
-                M_GUARDRAIL_BYPASSES_TOTAL,
-                1,
-                |k| k.label(reason),
-                || {
-                    metrics::counter!(
-                        M_GUARDRAIL_BYPASSES_TOTAL,
-                        "reason" => reason.to_string(),
-                    )
-                },
-            );
-        }
+    /// Count one request rejected by guardrail enforcement. The terminal
+    /// UsageEvent path calls this exactly once, including refusals that happen
+    /// before a guardrail member executes (for example a streamed-output
+    /// buffer overflow).
+    pub fn record_guardrail_blocked_request(&self) {
+        self.cached_counter(
+            M_GUARDRAIL_BLOCKS_TOTAL,
+            1,
+            |_| {},
+            || metrics::counter!(M_GUARDRAIL_BLOCKS_TOTAL),
+        );
+    }
+
+    fn record_guardrail_bypass_execution(&self, reason: &str) {
+        self.cached_counter(
+            M_GUARDRAIL_BYPASSES_TOTAL,
+            1,
+            |k| k.label(reason),
+            || {
+                metrics::counter!(
+                    M_GUARDRAIL_BYPASSES_TOTAL,
+                    "reason" => reason.to_string(),
+                )
+            },
+        );
     }
 
     /// Record one guardrail member execution on
@@ -1379,7 +1379,9 @@ impl Metrics {
                 )
             },
         );
-        self.record_guardrail_outcome(exec.result, exec.error_type);
+        if let ("bypassed", Some(reason)) = (exec.result, exec.error_type) {
+            self.record_guardrail_bypass_execution(reason);
+        }
     }
 
     /// Count one rate-limit rejection. `scope` is the exceeded
@@ -3660,6 +3662,9 @@ mod tests {
     #[test]
     fn guardrail_outcome_counters_increment() {
         let m = Metrics::new(false);
+        // Request-level block accounting is separate from timed executions:
+        // this also represents fail-closed paths that never call a member.
+        m.record_guardrail_blocked_request();
         for (result, error_type) in [
             ("blocked", None),
             ("bypassed", Some("bedrock_5xx")),
@@ -3675,7 +3680,8 @@ mod tests {
             });
         }
         let rendered = m.render();
-        // Exactly one block (the clean call must not increment it).
+        // Exactly one request block: the timed blocked execution must not
+        // double-count it.
         assert!(
             rendered.contains(&format!("{M_GUARDRAIL_BLOCKS_TOTAL} 1")),
             "want one block, got:\n{rendered}"

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -11,7 +11,8 @@
 //!   That is the full request for a non-streamed response and only time to
 //!   response START for a streamed one; `aisix_request_e2e_latency_seconds`
 //!   is the series that is end-to-end on both. See `request_metrics`.
-//! - `aisix_ratelimit_rejections_total{scope}` — counter for 429 flows.
+//! - `aisix_ratelimit_rejections_total{scope,layer,policy_id}` — counter for
+//!   429 flows.
 //! - `aisix_tokens_consumed_total{provider,model}` — counter of
 //!   `usage.total_tokens` summed across completed calls. Streamed calls are
 //!   included: they contribute from the end-of-stream emit, not at response
@@ -205,14 +206,13 @@ pub const M_BUDGET_DETAILS_PRESENT: &str = "aisix_budget_details_present";
 pub const M_REDIS_FAILURES_TOTAL: &str = "aisix_redis_failures_total";
 pub const M_USAGE_EVENT_DROPS_TOTAL: &str = "aisix_usage_event_drops_total";
 /// Guardrail outcomes (#379 observability). `aisix_guardrail_blocks_total`
-/// counts requests a guardrail rejected (input or output hook; policy or
-/// fail-closed combined). `aisix_guardrail_bypasses_total` counts fail-open
-/// events — a remote-API guardrail's upstream was unreachable but `fail_open`
-/// let the request through — sliced by the bounded DP-internal `reason`
-/// (e.g. `bedrock_5xx` / `bedrock_timeout` / `bedrock_throttled`).
-///
-/// Scope: recorded for `/v1/chat/completions` only until #519 brings the
-/// `/v1/messages` path in — read these as chat-path, not gateway-wide.
+/// counts guardrail executions that rejected a request (input or output hook;
+/// policy or fail-closed combined). `aisix_guardrail_bypasses_total` counts
+/// fail-open executions — a remote-API guardrail's upstream was unreachable
+/// but `fail_open` let the request through — sliced by the bounded DP-internal
+/// `reason` (e.g. `bedrock_5xx` / `bedrock_timeout` /
+/// `bedrock_throttled`). Both counters share the all-endpoint execution
+/// chokepoint with `aisix_guardrail_latency_seconds`.
 pub const M_GUARDRAIL_BLOCKS_TOTAL: &str = "aisix_guardrail_blocks_total";
 pub const M_GUARDRAIL_BYPASSES_TOTAL: &str = "aisix_guardrail_bypasses_total";
 
@@ -253,12 +253,11 @@ pub const M_AUTH_DECISIONS_TOTAL: &str = "aisix_auth_decisions_total";
 /// there is no separate `aisix_guardrail_requests_total` (LiteLLM's
 /// `litellm_guardrail_requests_total` equivalent = `sum by (...)` of it).
 pub const M_GUARDRAIL_LATENCY_SECONDS: &str = "aisix_guardrail_latency_seconds";
-/// Issue #408: counter for UsageEvents successfully enqueued onto the
-/// `UsageSink` (i.e. handed off to the telemetry worker for delivery
-/// to cp-api + per-env OTLP exporters). Operators slice this by:
-/// - `handler`: which OpenAI-shape handler emitted (chat /
-///   embeddings / responses / completions / rerank / audio /
-///   images / messages). Fixed enumeration, low cardinality.
+/// Issue #408: counter for UsageEvent emission attempts, incremented before
+/// the `UsageSink` accepts or rejects the event. Operators slice this by:
+/// - `handler`: the bounded handler family that emitted the event (for
+///   example `chat`, `messages`, `count_tokens`, `responses`, `mcp`, or
+///   `passthrough_route`). Fixed enumeration, low cardinality.
 /// - `status_code`: bucketed as `2xx` / `4xx` / `5xx`.
 /// - `status`: the raw code (`429`, `502`, ...), so a query can name one
 ///   failure mode instead of a whole family (AISIX-Cloud#1389). Named to
@@ -273,8 +272,8 @@ pub const M_GUARDRAIL_LATENCY_SECONDS: &str = "aisix_guardrail_latency_seconds";
 ///   their display name, from [`UsageEventLabels`]. Both come off one
 ///   ApiKey row, so the name is determined by the id and the pair is one
 ///   series, not one per name.
-/// - `inbound_protocol`: `openai` / `anthropic`. Matches the
-///   wire-level field on UsageEvent.
+/// - `inbound_protocol`: `openai` / `anthropic` / `mcp` / `other`, with
+///   non-HTTP and tunnel protocols folded into the bounded `other` bucket.
 /// - `upstream_protocol`: the wire protocol of the ProviderKey the event
 ///   was attributed to, so this family joins with the request and usage
 ///   families on that dimension (AISIX-Cloud#1403). Read off the SAME
@@ -1324,12 +1323,11 @@ impl Metrics {
         );
     }
 
-    /// Record one request's guardrail outcome. Called once per request from
-    /// the centralised telemetry emit, using the same data as the UsageEvent's
-    /// `guardrail_blocked` / `guardrail_bypassed_reason` fields. An empty
-    /// `bypass_reason` means no bypass occurred.
-    pub fn record_guardrail_outcome(&self, blocked: bool, bypass_reason: &str) {
-        if blocked {
+    /// Record the aggregate counters that accompany one timed guardrail
+    /// execution. Keeping this beside the per-guardrail histogram makes the
+    /// three families share the same all-endpoint coverage.
+    fn record_guardrail_outcome(&self, result: &str, error_type: Option<&str>) {
+        if result == "blocked" {
             self.cached_counter(
                 M_GUARDRAIL_BLOCKS_TOTAL,
                 1,
@@ -1337,15 +1335,15 @@ impl Metrics {
                 || metrics::counter!(M_GUARDRAIL_BLOCKS_TOTAL),
             );
         }
-        if !bypass_reason.is_empty() {
+        if let ("bypassed", Some(reason)) = (result, error_type) {
             self.cached_counter(
                 M_GUARDRAIL_BYPASSES_TOTAL,
                 1,
-                |k| k.label(bypass_reason),
+                |k| k.label(reason),
                 || {
                     metrics::counter!(
                         M_GUARDRAIL_BYPASSES_TOTAL,
-                        "reason" => bypass_reason.to_string(),
+                        "reason" => reason.to_string(),
                     )
                 },
             );
@@ -1381,6 +1379,7 @@ impl Metrics {
                 )
             },
         );
+        self.record_guardrail_outcome(exec.result, exec.error_type);
     }
 
     /// Count one rate-limit rejection. `scope` is the exceeded
@@ -2372,12 +2371,12 @@ impl Metrics {
     ///
     /// The surface labels are `&'static str` so prometheus cardinality is
     /// type-system-bounded:
-    /// - `handler`: OpenAI-shape endpoint name (`chat`, `embeddings`,
-    ///   `messages`, etc.)
+    /// - `handler`: bounded handler family (`chat`, `embeddings`,
+    ///   `messages`, `mcp`, etc.)
     /// - `status_code`: bucketed by `status_bucket()` (one of `2xx` /
     ///   `3xx` / `4xx` / `5xx` / `other`) — never a raw u16
     /// - `inbound_protocol`: normalised by the caller to one of
-    ///   `"openai"` / `"anthropic"` / `"other"` (audit MEDIUM-3 —
+    ///   `"openai"` / `"anthropic"` / `"mcp"` / `"other"` (audit MEDIUM-3 —
     ///   `&'static str` here prevents user-controlled cardinality)
     ///
     /// [`UsageEventLabels`] adds the model, the ProviderKey the event was
@@ -3661,9 +3660,20 @@ mod tests {
     #[test]
     fn guardrail_outcome_counters_increment() {
         let m = Metrics::new(false);
-        m.record_guardrail_outcome(true, ""); // blocked, no bypass
-        m.record_guardrail_outcome(false, "bedrock_5xx"); // fail-open bypass
-        m.record_guardrail_outcome(false, ""); // clean request → records nothing
+        for (result, error_type) in [
+            ("blocked", None),
+            ("bypassed", Some("bedrock_5xx")),
+            ("allowed", None),
+        ] {
+            m.record_guardrail_execution(&aisix_core::GuardrailExecution {
+                guardrail_name: "policy",
+                kind: "bedrock",
+                phase: "input",
+                result,
+                error_type,
+                elapsed: Duration::from_millis(1),
+            });
+        }
         let rendered = m.render();
         // Exactly one block (the clean call must not increment it).
         assert!(

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1078,6 +1078,56 @@ fn estimate_subcall_tokens(
     )
 }
 
+/// Preserve any provider-reported overhead while ensuring Anthropic-shaped
+/// cache counters, which sit beside input tokens, are included in the
+/// canonical total used for quotas and Prometheus.
+fn cache_inclusive_total(
+    reported_total: u64,
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    cache_creation_tokens: u32,
+    cache_read_tokens: u32,
+) -> u64 {
+    reported_total.max(crate::usage_attr::total_tokens_with_cache(
+        prompt_tokens,
+        completion_tokens,
+        cache_creation_tokens,
+        cache_read_tokens,
+    ))
+}
+
+#[derive(Clone)]
+struct EffectiveSubcallUsage {
+    usage: aisix_gateway::chat::UsageStats,
+    estimated: bool,
+}
+
+/// Resolve one ensemble sub-call's final accounting once, then share it
+/// between its UsageEvent, request-level Prometheus aggregate, and quota
+/// commit. The client-facing response still carries only upstream-reported
+/// usage; local estimates remain telemetry-only.
+fn effective_subcall_usage(
+    req: &ChatFormat,
+    model: &str,
+    reported: &aisix_gateway::chat::UsageStats,
+    output_text: &str,
+) -> EffectiveSubcallUsage {
+    let (prompt_tokens, completion_tokens, estimated) =
+        estimate_subcall_tokens(req, model, reported, output_text);
+    let mut usage = reported.clone();
+    usage.prompt_tokens = prompt_tokens;
+    usage.completion_tokens = completion_tokens;
+    usage.total_tokens = cache_inclusive_total(
+        u64::from(reported.total_tokens),
+        prompt_tokens,
+        completion_tokens,
+        usage.cache_creation_tokens,
+        usage.cache_read_tokens,
+    )
+    .min(u64::from(u32::MAX)) as u32;
+    EffectiveSubcallUsage { usage, estimated }
+}
+
 fn last_user_message_text(req: &ChatFormat) -> Option<String> {
     req.messages
         .iter()
@@ -2548,6 +2598,13 @@ async fn dispatch(
                 } else {
                     (prompt, completion, total, false)
                 };
+                let total = cache_inclusive_total(
+                    total,
+                    prompt.min(u64::from(u32::MAX)) as u32,
+                    completion.min(u64::from(u32::MAX)) as u32,
+                    cache_creation_tokens,
+                    cache_read_tokens,
+                );
                 // Capture the prompt + cached response for content-capturing
                 // exporters (gated). A cache hit still served content to the
                 // caller, so it's logged like a fresh response.
@@ -2992,16 +3049,13 @@ async fn dispatch(
     };
     let prompt = prompt_tokens_u32 as u64;
     let completion = completion_tokens_u32 as u64;
-    let total = if usage_estimated {
-        crate::usage_attr::total_tokens_with_cache(
-            prompt_tokens_u32,
-            completion_tokens_u32,
-            upstream.usage.cache_creation_tokens,
-            upstream.usage.cache_read_tokens,
-        )
-    } else {
-        upstream.usage.total_tokens as u64
-    };
+    let total = cache_inclusive_total(
+        u64::from(upstream.usage.total_tokens),
+        prompt_tokens_u32,
+        completion_tokens_u32,
+        upstream.usage.cache_creation_tokens,
+        upstream.usage.cache_read_tokens,
+    );
     // Snapshot the cache / reasoning counters + provider identity before
     // the upstream gets moved into render_response below — we need them
     // on the Success struct for telemetry.
@@ -3356,56 +3410,61 @@ async fn dispatch_ensemble(
     // `bypass` is passed per call (not captured) so the closure holds no
     // borrow of the mutable `bypass_reason`. `attempt_index` is the member's
     // 0-based slot; `blocked` sets the event's `guardrail_blocked` flag.
-    let emit_panel_member =
-        |member: &crate::ensemble::PanelOutcome, index: usize, blocked: bool, bypass: &str| {
-            let (sub_model_id, sub_provider_key_id, sub_upstream_model) =
-                resolve_sub(&member.model);
-            // #1074: a member backend that omitted usage gets its prompt
-            // estimated from the shared client request and its completion
-            // from the member's own answer text, tokenized with the member's
-            // resolved upstream model.
-            let (prompt_tokens, completion_tokens, usage_estimated) = estimate_subcall_tokens(
-                req,
-                &sub_upstream_model,
-                &member.usage,
-                &member.est_output_text,
-            );
-            let pk = crate::usage_attr::ResolvedPk::resolve(snapshot, &sub_provider_key_id);
-            emit_usage_event(
-                state,
-                snapshot,
-                &pk,
-                request_id,
-                &sub_model_id,
-                &req.model,
-                api_key_id,
-                200,
-                started.elapsed(),
-                prompt_tokens,
-                completion_tokens,
-                UsageExtras {
-                    cached_prompt_tokens: member.usage.cached_prompt_tokens,
-                    reasoning_tokens: member.usage.reasoning_tokens,
-                    cache_creation_tokens: member.usage.cache_creation_tokens,
-                    cache_read_tokens: member.usage.cache_read_tokens,
-                    usage_estimated,
-                    bypass_reason: bypass.to_string(),
-                    cache_status: CacheStatus::Disabled.as_str().to_string(),
-                    attempt_index: index as u32,
-                    attempt_kind: "panel".to_string(),
-                    attempt_model: member.model.clone(),
-                    applied_guardrails: applied_guardrails.to_vec(),
-                    ..UsageExtras::default()
-                },
-                /* cost_usd */ 0.0,
-                blocked,
-                client,
-                /* content */ None,
-                /* terminal */ false,
-                /* dispatched */ true,
-                audit,
-            );
+    let emit_panel_member = |member: &crate::ensemble::PanelOutcome,
+                             index: usize,
+                             prepared: Option<&EffectiveSubcallUsage>,
+                             blocked: bool,
+                             bypass: &str| {
+        let (sub_model_id, sub_provider_key_id, sub_upstream_model) = resolve_sub(&member.model);
+        let computed;
+        let effective = match prepared {
+            Some(usage) => usage,
+            None => {
+                computed = effective_subcall_usage(
+                    req,
+                    &sub_upstream_model,
+                    &member.usage,
+                    &member.est_output_text,
+                );
+                &computed
+            }
         };
+        let pk = crate::usage_attr::ResolvedPk::resolve(snapshot, &sub_provider_key_id);
+        emit_usage_event(
+            state,
+            snapshot,
+            &pk,
+            request_id,
+            &sub_model_id,
+            &req.model,
+            api_key_id,
+            200,
+            started.elapsed(),
+            effective.usage.prompt_tokens,
+            effective.usage.completion_tokens,
+            UsageExtras {
+                cached_prompt_tokens: effective.usage.cached_prompt_tokens,
+                reasoning_tokens: effective.usage.reasoning_tokens,
+                cache_creation_tokens: effective.usage.cache_creation_tokens,
+                cache_read_tokens: effective.usage.cache_read_tokens,
+                usage_estimated: effective.estimated,
+                bypass_reason: bypass.to_string(),
+                cache_status: CacheStatus::Disabled.as_str().to_string(),
+                attempt_index: index as u32,
+                attempt_kind: "panel".to_string(),
+                attempt_model: member.model.clone(),
+                applied_guardrails: applied_guardrails.to_vec(),
+                ..UsageExtras::default()
+            },
+            /* cost_usd */ 0.0,
+            blocked,
+            client,
+            /* content */ None,
+            /* terminal */ false,
+            /* dispatched */ true,
+            audit,
+        );
+    };
 
     let caller = crate::ensemble::ProxyModelCaller {
         state,
@@ -3444,13 +3503,24 @@ async fn dispatch_ensemble(
         // this for the emit + `DispatchFailure`. `panel` is borrowed so the
         // call site still owns it to compute `survivor_total`.
         let survivor_total = |panel: &[crate::ensemble::PanelOutcome]| -> u64 {
-            panel.iter().map(|p| u64::from(p.usage.total_tokens)).sum()
+            panel
+                .iter()
+                .map(|p| {
+                    cache_inclusive_total(
+                        u64::from(p.usage.total_tokens),
+                        p.usage.prompt_tokens,
+                        p.usage.completion_tokens,
+                        p.usage.cache_creation_tokens,
+                        p.usage.cache_read_tokens,
+                    )
+                })
+                .sum()
         };
         let emit_panel_then_fail =
             |panel: &[crate::ensemble::PanelOutcome], proxy_err: ProxyError| -> DispatchFailure {
                 for (index, member) in panel.iter().enumerate() {
                     emit_panel_member(
-                        member, index, /* blocked */ false, /* bypass */ "",
+                        member, index, None, /* blocked */ false, /* bypass */ "",
                     );
                 }
                 DispatchFailure::new(Some(model_id.to_string()), None, proxy_err)
@@ -3591,37 +3661,41 @@ async fn dispatch_ensemble(
         // this frame — it fires on stream drop), so the `emit_panel_member` /
         // `resolve_sub` borrowing closures above are unusable inside it. Clone
         // the per-member + judge telemetry inputs up front.
+        // The `'static` on_complete closure cannot borrow `req`. Resolve
+        // each panel member's estimation fallback now so its UsageEvent,
+        // request-level aggregate, and quota commit all consume the same
+        // final counters.
+        let req_for_panel_est = req.clone();
         struct PanelTelem {
             model_id: String,
             provider_key_id: String,
             attempt_model: String,
             usage: aisix_gateway::chat::UsageStats,
-            est_output_text: String,
-            /// Resolved upstream model — the tokenizer key for the #1074
-            /// estimate, pre-resolved here because the `'static` closure
-            /// can't reach the snapshot (mirrors `model_id`).
-            est_model: String,
+            usage_estimated: bool,
         }
         let panel_telem: Vec<PanelTelem> = panel
             .iter()
             .map(|p| {
                 let (model_id, provider_key_id, est_model) = resolve_sub(&p.model);
+                let effective = effective_subcall_usage(
+                    &req_for_panel_est,
+                    &est_model,
+                    &p.usage,
+                    &p.est_output_text,
+                );
                 PanelTelem {
                     model_id,
                     provider_key_id,
                     attempt_model: p.model.clone(),
-                    usage: p.usage.clone(),
-                    est_output_text: p.est_output_text.clone(),
-                    est_model,
+                    usage: effective.usage,
+                    usage_estimated: effective.estimated,
                 }
             })
             .collect();
-        // #1074: the `'static` on_complete closure cannot borrow `req`, so
-        // capture one clone for the panel-member prompt estimate (used only
-        // when a member backend omits usage — the guard in
-        // `estimate_subcall_tokens` skips the tokenizer otherwise).
-        let req_for_panel_est = req.clone();
-        let panel_total: u64 = panel.iter().map(|p| u64::from(p.usage.total_tokens)).sum();
+        let panel_total: u64 = panel_telem
+            .iter()
+            .map(|p| u64::from(p.usage.total_tokens))
+            .sum();
         // #614: field-wise panel usage sum (not just total_tokens) folded into
         // the client-facing terminal usage chunk via build_sse_stream's
         // `base_usage`, so a streamed ensemble reports the full panel+judge
@@ -3631,7 +3705,11 @@ async fn dispatch_ensemble(
             .fold(aisix_gateway::chat::UsageStats::default(), |acc, p| {
                 acc.saturating_add(&p.usage)
             });
-        let panel_usage_for_metrics = panel_usage_sum.clone();
+        let panel_usage_for_metrics = panel_telem
+            .iter()
+            .fold(aisix_gateway::chat::UsageStats::default(), |acc, p| {
+                acc.saturating_add(&p.usage)
+            });
         // The streamed judge estimator keys off `judge_model.upstream_model()`
         // directly (below), so resolve_sub's upstream_model is unused here.
         let (judge_model_id, judge_provider_key_id, _) = resolve_sub(&ensemble_cfg.judge.model);
@@ -3734,9 +3812,6 @@ async fn dispatch_ensemble(
                 let aggregate_output = panel_usage_for_metrics
                     .completion_tokens
                     .saturating_add(comp.completion_tokens);
-                let aggregate_total = panel_usage_for_metrics
-                    .total_tokens
-                    .saturating_add(comp.total_tokens.min(u64::from(u32::MAX)) as u32);
                 let aggregate_cached = panel_usage_for_metrics
                     .cached_prompt_tokens
                     .saturating_add(comp.cached_prompt_tokens);
@@ -3746,6 +3821,15 @@ async fn dispatch_ensemble(
                 let aggregate_cache_creation = panel_usage_for_metrics
                     .cache_creation_tokens
                     .saturating_add(comp.cache_creation_tokens);
+                let aggregate_total = cache_inclusive_total(
+                    u64::from(panel_usage_for_metrics.total_tokens)
+                        .saturating_add(comp.total_tokens),
+                    aggregate_input,
+                    aggregate_output,
+                    aggregate_cache_creation,
+                    aggregate_cache_read,
+                )
+                .min(u64::from(u32::MAX)) as u32;
                 // Telemetry: one event per panel member (attempt_kind "panel",
                 // index 0..N) carrying that member's own buffered usage, then
                 // one judge event (attempt_kind "judge", index N) from the
@@ -3754,17 +3838,6 @@ async fn dispatch_ensemble(
                 // moved into on_complete because the judge counts only land on
                 // the terminal SSE chunk.
                 for (index, member) in panel_telem.iter().enumerate() {
-                    // #1074: same or-semantics fallback as the non-streaming
-                    // panel emit — estimate a member's tokens when its backend
-                    // omitted usage (members were buffered, so their answer
-                    // text is available even though the judge is streamed).
-                    let (prompt_tokens, completion_tokens, usage_estimated) =
-                        estimate_subcall_tokens(
-                            &req_for_panel_est,
-                            &member.est_model,
-                            &member.usage,
-                            &member.est_output_text,
-                        );
                     let pk = crate::usage_attr::ResolvedPk::resolve(&snap, &member.provider_key_id);
                     emit_usage_event(
                         &state_for_telem,
@@ -3776,14 +3849,14 @@ async fn dispatch_ensemble(
                         &api_key_id_for_telem,
                         200,
                         started.elapsed(),
-                        prompt_tokens,
-                        completion_tokens,
+                        member.usage.prompt_tokens,
+                        member.usage.completion_tokens,
                         UsageExtras {
                             cached_prompt_tokens: member.usage.cached_prompt_tokens,
                             reasoning_tokens: member.usage.reasoning_tokens,
                             cache_creation_tokens: member.usage.cache_creation_tokens,
                             cache_read_tokens: member.usage.cache_read_tokens,
-                            usage_estimated,
+                            usage_estimated: member.usage_estimated,
                             bypass_reason: bypass_for_telem.clone(),
                             cache_status: CacheStatus::Disabled.as_str().to_string(),
                             attempt_index: index as u32,
@@ -4020,11 +4093,22 @@ async fn dispatch_ensemble(
                     )),
                 ),
             };
-            let survivor_total: u64 = panel.iter().map(|p| u64::from(p.usage.total_tokens)).sum();
+            let survivor_total: u64 = panel
+                .iter()
+                .map(|p| {
+                    cache_inclusive_total(
+                        u64::from(p.usage.total_tokens),
+                        p.usage.prompt_tokens,
+                        p.usage.completion_tokens,
+                        p.usage.cache_creation_tokens,
+                        p.usage.cache_read_tokens,
+                    )
+                })
+                .sum();
             reservation.commit_tokens(survivor_total).await;
             for (index, member) in panel.iter().enumerate() {
                 emit_panel_member(
-                    member, index, /* blocked */ false, /* bypass */ "",
+                    member, index, None, /* blocked */ false, /* bypass */ "",
                 );
             }
             return Err(DispatchFailure::new(
@@ -4038,13 +4122,27 @@ async fn dispatch_ensemble(
     // Aggregate client-facing usage: every billed sub-call (panel members
     // + judge) counts against quota, since each one already hit an
     // upstream. Commit once against the single entry-level reservation.
-    let panel_total: u64 = outcome
+    let judge_usage = outcome.response.usage.clone();
+    let effective_panel: Vec<EffectiveSubcallUsage> = outcome
         .panel
         .iter()
-        .map(|p| u64::from(p.usage.total_tokens))
+        .map(|member| {
+            let (_, _, upstream_model) = resolve_sub(&member.model);
+            effective_subcall_usage(req, &upstream_model, &member.usage, &member.est_output_text)
+        })
+        .collect();
+    let (_, _, judge_upstream_model) = resolve_sub(&outcome.judge_model);
+    let effective_judge = effective_subcall_usage(
+        &outcome.judge_req,
+        &judge_upstream_model,
+        &judge_usage,
+        &estimation_output_text(&outcome.response),
+    );
+    let panel_total: u64 = effective_panel
+        .iter()
+        .map(|u| u64::from(u.usage.total_tokens))
         .sum();
-    let judge_usage = outcome.response.usage.clone();
-    let total_tokens = panel_total + u64::from(judge_usage.total_tokens);
+    let total_tokens = panel_total + u64::from(effective_judge.usage.total_tokens);
     reservation.commit_tokens(total_tokens).await;
 
     // Emit one usage event per sub-call (each panel member + the judge),
@@ -4068,21 +4166,15 @@ async fn dispatch_ensemble(
                          hits: &[aisix_core::GuardrailMonitorHit],
                          terminal_judge: bool| {
         for (index, member) in outcome.panel.iter().enumerate() {
-            emit_panel_member(member, index, blocked, bypass);
+            emit_panel_member(
+                member,
+                index,
+                Some(&effective_panel[index]),
+                blocked,
+                bypass,
+            );
         }
-        let (judge_model_id, judge_provider_key_id, judge_upstream_model) =
-            resolve_sub(&outcome.judge_model);
-        // #1074: estimate the judge sub-call when its backend omitted usage —
-        // prompt from the judge's synthesis request, completion from the
-        // synthesized answer text (read post-mask; token count is
-        // mask-invariant to within placeholder length), tokenized with the
-        // judge's resolved upstream model.
-        let (judge_prompt, judge_completion, judge_estimated) = estimate_subcall_tokens(
-            &outcome.judge_req,
-            &judge_upstream_model,
-            &judge_usage,
-            &estimation_output_text(&outcome.response),
-        );
+        let (judge_model_id, judge_provider_key_id, _) = resolve_sub(&outcome.judge_model);
         let judge_pk = crate::usage_attr::ResolvedPk::resolve(snapshot, &judge_provider_key_id);
         emit_usage_event(
             state,
@@ -4094,14 +4186,14 @@ async fn dispatch_ensemble(
             api_key_id,
             200,
             started.elapsed(),
-            judge_prompt,
-            judge_completion,
+            effective_judge.usage.prompt_tokens,
+            effective_judge.usage.completion_tokens,
             UsageExtras {
-                cached_prompt_tokens: judge_usage.cached_prompt_tokens,
-                reasoning_tokens: judge_usage.reasoning_tokens,
-                cache_creation_tokens: judge_usage.cache_creation_tokens,
-                cache_read_tokens: judge_usage.cache_read_tokens,
-                usage_estimated: judge_estimated,
+                cached_prompt_tokens: effective_judge.usage.cached_prompt_tokens,
+                reasoning_tokens: effective_judge.usage.reasoning_tokens,
+                cache_creation_tokens: effective_judge.usage.cache_creation_tokens,
+                cache_read_tokens: effective_judge.usage.cache_read_tokens,
+                usage_estimated: effective_judge.estimated,
                 provider_request_id: crate::usage_attr::sanitize_provider_response_id(
                     &outcome.response.id,
                 ),
@@ -4227,6 +4319,11 @@ async fn dispatch_ensemble(
         .panel
         .iter()
         .fold(judge_usage.clone(), |acc, p| acc.saturating_add(&p.usage));
+    let metric_usage = effective_panel
+        .iter()
+        .fold(effective_judge.usage.clone(), |acc, p| {
+            acc.saturating_add(&p.usage)
+        });
     outcome.response.usage = aggregate_usage.clone();
     let response = Json(render_response(created_ts, outcome.response, &req.model)).into_response();
     Ok(Success {
@@ -4237,14 +4334,14 @@ async fn dispatch_ensemble(
         // Per-sub-call UsageEvents were emitted above, while record_success
         // consumes these aggregate fields for the request-level Prometheus
         // token families keyed by the ensemble alias.
-        prompt_tokens: Some(u64::from(aggregate_usage.prompt_tokens)),
-        completion_tokens: Some(u64::from(aggregate_usage.completion_tokens)),
-        total_tokens: Some(u64::from(aggregate_usage.total_tokens)),
+        prompt_tokens: Some(u64::from(metric_usage.prompt_tokens)),
+        completion_tokens: Some(u64::from(metric_usage.completion_tokens)),
+        total_tokens: Some(u64::from(metric_usage.total_tokens)),
         usage_estimated: false,
-        cached_prompt_tokens: aggregate_usage.cached_prompt_tokens,
-        reasoning_tokens: aggregate_usage.reasoning_tokens,
-        cache_creation_tokens: aggregate_usage.cache_creation_tokens,
-        cache_read_tokens: aggregate_usage.cache_read_tokens,
+        cached_prompt_tokens: metric_usage.cached_prompt_tokens,
+        reasoning_tokens: metric_usage.reasoning_tokens,
+        cache_creation_tokens: metric_usage.cache_creation_tokens,
+        cache_read_tokens: metric_usage.cache_read_tokens,
         provider_request_id: String::new(),
         provider_model_version: String::new(),
         provider_key_id: crate::request_metrics::UNKNOWN.to_string(),
@@ -5018,6 +5115,13 @@ impl<F: FnOnce(StreamCompletion)> Drop for CompleteOnDrop<F> {
                     );
                 }
             }
+            c.total_tokens = cache_inclusive_total(
+                c.total_tokens,
+                c.prompt_tokens,
+                c.completion_tokens,
+                c.cache_creation_tokens,
+                c.cache_read_tokens,
+            );
             f(c);
         }
     }
@@ -6037,7 +6141,10 @@ mod complete_on_drop_tests {
     //! StreamCompletion, set the shared atomic to simulate "N
     //! chunks delivered to the consumer", drop, observe the
     //! callback args.
-    use super::{estimate_subcall_tokens, AtomicU32, CompleteOnDrop, StreamCompletion};
+    use super::{
+        cache_inclusive_total, effective_subcall_usage, estimate_subcall_tokens, AtomicU32,
+        CompleteOnDrop, StreamCompletion,
+    };
     use std::sync::{Arc, Mutex};
 
     /// Build the guard with `delivered_count` pre-set on the
@@ -6221,6 +6328,27 @@ mod complete_on_drop_tests {
         assert_eq!(prompt, 17, "reported prompt preserved");
         assert_eq!(completion, 2, "missing completion estimated");
         assert!(estimated);
+    }
+
+    #[test]
+    fn effective_subcall_usage_is_cache_inclusive_and_preserves_overhead() {
+        let reported = aisix_gateway::chat::UsageStats {
+            prompt_tokens: 7,
+            completion_tokens: 11,
+            // Bedrock Converse reports a total that can exclude the two
+            // separate cache counters.
+            total_tokens: 18,
+            cache_creation_tokens: 5,
+            cache_read_tokens: 3,
+            ..Default::default()
+        };
+        let effective =
+            effective_subcall_usage(&subcall_req("Hello"), "relay-model", &reported, "reply");
+        assert_eq!(effective.usage.total_tokens, 26);
+        assert!(!effective.estimated);
+
+        let with_overhead = cache_inclusive_total(31, 7, 11, 5, 3);
+        assert_eq!(with_overhead, 31, "provider-reported overhead is preserved");
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -3631,6 +3631,7 @@ async fn dispatch_ensemble(
             .fold(aisix_gateway::chat::UsageStats::default(), |acc, p| {
                 acc.saturating_add(&p.usage)
             });
+        let panel_usage_for_metrics = panel_usage_sum.clone();
         // The streamed judge estimator keys off `judge_model.upstream_model()`
         // directly (below), so resolve_sub's upstream_model is unused here.
         let (judge_model_id, judge_provider_key_id, _) = resolve_sub(&ensemble_cfg.judge.model);
@@ -3727,6 +3728,24 @@ async fn dispatch_ensemble(
                 // Fresh snapshot at stream end, shared by every emit in this
                 // closure (#941) — see the single-model streaming path.
                 let snap = state_for_telem.snapshot.load();
+                let aggregate_input = panel_usage_for_metrics
+                    .prompt_tokens
+                    .saturating_add(comp.prompt_tokens);
+                let aggregate_output = panel_usage_for_metrics
+                    .completion_tokens
+                    .saturating_add(comp.completion_tokens);
+                let aggregate_total = panel_usage_for_metrics
+                    .total_tokens
+                    .saturating_add(comp.total_tokens.min(u64::from(u32::MAX)) as u32);
+                let aggregate_cached = panel_usage_for_metrics
+                    .cached_prompt_tokens
+                    .saturating_add(comp.cached_prompt_tokens);
+                let aggregate_cache_read = panel_usage_for_metrics
+                    .cache_read_tokens
+                    .saturating_add(comp.cache_read_tokens);
+                let aggregate_cache_creation = panel_usage_for_metrics
+                    .cache_creation_tokens
+                    .saturating_add(comp.cache_creation_tokens);
                 // Telemetry: one event per panel member (attempt_kind "panel",
                 // index 0..N) carrying that member's own buffered usage, then
                 // one judge event (attempt_kind "judge", index N) from the
@@ -3844,6 +3863,41 @@ async fn dispatch_ensemble(
                     /* dispatched */ true,
                     &audit_for_telem,
                 );
+                // The per-sub-call UsageEvents above preserve billing
+                // attribution. Prometheus token families are request-level,
+                // so record the client-visible panel+judge aggregate against
+                // the ensemble alias rather than dropping the request from
+                // those series entirely.
+                let owned_caller =
+                    crate::request_metrics::Caller::from_api_key_id(&snap, &api_key_id_for_telem);
+                let caller = owned_caller.as_caller();
+                let ensemble_pk =
+                    crate::usage_attr::ResolvedPk::resolve(&snap, crate::request_metrics::UNKNOWN);
+                crate::request_metrics::record_usage(
+                    &state_for_telem,
+                    "/v1/chat/completions",
+                    caller,
+                    crate::request_metrics::Upstream {
+                        provider: "ensemble",
+                        model: &bounded_model_for_telem,
+                        upstream_model: crate::request_metrics::UNKNOWN,
+                        pk: ensemble_pk.labels(),
+                        stream: true,
+                        is_fallback: false,
+                    },
+                    crate::request_metrics::Tokens {
+                        input: aggregate_input,
+                        output: aggregate_output,
+                        total: aggregate_total,
+                        cached: aggregate_cached,
+                        cache_read: aggregate_cache_read,
+                        cache_creation: aggregate_cache_creation,
+                        spend_usd: 0.0,
+                        client_type: state_for_telem
+                            .client_classifier
+                            .classify(&client_for_telem.user_agent),
+                    },
+                );
                 // SLO histograms (AISIX-Cloud#1011): the handler's
                 // record_success is stream-gated, so the ensemble stream
                 // records its e2e/TTFT here like the plain streaming path.
@@ -3866,6 +3920,23 @@ async fn dispatch_ensemble(
                         provider: "ensemble",
                         status: 200,
                         streaming: true,
+                    },
+                    Duration::from_millis(u64::from(comp.upstream_ttft_ms)),
+                );
+                state_for_telem.metrics.record_time_to_first_token(
+                    UsageLabels {
+                        endpoint: "/v1/chat/completions",
+                        inbound_protocol: "openai",
+                        upstream_protocol: ensemble_pk.labels().protocol(),
+                        provider: "ensemble",
+                        model: &bounded_model_for_telem,
+                        upstream_model: crate::request_metrics::UNKNOWN,
+                        provider_key_id: ensemble_pk.labels().id(),
+                        provider_key_name: ensemble_pk.labels().name(),
+                        api_key_id: caller.api_key_id,
+                        team_id: caller.team_id,
+                        user_id: caller.user_id,
+                        user_name: caller.user_name,
                     },
                     Duration::from_millis(u64::from(comp.upstream_ttft_ms)),
                 );
@@ -3898,8 +3969,8 @@ async fn dispatch_ensemble(
             cache_read_tokens: 0,
             provider_request_id: String::new(),
             provider_model_version: String::new(),
-            provider_key_id: String::new(),
-            upstream_model: String::new(),
+            provider_key_id: crate::request_metrics::UNKNOWN.to_string(),
+            upstream_model: crate::request_metrics::UNKNOWN.to_string(),
             finish_reason: String::new(),
             bypass_reason,
             cache_status: CacheStatus::Disabled,
@@ -4156,27 +4227,28 @@ async fn dispatch_ensemble(
         .panel
         .iter()
         .fold(judge_usage.clone(), |acc, p| acc.saturating_add(&p.usage));
-    outcome.response.usage = aggregate_usage;
+    outcome.response.usage = aggregate_usage.clone();
     let response = Json(render_response(created_ts, outcome.response, &req.model)).into_response();
     Ok(Success {
         response,
         // No single provider/model/key governs an ensemble response.
         provider: "ensemble".to_string(),
         model_id: model_id.to_string(),
-        // Per-sub-call usage was emitted above; the entry-level telemetry
-        // event is suppressed, so these top-level token fields are unused.
-        prompt_tokens: None,
-        completion_tokens: None,
-        total_tokens: None,
+        // Per-sub-call UsageEvents were emitted above, while record_success
+        // consumes these aggregate fields for the request-level Prometheus
+        // token families keyed by the ensemble alias.
+        prompt_tokens: Some(u64::from(aggregate_usage.prompt_tokens)),
+        completion_tokens: Some(u64::from(aggregate_usage.completion_tokens)),
+        total_tokens: Some(u64::from(aggregate_usage.total_tokens)),
         usage_estimated: false,
-        cached_prompt_tokens: 0,
-        reasoning_tokens: 0,
-        cache_creation_tokens: 0,
-        cache_read_tokens: 0,
+        cached_prompt_tokens: aggregate_usage.cached_prompt_tokens,
+        reasoning_tokens: aggregate_usage.reasoning_tokens,
+        cache_creation_tokens: aggregate_usage.cache_creation_tokens,
+        cache_read_tokens: aggregate_usage.cache_read_tokens,
         provider_request_id: String::new(),
         provider_model_version: String::new(),
-        provider_key_id: String::new(),
-        upstream_model: String::new(),
+        provider_key_id: crate::request_metrics::UNKNOWN.to_string(),
+        upstream_model: crate::request_metrics::UNKNOWN.to_string(),
         finish_reason: String::new(),
         cost_usd: 0.0,
         bypass_reason,
@@ -4435,12 +4507,6 @@ fn emit_usage_event(
         client.caller.user_id.as_deref(),
         client.caller.user_name.as_deref(),
     );
-    // Guardrail outcome counters (#379). Recorded here — the one place every
-    // chat path (success / error / streaming / cache-hit) funnels through —
-    // from the same guardrail fields the UsageEvent carries.
-    state
-        .metrics
-        .record_guardrail_outcome(guardrail_blocked, &event.guardrail_bypassed_reason);
     // Handler label "chat" matches the documented enumeration for
     // `aisix_usage_events_emitted_total` (#408). Keep `&'static str`
     // so prometheus cardinality stays bounded. Both emit legs (CP sink +

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1097,16 +1097,16 @@ fn cache_inclusive_total(
 }
 
 #[derive(Clone)]
-struct EffectiveSubcallUsage {
-    usage: aisix_gateway::chat::UsageStats,
-    estimated: bool,
+pub(crate) struct EffectiveSubcallUsage {
+    pub(crate) usage: aisix_gateway::chat::UsageStats,
+    pub(crate) estimated: bool,
 }
 
 /// Resolve one ensemble sub-call's final accounting once, then share it
 /// between its UsageEvent, request-level Prometheus aggregate, and quota
 /// commit. The client-facing response still carries only upstream-reported
 /// usage; local estimates remain telemetry-only.
-fn effective_subcall_usage(
+pub(crate) fn effective_subcall_usage(
     req: &ChatFormat,
     model: &str,
     reported: &aisix_gateway::chat::UsageStats,
@@ -3404,6 +3404,13 @@ async fn dispatch_ensemble(
             None => (String::new(), String::new(), display_name.to_string()),
         }
     };
+    let effective_panel_member_usage =
+        |member: &crate::ensemble::PanelOutcome| -> EffectiveSubcallUsage {
+            EffectiveSubcallUsage {
+                usage: member.effective_usage.clone(),
+                estimated: member.usage_estimated,
+            }
+        };
     // Emit one usage event for a single (already-billed) panel member.
     // Defined before the `run_ensemble` match so the InsufficientPanel arm
     // can bill the survivors too — they hit upstream just like a full panel.
@@ -3415,17 +3422,12 @@ async fn dispatch_ensemble(
                              prepared: Option<&EffectiveSubcallUsage>,
                              blocked: bool,
                              bypass: &str| {
-        let (sub_model_id, sub_provider_key_id, sub_upstream_model) = resolve_sub(&member.model);
+        let (sub_model_id, sub_provider_key_id, _) = resolve_sub(&member.model);
         let computed;
         let effective = match prepared {
             Some(usage) => usage,
             None => {
-                computed = effective_subcall_usage(
-                    req,
-                    &sub_upstream_model,
-                    &member.usage,
-                    &member.est_output_text,
-                );
+                computed = effective_panel_member_usage(member);
                 &computed
             }
         };
@@ -3465,6 +3467,15 @@ async fn dispatch_ensemble(
             audit,
         );
     };
+    // Failure exits bill every successful panel member even when the
+    // upstream omitted usage. Share the same normalized accounting used by
+    // UsageEvent emission so quota and telemetry cannot diverge.
+    let survivor_total = |panel: &[crate::ensemble::PanelOutcome]| -> u64 {
+        panel
+            .iter()
+            .map(|member| u64::from(effective_panel_member_usage(member).usage.total_tokens))
+            .sum()
+    };
 
     let caller = crate::ensemble::ProxyModelCaller {
         state,
@@ -3502,20 +3513,6 @@ async fn dispatch_ensemble(
         // inline FIRST (mirroring the non-streaming ensemble path), then calls
         // this for the emit + `DispatchFailure`. `panel` is borrowed so the
         // call site still owns it to compute `survivor_total`.
-        let survivor_total = |panel: &[crate::ensemble::PanelOutcome]| -> u64 {
-            panel
-                .iter()
-                .map(|p| {
-                    cache_inclusive_total(
-                        u64::from(p.usage.total_tokens),
-                        p.usage.prompt_tokens,
-                        p.usage.completion_tokens,
-                        p.usage.cache_creation_tokens,
-                        p.usage.cache_read_tokens,
-                    )
-                })
-                .sum()
-        };
         let emit_panel_then_fail =
             |panel: &[crate::ensemble::PanelOutcome], proxy_err: ProxyError| -> DispatchFailure {
                 for (index, member) in panel.iter().enumerate() {
@@ -3661,11 +3658,9 @@ async fn dispatch_ensemble(
         // this frame — it fires on stream drop), so the `emit_panel_member` /
         // `resolve_sub` borrowing closures above are unusable inside it. Clone
         // the per-member + judge telemetry inputs up front.
-        // The `'static` on_complete closure cannot borrow `req`. Resolve
-        // each panel member's estimation fallback now so its UsageEvent,
-        // request-level aggregate, and quota commit all consume the same
-        // final counters.
-        let req_for_panel_est = req.clone();
+        // Copy the accounting already resolved by `ProxyModelCaller` so
+        // member quota, parent quota, UsageEvent, and Prometheus share the
+        // same counters inside the `'static` completion closure.
         struct PanelTelem {
             model_id: String,
             provider_key_id: String,
@@ -3676,19 +3671,13 @@ async fn dispatch_ensemble(
         let panel_telem: Vec<PanelTelem> = panel
             .iter()
             .map(|p| {
-                let (model_id, provider_key_id, est_model) = resolve_sub(&p.model);
-                let effective = effective_subcall_usage(
-                    &req_for_panel_est,
-                    &est_model,
-                    &p.usage,
-                    &p.est_output_text,
-                );
+                let (model_id, provider_key_id, _) = resolve_sub(&p.model);
                 PanelTelem {
                     model_id,
                     provider_key_id,
                     attempt_model: p.model.clone(),
-                    usage: effective.usage,
-                    usage_estimated: effective.estimated,
+                    usage: p.effective_usage.clone(),
+                    usage_estimated: p.usage_estimated,
                 }
             })
             .collect();
@@ -4093,19 +4082,7 @@ async fn dispatch_ensemble(
                     )),
                 ),
             };
-            let survivor_total: u64 = panel
-                .iter()
-                .map(|p| {
-                    cache_inclusive_total(
-                        u64::from(p.usage.total_tokens),
-                        p.usage.prompt_tokens,
-                        p.usage.completion_tokens,
-                        p.usage.cache_creation_tokens,
-                        p.usage.cache_read_tokens,
-                    )
-                })
-                .sum();
-            reservation.commit_tokens(survivor_total).await;
+            reservation.commit_tokens(survivor_total(&panel)).await;
             for (index, member) in panel.iter().enumerate() {
                 emit_panel_member(
                     member, index, None, /* blocked */ false, /* bypass */ "",
@@ -4126,18 +4103,12 @@ async fn dispatch_ensemble(
     let effective_panel: Vec<EffectiveSubcallUsage> = outcome
         .panel
         .iter()
-        .map(|member| {
-            let (_, _, upstream_model) = resolve_sub(&member.model);
-            effective_subcall_usage(req, &upstream_model, &member.usage, &member.est_output_text)
-        })
+        .map(effective_panel_member_usage)
         .collect();
-    let (_, _, judge_upstream_model) = resolve_sub(&outcome.judge_model);
-    let effective_judge = effective_subcall_usage(
-        &outcome.judge_req,
-        &judge_upstream_model,
-        &judge_usage,
-        &estimation_output_text(&outcome.response),
-    );
+    let effective_judge = EffectiveSubcallUsage {
+        usage: outcome.judge_effective_usage.clone(),
+        estimated: outcome.judge_usage_estimated,
+    };
     let panel_total: u64 = effective_panel
         .iter()
         .map(|u| u64::from(u.usage.total_tokens))

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -72,9 +72,16 @@ Candidate answers:
 /// Dispatches one resolved chat request to a model by its `display_name`.
 /// The production impl resolves the name to a Bridge + ProviderKey and
 /// calls `Bridge::chat`; tests supply a scripted mock.
+#[derive(Debug)]
+pub struct ModelCallOutcome {
+    pub response: ChatResponse,
+    pub effective_usage: UsageStats,
+    pub usage_estimated: bool,
+}
+
 #[async_trait]
 pub trait ModelCaller: Send + Sync {
-    async fn call(&self, target: &str, req: &ChatFormat) -> Result<ChatResponse, BridgeError>;
+    async fn call(&self, target: &str, req: &ChatFormat) -> Result<ModelCallOutcome, BridgeError>;
 }
 
 /// Production [`ModelCaller`] used by the chat dispatch layer. Resolves
@@ -100,7 +107,7 @@ pub(crate) struct ProxyModelCaller<'a> {
 
 #[async_trait]
 impl ModelCaller for ProxyModelCaller<'_> {
-    async fn call(&self, target: &str, req: &ChatFormat) -> Result<ChatResponse, BridgeError> {
+    async fn call(&self, target: &str, req: &ChatFormat) -> Result<ModelCallOutcome, BridgeError> {
         // Resolve the member's display_name against the live snapshot.
         // A missing entry is a misconfigured ensemble (a panel/judge name
         // that no longer points at a real Model) → 400 InvalidUpstreamConfig.
@@ -189,10 +196,20 @@ impl ModelCaller for ProxyModelCaller<'_> {
             bridge.chat(req, &ctx)
         })
         .await?;
+        let effective = crate::chat::effective_subcall_usage(
+            req,
+            model.upstream_model().unwrap_or(target),
+            &response.usage,
+            &crate::chat::estimation_output_text(&response),
+        );
         reservation
-            .commit_tokens(u64::from(response.usage.total_tokens))
+            .commit_tokens(u64::from(effective.usage.total_tokens))
             .await;
-        Ok(response)
+        Ok(ModelCallOutcome {
+            response,
+            effective_usage: effective.usage,
+            usage_estimated: effective.estimated,
+        })
     }
 }
 
@@ -201,12 +218,12 @@ impl ModelCaller for ProxyModelCaller<'_> {
 #[derive(Debug)]
 pub struct PanelOutcome {
     pub model: String,
+    /// Provider-reported usage retained for the client-facing aggregate.
     pub usage: UsageStats,
-    /// The member's answer text (content + reasoning + tool-call text),
-    /// captured so the dispatch layer can estimate this sub-call's
-    /// completion tokens when the member backend reports no usage
-    /// (AISIX-Cloud#1074). Never billed directly — only a fallback.
-    pub est_output_text: String,
+    /// Final accounting shared by member quota, parent quota, telemetry, and
+    /// request-level metrics. Local estimates never replace `usage` above.
+    pub effective_usage: UsageStats,
+    pub usage_estimated: bool,
 }
 
 /// Everything the dispatch layer needs after an ensemble run: the judge's
@@ -218,12 +235,8 @@ pub struct EnsembleOutcome {
     pub response: ChatResponse,
     pub panel: Vec<PanelOutcome>,
     pub judge_model: String,
-    /// The judge's synthesis request, kept so the dispatch layer can
-    /// estimate the judge sub-call's prompt tokens when the judge backend
-    /// reports no usage (AISIX-Cloud#1074). The streaming path builds its
-    /// own judge estimator from `run_ensemble_panel`'s `judge_req`; this
-    /// field carries the same request out of the buffered path.
-    pub judge_req: ChatFormat,
+    pub judge_effective_usage: UsageStats,
+    pub judge_usage_estimated: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -303,11 +316,13 @@ pub(crate) async fn run_ensemble_panel(
     let mut candidates: Vec<ChatResponse> = Vec::new();
     for (model, result) in results {
         match result {
-            Ok(resp) => {
+            Ok(outcome) => {
+                let resp = outcome.response;
                 panel.push(PanelOutcome {
                     model,
                     usage: resp.usage.clone(),
-                    est_output_text: crate::chat::estimation_output_text(&resp),
+                    effective_usage: outcome.effective_usage,
+                    usage_estimated: outcome.usage_estimated,
                 });
                 candidates.push(resp);
             }
@@ -350,7 +365,7 @@ pub async fn run_ensemble(
     // the judge model's own retry budget — it used to be a hardcoded single
     // retry here, which both ignored the operator's configuration and would
     // have stacked on top of the caller-level budget.
-    let response =
+    let judge =
         match call_with_optional_timeout(caller, &config.judge.model, &judge_req, config.timeout())
             .await
         {
@@ -361,10 +376,11 @@ pub async fn run_ensemble(
         };
 
     Ok(EnsembleOutcome {
-        response,
+        response: judge.response,
         panel,
         judge_model: config.judge.model.clone(),
-        judge_req,
+        judge_effective_usage: judge.effective_usage,
+        judge_usage_estimated: judge.usage_estimated,
     })
 }
 
@@ -457,7 +473,7 @@ async fn call_with_optional_timeout(
     target: &str,
     req: &ChatFormat,
     timeout: Option<Duration>,
-) -> Result<ChatResponse, BridgeError> {
+) -> Result<ModelCallOutcome, BridgeError> {
     match timeout {
         Some(d) => match tokio::time::timeout(d, caller.call(target, req)).await {
             Ok(result) => result,
@@ -518,7 +534,11 @@ mod tests {
 
     #[async_trait]
     impl ModelCaller for MockCaller {
-        async fn call(&self, target: &str, req: &ChatFormat) -> Result<ChatResponse, BridgeError> {
+        async fn call(
+            &self,
+            target: &str,
+            req: &ChatFormat,
+        ) -> Result<ModelCallOutcome, BridgeError> {
             self.calls
                 .lock()
                 .unwrap()
@@ -527,9 +547,14 @@ mod tests {
             let queue = scripted
                 .get_mut(target)
                 .unwrap_or_else(|| panic!("no scripted response for target {target:?}"));
-            queue
+            let response = queue
                 .pop_front()
-                .unwrap_or_else(|| panic!("scripted responses exhausted for target {target:?}"))
+                .unwrap_or_else(|| panic!("scripted responses exhausted for target {target:?}"))?;
+            Ok(ModelCallOutcome {
+                effective_usage: response.usage.clone(),
+                response,
+                usage_estimated: false,
+            })
         }
     }
 

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -15,7 +15,9 @@
 //! 400 with an explanatory message.
 
 use aisix_gateway::{ChatFormat, ChatMessage};
-use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, LatencyLabels, UsageEvent};
+use aisix_obs::{
+    content_capture_cap, AccessLog, CapturedContent, LatencyLabels, UsageEvent, UsageLabels,
+};
 use axum::extract::State;
 use axum::http::{HeaderName, HeaderValue};
 use axum::response::{IntoResponse, Response};
@@ -3201,8 +3203,8 @@ fn emit_usage_event(
     // usage-bearing paths (non-streaming, verbatim streaming, bridge
     // streaming) funnel through here. `requested_model` resolved at dispatch
     // on every path that reaches this emit, so the label is bounded by the
-    // configured model set. The per-key `aisix_llm_*_tokens_total` family
-    // intentionally stays chat/messages-scoped (cross-API audit #646-652).
+    // configured model set. The shared call below also keeps the per-key
+    // `aisix_llm_*_tokens_total` families on the same path.
     // #1002: cache-inclusive total via the shared helper — cache counters are
     // non-zero only on the #825 Anthropic bridge path.
     let total_all = total_tokens_with_cache(
@@ -3212,10 +3214,11 @@ fn emit_usage_event(
         usage.cache_read_tokens,
     );
     let owned_caller = crate::request_metrics::Caller::from_api_key_id(snap, api_key_id);
+    let caller = owned_caller.as_caller();
     crate::request_metrics::record_usage(
         state,
         "/v1/responses",
-        owned_caller.as_caller(),
+        caller,
         crate::request_metrics::Upstream {
             provider,
             model: requested_model,
@@ -3234,6 +3237,38 @@ fn emit_usage_event(
             client_type: state.client_classifier.classify(&client.user_agent),
         },
     );
+    if usage.upstream_ttft_ms > 0 {
+        let (bounded_model, bounded_upstream) =
+            crate::usage_attr::metric_model_label_pair(snap, requested_model, upstream_model);
+        let ttft = Duration::from_millis(u64::from(usage.upstream_ttft_ms));
+        state.metrics.record_request_ttft(
+            LatencyLabels {
+                endpoint: "/v1/responses",
+                model: bounded_model.as_ref(),
+                provider,
+                status: status_code,
+                streaming: true,
+            },
+            ttft,
+        );
+        state.metrics.record_time_to_first_token(
+            UsageLabels {
+                endpoint: "/v1/responses",
+                inbound_protocol: "openai",
+                upstream_protocol: pk.labels().protocol(),
+                provider,
+                model: bounded_model.as_ref(),
+                upstream_model: bounded_upstream.as_ref(),
+                provider_key_id: pk.labels().id(),
+                provider_key_name: pk.labels().name(),
+                api_key_id: caller.api_key_id,
+                team_id: caller.team_id,
+                user_id: caller.user_id,
+                user_name: caller.user_name,
+            },
+            ttft,
+        );
+    }
 }
 
 /// Emit a zero-token `UsageEvent` for a failed / pre-dispatch attempt

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1292,6 +1292,7 @@ async fn responses_to_target(
             let read_to = timeouts.stream;
             let mut buf: Vec<u8> = Vec::new();
             let mut saw_chunk = false;
+            let mut upstream_ttft_ms = 0;
             loop {
                 // #554: bound each read so a stalled upstream fails over —
                 // the buffer path hasn't sent anything to the client yet, so
@@ -1361,6 +1362,44 @@ async fn responses_to_target(
                     ));
                 }
                 buf.extend_from_slice(&chunk);
+                if upstream_ttft_ms == 0 && has_complete_responses_sse_event(&buf) {
+                    upstream_ttft_ms =
+                        send_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+                }
+            }
+            // #808: the whole SSE response is buffered here, so parse its
+            // terminal event for usage and let the handler emit (the body is
+            // a single complete chunk now, not a live stream). Do this before
+            // the guardrail verdict so a billed-then-blocked response keeps
+            // both its token usage and its first-frame latency.
+            //
+            // Token-estimation fallback (AISIX-Cloud#1074): a buffered
+            // stream with zero/missing usage fills the counters locally —
+            // telemetry only, the buffered bytes forward untouched.
+            let mut usage = responses_sse_usage(&buf).unwrap_or_default();
+            usage.upstream_ttft_ms = upstream_ttft_ms;
+            // The usage gate is independent of the id: a stream whose
+            // terminal frame reported no usage still names the upstream
+            // call it was (AISIX-Cloud#1289).
+            if usage.provider_request_id.is_empty() {
+                usage.provider_request_id = responses_sse_provider_request_id(&buf);
+            }
+            if usage.prompt_tokens == 0 || usage.completion_tokens == 0 {
+                let est = crate::token_estimate::Estimator::new(
+                    &upstream_model,
+                    crate::token_estimate::PromptInput::Responses(body.clone()),
+                );
+                let filled = crate::token_estimate::fill_missing(
+                    &est,
+                    usage.prompt_tokens,
+                    usage.completion_tokens,
+                    Some(&responses_sse_output_text(&buf)),
+                );
+                if filled.estimated {
+                    usage.prompt_tokens = filled.prompt_tokens;
+                    usage.completion_tokens = filled.completion_tokens;
+                    usage.usage_estimated = true;
+                }
             }
             let out_text = responses_sse_output_text(&buf);
             let synth = synth_chat_response(&upstream_model, out_text);
@@ -1399,11 +1438,34 @@ async fn responses_to_target(
                     reason = %reason,
                     "guardrail blocked streaming /v1/responses response",
                 );
-                return Err(crate::error::guardrail_block_error(
-                    "response",
-                    guardrail_name.as_deref(),
-                    unavailable.as_deref(),
-                ));
+                // The upstream completed and billed this request. Return the
+                // refusal as a successful dispatch envelope so the handler
+                // emits the terminal usage + TTFT observation with status
+                // 422, matching the cross-provider and non-streaming paths.
+                return Ok(ResponseDispatchSuccess {
+                    response: crate::error::guardrail_block_error(
+                        "response",
+                        guardrail_name.as_deref(),
+                        unavailable.as_deref(),
+                    )
+                    .into_response(),
+                    provider: provider_label,
+                    usage: Some(usage),
+                    model_id: model_id.to_string(),
+                    provider_key_id: provider_key_id.clone(),
+                    upstream_model: upstream_model.clone(),
+                    routing: RoutingTelemetry::default(),
+                    guardrail_blocked: true,
+                    usage_handled_by_stream: false,
+                    output_redactions: crate::redact::RedactionCounts::new(),
+                    output_monitor_hits,
+                    captured_content: match (&captured_prompt, content_cap) {
+                        (Some(prompt), Some(cap)) => {
+                            Some(CapturedContent::new(prompt, "", cap as usize))
+                        }
+                        _ => None,
+                    },
+                });
             }
             // #932: the whole SSE response is held here — mask the frames
             // (channel reassembly) before anything reaches the wire.
@@ -1425,40 +1487,6 @@ async fn responses_to_target(
                 requested_model,
                 crate::model_echo::responses_snapshot_model,
             );
-            // #808: the whole SSE response is buffered here, so parse its
-            // terminal event for usage and let the handler emit (the body is
-            // a single complete chunk now, not a live stream).
-            //
-            // Token-estimation fallback (AISIX-Cloud#1074): a buffered
-            // stream with zero/missing usage fills the counters locally —
-            // telemetry only, the buffered bytes forward untouched.
-            let usage = {
-                let mut u = responses_sse_usage(&buf).unwrap_or_default();
-                // The usage gate is independent of the id: a stream whose
-                // terminal frame reported no usage still names the upstream
-                // call it was (AISIX-Cloud#1289).
-                if u.provider_request_id.is_empty() {
-                    u.provider_request_id = responses_sse_provider_request_id(&buf);
-                }
-                if u.prompt_tokens == 0 || u.completion_tokens == 0 {
-                    let est = crate::token_estimate::Estimator::new(
-                        &upstream_model,
-                        crate::token_estimate::PromptInput::Responses(body.clone()),
-                    );
-                    let filled = crate::token_estimate::fill_missing(
-                        &est,
-                        u.prompt_tokens,
-                        u.completion_tokens,
-                        Some(&responses_sse_output_text(&buf)),
-                    );
-                    if filled.estimated {
-                        u.prompt_tokens = filled.prompt_tokens;
-                        u.completion_tokens = filled.completion_tokens;
-                        u.usage_estimated = true;
-                    }
-                }
-                Some(u)
-            };
             // Content capture (AISIX-Cloud#947): the assembled output text,
             // read from the POST-redaction buffer so masked PII stays masked
             // in the exported content.
@@ -1475,7 +1503,7 @@ async fn responses_to_target(
             return Ok(ResponseDispatchSuccess {
                 response,
                 provider: provider_label,
-                usage,
+                usage: Some(usage),
                 model_id: model_id.to_string(),
                 provider_key_id: provider_key_id.clone(),
                 upstream_model: upstream_model.clone(),
@@ -2480,6 +2508,23 @@ fn parse_responses_terminal_usage(json: &Value) -> Option<ResponseUsage> {
     )
     .then(|| json.get("response").and_then(extract_response_usage))
     .flatten()
+}
+
+/// Whether the buffered prefix contains at least one complete, parseable
+/// Responses SSE event. Comments, keepalives, `[DONE]`, and partial frames
+/// do not stop the TTFT clock.
+fn has_complete_responses_sse_event(bytes: &[u8]) -> bool {
+    let mut offset = 0;
+    while let Some(end) = crate::messages::find_frame_end(&bytes[offset..]) {
+        let frame = &bytes[offset..offset + end];
+        if crate::messages::extract_sse_data_line(frame)
+            .is_some_and(|data| data != b"[DONE]" && serde_json::from_slice::<Value>(data).is_ok())
+        {
+            return true;
+        }
+        offset += end;
+    }
+    false
 }
 
 /// Scan a fully-buffered Responses-API SSE body for the terminal event's

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1343,6 +1343,14 @@ async fn responses_to_target(
                     })
                     .map_err(ProxyError::Bridge)?;
                 if buf.len() + chunk.len() > max_buffer_bytes {
+                    let remaining = max_buffer_bytes.saturating_sub(buf.len());
+                    if upstream_ttft_ms == 0 && remaining > 0 {
+                        buf.extend_from_slice(&chunk[..remaining.min(chunk.len())]);
+                        if has_complete_responses_sse_event(&buf) {
+                            upstream_ttft_ms =
+                                attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+                        }
+                    }
                     // Unlike chat's BufferFull, we always fail closed on
                     // overflow regardless of `on_exceeded_fail_open`: an
                     // output-hook guardrail must not release a response it
@@ -1355,16 +1363,42 @@ async fn responses_to_target(
                         max_buffer_bytes,
                         "streaming /v1/responses output exceeded buffer cap; failing closed",
                     );
-                    return Err(crate::error::guardrail_block_error(
-                        "response",
-                        None,
-                        Some(crate::error::TAG_OUTPUT_BUFFER_EXCEEDED),
-                    ));
+                    // At least one upstream frame may already have arrived.
+                    // Return the refusal as a terminal dispatch envelope so
+                    // that measured TTFT is emitted exactly once even though
+                    // the terminal usage frame was never reached.
+                    return Ok(ResponseDispatchSuccess {
+                        response: crate::error::guardrail_block_error(
+                            "response",
+                            None,
+                            Some(crate::error::TAG_OUTPUT_BUFFER_EXCEEDED),
+                        )
+                        .into_response(),
+                        provider: provider_label,
+                        usage: Some(ResponseUsage {
+                            upstream_ttft_ms,
+                            ..Default::default()
+                        }),
+                        model_id: model_id.to_string(),
+                        provider_key_id: provider_key_id.clone(),
+                        upstream_model: upstream_model.clone(),
+                        routing: RoutingTelemetry::default(),
+                        guardrail_blocked: true,
+                        usage_handled_by_stream: false,
+                        captured_content: match (&captured_prompt, content_cap) {
+                            (Some(prompt), Some(cap)) => {
+                                Some(CapturedContent::new(prompt, "", cap as usize))
+                            }
+                            _ => None,
+                        },
+                        output_redactions: crate::redact::RedactionCounts::new(),
+                        output_monitor_hits: Vec::new(),
+                    });
                 }
                 buf.extend_from_slice(&chunk);
                 if upstream_ttft_ms == 0 && has_complete_responses_sse_event(&buf) {
                     upstream_ttft_ms =
-                        send_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+                        attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
                 }
             }
             // #808: the whole SSE response is buffered here, so parse its

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -691,6 +691,14 @@ pub(crate) fn emit_usage(
     // present on a family's success path and missing from its error or
     // streaming one (AISIX-Cloud#1461).
     event.operation = surface.operation.to_string();
+    // Request-level guardrail blocks are recorded from the terminal event,
+    // not from an individual timed execution. Some fail-closed paths (for
+    // example a streamed-output buffer overflow) reject before a guardrail
+    // member runs, while retries and ensembles can emit several non-terminal
+    // events for one request.
+    if terminal && event.guardrail_blocked {
+        state.metrics.record_guardrail_blocked_request();
+    }
     let emission = trace.map(|bundle| {
         event.trace_id = bundle.trace_id_hex();
         bundle.emission(

--- a/tests/e2e/src/cases/ensemble-prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/ensemble-prometheus-metrics-e2e.test.ts
@@ -24,6 +24,12 @@ const NONSTREAM_MODEL = "prom-ensemble-nonstream";
 const STREAM_MODEL = "prom-ensemble-stream";
 const NONSTREAM_ESTIMATED_MODEL = "prom-ensemble-nonstream-estimated";
 const STREAM_ESTIMATED_MODEL = "prom-ensemble-stream-estimated";
+const NONSTREAM_FAILED_ESTIMATED_MODEL = "prom-ensemble-nonstream-failed-estimated";
+const STREAM_FAILED_ESTIMATED_MODEL = "prom-ensemble-stream-failed-estimated";
+const PANEL_MEMBER_QUOTA_MODEL = "prom-ensemble-panel-member-quota";
+const JUDGE_MEMBER_QUOTA_MODEL = "prom-ensemble-judge-member-quota";
+const NONSTREAM_FAILURE_CALLER = "sk-ensemble-failed-nonstream";
+const STREAM_FAILURE_CALLER = "sk-ensemble-failed-stream";
 
 const PANEL_USAGE = { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 };
 const JUDGE_USAGE = { prompt_tokens: 7, completion_tokens: 11, total_tokens: 18 };
@@ -120,6 +126,20 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
     const judgeNoUsage = await startOpenAiUpstream({
       nonStreamBody: chatBody("chatcmpl-judge-est", "estimated buffered synthesis"),
     });
+    const judgeFailure = await startOpenAiUpstream({
+      status: 500,
+      errorBody: { error: { message: "judge unavailable", type: "server_error" } },
+    });
+    const panelFailure = await startOpenAiUpstream({
+      status: 500,
+      errorBody: { error: { message: "panel unavailable", type: "server_error" } },
+    });
+    const quotaPanel = await startOpenAiUpstream({
+      nonStreamBody: chatBody("chatcmpl-panel-quota", "estimated quota panel answer"),
+    });
+    const quotaJudge = await startOpenAiUpstream({
+      nonStreamBody: chatBody("chatcmpl-judge-quota", "estimated quota synthesis"),
+    });
     upstreams.push(
       panelA,
       panelB,
@@ -128,11 +148,19 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
       panelNoUsageA,
       panelNoUsageB,
       judgeNoUsage,
+      judgeFailure,
+      panelFailure,
+      quotaPanel,
+      quotaJudge,
     );
 
     app = await spawnApp();
     const seed = new SeedClient(etcd, app.etcdPrefix);
-    const seedDirect = async (displayName: string, upstream: OpenAiUpstream) => {
+    const seedDirect = async (
+      displayName: string,
+      upstream: OpenAiUpstream,
+      extra: Record<string, unknown> = {},
+    ) => {
       const pk = await seed.createProviderKey({
         display_name: `${displayName}-pk`,
         secret: "sk-mock",
@@ -143,6 +171,7 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
         provider: "openai",
         model_name: "gpt-4o-mini",
         provider_key_id: pk.id,
+        ...extra,
       });
     };
     await seedDirect("prom-ensemble-panel-a", panelA);
@@ -152,6 +181,14 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
     await seedDirect("prom-ensemble-panel-est-a", panelNoUsageA);
     await seedDirect("prom-ensemble-panel-est-b", panelNoUsageB);
     await seedDirect("prom-ensemble-judge-est", judgeNoUsage);
+    await seedDirect("prom-ensemble-judge-fail", judgeFailure);
+    await seedDirect("prom-ensemble-panel-fail", panelFailure);
+    await seedDirect("prom-ensemble-panel-quota", quotaPanel, {
+      rate_limit: { tpd: 1 },
+    });
+    await seedDirect("prom-ensemble-judge-quota", quotaJudge, {
+      rate_limit: { tpd: 1 },
+    });
 
     await seed.createModel({
       display_name: NONSTREAM_MODEL,
@@ -191,6 +228,47 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
         min_responses: 2,
       },
     });
+    await seed.createModel({
+      display_name: NONSTREAM_FAILED_ESTIMATED_MODEL,
+      ensemble: {
+        panel: [
+          { model: "prom-ensemble-panel-est-a" },
+          { model: "prom-ensemble-panel-fail" },
+        ],
+        judge: { model: "prom-ensemble-judge-fail" },
+        min_responses: 2,
+      },
+    });
+    await seed.createModel({
+      display_name: STREAM_FAILED_ESTIMATED_MODEL,
+      ensemble: {
+        panel: [
+          { model: "prom-ensemble-panel-est-a" },
+          { model: "prom-ensemble-panel-est-b" },
+        ],
+        judge: { model: "prom-ensemble-judge-fail" },
+        min_responses: 2,
+      },
+    });
+    await seed.createModel({
+      display_name: PANEL_MEMBER_QUOTA_MODEL,
+      ensemble: {
+        panel: [
+          { model: "prom-ensemble-panel-quota" },
+          { model: "prom-ensemble-panel-a" },
+        ],
+        judge: { model: "prom-ensemble-judge-ns" },
+        min_responses: 2,
+      },
+    });
+    await seed.createModel({
+      display_name: JUDGE_MEMBER_QUOTA_MODEL,
+      ensemble: {
+        panel: [{ model: "prom-ensemble-panel-a" }, { model: "prom-ensemble-panel-b" }],
+        judge: { model: "prom-ensemble-judge-quota" },
+        min_responses: 2,
+      },
+    });
     await seed.createApiKey({
       key_hash: CALLER_HASH,
       allowed_models: [
@@ -198,6 +276,10 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
         STREAM_MODEL,
         NONSTREAM_ESTIMATED_MODEL,
         STREAM_ESTIMATED_MODEL,
+        NONSTREAM_FAILED_ESTIMATED_MODEL,
+        STREAM_FAILED_ESTIMATED_MODEL,
+        PANEL_MEMBER_QUOTA_MODEL,
+        JUDGE_MEMBER_QUOTA_MODEL,
         "prom-ensemble-panel-a",
         "prom-ensemble-panel-b",
         "prom-ensemble-judge-ns",
@@ -205,8 +287,26 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
         "prom-ensemble-panel-est-a",
         "prom-ensemble-panel-est-b",
         "prom-ensemble-judge-est",
+        "prom-ensemble-panel-quota",
+        "prom-ensemble-judge-quota",
       ],
     });
+    for (const [caller, model] of [
+      [NONSTREAM_FAILURE_CALLER, NONSTREAM_FAILED_ESTIMATED_MODEL],
+      [STREAM_FAILURE_CALLER, STREAM_FAILED_ESTIMATED_MODEL],
+    ] as const) {
+      await seed.createApiKey({
+        key_hash: createHash("sha256").update(caller).digest("hex"),
+        allowed_models: [
+          model,
+          "prom-ensemble-panel-est-a",
+          "prom-ensemble-panel-est-b",
+          "prom-ensemble-panel-fail",
+          "prom-ensemble-judge-fail",
+        ],
+        rate_limit: { tpd: 1 },
+      });
+    }
 
     const proxy = new ProxyClient(app.proxyUrl, CALLER);
     await waitConfigPropagation(async () => {
@@ -218,6 +318,10 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
         STREAM_MODEL,
         NONSTREAM_ESTIMATED_MODEL,
         STREAM_ESTIMATED_MODEL,
+        NONSTREAM_FAILED_ESTIMATED_MODEL,
+        STREAM_FAILED_ESTIMATED_MODEL,
+        PANEL_MEMBER_QUOTA_MODEL,
+        JUDGE_MEMBER_QUOTA_MODEL,
       ].every((name) =>
         models.some((model) => model.id === name),
       );
@@ -243,6 +347,24 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
     provider_key_id: "unknown",
     provider_key_name: "unknown",
   });
+
+  const ensembleRequest = async (
+    model: string,
+    caller: string,
+    stream: boolean,
+  ): Promise<Response> =>
+    fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${caller}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "bill surviving panel members" }],
+        stream,
+      }),
+    });
 
   test("non-streaming request records the aggregate token counters under the ensemble alias", async (ctx) => {
     if (!etcdReachable || !app) {
@@ -465,5 +587,60 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
           tokenLabels(STREAM_ESTIMATED_MODEL),
         ),
     ).toBeGreaterThan(JUDGE_USAGE.total_tokens);
+  });
+
+  for (const [name, model, caller, stream] of [
+    [
+      "non-streaming",
+      NONSTREAM_FAILED_ESTIMATED_MODEL,
+      NONSTREAM_FAILURE_CALLER,
+      false,
+    ],
+    ["streaming", STREAM_FAILED_ESTIMATED_MODEL, STREAM_FAILURE_CALLER, true],
+  ] as const) {
+    test(`${name} failure commits estimated usage for successful panel members`, async (ctx) => {
+      if (!etcdReachable || !app) {
+        ctx.skip();
+        return;
+      }
+
+      const first = await ensembleRequest(model, caller, stream);
+      await first.text();
+      expect(first.status).toBe(502);
+
+      const second = await ensembleRequest(model, caller, stream);
+      await second.text();
+      expect(second.status).toBe(429);
+    });
+  }
+
+  test("estimated panel usage is committed to the panel member model quota", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const first = await ensembleRequest(PANEL_MEMBER_QUOTA_MODEL, CALLER, false);
+    await first.text();
+    expect(first.status).toBe(200);
+
+    const second = await ensembleRequest(PANEL_MEMBER_QUOTA_MODEL, CALLER, false);
+    await second.text();
+    expect(second.status).toBe(502);
+  });
+
+  test("estimated judge usage is committed to the judge member model quota", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const first = await ensembleRequest(JUDGE_MEMBER_QUOTA_MODEL, CALLER, false);
+    await first.text();
+    expect(first.status).toBe(200);
+
+    const second = await ensembleRequest(JUDGE_MEMBER_QUOTA_MODEL, CALLER, false);
+    await second.text();
+    expect(second.status).toBe(429);
   });
 });

--- a/tests/e2e/src/cases/ensemble-prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/ensemble-prometheus-metrics-e2e.test.ts
@@ -22,12 +22,14 @@ const CALLER = "sk-ensemble-prometheus-caller";
 const CALLER_HASH = createHash("sha256").update(CALLER).digest("hex");
 const NONSTREAM_MODEL = "prom-ensemble-nonstream";
 const STREAM_MODEL = "prom-ensemble-stream";
+const NONSTREAM_ESTIMATED_MODEL = "prom-ensemble-nonstream-estimated";
+const STREAM_ESTIMATED_MODEL = "prom-ensemble-stream-estimated";
 
 const PANEL_USAGE = { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 };
 const JUDGE_USAGE = { prompt_tokens: 7, completion_tokens: 11, total_tokens: 18 };
 const AGGREGATE = { input: 11, output: 17, total: 28 };
 
-function chatBody(id: string, content: string, usage: typeof PANEL_USAGE) {
+function chatBody(id: string, content: string, usage?: typeof PANEL_USAGE) {
   return {
     id,
     object: "chat.completion",
@@ -40,7 +42,7 @@ function chatBody(id: string, content: string, usage: typeof PANEL_USAGE) {
         finish_reason: "stop",
       },
     ],
-    usage,
+    ...(usage ? { usage } : {}),
   };
 }
 
@@ -109,7 +111,24 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
       streamEvents: streamEvents(),
       firstEventDelayMs: 25,
     });
-    upstreams.push(panelA, panelB, judgeNonstream, judgeStream);
+    const panelNoUsageA = await startOpenAiUpstream({
+      nonStreamBody: chatBody("chatcmpl-panel-est-a", "estimated panel answer A"),
+    });
+    const panelNoUsageB = await startOpenAiUpstream({
+      nonStreamBody: chatBody("chatcmpl-panel-est-b", "estimated panel answer B"),
+    });
+    const judgeNoUsage = await startOpenAiUpstream({
+      nonStreamBody: chatBody("chatcmpl-judge-est", "estimated buffered synthesis"),
+    });
+    upstreams.push(
+      panelA,
+      panelB,
+      judgeNonstream,
+      judgeStream,
+      panelNoUsageA,
+      panelNoUsageB,
+      judgeNoUsage,
+    );
 
     app = await spawnApp();
     const seed = new SeedClient(etcd, app.etcdPrefix);
@@ -130,6 +149,9 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
     await seedDirect("prom-ensemble-panel-b", panelB);
     await seedDirect("prom-ensemble-judge-ns", judgeNonstream);
     await seedDirect("prom-ensemble-judge-stream", judgeStream);
+    await seedDirect("prom-ensemble-panel-est-a", panelNoUsageA);
+    await seedDirect("prom-ensemble-panel-est-b", panelNoUsageB);
+    await seedDirect("prom-ensemble-judge-est", judgeNoUsage);
 
     await seed.createModel({
       display_name: NONSTREAM_MODEL,
@@ -147,15 +169,42 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
         min_responses: 2,
       },
     });
+    await seed.createModel({
+      display_name: NONSTREAM_ESTIMATED_MODEL,
+      ensemble: {
+        panel: [
+          { model: "prom-ensemble-panel-est-a" },
+          { model: "prom-ensemble-panel-est-b" },
+        ],
+        judge: { model: "prom-ensemble-judge-est" },
+        min_responses: 2,
+      },
+    });
+    await seed.createModel({
+      display_name: STREAM_ESTIMATED_MODEL,
+      ensemble: {
+        panel: [
+          { model: "prom-ensemble-panel-est-a" },
+          { model: "prom-ensemble-panel-est-b" },
+        ],
+        judge: { model: "prom-ensemble-judge-stream" },
+        min_responses: 2,
+      },
+    });
     await seed.createApiKey({
       key_hash: CALLER_HASH,
       allowed_models: [
         NONSTREAM_MODEL,
         STREAM_MODEL,
+        NONSTREAM_ESTIMATED_MODEL,
+        STREAM_ESTIMATED_MODEL,
         "prom-ensemble-panel-a",
         "prom-ensemble-panel-b",
         "prom-ensemble-judge-ns",
         "prom-ensemble-judge-stream",
+        "prom-ensemble-panel-est-a",
+        "prom-ensemble-panel-est-b",
+        "prom-ensemble-judge-est",
       ],
     });
 
@@ -164,7 +213,12 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
       const res = await proxy.listModels();
       if (res.status !== 200) return false;
       const models = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
-      return [NONSTREAM_MODEL, STREAM_MODEL].every((name) =>
+      return [
+        NONSTREAM_MODEL,
+        STREAM_MODEL,
+        NONSTREAM_ESTIMATED_MODEL,
+        STREAM_ESTIMATED_MODEL,
+      ].every((name) =>
         models.some((model) => model.id === name),
       );
     });
@@ -292,16 +346,124 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
         metricValue(before, "aisix_request_ttft_seconds_count", lowCardLabels),
     ).toBe(1);
     expect(
-      metricValue(after, "aisix_llm_time_to_first_token_seconds_count", {
-        ...labels,
-        inbound_protocol: "openai",
-        upstream_protocol: "unknown",
-      }) -
-        metricValue(before, "aisix_llm_time_to_first_token_seconds_count", {
-          ...labels,
-          inbound_protocol: "openai",
-          upstream_protocol: "unknown",
-        }),
+      metricValue(after, "aisix_request_ttft_seconds_sum", lowCardLabels) -
+        metricValue(before, "aisix_request_ttft_seconds_sum", lowCardLabels),
+    ).toBeGreaterThan(0);
+    const detailedLabels = {
+      ...labels,
+      inbound_protocol: "openai",
+      upstream_protocol: "unknown",
+    };
+    expect(
+      metricValue(after, "aisix_llm_time_to_first_token_seconds_count", detailedLabels) -
+        metricValue(before, "aisix_llm_time_to_first_token_seconds_count", detailedLabels),
     ).toBe(1);
+    expect(
+      metricValue(after, "aisix_llm_time_to_first_token_seconds_sum", detailedLabels) -
+        metricValue(before, "aisix_llm_time_to_first_token_seconds_sum", detailedLabels),
+    ).toBeGreaterThan(0);
+  });
+
+  test("locally estimated subcalls contribute to non-streaming and streaming aggregates", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const before = await scrape();
+    const client = new OpenAI({ apiKey: CALLER, baseURL: `${app.proxyUrl}/v1`, maxRetries: 0 });
+
+    const nonstream = await client.chat.completions.create({
+      model: NONSTREAM_ESTIMATED_MODEL,
+      messages: [{ role: "user", content: "estimate every subcall" }],
+    });
+    expect(nonstream.choices[0]?.message?.content).toContain("estimated buffered synthesis");
+
+    const stream = await client.chat.completions.create({
+      model: STREAM_ESTIMATED_MODEL,
+      messages: [{ role: "user", content: "estimate the panel" }],
+      stream: true,
+    });
+    for await (const _chunk of stream) {
+      // Drain the stream so on_complete records its aggregate.
+    }
+
+    let after = "";
+    const deadline = Date.now() + 10_000;
+    for (;;) {
+      after = await scrape();
+      const nonstreamTotal =
+        metricValue(
+          after,
+          "aisix_llm_total_tokens_total",
+          tokenLabels(NONSTREAM_ESTIMATED_MODEL),
+        ) -
+        metricValue(
+          before,
+          "aisix_llm_total_tokens_total",
+          tokenLabels(NONSTREAM_ESTIMATED_MODEL),
+        );
+      const streamTotal =
+        metricValue(
+          after,
+          "aisix_llm_total_tokens_total",
+          tokenLabels(STREAM_ESTIMATED_MODEL),
+        ) -
+        metricValue(
+          before,
+          "aisix_llm_total_tokens_total",
+          tokenLabels(STREAM_ESTIMATED_MODEL),
+        );
+      if (nonstreamTotal > 0 && streamTotal > JUDGE_USAGE.total_tokens) break;
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    for (const metric of [
+      "aisix_llm_input_tokens_total",
+      "aisix_llm_output_tokens_total",
+      "aisix_llm_total_tokens_total",
+    ]) {
+      expect(
+        metricValue(after, metric, tokenLabels(NONSTREAM_ESTIMATED_MODEL)) -
+          metricValue(before, metric, tokenLabels(NONSTREAM_ESTIMATED_MODEL)),
+        `${metric} non-streaming estimate`,
+      ).toBeGreaterThan(0);
+    }
+    expect(
+      metricValue(
+        after,
+        "aisix_llm_input_tokens_total",
+        tokenLabels(STREAM_ESTIMATED_MODEL),
+      ) -
+        metricValue(
+          before,
+          "aisix_llm_input_tokens_total",
+          tokenLabels(STREAM_ESTIMATED_MODEL),
+        ),
+    ).toBeGreaterThan(JUDGE_USAGE.prompt_tokens);
+    expect(
+      metricValue(
+        after,
+        "aisix_llm_output_tokens_total",
+        tokenLabels(STREAM_ESTIMATED_MODEL),
+      ) -
+        metricValue(
+          before,
+          "aisix_llm_output_tokens_total",
+          tokenLabels(STREAM_ESTIMATED_MODEL),
+        ),
+    ).toBeGreaterThan(JUDGE_USAGE.completion_tokens);
+    expect(
+      metricValue(
+        after,
+        "aisix_llm_total_tokens_total",
+        tokenLabels(STREAM_ESTIMATED_MODEL),
+      ) -
+        metricValue(
+          before,
+          "aisix_llm_total_tokens_total",
+          tokenLabels(STREAM_ESTIMATED_MODEL),
+        ),
+    ).toBeGreaterThan(JUDGE_USAGE.total_tokens);
   });
 });

--- a/tests/e2e/src/cases/ensemble-prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/ensemble-prometheus-metrics-e2e.test.ts
@@ -1,0 +1,307 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// An ensemble emits one UsageEvent per panel member and judge, but its
+// Prometheus families describe the caller-visible request. They therefore
+// carry the panel+judge aggregate under the ensemble alias. Before this
+// coverage test, both streaming and non-streaming ensemble requests silently
+// emitted zero token metrics, and streaming omitted the detailed TTFT family.
+
+const CALLER = "sk-ensemble-prometheus-caller";
+const CALLER_HASH = createHash("sha256").update(CALLER).digest("hex");
+const NONSTREAM_MODEL = "prom-ensemble-nonstream";
+const STREAM_MODEL = "prom-ensemble-stream";
+
+const PANEL_USAGE = { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 };
+const JUDGE_USAGE = { prompt_tokens: 7, completion_tokens: 11, total_tokens: 18 };
+const AGGREGATE = { input: 11, output: 17, total: 28 };
+
+function chatBody(id: string, content: string, usage: typeof PANEL_USAGE) {
+  return {
+    id,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage,
+  };
+}
+
+function streamEvents() {
+  return [
+    JSON.stringify({
+      id: "chatcmpl-prom-ensemble-stream",
+      object: "chat.completion.chunk",
+      model: "gpt-4o-mini",
+      choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+    }),
+    JSON.stringify({
+      id: "chatcmpl-prom-ensemble-stream",
+      object: "chat.completion.chunk",
+      model: "gpt-4o-mini",
+      choices: [{ index: 0, delta: { content: "streamed synthesis" }, finish_reason: null }],
+    }),
+    JSON.stringify({
+      id: "chatcmpl-prom-ensemble-stream",
+      object: "chat.completion.chunk",
+      model: "gpt-4o-mini",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: JUDGE_USAGE,
+    }),
+    "[DONE]",
+  ];
+}
+
+function metricValue(
+  scrape: string,
+  series: string,
+  labels: Record<string, string>,
+): number {
+  return scrape
+    .split("\n")
+    .filter(
+      (line) =>
+        line.startsWith(`${series}{`) &&
+        Object.entries(labels).every(([key, value]) => line.includes(`${key}="${value}"`)),
+    )
+    .map((line) => Number(line.trim().split(/\s+/).at(-1)))
+    .filter((value) => !Number.isNaN(value))
+    .reduce((sum, value) => sum + value, 0);
+}
+
+describe("ensemble Prometheus token and TTFT coverage", () => {
+  let app: SpawnedApp | undefined;
+  const upstreams: OpenAiUpstream[] = [];
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    const panelA = await startOpenAiUpstream({
+      nonStreamBody: chatBody("chatcmpl-panel-a", "panel answer A", PANEL_USAGE),
+    });
+    const panelB = await startOpenAiUpstream({
+      nonStreamBody: chatBody("chatcmpl-panel-b", "panel answer B", PANEL_USAGE),
+    });
+    const judgeNonstream = await startOpenAiUpstream({
+      nonStreamBody: chatBody("chatcmpl-judge-ns", "buffered synthesis", JUDGE_USAGE),
+    });
+    const judgeStream = await startOpenAiUpstream({
+      streamEvents: streamEvents(),
+      firstEventDelayMs: 25,
+    });
+    upstreams.push(panelA, panelB, judgeNonstream, judgeStream);
+
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    const seedDirect = async (displayName: string, upstream: OpenAiUpstream) => {
+      const pk = await seed.createProviderKey({
+        display_name: `${displayName}-pk`,
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+      });
+      await seed.createModel({
+        display_name: displayName,
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pk.id,
+      });
+    };
+    await seedDirect("prom-ensemble-panel-a", panelA);
+    await seedDirect("prom-ensemble-panel-b", panelB);
+    await seedDirect("prom-ensemble-judge-ns", judgeNonstream);
+    await seedDirect("prom-ensemble-judge-stream", judgeStream);
+
+    await seed.createModel({
+      display_name: NONSTREAM_MODEL,
+      ensemble: {
+        panel: [{ model: "prom-ensemble-panel-a" }, { model: "prom-ensemble-panel-b" }],
+        judge: { model: "prom-ensemble-judge-ns" },
+        min_responses: 2,
+      },
+    });
+    await seed.createModel({
+      display_name: STREAM_MODEL,
+      ensemble: {
+        panel: [{ model: "prom-ensemble-panel-a" }, { model: "prom-ensemble-panel-b" }],
+        judge: { model: "prom-ensemble-judge-stream" },
+        min_responses: 2,
+      },
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_HASH,
+      allowed_models: [
+        NONSTREAM_MODEL,
+        STREAM_MODEL,
+        "prom-ensemble-panel-a",
+        "prom-ensemble-panel-b",
+        "prom-ensemble-judge-ns",
+        "prom-ensemble-judge-stream",
+      ],
+    });
+
+    const proxy = new ProxyClient(app.proxyUrl, CALLER);
+    await waitConfigPropagation(async () => {
+      const res = await proxy.listModels();
+      if (res.status !== 200) return false;
+      const models = (res.body as { data?: Array<{ id?: string }> }).data ?? [];
+      return [NONSTREAM_MODEL, STREAM_MODEL].every((name) =>
+        models.some((model) => model.id === name),
+      );
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((upstream) => upstream.close()));
+  });
+
+  const scrape = async (): Promise<string> => {
+    const res = await fetch(`${app!.metricsUrl}/metrics`);
+    expect(res.status).toBe(200);
+    return res.text();
+  };
+
+  const tokenLabels = (model: string) => ({
+    endpoint: "/v1/chat/completions",
+    provider: "ensemble",
+    model,
+    upstream_model: "unknown",
+    provider_key_id: "unknown",
+    provider_key_name: "unknown",
+  });
+
+  test("non-streaming request records the aggregate token counters under the ensemble alias", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const before = await scrape();
+    const client = new OpenAI({ apiKey: CALLER, baseURL: `${app.proxyUrl}/v1`, maxRetries: 0 });
+    const response = await client.chat.completions.create({
+      model: NONSTREAM_MODEL,
+      messages: [{ role: "user", content: "synthesize" }],
+    });
+    expect(response.usage?.prompt_tokens).toBe(AGGREGATE.input);
+    expect(response.usage?.completion_tokens).toBe(AGGREGATE.output);
+    expect(response.usage?.total_tokens).toBe(AGGREGATE.total);
+
+    const after = await scrape();
+    const labels = tokenLabels(NONSTREAM_MODEL);
+    expect(
+      metricValue(after, "aisix_llm_input_tokens_total", labels) -
+        metricValue(before, "aisix_llm_input_tokens_total", labels),
+    ).toBe(AGGREGATE.input);
+    expect(
+      metricValue(after, "aisix_llm_output_tokens_total", labels) -
+        metricValue(before, "aisix_llm_output_tokens_total", labels),
+    ).toBe(AGGREGATE.output);
+    expect(
+      metricValue(after, "aisix_llm_total_tokens_total", labels) -
+        metricValue(before, "aisix_llm_total_tokens_total", labels),
+    ).toBe(AGGREGATE.total);
+  });
+
+  test("streaming request records aggregate tokens and both TTFT families once", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const before = await scrape();
+    const client = new OpenAI({ apiKey: CALLER, baseURL: `${app.proxyUrl}/v1`, maxRetries: 0 });
+    const stream = await client.chat.completions.create({
+      model: STREAM_MODEL,
+      messages: [{ role: "user", content: "stream a synthesis" }],
+      stream: true,
+    });
+    let content = "";
+    for await (const chunk of stream) {
+      content += chunk.choices[0]?.delta?.content ?? "";
+    }
+    expect(content).toBe("streamed synthesis");
+
+    const labels = tokenLabels(STREAM_MODEL);
+    let after = "";
+    const deadline = Date.now() + 10_000;
+    for (;;) {
+      after = await scrape();
+      if (
+        metricValue(after, "aisix_llm_total_tokens_total", labels) -
+          metricValue(before, "aisix_llm_total_tokens_total", labels) ===
+          AGGREGATE.total &&
+        metricValue(after, "aisix_request_ttft_seconds_count", {
+          endpoint: "/v1/chat/completions",
+          provider: "ensemble",
+          model: STREAM_MODEL,
+          streaming: "true",
+        }) -
+          metricValue(before, "aisix_request_ttft_seconds_count", {
+            endpoint: "/v1/chat/completions",
+            provider: "ensemble",
+            model: STREAM_MODEL,
+            streaming: "true",
+          }) ===
+          1
+      ) {
+        break;
+      }
+      if (Date.now() > deadline) break;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    expect(
+      metricValue(after, "aisix_llm_input_tokens_total", labels) -
+        metricValue(before, "aisix_llm_input_tokens_total", labels),
+    ).toBe(AGGREGATE.input);
+    expect(
+      metricValue(after, "aisix_llm_output_tokens_total", labels) -
+        metricValue(before, "aisix_llm_output_tokens_total", labels),
+    ).toBe(AGGREGATE.output);
+    expect(
+      metricValue(after, "aisix_llm_total_tokens_total", labels) -
+        metricValue(before, "aisix_llm_total_tokens_total", labels),
+    ).toBe(AGGREGATE.total);
+
+    const lowCardLabels = {
+      endpoint: "/v1/chat/completions",
+      provider: "ensemble",
+      model: STREAM_MODEL,
+      streaming: "true",
+    };
+    expect(
+      metricValue(after, "aisix_request_ttft_seconds_count", lowCardLabels) -
+        metricValue(before, "aisix_request_ttft_seconds_count", lowCardLabels),
+    ).toBe(1);
+    expect(
+      metricValue(after, "aisix_llm_time_to_first_token_seconds_count", {
+        ...labels,
+        inbound_protocol: "openai",
+        upstream_protocol: "unknown",
+      }) -
+        metricValue(before, "aisix_llm_time_to_first_token_seconds_count", {
+          ...labels,
+          inbound_protocol: "openai",
+          upstream_protocol: "unknown",
+        }),
+    ).toBe(1);
+  });
+});

--- a/tests/e2e/src/cases/ensemble-prometheus-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/ensemble-prometheus-metrics-e2e.test.ts
@@ -269,6 +269,22 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
         min_responses: 2,
       },
     });
+    for (const [caller, model] of [
+      [NONSTREAM_FAILURE_CALLER, NONSTREAM_FAILED_ESTIMATED_MODEL],
+      [STREAM_FAILURE_CALLER, STREAM_FAILED_ESTIMATED_MODEL],
+    ] as const) {
+      await seed.createApiKey({
+        key_hash: createHash("sha256").update(caller).digest("hex"),
+        allowed_models: [
+          model,
+          "prom-ensemble-panel-est-a",
+          "prom-ensemble-panel-est-b",
+          "prom-ensemble-panel-fail",
+          "prom-ensemble-judge-fail",
+        ],
+        rate_limit: { tpd: 1 },
+      });
+    }
     await seed.createApiKey({
       key_hash: CALLER_HASH,
       allowed_models: [
@@ -291,22 +307,6 @@ describe("ensemble Prometheus token and TTFT coverage", () => {
         "prom-ensemble-judge-quota",
       ],
     });
-    for (const [caller, model] of [
-      [NONSTREAM_FAILURE_CALLER, NONSTREAM_FAILED_ESTIMATED_MODEL],
-      [STREAM_FAILURE_CALLER, STREAM_FAILED_ESTIMATED_MODEL],
-    ] as const) {
-      await seed.createApiKey({
-        key_hash: createHash("sha256").update(caller).digest("hex"),
-        allowed_models: [
-          model,
-          "prom-ensemble-panel-est-a",
-          "prom-ensemble-panel-est-b",
-          "prom-ensemble-panel-fail",
-          "prom-ensemble-judge-fail",
-        ],
-        rate_limit: { tpd: 1 },
-      });
-    }
 
     const proxy = new ProxyClient(app.proxyUrl, CALLER);
     await waitConfigPropagation(async () => {

--- a/tests/e2e/src/cases/guardrail-metrics-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-metrics-e2e.test.ts
@@ -22,6 +22,11 @@ import {
 // (moderation 5xx + fail_open), and monitor-mode would_block. The series
 // must render as a real bucketed histogram (`_bucket{le=…}`), not a
 // summary, so operators can compute P50/P95/P99.
+//
+// The aggregate block/bypass counters share that same execution chokepoint.
+// A protocol matrix below pins their coverage across Chat Completions,
+// Messages, and Responses; before this regression fix they were emitted by
+// the Chat UsageEvent path alone.
 
 const CALLER = "sk-guardrail-metrics-e2e-caller";
 const hash = (s: string) => createHash("sha256").update(s).digest("hex");
@@ -34,6 +39,7 @@ const ERROR_MARKER = "moderationfivehundredmarker";
 
 const MODEL_CLEAN = "guardrail-metrics-clean";
 const MODEL_LEAKY = "guardrail-metrics-leaky";
+const MODEL_PROTOCOL_MATRIX = "guardrail-metrics-protocol-matrix";
 
 interface ModerationMock {
   baseUrl: string;
@@ -128,6 +134,25 @@ function guardrailCount(scrape: string, labels: Record<string, string>): number 
   return sum;
 }
 
+function counterValue(
+  scrape: string,
+  series: string,
+  labels: Record<string, string> = {},
+): number {
+  let sum = 0;
+  for (const line of scrape.split("\n")) {
+    if (line !== series && !line.startsWith(`${series}{`) && !line.startsWith(`${series} `)) {
+      continue;
+    }
+    if (!Object.entries(labels).every(([k, v]) => line.includes(`${k}="${v}"`))) {
+      continue;
+    }
+    const value = Number(line.trim().split(/\s+/).at(-1));
+    if (!Number.isNaN(value)) sum += value;
+  }
+  return sum;
+}
+
 describe("guardrail latency metrics e2e: per-execution histogram", () => {
   let app: SpawnedApp | undefined;
   let cleanUpstream: OpenAiUpstream | undefined;
@@ -170,9 +195,22 @@ describe("guardrail latency metrics e2e: per-execution histogram", () => {
         provider_key_id: pk.id,
       });
     }
+    const protocolPk = await seed.createProviderKey({
+      display_name: `${MODEL_PROTOCOL_MATRIX}-pk`,
+      provider: "deepseek",
+      adapter: "openai",
+      secret: "sk-mock",
+      api_base: `${cleanUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: MODEL_PROTOCOL_MATRIX,
+      provider: "deepseek",
+      model_name: "deepseek-chat",
+      provider_key_id: protocolPk.id,
+    });
     await seed.createApiKey({
       key_hash: hash(CALLER),
-      allowed_models: [MODEL_CLEAN, MODEL_LEAKY],
+      allowed_models: [MODEL_CLEAN, MODEL_LEAKY, MODEL_PROTOCOL_MATRIX],
     });
 
     // Env-wide guardrails, distinct kinds/phases/modes. The blocking input
@@ -256,6 +294,42 @@ describe("guardrail latency metrics e2e: per-execution histogram", () => {
     expect(caught).toBeInstanceOf(APIError);
     if (!(caught instanceof APIError)) throw new Error("unreachable");
     expect(caught.status).toBe(422);
+  };
+
+  const protocolRequest = async (
+    protocol: "chat" | "messages" | "responses",
+    content: string,
+  ): Promise<Response> => {
+    const request = {
+      chat: {
+        path: "/v1/chat/completions",
+        body: {
+          model: MODEL_PROTOCOL_MATRIX,
+          messages: [{ role: "user", content }],
+        },
+      },
+      messages: {
+        path: "/v1/messages",
+        body: {
+          model: MODEL_PROTOCOL_MATRIX,
+          max_tokens: 16,
+          messages: [{ role: "user", content }],
+        },
+      },
+      responses: {
+        path: "/v1/responses",
+        body: { model: MODEL_PROTOCOL_MATRIX, input: content },
+      },
+    }[protocol];
+    return fetch(`${app!.proxyUrl}${request.path}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER}`,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(request.body),
+    });
   };
 
   test("clean request records result=allowed for every consulted guardrail, as a real bucketed histogram", async (ctx) => {
@@ -409,5 +483,42 @@ describe("guardrail latency metrics e2e: per-execution histogram", () => {
     expect(guardrailCount(after, labels)).toBeGreaterThan(
       guardrailCount(before, labels),
     );
+  });
+
+  test("aggregate block counter covers Chat, Messages, and Responses", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    let body = await scrape();
+    let previous = counterValue(body, "aisix_guardrail_blocks_total");
+    for (const protocol of ["chat", "messages", "responses"] as const) {
+      const res = await protocolRequest(protocol, `matrix ${protocol} ${KW_BLOCK_MARKER}`);
+      await res.text();
+      expect(res.status, `${protocol} block status`).toBe(422);
+      body = await scrape();
+      const current = counterValue(body, "aisix_guardrail_blocks_total");
+      expect(current, `${protocol} block counter`).toBe(previous + 1);
+      previous = current;
+    }
+  });
+
+  test("aggregate bypass counter covers Chat, Messages, and Responses", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    const labels = { reason: "openai_moderation_5xx" };
+    let body = await scrape();
+    let previous = counterValue(body, "aisix_guardrail_bypasses_total", labels);
+    for (const protocol of ["chat", "messages", "responses"] as const) {
+      const res = await protocolRequest(protocol, `matrix ${protocol} ${ERROR_MARKER}`);
+      const responseBody = await res.text();
+      expect(res.status, `${protocol} bypass status: ${responseBody}`).toBe(200);
+      body = await scrape();
+      const current = counterValue(body, "aisix_guardrail_bypasses_total", labels);
+      expect(current, `${protocol} bypass counter`).toBe(previous + 1);
+      previous = current;
+    }
   });
 });

--- a/tests/e2e/src/cases/latency-histograms-e2e.test.ts
+++ b/tests/e2e/src/cases/latency-histograms-e2e.test.ts
@@ -29,11 +29,17 @@ const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("he
 
 const E2E_SERIES = "aisix_request_e2e_latency_seconds";
 const TTFT_SERIES = "aisix_request_ttft_seconds";
+const DETAILED_TTFT_SERIES = "aisix_llm_time_to_first_token_seconds";
+
+const RESPONSES_NATIVE_MODEL = "histo-responses-native";
+const RESPONSES_BRIDGE_MODEL = "histo-responses-bridge";
 
 describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
   let streamUpstream: OpenAiUpstream | undefined;
+  let responsesNativeUpstream: OpenAiUpstream | undefined;
+  let responsesBridgeUpstream: OpenAiUpstream | undefined;
   let failUpstream: OpenAiUpstream | undefined;
   let etcdReachable = false;
 
@@ -69,6 +75,51 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
       ],
       eventDelayMs: 20,
     });
+    responsesNativeUpstream = await startOpenAiUpstream({
+      streamEvents: [
+        JSON.stringify({
+          type: "response.created",
+          response: { id: "resp-histo-native", model: "gpt-4o-mini" },
+        }),
+        JSON.stringify({ type: "response.output_text.delta", delta: "native reply" }),
+        JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "resp-histo-native",
+            status: "completed",
+            model: "gpt-4o-mini",
+            usage: { input_tokens: 7, output_tokens: 3, total_tokens: 10 },
+          },
+        }),
+        "[DONE]",
+      ],
+      firstEventDelayMs: 25,
+    });
+    responsesBridgeUpstream = await startOpenAiUpstream({
+      streamEvents: [
+        JSON.stringify({
+          id: "chatcmpl-histo-bridge",
+          object: "chat.completion.chunk",
+          model: "deepseek-chat",
+          choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+        }),
+        JSON.stringify({
+          id: "chatcmpl-histo-bridge",
+          object: "chat.completion.chunk",
+          model: "deepseek-chat",
+          choices: [{ index: 0, delta: { content: "bridged reply" }, finish_reason: null }],
+        }),
+        JSON.stringify({
+          id: "chatcmpl-histo-bridge",
+          object: "chat.completion.chunk",
+          model: "deepseek-chat",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 11, completion_tokens: 5, total_tokens: 16 },
+        }),
+        "[DONE]",
+      ],
+      firstEventDelayMs: 25,
+    });
     failUpstream = await startOpenAiUpstream({
       status: 500,
       errorBody: { error: { message: "mock outage", type: "server_error" } },
@@ -99,6 +150,30 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
       model_name: "gpt-4o-mini",
       provider_key_id: streamPk.id,
     });
+    const responsesNativePk = await seed.createProviderKey({
+      display_name: "histo-responses-native-pk",
+      secret: "sk-mock",
+      api_base: `${responsesNativeUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: RESPONSES_NATIVE_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: responsesNativePk.id,
+    });
+    const responsesBridgePk = await seed.createProviderKey({
+      display_name: "histo-responses-bridge-pk",
+      provider: "deepseek",
+      adapter: "openai",
+      secret: "sk-mock",
+      api_base: `${responsesBridgeUpstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: RESPONSES_BRIDGE_MODEL,
+      provider: "deepseek",
+      model_name: "deepseek-chat",
+      provider_key_id: responsesBridgePk.id,
+    });
     const failPk = await seed.createProviderKey({
       display_name: "histo-fail-pk",
       secret: "sk-mock",
@@ -112,7 +187,13 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
     });
     await seed.createApiKey({
       key_hash: CALLER_KEY_HASH,
-      allowed_models: ["histo-model", "histo-stream-model", "histo-fail-model"],
+      allowed_models: [
+        "histo-model",
+        "histo-stream-model",
+        "histo-fail-model",
+        RESPONSES_NATIVE_MODEL,
+        RESPONSES_BRIDGE_MODEL,
+      ],
     });
 
     await waitConfigPropagation(async () => {
@@ -125,6 +206,8 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
     await app?.exit();
     await upstream?.close();
     await streamUpstream?.close();
+    await responsesNativeUpstream?.close();
+    await responsesBridgeUpstream?.close();
     await failUpstream?.close();
   });
 
@@ -149,6 +232,19 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
     const res = await fetch(`${app!.metricsUrl}/metrics`);
     expect(res.status).toBe(200);
     return res.text();
+  }
+
+  async function responses(model: string): Promise<Response> {
+    const res = await fetch(`${app!.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ model, input: "hello", stream: true }),
+    });
+    await res.text();
+    return res;
   }
 
   /** Lines of `series` matching every given label pair. */
@@ -284,5 +380,60 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
     expect(body).not.toContain("aisix_llm_request_duration_seconds_bucket");
     expect(body).not.toContain("aisix_proxy_request_duration_seconds_bucket");
     expect(body).toContain("aisix_llm_request_duration_seconds");
+  });
+
+  test("native and bridged Responses streams record both TTFT families exactly once", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+    expect((await responses(RESPONSES_NATIVE_MODEL)).status).toBe(200);
+    expect((await responses(RESPONSES_BRIDGE_MODEL)).status).toBe(200);
+
+    let body = "";
+    const deadline = Date.now() + 10_000;
+    for (;;) {
+      body = await scrape();
+      const complete = [RESPONSES_NATIVE_MODEL, RESPONSES_BRIDGE_MODEL].every(
+        (model) =>
+          countOf(body, TTFT_SERIES, {
+            endpoint: "/v1/responses",
+            model,
+          }) === 1 &&
+          countOf(body, DETAILED_TTFT_SERIES, {
+            endpoint: "/v1/responses",
+            model,
+          }) === 1,
+      );
+      if (complete || Date.now() > deadline) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    for (const [model, provider] of [
+      [RESPONSES_NATIVE_MODEL, "openai"],
+      [RESPONSES_BRIDGE_MODEL, "deepseek"],
+    ] as const) {
+      const lowCardLabels = {
+        endpoint: "/v1/responses",
+        model,
+        provider,
+        streaming: "true",
+        status_class: "2xx",
+      };
+      expect(
+        bucketLines(body, TTFT_SERIES, lowCardLabels).length,
+        `${model} low-cardinality TTFT buckets`,
+      ).toBeGreaterThan(0);
+      expect(countOf(body, TTFT_SERIES, lowCardLabels)).toBe(1);
+
+      const detailedLabels = {
+        endpoint: "/v1/responses",
+        model,
+        provider,
+        inbound_protocol: "openai",
+        upstream_protocol: "openai",
+      };
+      expect(countOf(body, DETAILED_TTFT_SERIES, detailedLabels)).toBe(1);
+    }
   });
 });

--- a/tests/e2e/src/cases/latency-histograms-e2e.test.ts
+++ b/tests/e2e/src/cases/latency-histograms-e2e.test.ts
@@ -41,6 +41,7 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
   let responsesNativeUpstream: OpenAiUpstream | undefined;
   let responsesBridgeUpstream: OpenAiUpstream | undefined;
   let failUpstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
   let etcdReachable = false;
 
   beforeAll(async () => {
@@ -126,7 +127,7 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
     });
 
     app = await spawnApp();
-    const seed = new SeedClient(etcd, app.etcdPrefix);
+    seed = new SeedClient(etcd, app.etcdPrefix);
 
     const pk = await seed.createProviderKey({
       display_name: "histo-pk",
@@ -269,6 +270,20 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
       .reduce((a, b) => a + b, 0);
   }
 
+  /** Sum of `series`_sum across label combinations matching `labels`. */
+  function sumOf(body: string, series: string, labels: Record<string, string>): number {
+    return body
+      .split("\n")
+      .filter(
+        (l) =>
+          l.startsWith(`${series}_sum{`) &&
+          Object.entries(labels).every(([k, v]) => l.includes(`${k}="${v}"`)),
+      )
+      .map((l) => Number(l.split("}").at(-1)!.trim()))
+      .filter((v) => !Number.isNaN(v))
+      .reduce((a, b) => a + b, 0);
+  }
+
   test("non-streaming, streaming and failed requests land in le-bucketed series", async (ctx) => {
     if (!etcdReachable || !app) {
       ctx.skip();
@@ -387,6 +402,7 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
       ctx.skip();
       return;
     }
+    const before = await scrape();
     expect((await responses(RESPONSES_NATIVE_MODEL)).status).toBe(200);
     expect((await responses(RESPONSES_BRIDGE_MODEL)).status).toBe(200);
 
@@ -425,6 +441,10 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
         `${model} low-cardinality TTFT buckets`,
       ).toBeGreaterThan(0);
       expect(countOf(body, TTFT_SERIES, lowCardLabels)).toBe(1);
+      expect(
+        sumOf(body, TTFT_SERIES, lowCardLabels) -
+          sumOf(before, TTFT_SERIES, lowCardLabels),
+      ).toBeGreaterThan(0);
 
       const detailedLabels = {
         endpoint: "/v1/responses",
@@ -434,6 +454,79 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
         upstream_protocol: "openai",
       };
       expect(countOf(body, DETAILED_TTFT_SERIES, detailedLabels)).toBe(1);
+      expect(
+        sumOf(body, DETAILED_TTFT_SERIES, detailedLabels) -
+          sumOf(before, DETAILED_TTFT_SERIES, detailedLabels),
+      ).toBeGreaterThan(0);
     }
+  });
+
+  test("buffered Responses output-guardrail paths retain TTFT on allow and block", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    const guardrailBody = (pattern: string) => ({
+      name: "histo-responses-output",
+      enabled: true,
+      hook_point: "output",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: pattern }],
+    });
+    const guardrail = await seed.createGuardrail(guardrailBody("native reply"));
+
+    // A 422 proves the output rule has propagated and the native Responses
+    // stream took the whole-response hold-back path.
+    await waitConfigPropagation(async () => {
+      return (await responses(RESPONSES_NATIVE_MODEL)).status === 422;
+    });
+
+    const assertDelta = async (status: number, statusClass: "2xx" | "4xx") => {
+      const before = await scrape();
+      expect((await responses(RESPONSES_NATIVE_MODEL)).status).toBe(status);
+      const after = await scrape();
+      const lowCardLabels = {
+        endpoint: "/v1/responses",
+        model: RESPONSES_NATIVE_MODEL,
+        provider: "openai",
+        streaming: "true",
+        status_class: statusClass,
+      };
+      const detailedLabels = {
+        endpoint: "/v1/responses",
+        model: RESPONSES_NATIVE_MODEL,
+        provider: "openai",
+        inbound_protocol: "openai",
+        upstream_protocol: "openai",
+      };
+      expect(
+        countOf(after, TTFT_SERIES, lowCardLabels) -
+          countOf(before, TTFT_SERIES, lowCardLabels),
+      ).toBe(1);
+      expect(
+        sumOf(after, TTFT_SERIES, lowCardLabels) -
+          sumOf(before, TTFT_SERIES, lowCardLabels),
+      ).toBeGreaterThan(0);
+      expect(
+        countOf(after, DETAILED_TTFT_SERIES, detailedLabels) -
+          countOf(before, DETAILED_TTFT_SERIES, detailedLabels),
+      ).toBe(1);
+      expect(
+        sumOf(after, DETAILED_TTFT_SERIES, detailedLabels) -
+          sumOf(before, DETAILED_TTFT_SERIES, detailedLabels),
+      ).toBeGreaterThan(0);
+    };
+
+    await assertDelta(422, "4xx");
+
+    await seed.update(
+      "guardrails",
+      guardrail.id as string,
+      guardrailBody("never-matches-native-response"),
+    );
+    await waitConfigPropagation(async () => {
+      return (await responses(RESPONSES_NATIVE_MODEL)).status === 200;
+    });
+    await assertDelta(200, "2xx");
   });
 });

--- a/tests/e2e/src/cases/latency-histograms-e2e.test.ts
+++ b/tests/e2e/src/cases/latency-histograms-e2e.test.ts
@@ -235,6 +235,22 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
     return res.text();
   }
 
+  async function appliedConfig(): Promise<
+    | { applySeq: number; resourceCounts: Record<string, number> }
+    | undefined
+  > {
+    const res = await fetch(`${app!.metricsUrl}/status/config`);
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as {
+      applied?: { apply_seq?: number; resource_counts?: Record<string, number> };
+    };
+    if (typeof body.applied?.apply_seq !== "number") return undefined;
+    return {
+      applySeq: body.applied.apply_seq,
+      resourceCounts: body.applied.resource_counts ?? {},
+    };
+  }
+
   async function responses(model: string): Promise<Response> {
     const res = await fetch(`${app!.proxyUrl}/v1/responses`, {
       method: "POST",
@@ -473,12 +489,18 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
       kind: "keyword",
       patterns: [{ kind: "literal", value: pattern }],
     });
+    const beforeCreate = await appliedConfig();
+    expect(beforeCreate).toBeDefined();
     const guardrail = await seed.createGuardrail(guardrailBody("native reply"));
 
-    // A 422 proves the output rule has propagated and the native Responses
-    // stream took the whole-response hold-back path.
     await waitConfigPropagation(async () => {
-      return (await responses(RESPONSES_NATIVE_MODEL)).status === 422;
+      const applied = await appliedConfig();
+      return (
+        applied !== undefined &&
+        applied.applySeq > beforeCreate!.applySeq &&
+        applied.resourceCounts.guardrails === 1 &&
+        applied.resourceCounts.guardrail_attachments === 1
+      );
     });
 
     const assertDelta = async (status: number, statusClass: "2xx" | "4xx") => {
@@ -519,13 +541,16 @@ describe("latency histograms e2e: bucketed TTFT + e2e latency (#1011)", () => {
 
     await assertDelta(422, "4xx");
 
+    const beforeUpdate = await appliedConfig();
+    expect(beforeUpdate).toBeDefined();
     await seed.update(
       "guardrails",
       guardrail.id as string,
       guardrailBody("never-matches-native-response"),
     );
     await waitConfigPropagation(async () => {
-      return (await responses(RESPONSES_NATIVE_MODEL)).status === 200;
+      const applied = await appliedConfig();
+      return applied !== undefined && applied.applySeq > beforeUpdate!.applySeq;
     });
     await assertDelta(200, "2xx");
   });

--- a/tests/e2e/src/cases/responses-streaming-monitor-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/responses-streaming-monitor-guardrail-e2e.test.ts
@@ -72,6 +72,15 @@ function guardrailBody(enforcementMode: "block" | "monitor") {
   };
 }
 
+function counterValue(scrape: string, series: string): number {
+  return scrape
+    .split("\n")
+    .filter((line) => line === series || line.startsWith(`${series} `))
+    .map((line) => Number(line.trim().split(/\s+/).at(-1)))
+    .filter((value) => !Number.isNaN(value))
+    .reduce((sum, value) => sum + value, 0);
+}
+
 describe("responses streaming with monitor-mode output guardrail (AISIX-Cloud#1010)", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
@@ -142,10 +151,17 @@ describe("responses streaming with monitor-mode output guardrail (AISIX-Cloud#10
       const { status } = await streamOnce();
       return status === 422;
     });
+    const metricsBefore = await (await fetch(`${app.metricsUrl}/metrics`)).text();
     const blocked = await streamOnce();
     expect(blocked.status).toBe(422);
     expect(blocked.body).toContain("content_filter");
     expect(blocked.body).not.toContain(DELTA_TEXT);
+    const metricsAfter = await (await fetch(`${app.metricsUrl}/metrics`)).text();
+    expect(
+      counterValue(metricsAfter, "aisix_guardrail_blocks_total") -
+        counterValue(metricsBefore, "aisix_guardrail_blocks_total"),
+      "buffer-cap fail-closed is still a guardrail-blocked request even though no member executed",
+    ).toBe(1);
 
     // 2. Flip the SAME rule to monitor (full-resource PUT).
     await seed.update("guardrails", guardrailId, guardrailBody("monitor"));

--- a/tests/e2e/src/cases/responses-streaming-monitor-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/responses-streaming-monitor-guardrail-e2e.test.ts
@@ -112,7 +112,10 @@ describe("responses streaming with monitor-mode output guardrail (AISIX-Cloud#10
     etcdReachable = await etcd.ping();
     if (!etcdReachable) return;
 
-    upstream = await startOpenAiUpstream({ streamEvents: STREAM_EVENTS });
+    upstream = await startOpenAiUpstream({
+      streamEvents: STREAM_EVENTS,
+      firstEventDelayMs: 25,
+    });
     app = await spawnApp();
     seed = new SeedClient(etcd, app.etcdPrefix);
 

--- a/tests/e2e/src/cases/responses-streaming-monitor-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/responses-streaming-monitor-guardrail-e2e.test.ts
@@ -81,6 +81,25 @@ function counterValue(scrape: string, series: string): number {
     .reduce((sum, value) => sum + value, 0);
 }
 
+function metricValue(
+  scrape: string,
+  series: string,
+  labels: Record<string, string>,
+): number {
+  return scrape
+    .split("\n")
+    .filter(
+      (line) =>
+        line.startsWith(`${series}{`) &&
+        Object.entries(labels).every(([key, value]) =>
+          line.includes(`${key}="${value}"`),
+        ),
+    )
+    .map((line) => Number(line.trim().split(/\s+/).at(-1)))
+    .filter((value) => !Number.isNaN(value))
+    .reduce((sum, value) => sum + value, 0);
+}
+
 describe("responses streaming with monitor-mode output guardrail (AISIX-Cloud#1010)", () => {
   let app: SpawnedApp | undefined;
   let upstream: OpenAiUpstream | undefined;
@@ -151,17 +170,67 @@ describe("responses streaming with monitor-mode output guardrail (AISIX-Cloud#10
       const { status } = await streamOnce();
       return status === 422;
     });
-    const metricsBefore = await (await fetch(`${app.metricsUrl}/metrics`)).text();
+    const metricsBeforeResponse = await fetch(`${app.metricsUrl}/metrics`);
+    expect(metricsBeforeResponse.status).toBe(200);
+    const metricsBefore = await metricsBeforeResponse.text();
     const blocked = await streamOnce();
     expect(blocked.status).toBe(422);
     expect(blocked.body).toContain("content_filter");
     expect(blocked.body).not.toContain(DELTA_TEXT);
-    const metricsAfter = await (await fetch(`${app.metricsUrl}/metrics`)).text();
+    const metricsAfterResponse = await fetch(`${app.metricsUrl}/metrics`);
+    expect(metricsAfterResponse.status).toBe(200);
+    const metricsAfter = await metricsAfterResponse.text();
     expect(
       counterValue(metricsAfter, "aisix_guardrail_blocks_total") -
         counterValue(metricsBefore, "aisix_guardrail_blocks_total"),
       "buffer-cap fail-closed is still a guardrail-blocked request even though no member executed",
     ).toBe(1);
+    const lowCardLabels = {
+      endpoint: "/v1/responses",
+      model: "gr-1010-model",
+      provider: "openai",
+      streaming: "true",
+      status_class: "4xx",
+    };
+    expect(
+      metricValue(metricsAfter, "aisix_request_ttft_seconds_count", lowCardLabels) -
+        metricValue(metricsBefore, "aisix_request_ttft_seconds_count", lowCardLabels),
+    ).toBe(1);
+    expect(
+      metricValue(metricsAfter, "aisix_request_ttft_seconds_sum", lowCardLabels) -
+        metricValue(metricsBefore, "aisix_request_ttft_seconds_sum", lowCardLabels),
+    ).toBeGreaterThan(0);
+    const detailedLabels = {
+      endpoint: "/v1/responses",
+      model: "gr-1010-model",
+      provider: "openai",
+      inbound_protocol: "openai",
+      upstream_protocol: "openai",
+    };
+    expect(
+      metricValue(
+        metricsAfter,
+        "aisix_llm_time_to_first_token_seconds_count",
+        detailedLabels,
+      ) -
+        metricValue(
+          metricsBefore,
+          "aisix_llm_time_to_first_token_seconds_count",
+          detailedLabels,
+        ),
+    ).toBe(1);
+    expect(
+      metricValue(
+        metricsAfter,
+        "aisix_llm_time_to_first_token_seconds_sum",
+        detailedLabels,
+      ) -
+        metricValue(
+          metricsBefore,
+          "aisix_llm_time_to_first_token_seconds_sum",
+          detailedLabels,
+        ),
+    ).toBeGreaterThan(0);
 
     // 2. Flip the SAME rule to monitor (full-resource PUT).
     await seed.update("guardrails", guardrailId, guardrailBody("monitor"));


### PR DESCRIPTION
This fixes the metric coverage gaps exposed by streaming Responses and the broader endpoint audit.

- Emit both TTFT families for native and cross-provider streaming Responses, including buffered output-guardrail allow, block, and buffer-cap fail-closed paths.
- Record request-level token metrics and detailed TTFT for ensemble Chat Completions.
- Resolve locally estimated ensemble subcall usage once and reuse it for panel/judge model quotas, parent/API-key quotas, UsageEvents, and Prometheus on success, insufficient-panel, and judge-failure paths.
- Keep cache-inclusive totals for providers that report cache counters separately without discarding provider-reported overhead.
- Count guardrail-blocked requests from the shared terminal event path, including fail-closed paths with no timed guardrail execution; keep fail-open bypass accounting on the shared execution path.
- Ignore the alternate Cargo build directory `target-anon/`.
- Add end-to-end regressions for Responses TTFT, guardrail protocol and buffer-overflow coverage, and streaming/non-streaming ensemble accounting with both reported and missing usage.

`aisix_guardrail_blocks_total` remains a request-level counter. `aisix_guardrail_bypasses_total` counts fail-open executions by bounded reason, while detailed per-guardrail dimensions remain available on `aisix_guardrail_latency_seconds_count`.

Fixes api7/AISIX-Cloud#1478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token accounting across direct, cached, streaming, and ensemble requests, including estimated usage.
  * Preserved provider overhead and cache usage in reported totals and quota calculations.
  * Improved time-to-first-token reporting for streamed Responses, including blocked requests.
  * Standardized blocked Responses handling with consistent status, usage, and telemetry.
  * Prevented duplicate guardrail block metrics for a single request.
* **Tests**
  * Expanded coverage for guardrail metrics, token estimates, streaming latency, quota handling, and blocked Responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
