### PR TITLE
fix(proxy): seal a buffered SSE body before the output guardrail scans it

### DIFF
--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3718,12 +3718,12 @@ where
         // than it was before this relay became frame-aligned, and truncating
         // a response over a missing terminator would be a regression.
         //
-        // Under a hold-back policy, DROP them. Only complete frames reach
-        // `drain_anthropic_sse_frames`, so an unterminated tail never fed
-        // `response_text` and was therefore never scanned — releasing it
-        // after the output check is exactly the bypass hold-back exists to
-        // prevent, and a client cannot parse a frame with no terminator
-        // anyway. Fail closed.
+        // Under a hold-back policy, SEAL them: a fragment that parses is
+        // completed with the terminator the upstream left off and held with
+        // the rest, so both the block scan and the redaction pass read it as
+        // an ordinary frame; one that does not parse is dropped, because
+        // nothing can extract its text and releasing it after the output
+        // check is exactly the bypass hold-back exists to prevent.
         if !buf.is_empty() {
             let tail = std::mem::take(&mut buf);
             // The upstream has ended, so this fragment is a final frame it
@@ -3734,48 +3734,19 @@ where
             // released, which is what keeps a provider that omits the last
             // terminator from losing its `message_stop` behind a guardrail.
             //
-            // `scannable` is false only when the fragment is not parseable —
-            // truncated mid-JSON. Nothing can extract its text, so releasing
-            // it WOULD be the bypass, and that case alone fails closed.
-            let scannable = match extract_sse_data_line(&tail) {
-                Some(data) => match serde_json::from_slice::<Value>(data) {
-                    Ok(json) => {
-                        update_anthropic_usage(
-                            guard.usage(),
-                            &json,
-                            attempt_started,
-                            &mut first_token_seen,
-                        );
-                        true
-                    }
-                    Err(_) => false,
-                },
-                // No `data:` line at all (a comment / keepalive): nothing to
-                // scan, so nothing to withhold.
-                None => true,
-            };
-            if hold_policy.is_some() && !scannable {
-                tracing::warn!(
-                    guardrail_hook = "output",
-                    dropped = tail.len(),
-                    "streaming /v1/messages passthrough ended on an SSE frame that \
-                     could not be parsed; dropping it rather than releasing it past \
-                     the output guardrail",
-                );
-                // When that fragment was the ENTIRE response, dropping it
-                // silently would hand the caller an empty 200 and no signal at
-                // all — and the scan is skipped too, since nothing ever
-                // reached `response_text`. Refuse explicitly instead, the same
-                // shape the frame-cap arm above uses.
-                if held.is_empty() {
-                    guard.usage().guardrail_blocked = true;
-                    yield Ok(Bytes::from(guardrail_block_frame(
-                        None,
-                        Some(crate::error::TAG_UNSCANNABLE_BODY),
-                    )));
-                    return;
+            // Its counts are as real as any other frame's, so read them
+            // whether or not the fragment survives the seal below.
+            if let Some(data) = extract_sse_data_line(&tail) {
+                if let Ok(json) = serde_json::from_slice::<Value>(data) {
+                    update_anthropic_usage(
+                        guard.usage(),
+                        &json,
+                        attempt_started,
+                        &mut first_token_seen,
+                    );
                 }
-            } else if let Some(max_hold) = hold_policy {
+            }
+            if let Some(max_hold) = hold_policy {
                 // Scanned like every other frame — hold it with them, but
                 // under the same size policy: this path reaches `held`
                 // outside the loop, so without this the last frame could
@@ -3786,6 +3757,39 @@ where
                     crate::model_echo::anthropic_message_model,
                 )
                 .unwrap_or(tail);
+                // #1091: seal the fragment before it joins `held`. Holding
+                // it unterminated made the block scan read it (it parses the
+                // text out line by line) while the redaction pass handed it
+                // back as `trailing` and appended it verbatim — so a
+                // maskable literal in this last frame went out unmasked.
+                // Sealed, it is an ordinary frame to both passes; an
+                // unparseable one is cut instead, because nothing can
+                // extract its text and releasing it WOULD be the bypass.
+                let mut tail = tail;
+                if let crate::redact::SseTailSeal::Dropped { dropped } =
+                    crate::redact::seal_buffered_sse(&mut tail)
+                {
+                    tracing::warn!(
+                        guardrail_hook = "output",
+                        dropped,
+                        "streaming /v1/messages passthrough ended on an SSE frame that \
+                         could not be parsed; dropping it rather than releasing it past \
+                         the output guardrail",
+                    );
+                    // When that fragment was the ENTIRE response, dropping it
+                    // silently would hand the caller an empty 200 and no signal at
+                    // all — and the scan is skipped too, since nothing ever
+                    // reached `response_text`. Refuse explicitly instead, the same
+                    // shape the frame-cap arm above uses.
+                    if held.is_empty() {
+                        guard.usage().guardrail_blocked = true;
+                        yield Ok(Bytes::from(guardrail_block_frame(
+                            None,
+                            Some(crate::error::TAG_UNSCANNABLE_BODY),
+                        )));
+                        return;
+                    }
+                }
                 if held.len() + tail.len() > max_hold {
                     tracing::warn!(
                         guardrail_hook = "output",

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3757,23 +3757,40 @@ where
                     crate::model_echo::anthropic_message_model,
                 )
                 .unwrap_or(tail);
-                // #1091: seal the fragment before it joins `held`. Holding
-                // it unterminated made the block scan read it (it parses the
-                // text out line by line) while the redaction pass handed it
-                // back as `trailing` and appended it verbatim — so a
-                // maskable literal in this last frame went out unmasked.
-                // Sealed, it is an ordinary frame to both passes; an
-                // unparseable one is cut instead, because nothing can
-                // extract its text and releasing it WOULD be the bypass.
-                let mut tail = tail;
+                if held.len() + tail.len() > max_hold {
+                    tracing::warn!(
+                        guardrail_hook = "output",
+                        max_buffer_bytes = max_hold,
+                        "streaming /v1/messages passthrough exceeded hold-back cap on its \
+                         final frame; failing closed",
+                    );
+                    guard.usage().guardrail_blocked = true;
+                    yield Ok(Bytes::from(guardrail_block_frame(
+                        None,
+                        Some(crate::error::TAG_OUTPUT_BUFFER_EXCEEDED),
+                    )));
+                    return;
+                }
+                held.extend_from_slice(&tail);
+                // #1091: seal what will actually be released. Held
+                // unterminated, this fragment was read by the block scan
+                // (which parses text out line by line) but handed back by
+                // the redaction pass as `trailing` and appended verbatim —
+                // so a maskable literal in the last frame went out unmasked.
+                // Sealed, it is an ordinary frame to both passes. Sealing
+                // `held` rather than the fragment alone is deliberate: the
+                // frames already in it are what say which line ending this
+                // upstream writes.
                 if let crate::redact::SseTailSeal::Dropped { dropped } =
-                    crate::redact::seal_buffered_sse(&mut tail)
+                    crate::redact::seal_buffered_sse(&mut held)
                 {
+                    // Not one parseable frame — nothing can extract its
+                    // text, so releasing it WOULD be the bypass.
                     tracing::warn!(
                         guardrail_hook = "output",
                         dropped,
                         "streaming /v1/messages passthrough ended on an SSE frame that \
-                         could not be parsed; dropping it rather than releasing it past \
+                         could not be scanned; dropping it rather than releasing it past \
                          the output guardrail",
                     );
                     // When that fragment was the ENTIRE response, dropping it
@@ -3790,21 +3807,6 @@ where
                         return;
                     }
                 }
-                if held.len() + tail.len() > max_hold {
-                    tracing::warn!(
-                        guardrail_hook = "output",
-                        max_buffer_bytes = max_hold,
-                        "streaming /v1/messages passthrough exceeded hold-back cap on its \
-                         final frame; failing closed",
-                    );
-                    guard.usage().guardrail_blocked = true;
-                    yield Ok(Bytes::from(guardrail_block_frame(
-                        None,
-                        Some(crate::error::TAG_OUTPUT_BUFFER_EXCEEDED),
-                    )));
-                    return;
-                }
-                held.extend_from_slice(&tail);
             } else {
                 // Restamp on the way out, for the same reason the `/v1/responses`
                 // relay does: the upstream has ended, so this is a final frame it

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -982,12 +982,20 @@ pub fn seal_buffered_sse(buf: &mut Vec<u8>) -> SseTailSeal {
         buf.truncate(end);
         return SseTailSeal::Dropped { dropped };
     }
+    // A fragment that stopped part-way through its terminator says which
+    // style it was writing; one that stopped right after its payload says
+    // nothing, so the frames before it are the only evidence.
+    let crlf_stream = buf[..end].ends_with(b"\r\n\r\n");
     let pad: &[u8] = if buf.ends_with(b"\r\n\r") {
         b"\n"
     } else if buf.ends_with(b"\r\n") {
         b"\r\n"
+    } else if buf.ends_with(b"\r") && crlf_stream {
+        b"\n\r\n"
     } else if buf.ends_with(b"\n") {
         b"\n"
+    } else if crlf_stream {
+        b"\r\n\r\n"
     } else {
         b"\n\n"
     };
@@ -1921,6 +1929,35 @@ mod tests {
             SseTailSeal::Completed { padded: 1 }
         );
         assert_eq!(partial, b"data: {\"a\":1}\r\n\r\n");
+    }
+
+    #[test]
+    fn seal_keeps_a_crlf_stream_crlf_when_the_tail_has_no_terminator_bytes() {
+        // The fragment itself carries no clue — it stops right after its
+        // payload — so the completed frames before it settle the style.
+        let mut raw = concat!(
+            "event: response.output_text.delta\r\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"m\",\"delta\":\"hello \"}\r\n\r\n",
+            "event: response.output_text.delta\r\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"m\",\"delta\":\"mail a@x.com\"}",
+        )
+        .as_bytes()
+        .to_vec();
+        assert_eq!(
+            seal_buffered_sse(&mut raw),
+            SseTailSeal::Completed { padded: 4 }
+        );
+        assert!(raw.ends_with(b"\r\n\r\n"));
+        // And the sealed frame is a frame to the redactor, like the first.
+        let (out, _) = redact_responses_sse(both().as_ref(), &raw).unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert!(!out.contains("a@x.com"), "out: {out}");
+        assert_eq!(out.matches("data:").count(), 2, "out: {out}");
+        // Half a payload line written: the CR is there, its LF is not.
+        let mut half_line = b"data: {\"a\":1}\r\n\r\ndata: {\"b\":2}\r".to_vec();
+        assert_eq!(
+            seal_buffered_sse(&mut half_line),
+            SseTailSeal::Completed { padded: 3 }
+        );
+        assert!(half_line.ends_with(b"data: {\"b\":2}\r\n\r\n"));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -818,6 +818,9 @@ struct SseFrame {
     raw: Vec<u8>,
     /// Parsed `data:` payload, when the frame carries one.
     data: Option<Value>,
+    /// The blank line that ended this frame, re-emitted as the upstream
+    /// wrote it — a masked CRLF document must not come back LF-framed.
+    term: &'static [u8],
     dirty: bool,
 }
 
@@ -840,6 +843,12 @@ impl SseFrame {
                 if !data_written {
                     out.push_str("data: ");
                     out.push_str(&serde_json::to_string(data).unwrap_or_default());
+                    // Keep the line's own ending: the rest of the frame
+                    // passes through verbatim, so dropping the `\r` here
+                    // alone would leave one LF line in a CRLF frame.
+                    if line.ends_with('\r') {
+                        out.push('\r');
+                    }
                     out.push('\n');
                     data_written = true;
                 }
@@ -865,20 +874,21 @@ impl SseFrame {
 /// which is exactly how an unterminated final frame slipped past one pass
 /// while the other read it (#1091).
 ///
-/// Both blank-line forms count. The scan passes read lines and trim, so a
-/// CRLF-framed upstream is ordinary text to them; a splitter that knew only
-/// `\n\n` would hand that whole body back as one unframed blob, and the
-/// redactor would then rewrite it as a single frame — dropping every
-/// `data:` line after the first. Same disagreement, second costume.
+/// It is the relay's own `messages::find_frame_end`, deliberately called
+/// rather than reimplemented: two functions that agree today are how the
+/// disagreement this fixes got in. That one is CRLF-aware, and it has to
+/// be — the scan passes read lines and trim, so a CRLF-framed upstream is
+/// ordinary text to them, while a splitter that knew only `\n\n` would hand
+/// the whole body back as one unframed blob and the redactor would render
+/// it down to its first `data:` line. Same disagreement, second costume.
 fn frame_terminator(raw: &[u8]) -> Option<(usize, usize)> {
-    let lf = raw.windows(2).position(|w| w == b"\n\n");
-    let crlf = raw.windows(4).position(|w| w == b"\r\n\r\n");
-    match (lf, crlf) {
-        (Some(l), Some(c)) => Some(if c < l { (c, 4) } else { (l, 2) }),
-        (Some(l), None) => Some((l, 2)),
-        (None, Some(c)) => Some((c, 4)),
-        (None, None) => None,
-    }
+    let end = crate::messages::find_frame_end(raw)?;
+    let term: &'static [u8] = if raw[..end].ends_with(b"\r\n\r\n") {
+        b"\r\n\r\n"
+    } else {
+        b"\n\n"
+    };
+    Some((end - term.len(), term.len()))
 }
 
 /// Byte offset just past the LAST complete frame terminator in `raw`
@@ -903,6 +913,16 @@ fn frame_data_line(frame_raw: &[u8]) -> Option<String> {
         .map(|l| l["data:".len()..].trim().to_owned())
 }
 
+/// Every `data:` line in a frame, un-parsed. A well-formed frame has at
+/// most one; more than one means the bytes are not one frame.
+fn frame_data_lines(frame_raw: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(frame_raw)
+        .split('\n')
+        .filter(|l| l.starts_with("data:"))
+        .map(|l| l["data:".len()..].trim().to_owned())
+        .collect()
+}
+
 /// Split a buffered SSE byte stream into frames on the blank-line
 /// separator. Returns `(frames, trailing)` where `trailing` is a
 /// partial frame with no terminator yet (forwarded verbatim). Call
@@ -917,6 +937,7 @@ fn split_sse_frames(raw: &[u8]) -> (Vec<SseFrame>, &[u8]) {
         frames.push(SseFrame {
             raw: frame_raw.to_vec(),
             data: frame_data_line(frame_raw).and_then(|l| serde_json::from_str::<Value>(&l).ok()),
+            term: if len == 4 { b"\r\n\r\n" } else { b"\n\n" },
             dirty: false,
         });
         rest = &rest[pos + len..];
@@ -949,13 +970,14 @@ pub enum SseTailSeal {
 /// So the fragment is resolved BEFORE either pass runs, exactly as the
 /// `/v1/messages` EOF tail is:
 ///
-/// - it parses, or carries nothing a scan could read — no `data:` line at
-///   all (a comment / keepalive), an empty payload, or the `[DONE]`
-///   sentinel: complete the terminator the upstream left off. It is then an ordinary
+/// - it is ONE frame and it parses, or carries nothing a scan could read —
+///   no `data:` line at all (a comment / keepalive), an empty payload, or
+///   the `[DONE]` sentinel: complete the terminator the upstream left off. It is then an ordinary
 ///   frame, scanned and maskable like every other one, and the client gets a
 ///   frame it can actually parse.
-/// - it does not parse: nothing can extract its text, so releasing it WOULD
-///   be the bypass. It is cut, and the caller warns. A caller whose buffer
+/// - it does not parse, or is not one frame at all (several `data:` lines
+///   with no blank line between them): nothing can extract its text, so
+///   releasing it WOULD be the bypass. It is cut, and the caller warns. A caller whose buffer
 ///   is left empty by that cut has nothing scanned at all and must refuse
 ///   (`unscannable_body`) rather than answer with an empty 200.
 ///
@@ -968,31 +990,41 @@ pub fn seal_buffered_sse(buf: &mut Vec<u8>) -> SseTailSeal {
     if end == buf.len() {
         return SseTailSeal::Terminated;
     }
-    let scannable = match frame_data_line(&buf[end..]) {
-        // An empty payload and the `[DONE]` sentinel carry no text — the
-        // scan passes skip both — so cutting one protects nothing and takes
-        // the terminal event the client is waiting for with it.
-        Some(line) => {
-            line.is_empty() || line == "[DONE]" || serde_json::from_str::<Value>(&line).is_ok()
-        }
-        None => true,
-    };
+    let payloads = frame_data_lines(&buf[end..]);
+    // One frame carries one payload here. Several `data:` lines with no
+    // blank line between them are an upstream that never wrote its frame
+    // separators, and padding THAT into a single frame is worse than
+    // leaving it: the redactor renders a rewritten frame down to its first
+    // `data:` line, so masking would silently delete everything after it.
+    // Nothing can frame it, so nothing can scan it — cut it.
+    //
+    // Otherwise: an empty payload and the `[DONE]` sentinel carry no text
+    // (the scan passes skip both), so cutting one protects nothing and
+    // takes the terminal event the client is waiting for with it.
+    let scannable = payloads.len() <= 1
+        && payloads
+            .iter()
+            .all(|l| l.is_empty() || l == "[DONE]" || serde_json::from_str::<Value>(l).is_ok());
     if !scannable {
         let dropped = buf.len() - end;
         buf.truncate(end);
         return SseTailSeal::Dropped { dropped };
     }
-    // A fragment that stopped part-way through its terminator says which
-    // style it was writing; one that stopped right after its payload says
-    // nothing, so the frames before it are the only evidence.
+    // How much of its terminator the FRAGMENT wrote — read `buf` here and a
+    // one-byte fragment borrows the previous frame's terminator to match a
+    // longer pattern, so the pad comes up short and the seal leaves a tail
+    // behind. A fragment that stopped part-way through its terminator says
+    // which style it was writing; one that stopped right after its payload
+    // says nothing, so the frames before it are the only evidence.
+    let frag = &buf[end..];
     let crlf_stream = buf[..end].ends_with(b"\r\n\r\n");
-    let pad: &[u8] = if buf.ends_with(b"\r\n\r") {
+    let pad: &[u8] = if frag.ends_with(b"\r\n\r") {
         b"\n"
-    } else if buf.ends_with(b"\r\n") {
+    } else if frag.ends_with(b"\r\n") {
         b"\r\n"
-    } else if buf.ends_with(b"\r") && crlf_stream {
+    } else if frag.ends_with(b"\r") && crlf_stream {
         b"\n\r\n"
-    } else if buf.ends_with(b"\n") {
+    } else if frag.ends_with(b"\n") {
         b"\n"
     } else if crlf_stream {
         b"\r\n\r\n"
@@ -1158,7 +1190,7 @@ pub fn redact_anthropic_sse(
     let mut out = Vec::with_capacity(raw.len());
     for frame in &frames {
         out.extend_from_slice(&frame.render());
-        out.extend_from_slice(b"\n\n");
+        out.extend_from_slice(frame.term);
     }
     out.extend_from_slice(trailing);
     Some((out, counts))
@@ -1430,7 +1462,7 @@ pub fn redact_responses_sse(
     let mut out = Vec::with_capacity(raw.len());
     for frame in &frames {
         out.extend_from_slice(&frame.render());
-        out.extend_from_slice(b"\n\n");
+        out.extend_from_slice(frame.term);
     }
     out.extend_from_slice(trailing);
     Some((out, counts))
@@ -1958,6 +1990,92 @@ mod tests {
             SseTailSeal::Completed { padded: 3 }
         );
         assert!(half_line.ends_with(b"data: {\"b\":2}\r\n\r\n"));
+    }
+
+    #[test]
+    fn seal_cuts_a_fragment_that_is_several_frames_run_together() {
+        // An upstream that never wrote its blank lines. Padding this into
+        // ONE frame would be worse than leaving it: the redactor writes only
+        // the first `data:` line of a frame it rewrites, so a mask would
+        // delete `KEEPME` and the terminal event with it.
+        let mut raw = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"m\",\"delta\":\"mail a@x.com\"}\n",
+            "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"m\",\"delta\":\" and KEEPME\"}\n",
+            "data: {\"type\":\"response.completed\",\"response\":{}}",
+        )
+        .as_bytes()
+        .to_vec();
+        assert!(matches!(
+            seal_buffered_sse(&mut raw),
+            SseTailSeal::Dropped { .. }
+        ));
+        // Nothing was scanned, so nothing is released — the caller refuses.
+        assert!(raw.is_empty());
+    }
+
+    #[test]
+    fn a_masked_crlf_document_stays_crlf_framed() {
+        let chain = both();
+        let raw = concat!(
+            "event: response.output_text.delta\r\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"m\",\"delta\":\"mail a@x.com\"}\r\n\r\n",
+            "event: response.completed\r\ndata: {\"type\":\"response.completed\",\"response\":{}}\r\n\r\n",
+        )
+        .as_bytes()
+        .to_vec();
+        let (out, _) = redact_responses_sse(chain.as_ref(), &raw).unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert!(out.contains("[EMAIL_REDACTED]"), "out: {out}");
+        // The mask must not re-frame the document it passed through: every
+        // terminator, and the rewritten line's own ending, stay CRLF.
+        assert!(!out.contains("\n\n"), "LF-framed after masking: {out:?}");
+        assert_eq!(out.matches("\r\n\r\n").count(), 2, "out: {out:?}");
+        // `split`, not `lines`: the latter strips the very `\r` under test.
+        let masked = out
+            .split('\n')
+            .find(|l| l.contains("[EMAIL_REDACTED]"))
+            .expect("the masked line");
+        assert!(
+            masked.ends_with('\r'),
+            "rewritten line lost its CR: {masked:?}"
+        );
+    }
+
+    #[test]
+    fn seal_always_leaves_the_buffer_ending_on_a_terminator() {
+        // The invariant the whole fix rests on, and the one `split_sse_frames`
+        // documents: after a seal there is no trailing fragment left for the
+        // two passes to read differently. Exhaustive over the bytes that can
+        // form a terminator plus one payload byte, so the boundary cases
+        // (a fragment that is a lone `\r` after a CRLF frame, a `\n\n\n`
+        // run, an empty buffer) are covered by construction rather than by
+        // imagination.
+        let alphabet = [b'a', b'\n', b'\r'];
+        let mut words: Vec<Vec<u8>> = vec![Vec::new()];
+        for _ in 0..7 {
+            let mut next = Vec::new();
+            for w in &words {
+                for b in alphabet {
+                    let mut w = w.clone();
+                    w.push(b);
+                    next.push(w);
+                }
+            }
+            for w in &words {
+                let mut buf = w.clone();
+                let before = buf.clone();
+                seal_buffered_sse(&mut buf);
+                assert_eq!(
+                    last_frame_end(&buf),
+                    buf.len(),
+                    "sealed {before:?} into {buf:?}, which still has a tail",
+                );
+                // And sealing is settled: a second pass changes nothing.
+                let once = buf.clone();
+                assert_eq!(seal_buffered_sse(&mut buf), SseTailSeal::Terminated);
+                assert_eq!(buf, once, "seal is not idempotent on {before:?}");
+            }
+            words = next;
+        }
     }
 
     #[test]

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -857,32 +857,114 @@ impl SseFrame {
     }
 }
 
+/// Offset of the first frame terminator (a blank line) in `raw`.
+///
+/// The ONE place this crate decides where an SSE frame ends. Everything
+/// below derives from it, so the frame-based redaction pass and the
+/// line-based scan passes cannot end up with two notions of framing —
+/// which is exactly how an unterminated final frame slipped past one pass
+/// while the other read it (#1091).
+fn frame_terminator(raw: &[u8]) -> Option<usize> {
+    raw.windows(2).position(|w| w == b"\n\n")
+}
+
+/// Byte offset just past the LAST complete frame terminator in `raw`
+/// (`0` when there is none, `raw.len()` when the body ends on one).
+/// `raw[end..]` is therefore the unterminated trailing fragment.
+fn last_frame_end(raw: &[u8]) -> usize {
+    let mut end = 0usize;
+    let mut rest = raw;
+    while let Some(pos) = frame_terminator(rest) {
+        end += pos + 2;
+        rest = &rest[pos + 2..];
+    }
+    end
+}
+
+/// The text of a frame's `data:` line, un-parsed (`None` = the frame
+/// carries no `data:` line at all — a comment or keepalive).
+fn frame_data_line(frame_raw: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(frame_raw)
+        .split('\n')
+        .find(|l| l.starts_with("data:"))
+        .map(|l| l["data:".len()..].trim().to_owned())
+}
+
 /// Split a buffered SSE byte stream into frames on the blank-line
 /// separator. Returns `(frames, trailing)` where `trailing` is a
-/// partial frame with no terminator yet (forwarded verbatim).
+/// partial frame with no terminator yet (forwarded verbatim). Call
+/// [`seal_buffered_sse`] first on anything a guardrail will scan, and
+/// `trailing` is empty by construction.
 fn split_sse_frames(raw: &[u8]) -> (Vec<SseFrame>, &[u8]) {
+    let (complete, trailing) = raw.split_at(last_frame_end(raw));
     let mut frames = Vec::new();
-    let mut start = 0usize;
-    let mut i = 0usize;
-    while i + 1 < raw.len() {
-        if raw[i] == b'\n' && raw[i + 1] == b'\n' {
-            let frame_raw = &raw[start..i];
-            let data = String::from_utf8_lossy(frame_raw)
-                .split('\n')
-                .find(|l| l.starts_with("data:"))
-                .and_then(|l| serde_json::from_str::<Value>(l["data:".len()..].trim()).ok());
-            frames.push(SseFrame {
-                raw: frame_raw.to_vec(),
-                data,
-                dirty: false,
-            });
-            start = i + 2;
-            i += 2;
-        } else {
-            i += 1;
-        }
+    let mut rest = complete;
+    while let Some(pos) = frame_terminator(rest) {
+        let frame_raw = &rest[..pos];
+        frames.push(SseFrame {
+            raw: frame_raw.to_vec(),
+            data: frame_data_line(frame_raw).and_then(|l| serde_json::from_str::<Value>(&l).ok()),
+            dirty: false,
+        });
+        rest = &rest[pos + 2..];
     }
-    (frames, &raw[start..])
+    (frames, trailing)
+}
+
+/// What [`seal_buffered_sse`] did with a buffered body's trailing bytes.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SseTailSeal {
+    /// The body already ended on a frame terminator; nothing to do.
+    Terminated,
+    /// A final frame the upstream never terminated, but which parses:
+    /// the missing terminator bytes were appended.
+    Completed { padded: usize },
+    /// A final frame that cannot be parsed, and so cannot be scanned:
+    /// it was cut from the buffer.
+    Dropped { dropped: usize },
+}
+
+/// Seal a fully-buffered SSE body so a guardrail scan and the redaction
+/// pass read the SAME frames (#1091).
+///
+/// A non-conformant upstream can end mid-frame. That fragment is where the
+/// two passes disagreed: the line-based block scan reads whatever lines it
+/// finds, while the frame-based redactor hands the fragment back as
+/// `trailing` and appends it verbatim — never masked. Either way something
+/// unscanned reaches the client.
+///
+/// So the fragment is resolved BEFORE either pass runs, exactly as the
+/// `/v1/messages` EOF tail is:
+///
+/// - it parses (or carries no `data:` line at all — a comment / keepalive):
+///   complete the terminator the upstream left off. It is then an ordinary
+///   frame, scanned and maskable like every other one, and the client gets a
+///   frame it can actually parse.
+/// - it does not parse: nothing can extract its text, so releasing it WOULD
+///   be the bypass. It is cut, and the caller warns. A caller whose buffer
+///   is left empty by that cut has nothing scanned at all and must refuse
+///   (`unscannable_body`) rather than answer with an empty 200.
+///
+/// Pads by what is MISSING, not a fixed `\n\n`: a fragment that already
+/// ends in one `\n` needs one more, and two would leave a stray blank line
+/// in the released bytes.
+pub fn seal_buffered_sse(buf: &mut Vec<u8>) -> SseTailSeal {
+    let end = last_frame_end(buf);
+    if end == buf.len() {
+        return SseTailSeal::Terminated;
+    }
+    let scannable = match frame_data_line(&buf[end..]) {
+        Some(line) => serde_json::from_str::<Value>(&line).is_ok(),
+        None => true,
+    };
+    if !scannable {
+        let dropped = buf.len() - end;
+        buf.truncate(end);
+        return SseTailSeal::Dropped { dropped };
+    }
+    let pad: &[u8] = if buf.ends_with(b"\n") { b"\n" } else { b"\n\n" };
+    buf.extend_from_slice(pad);
+    SseTailSeal::Completed { padded: pad.len() }
 }
 
 /// Mask a fully-buffered Anthropic-native SSE response (the `/v1/messages`
@@ -1682,6 +1764,111 @@ mod tests {
         assert!(!out.contains("a@"), "original fragments gone: {out}");
         assert!(out.contains("[EMAIL_REDACTED]"), "out: {out}");
         assert_eq!(counts.get("email"), Some(&1));
+    }
+
+    // #1091: an upstream that ends mid-frame used to leave the two passes
+    // reading different bytes — the line-based block scan saw the fragment,
+    // the frame-based redactor appended it verbatim without masking it. The
+    // seal is what makes both read the same frames, so these assert the
+    // masking THROUGH it: drop the `seal_buffered_sse` call and the PII
+    // literal comes back.
+    #[test]
+    fn responses_sse_masks_a_final_frame_the_upstream_never_terminated() {
+        let chain = both();
+        let mut raw = concat!(
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"m\",\"delta\":\"hello \"}\n\n",
+            // Complete JSON, only the terminating blank line missing.
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"m\",\"delta\":\"mail a@x.com\"}",
+        )
+        .as_bytes()
+        .to_vec();
+        assert_eq!(
+            seal_buffered_sse(&mut raw),
+            SseTailSeal::Completed { padded: 2 }
+        );
+        let (out, counts) = redact_responses_sse(chain.as_ref(), &raw)
+            .expect("the sealed tail must reach the redactor");
+        let out = String::from_utf8(out).unwrap();
+        assert!(!out.contains("a@x.com"), "tail left unmasked: {out}");
+        assert!(out.contains("[EMAIL_REDACTED]"), "out: {out}");
+        assert_eq!(counts.get("email"), Some(&1));
+        // And the client gets a frame it can actually parse.
+        assert!(out.ends_with("\n\n"), "out: {out}");
+    }
+
+    #[test]
+    fn anthropic_sse_masks_a_final_frame_the_upstream_never_terminated() {
+        let chain = both();
+        let mut raw = concat!(
+            "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello \"}}\n\n",
+            "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"mail a@x.com\"}}",
+        )
+        .as_bytes()
+        .to_vec();
+        assert_eq!(
+            seal_buffered_sse(&mut raw),
+            SseTailSeal::Completed { padded: 2 }
+        );
+        let (out, counts) = redact_anthropic_sse(chain.as_ref(), &raw)
+            .expect("the sealed tail must reach the redactor");
+        let out = String::from_utf8(out).unwrap();
+        assert!(!out.contains("a@x.com"), "tail left unmasked: {out}");
+        assert!(out.contains("[EMAIL_REDACTED]"), "out: {out}");
+        assert_eq!(counts.get("email"), Some(&1));
+        assert!(out.ends_with("\n\n"), "out: {out}");
+    }
+
+    #[test]
+    fn seal_leaves_a_terminated_body_byte_identical() {
+        let raw = b"event: x\ndata: {\"a\":1}\n\n".to_vec();
+        let mut sealed = raw.clone();
+        assert_eq!(seal_buffered_sse(&mut sealed), SseTailSeal::Terminated);
+        assert_eq!(sealed, raw);
+    }
+
+    #[test]
+    fn seal_pads_by_what_the_upstream_left_off() {
+        // Nothing of the terminator written.
+        let mut none = b"data: {\"a\":1}".to_vec();
+        assert_eq!(
+            seal_buffered_sse(&mut none),
+            SseTailSeal::Completed { padded: 2 }
+        );
+        assert_eq!(none, b"data: {\"a\":1}\n\n");
+        // Half of it written: one newline is what is missing, and padding a
+        // fixed `\n\n` here would leave a stray blank line in the frames.
+        let mut half = b"data: {\"a\":1}\n".to_vec();
+        assert_eq!(
+            seal_buffered_sse(&mut half),
+            SseTailSeal::Completed { padded: 1 }
+        );
+        assert_eq!(half, b"data: {\"a\":1}\n\n");
+        // A comment / keepalive carries nothing to scan, so it is kept.
+        let mut comment = b"data: {\"a\":1}\n\n: ping".to_vec();
+        assert_eq!(
+            seal_buffered_sse(&mut comment),
+            SseTailSeal::Completed { padded: 2 }
+        );
+    }
+
+    #[test]
+    fn seal_cuts_a_final_frame_that_cannot_be_parsed() {
+        // Truncated mid-JSON: nothing can extract its text, so nothing can
+        // scan it, so it must not be released.
+        let mut raw = b"data: {\"a\":1}\n\ndata: {\"text\":\"SECRET".to_vec();
+        assert_eq!(
+            seal_buffered_sse(&mut raw),
+            SseTailSeal::Dropped { dropped: 21 },
+        );
+        assert_eq!(raw, b"data: {\"a\":1}\n\n");
+        // When it is the WHOLE body the buffer is left empty — the caller
+        // refuses rather than answering with an empty 200.
+        let mut only = b"data: {\"text\":\"SECRET".to_vec();
+        assert!(matches!(
+            seal_buffered_sse(&mut only),
+            SseTailSeal::Dropped { .. }
+        ));
+        assert!(only.is_empty());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -857,15 +857,28 @@ impl SseFrame {
     }
 }
 
-/// Offset of the first frame terminator (a blank line) in `raw`.
+/// Offset and length of the first frame terminator (a blank line) in `raw`.
 ///
 /// The ONE place this crate decides where an SSE frame ends. Everything
 /// below derives from it, so the frame-based redaction pass and the
 /// line-based scan passes cannot end up with two notions of framing —
 /// which is exactly how an unterminated final frame slipped past one pass
 /// while the other read it (#1091).
-fn frame_terminator(raw: &[u8]) -> Option<usize> {
-    raw.windows(2).position(|w| w == b"\n\n")
+///
+/// Both blank-line forms count. The scan passes read lines and trim, so a
+/// CRLF-framed upstream is ordinary text to them; a splitter that knew only
+/// `\n\n` would hand that whole body back as one unframed blob, and the
+/// redactor would then rewrite it as a single frame — dropping every
+/// `data:` line after the first. Same disagreement, second costume.
+fn frame_terminator(raw: &[u8]) -> Option<(usize, usize)> {
+    let lf = raw.windows(2).position(|w| w == b"\n\n");
+    let crlf = raw.windows(4).position(|w| w == b"\r\n\r\n");
+    match (lf, crlf) {
+        (Some(l), Some(c)) => Some(if c < l { (c, 4) } else { (l, 2) }),
+        (Some(l), None) => Some((l, 2)),
+        (None, Some(c)) => Some((c, 4)),
+        (None, None) => None,
+    }
 }
 
 /// Byte offset just past the LAST complete frame terminator in `raw`
@@ -874,9 +887,9 @@ fn frame_terminator(raw: &[u8]) -> Option<usize> {
 fn last_frame_end(raw: &[u8]) -> usize {
     let mut end = 0usize;
     let mut rest = raw;
-    while let Some(pos) = frame_terminator(rest) {
-        end += pos + 2;
-        rest = &rest[pos + 2..];
+    while let Some((pos, len)) = frame_terminator(rest) {
+        end += pos + len;
+        rest = &rest[pos + len..];
     }
     end
 }
@@ -899,14 +912,14 @@ fn split_sse_frames(raw: &[u8]) -> (Vec<SseFrame>, &[u8]) {
     let (complete, trailing) = raw.split_at(last_frame_end(raw));
     let mut frames = Vec::new();
     let mut rest = complete;
-    while let Some(pos) = frame_terminator(rest) {
+    while let Some((pos, len)) = frame_terminator(rest) {
         let frame_raw = &rest[..pos];
         frames.push(SseFrame {
             raw: frame_raw.to_vec(),
             data: frame_data_line(frame_raw).and_then(|l| serde_json::from_str::<Value>(&l).ok()),
             dirty: false,
         });
-        rest = &rest[pos + 2..];
+        rest = &rest[pos + len..];
     }
     (frames, trailing)
 }
@@ -946,8 +959,9 @@ pub enum SseTailSeal {
 ///   (`unscannable_body`) rather than answer with an empty 200.
 ///
 /// Pads by what is MISSING, not a fixed `\n\n`: a fragment that already
-/// ends in one `\n` needs one more, and two would leave a stray blank line
-/// in the released bytes.
+/// ends in half its terminator needs only the other half, and a full pad
+/// would leave a stray blank line in the released bytes. The upstream's own
+/// line ending is matched, so a CRLF stream stays a CRLF stream.
 pub fn seal_buffered_sse(buf: &mut Vec<u8>) -> SseTailSeal {
     let end = last_frame_end(buf);
     if end == buf.len() {
@@ -962,7 +976,15 @@ pub fn seal_buffered_sse(buf: &mut Vec<u8>) -> SseTailSeal {
         buf.truncate(end);
         return SseTailSeal::Dropped { dropped };
     }
-    let pad: &[u8] = if buf.ends_with(b"\n") { b"\n" } else { b"\n\n" };
+    let pad: &[u8] = if buf.ends_with(b"\r\n\r") {
+        b"\n"
+    } else if buf.ends_with(b"\r\n") {
+        b"\r\n"
+    } else if buf.ends_with(b"\n") {
+        b"\n"
+    } else {
+        b"\n\n"
+    };
     buf.extend_from_slice(pad);
     SseTailSeal::Completed { padded: pad.len() }
 }
@@ -1849,6 +1871,50 @@ mod tests {
             seal_buffered_sse(&mut comment),
             SseTailSeal::Completed { padded: 2 }
         );
+    }
+
+    #[test]
+    fn crlf_framed_bodies_are_framed_and_masked_like_any_other() {
+        let chain = both();
+        // A CRLF-framed stream is ordinary text to the line-based scan, so
+        // the redactor has to read the same frames out of it. Reading none
+        // would leave it unmasked; reading ONE would drop every `data:` line
+        // after the first when that frame is rewritten.
+        let raw = concat!(
+            "event: response.output_text.delta\r\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"m\",\"delta\":\"mail a@\"}\r\n\r\n",
+            "event: response.output_text.delta\r\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"m\",\"delta\":\"x.com ok\"}\r\n\r\n",
+            "event: response.completed\r\ndata: {\"type\":\"response.completed\",\"response\":{}}\r\n\r\n",
+        )
+        .as_bytes()
+        .to_vec();
+        let mut sealed = raw.clone();
+        assert_eq!(seal_buffered_sse(&mut sealed), SseTailSeal::Terminated);
+        assert_eq!(sealed, raw, "a terminated CRLF body must not be repadded");
+        let (out, counts) = redact_responses_sse(chain.as_ref(), &sealed).unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert!(!out.contains("a@x.com"), "out: {out}");
+        assert!(out.contains("[EMAIL_REDACTED]"), "out: {out}");
+        assert_eq!(counts.get("email"), Some(&1));
+        // Every frame survives the rewrite.
+        assert_eq!(out.matches("data:").count(), 3, "out: {out}");
+        assert!(out.contains("response.completed"), "out: {out}");
+    }
+
+    #[test]
+    fn seal_matches_the_upstreams_own_line_ending() {
+        let mut crlf = b"data: {\"a\":1}\r\n".to_vec();
+        assert_eq!(
+            seal_buffered_sse(&mut crlf),
+            SseTailSeal::Completed { padded: 2 }
+        );
+        assert_eq!(crlf, b"data: {\"a\":1}\r\n\r\n");
+        // Three quarters of a CRLF terminator written.
+        let mut partial = b"data: {\"a\":1}\r\n\r".to_vec();
+        assert_eq!(
+            seal_buffered_sse(&mut partial),
+            SseTailSeal::Completed { padded: 1 }
+        );
+        assert_eq!(partial, b"data: {\"a\":1}\r\n\r\n");
     }
 
     #[test]

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -949,8 +949,9 @@ pub enum SseTailSeal {
 /// So the fragment is resolved BEFORE either pass runs, exactly as the
 /// `/v1/messages` EOF tail is:
 ///
-/// - it parses (or carries no `data:` line at all — a comment / keepalive):
-///   complete the terminator the upstream left off. It is then an ordinary
+/// - it parses, or carries nothing a scan could read — no `data:` line at
+///   all (a comment / keepalive), an empty payload, or the `[DONE]`
+///   sentinel: complete the terminator the upstream left off. It is then an ordinary
 ///   frame, scanned and maskable like every other one, and the client gets a
 ///   frame it can actually parse.
 /// - it does not parse: nothing can extract its text, so releasing it WOULD
@@ -968,7 +969,12 @@ pub fn seal_buffered_sse(buf: &mut Vec<u8>) -> SseTailSeal {
         return SseTailSeal::Terminated;
     }
     let scannable = match frame_data_line(&buf[end..]) {
-        Some(line) => serde_json::from_str::<Value>(&line).is_ok(),
+        // An empty payload and the `[DONE]` sentinel carry no text — the
+        // scan passes skip both — so cutting one protects nothing and takes
+        // the terminal event the client is waiting for with it.
+        Some(line) => {
+            line.is_empty() || line == "[DONE]" || serde_json::from_str::<Value>(&line).is_ok()
+        }
         None => true,
     };
     if !scannable {
@@ -1915,6 +1921,22 @@ mod tests {
             SseTailSeal::Completed { padded: 1 }
         );
         assert_eq!(partial, b"data: {\"a\":1}\r\n\r\n");
+    }
+
+    #[test]
+    fn seal_keeps_a_final_frame_with_nothing_to_scan() {
+        // Neither payload is JSON, and neither carries text any pass reads —
+        // cutting them would only cost the client its terminal event.
+        for tail in ["data: [DONE]", "data:"] {
+            let mut raw = format!("data: {{\"a\":1}}\n\n{tail}").into_bytes();
+            assert!(
+                matches!(seal_buffered_sse(&mut raw), SseTailSeal::Completed { .. }),
+                "cut {tail}",
+            );
+            assert!(String::from_utf8(raw)
+                .unwrap()
+                .ends_with(&format!("{tail}\n\n")));
+        }
     }
 
     #[test]

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1401,6 +1401,58 @@ async fn responses_to_target(
                         attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
                 }
             }
+            // #1091: an upstream that ends mid-frame leaves a fragment the
+            // two passes below read differently — the line-based scan sees
+            // it, the frame-based redactor appends it verbatim without ever
+            // masking it. Seal the buffer first, so both read the same
+            // frames: a parseable final frame gets the terminator its
+            // upstream left off, an unparseable one is cut.
+            if let crate::redact::SseTailSeal::Dropped { dropped } =
+                crate::redact::seal_buffered_sse(&mut buf)
+            {
+                tracing::warn!(
+                    guardrail_hook = "output",
+                    model = %model.display_name,
+                    dropped,
+                    "streaming /v1/responses ended on an SSE frame that could not be \
+                     parsed; dropping it rather than releasing it past the output \
+                     guardrail",
+                );
+                // Nothing else arrived: the whole response was that one
+                // unparseable frame. Dropping it silently would hand the
+                // caller an empty 200 with no signal, and there is no
+                // scanned content to release — refuse, the same shape the
+                // buffer-cap arm above and `/v1/messages` use.
+                if buf.is_empty() {
+                    return Ok(ResponseDispatchSuccess {
+                        response: crate::error::guardrail_block_error(
+                            "response",
+                            None,
+                            Some(crate::error::TAG_UNSCANNABLE_BODY),
+                        )
+                        .into_response(),
+                        provider: provider_label,
+                        usage: Some(ResponseUsage {
+                            upstream_ttft_ms,
+                            ..Default::default()
+                        }),
+                        model_id: model_id.to_string(),
+                        provider_key_id: provider_key_id.clone(),
+                        upstream_model: upstream_model.clone(),
+                        routing: RoutingTelemetry::default(),
+                        guardrail_blocked: true,
+                        usage_handled_by_stream: false,
+                        captured_content: match (&captured_prompt, content_cap) {
+                            (Some(prompt), Some(cap)) => {
+                                Some(CapturedContent::new(prompt, "", cap as usize))
+                            }
+                            _ => None,
+                        },
+                        output_redactions: crate::redact::RedactionCounts::new(),
+                        output_monitor_hits: Vec::new(),
+                    });
+                }
+            }
             // #808: the whole SSE response is buffered here, so parse its
             // terminal event for usage and let the handler emit (the body is
             // a single complete chunk now, not a live stream). Do this before

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -577,12 +577,13 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
     expect(text.trimEnd().endsWith("data: [DONE]")).toBe(true);
   });
 
-  // The same hold-back policy on `/v1/messages`. Only COMPLETE frames feed
-  // the text the output guardrail scans, so an upstream that dies mid-frame
-  // leaves a tail nothing ever inspected. Releasing it after the scan would
-  // be a way around the very check hold-back exists to apply, so it is
-  // dropped — the client could not have parsed an unterminated frame anyway.
-  test("/v1/messages hold-back drops an unterminated tail instead of releasing it unscanned", async (ctx) => {
+  // The same hold-back policy on `/v1/messages`, with an upstream that dies
+  // mid-JSON. Nothing can extract that fragment's text, so no pass can scan
+  // it, and releasing it would be a way around the very check hold-back
+  // exists to apply — it is cut. (A fragment that PARSES is a different
+  // case: it is sealed and released, scanned and masked like any other
+  // frame. That one is two tests below.)
+  test("/v1/messages hold-back drops an unscannable tail instead of releasing it", async (ctx) => {
     if (!etcdReachable || !app || !seed) return void ctx.skip();
 
     const upstream = await startOpenAiUpstream({
@@ -642,7 +643,7 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
     // The scanned frames are delivered, with the alias restamped...
     expect(text).toContain('"model":"echo-tail"');
     expect(text).toContain('"text":"delivered text"');
-    // ...and the unterminated, never-scanned tail is not.
+    // ...and the unparseable, never-scanned tail is not.
     expect(text).not.toContain("NEVERSCANNEDTAIL");
   });
   // #1091. An upstream that ends mid-frame leaves a fragment behind, and the

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -500,6 +500,16 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
       kind: "keyword",
       patterns: [{ kind: "literal", value: "ABSOLUTELYFORBIDDENWORD" }],
     });
+    // Mask-capable, for the #1091 cases below: a buffered response's last
+    // frame has to be masked as well as scanned, and those are two different
+    // passes over the same bytes. Masks nothing in the cases above.
+    await seed.createGuardrail({
+      name: "gr-model-echo-mask",
+      enabled: true,
+      hook_point: "output",
+      kind: "pii",
+      detectors: [{ type: "email", action: "mask" }],
+    });
   });
 
   afterAll(async () => {
@@ -634,5 +644,192 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
     expect(text).toContain('"text":"delivered text"');
     // ...and the unterminated, never-scanned tail is not.
     expect(text).not.toContain("NEVERSCANNEDTAIL");
+  });
+  // #1091. An upstream that ends mid-frame leaves a fragment behind, and the
+  // two passes a buffered response goes through used to read it differently:
+  // the block scan walks lines, the redactor walks terminator-delimited
+  // frames. Whichever pass missed it, something unscanned reached the caller.
+  // The three cases below are the shapes that produced, in order: a forbidden
+  // literal nobody scanned, and PII nobody masked — on both routes that
+  // buffer.
+
+  test("/v1/responses: a truncated final frame is dropped, not released past the block scan", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: response.created\ndata: {"type":"response.created","response":{"id":"resp_cut","object":"response","status":"in_progress","model":"${UPSTREAM_REPORTED_MODEL}"}}\n\n`,
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","item_id":"m","delta":"perfectly fine text"}\n\n`,
+        // Cut mid-JSON. The scan reads `data:` lines and parses each one, so
+        // this frame's text is invisible to it — including the literal the
+        // guardrail blocks on.
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","item_id":"m","delta":"ABSOLUTELYFORBIDDENWORD`,
+      ],
+    });
+    upstreams.push(upstream);
+
+    const pk = await seed.createProviderKey({
+      display_name: "pk-echo-cut-tail",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "echo-cut-tail",
+      provider: "openai",
+      model_name: CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === "echo-cut-tail");
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-cut-tail",
+        input: "say something",
+        stream: true,
+      }),
+    });
+    // 200, not a 422: the scanned frames cleared, so the response is
+    // delivered — with the unscannable frame cut out of it. Asserting the
+    // status is what separates "dropped" from "blocked" here, since a block
+    // envelope would also not carry the literal.
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('"delta":"perfectly fine text"');
+    expect(text).not.toContain("ABSOLUTELYFORBIDDENWORD");
+  });
+
+  test("/v1/responses: a final frame missing only its terminator is masked, not released raw", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: response.created\ndata: {"type":"response.created","response":{"id":"resp_tail","object":"response","status":"in_progress","model":"${UPSTREAM_REPORTED_MODEL}"}}\n\n`,
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","item_id":"m","delta":"write to "}\n\n`,
+        // Complete JSON — only the blank line is missing. The block scan sees
+        // this one; the redactor did not, and appended it verbatim.
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","item_id":"m","delta":"tail@example.com"}`,
+      ],
+    });
+    upstreams.push(upstream);
+
+    const pk = await seed.createProviderKey({
+      display_name: "pk-echo-mask-tail",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "echo-mask-tail",
+      provider: "openai",
+      model_name: CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === "echo-mask-tail");
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-mask-tail",
+        input: "who do I write to",
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).not.toContain("tail@example.com");
+    // Kept and masked, not dropped: the frame parses, so it is scanned
+    // content like any other — and the caller gets a frame it can parse.
+    expect(text).toContain("[EMAIL_REDACTED]");
+    expect(text.endsWith("\n\n")).toBe(true);
+  });
+
+  test("/v1/messages hold-back: a final frame missing only its terminator is masked too", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: message_start\ndata: {"type":"message_start","message":{"id":"msg_mask_tail","type":"message","role":"assistant","model":"${UPSTREAM_REPORTED_MODEL}","content":[],"usage":{"input_tokens":4,"output_tokens":0}}}\n\n`,
+        `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"write to "}}\n\n`,
+        // Parseable, so the hold-back keeps it (#1086) — but it reached the
+        // released bytes without ever passing the redaction pass.
+        `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"tail@example.com"}}`,
+      ],
+    });
+    upstreams.push(upstream);
+
+    const pk = await seed.createProviderKey({
+      display_name: "pk-echo-mask-tail-anthropic",
+      secret: "sk-mock",
+      api_base: upstream.baseUrl,
+      provider: "anthropic",
+      adapter: "anthropic",
+    });
+    await seed.createModel({
+      display_name: "echo-mask-tail-anthropic",
+      provider: "anthropic",
+      model_name: CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === "echo-mask-tail-anthropic");
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-mask-tail-anthropic",
+        max_tokens: 16,
+        stream: true,
+        messages: [{ role: "user", content: "who do I write to" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).not.toContain("tail@example.com");
+    expect(text).toContain("[EMAIL_REDACTED]");
+    expect(text.endsWith("\n\n")).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

A block- or mask-capable output guardrail buffers a streamed response whole and returns it as one body. Two passes then run over that buffer, and they disagreed about framing: the block scan (`responses_sse_output_text`) walks **lines**, while the redaction pass (`redact_responses_sse` / `redact_anthropic_sse`) walks **terminator-delimited frames** and hands anything after the last terminator back as `trailing`, appending it verbatim via `out.extend_from_slice(trailing)`.

So when an upstream ends mid-frame, whichever pass missed that fragment let something unscanned reach the client.

`/v1/responses` was reachable in both shapes:

- **Block bypass** — the fragment's JSON is cut, so the line scan `continue`s past a `data:` line it cannot parse. A forbidden literal sitting in that frame is never seen, the verdict is Pass, and the whole buffer (fragment included) is returned.
- **Mask bypass** — the fragment's JSON is complete and only the terminating blank line is missing. The block pass does see it, but the redactor returns it as `trailing` and appends it unmasked. PII in the last frame goes out raw.

## The issue's premise was wrong: `/v1/messages` was not clean

The report said `/v1/messages` was safe after #1086 because its hold-back buffer only ever accumulates complete drained frames, so its trailing fragment is always empty. That is not what merged: the follow-up commit `d463c01f` ("parse the EOF tail instead of dropping it") deliberately **keeps** a parseable unterminated tail, so a provider that omits its last terminator does not lose its `message_stop` behind a guardrail. That tail is appended to `held` without a terminator, so it reaches the redaction pass as `trailing` — the identical mask bypass. Confirmed at unit level before fixing: with the PII only in the trailing fragment, both `redact_responses_sse` and `redact_anthropic_sse` return `None`, i.e. "nothing matched, forward verbatim".

Both routes are therefore fixed here, as one bug class.

## The fix

One shared helper, `redact::seal_buffered_sse`, runs **before** either pass on both routes:

- A final frame that **parses**, or that carries nothing a scan could read — no `data:` line at all (a comment / keepalive), an empty payload, or the `[DONE]` sentinel — gets the terminator its upstream left off. It is then an ordinary frame to both passes: scanned for blocked literals *and* eligible for masking, and the client gets a frame it can actually parse. Padding is by what is **missing**, in the upstream's own line ending, so a stream that wrote half its terminator does not end up with a stray blank line.
- A final frame that **cannot be parsed**, or that is not one frame at all (several `data:` lines with no blank line between them — an upstream that never wrote its separators), is cut, with a warning. Nothing can extract its text, so releasing it is the bypass. Padding the second shape into a single frame would be worse than leaving it: the redactor writes only the first `data:` line of a frame it rewrites, so a mask would silently delete the rest.
- If that cut empties the buffer — the whole response was one unparseable frame — the request is refused with `unscannable_body` rather than answered with an empty 200, matching the shape `/v1/messages` already used.

The framing itself now has one definition, and literally one: `frame_terminator` calls `messages::find_frame_end` — the relay's own, CRLF-aware, single-pass — rather than reimplementing it, and `last_frame_end`, `split_sse_frames` and `seal_buffered_sse` all derive from that. Two functions that agree today are how this disagreement got in. It matters that it knows both blank-line forms: the scan passes read lines and trim, so a CRLF-framed upstream is ordinary text to them, while the splitter used to hand that whole body back as one unframed blob and mask none of it. Masking now also re-emits each frame with the terminator it arrived with, so a masked CRLF document is not silently re-framed to LF.

## Client-visible behaviour

- `/v1/responses`, streamed behind a buffering output guardrail: an unparseable final frame is no longer delivered (it never was scanned); a parseable one is delivered masked instead of raw.
- `/v1/messages`, hold-back path: a parseable final frame is still delivered — now masked — and the released bytes carry the trailing terminator the upstream omitted. A client cannot parse a terminator-less frame anyway, so completing it is an improvement rather than a change of content. The live-forward (non-hold-back) relay is untouched.
- A CRLF-framed buffered response is now split, scanned and masked like an LF-framed one. A fully terminated body of either form is byte-identical to before.

## Sibling audit

Every other path that buffers an SSE body for an output guardrail was checked for the same framing disagreement:

- **`/v1/responses` cross-provider bridge** (`responses_bridge.rs`) — clean. Its `held` frames are this gateway's own encoder output (`SseEvent::to_sse_string()`), always terminated.
- **`/v1/chat/completions` hold-back** (`chat.rs`) — clean. It holds decoded `ChatChunk` values and masks them as structs; there is no raw frame boundary to disagree about.
- **Streaming audio transcription** (`audio.rs`) — not in this class. A hold-back chain there does keep the buffered relay (`live_relay` excludes it deliberately), but that path has no frame-level pass at all: `transcription_output_text` and `redact_transcription_response` both read the whole body as one JSON-or-plain-text document, so the two passes read the same thing and there is no frame boundary to disagree about.

## Tests

- `redact.rs` unit tests, both routes: several complete frames plus a tail whose JSON is complete but whose blank line is missing, carrying a maskable literal — the exact case that proved the bug — asserted through the seal. Plus the seal's own behaviour: terminated bodies (LF and CRLF) are byte-identical, padding is by what is missing in the upstream's line ending, a payload with nothing to scan is kept, an unparseable tail is cut and can leave the buffer empty, and a CRLF body is split into all its frames rather than one.
- e2e in `tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts`: `/v1/responses` with `stream: true` behind a buffering guardrail for both #1091 shapes, and `/v1/messages` hold-back for the mask shape.
- An exhaustive invariant test over `{a, \n, \r}` words up to length 7: after a seal the buffer always ends on a frame terminator (the property `split_sse_frames` documents), and a second seal changes nothing. It catches the case where the pad read the whole buffer rather than the fragment, and a one-byte `\r` fragment borrowed the previous frame's terminator to match a longer pattern.
- Mutation-verified locally: with the seal made a no-op, all three new e2e cases fail on their leak assertion, as does the pre-existing `/v1/messages` unterminated-tail case — which also confirms that behaviour now runs through the shared helper rather than a second copy of it. Each new unit test was likewise checked red against the code it pins.

## Deferred, with an issue

The frames *before* the fragment still take the old path: a terminated frame whose `data:` payload is not one JSON document — plain text, or several `data:` lines — is skipped by both passes (released unscanned) or, when masked, loses everything after its first `data:` line. Pre-existing, unreachable from the providers we proxy (model output arrives as JSON delta events, one `data:` line per frame), and a different decision from this one, so it is filed as #1100 rather than folded in here.

Fixes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)
