### PR TITLE
fix(proxy): refuse streamed /v1/completions, and finish the client-facing model echo

### DIFF
--- a/crates/aisix-gateway/src/bridge.rs
+++ b/crates/aisix-gateway/src/bridge.rs
@@ -244,6 +244,41 @@ fn timeout_cause_suffix(cause: &str) -> String {
     }
 }
 
+/// A non-chat operation a Bridge may or may not implement.
+///
+/// The value domain is closed on purpose: it names exactly the three
+/// [`Bridge`] methods that ship a default implementation, and it is what
+/// [`BridgeError::UnsupportedCapability`] carries. Before it existed the
+/// proxy decided the 501 by searching the error's message text for a
+/// phrase, so rewording the sentence below would have silently turned a
+/// 501 into a 500 with nothing to catch it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeCapability {
+    /// [`Bridge::embed`] — `/v1/embeddings`.
+    Embeddings,
+    /// [`Bridge::complete`] — `/v1/completions`.
+    TextCompletions,
+    /// [`Bridge::generate_image`] — `/v1/images/generations`.
+    ImageGeneration,
+}
+
+impl BridgeCapability {
+    /// The words the client-facing message names this capability by.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Embeddings => "embeddings",
+            Self::TextCompletions => "text completions",
+            Self::ImageGeneration => "image generation",
+        }
+    }
+}
+
+impl std::fmt::Display for BridgeCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Error surfaced by any Bridge. Each variant maps to a stable
 /// client-visible HTTP status and OpenAI-style error code so the proxy
 /// layer can translate without further inspection.
@@ -308,6 +343,21 @@ pub enum BridgeError {
     },
     #[error("bridge is misconfigured: {0}")]
     Config(String),
+    /// The provider's bridge does not implement this operation at all —
+    /// the [`Bridge`] default impl answered, so no request was built and no
+    /// upstream was contacted.
+    ///
+    /// Static per adapter: the same provider will answer the same way for
+    /// every request, which is why it is the one failure that must not
+    /// spend a retry ([`crate::BridgeError`] consumers in the proxy's
+    /// `routing::is_retryable`).
+    ///
+    /// It carries the SAME status, error type and telemetry class as
+    /// [`Config`](Self::Config), which it was spelled as until #1093 — the
+    /// point of the variant is that a status decision no longer reads the
+    /// message text, not that any response changed.
+    #[error("this provider does not support {0}")]
+    UnsupportedCapability(BridgeCapability),
     /// Customer-fixable upstream config — the admin's ProviderKey/Model
     /// is set up wrong (missing api_base, missing model_name) or the
     /// caller's request is malformed (e.g. split_system shape). Maps to
@@ -623,7 +673,14 @@ impl BridgeError {
                 Some(s) if (400..500).contains(s) => *s,
                 _ => 502,
             },
-            BridgeError::Config(_) => 500,
+            // Same 500 as `Config`, which this variant was spelled as
+            // before it was typed. The three routes that turn it into a
+            // 501 build that response inline (they answer it as a dispatch
+            // success, not through `ProxyError`), and the other two callers
+            // of the `embed` default — the semantic router and the guardrail
+            // embedder — surface it through this table. Mapping it to 501
+            // here would change what those two return.
+            BridgeError::Config(_) | BridgeError::UnsupportedCapability(_) => 500,
             BridgeError::InvalidUpstreamConfig(_) => 400,
             BridgeError::InvalidUpstreamCredentials(_) => 401,
             BridgeError::Transport(_) => 502,
@@ -658,6 +715,7 @@ impl BridgeError {
             | BridgeError::Transport(_)
             | BridgeError::StreamAborted => true,
             BridgeError::Config(_)
+            | BridgeError::UnsupportedCapability(_)
             | BridgeError::InvalidUpstreamConfig(_)
             | BridgeError::InvalidUpstreamCredentials(_) => false,
         }
@@ -670,7 +728,7 @@ impl BridgeError {
             BridgeError::UpstreamStatus { .. } => "upstream_error",
             BridgeError::UpstreamDecode(_) => "upstream_decode_error",
             BridgeError::UpstreamInBand { .. } => "upstream_in_band_error",
-            BridgeError::Config(_) => "config_error",
+            BridgeError::Config(_) | BridgeError::UnsupportedCapability(_) => "config_error",
             BridgeError::InvalidUpstreamConfig(_) => "invalid_request_error",
             BridgeError::InvalidUpstreamCredentials(_) => "authentication_error",
             BridgeError::Transport(_) => "transport_error",
@@ -723,15 +781,16 @@ pub trait Bridge: Send + Sync + 'static {
     ) -> Result<ChatChunkStream, BridgeError>;
 
     /// Embedding call: text(s) → float vectors. Providers that do not
-    /// support embeddings return [`BridgeError::Config`] with a clear
-    /// message so the proxy can surface a 501 rather than a 502.
+    /// support embeddings keep the default, which returns
+    /// [`BridgeError::UnsupportedCapability`] so `/v1/embeddings` can
+    /// surface a 501 rather than a 502.
     async fn embed(
         &self,
         _req: &EmbeddingRequest,
         _ctx: &BridgeContext,
     ) -> Result<EmbeddingResponse, BridgeError> {
-        Err(BridgeError::Config(
-            "this provider does not support embeddings".into(),
+        Err(BridgeError::UnsupportedCapability(
+            BridgeCapability::Embeddings,
         ))
     }
 
@@ -743,14 +802,16 @@ pub trait Bridge: Send + Sync + 'static {
     /// between providers are the caller's responsibility.
     ///
     /// Providers that do not expose a `/completions` endpoint should keep
-    /// the default, which returns a 501-mapped [`BridgeError::Config`].
+    /// the default, which returns
+    /// [`BridgeError::UnsupportedCapability`] — the value `/v1/completions`
+    /// turns into a 501.
     async fn complete(
         &self,
         _body: &serde_json::Value,
         _ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        Err(BridgeError::Config(
-            "this provider does not support text completions".into(),
+        Err(BridgeError::UnsupportedCapability(
+            BridgeCapability::TextCompletions,
         ))
     }
 
@@ -761,14 +822,16 @@ pub trait Bridge: Send + Sync + 'static {
     /// body JSON is returned as-is from the upstream.
     ///
     /// Providers that do not expose an image generation endpoint should keep
-    /// the default, which returns a 501-mapped [`BridgeError::Config`].
+    /// the default, which returns
+    /// [`BridgeError::UnsupportedCapability`] — the value
+    /// `/v1/images/generations` turns into a 501.
     async fn generate_image(
         &self,
         _body: &serde_json::Value,
         _ctx: &BridgeContext,
     ) -> Result<serde_json::Value, BridgeError> {
-        Err(BridgeError::Config(
-            "this provider does not support image generation".into(),
+        Err(BridgeError::UnsupportedCapability(
+            BridgeCapability::ImageGeneration,
         ))
     }
 }
@@ -776,6 +839,107 @@ pub trait Bridge: Send + Sync + 'static {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chat::{
+        ChatFormat, ChatMessage, ChatResponse, EmbeddingRequest, FinishReason, UsageStats,
+    };
+
+    /// A Bridge that implements only what the trait requires, so the three
+    /// optional operations fall through to their defaults — the shape every
+    /// provider that does not speak embeddings / text completions / image
+    /// generation actually has.
+    struct ChatOnlyBridge;
+
+    #[async_trait::async_trait]
+    impl Bridge for ChatOnlyBridge {
+        fn name(&self) -> &'static str {
+            "chat-only"
+        }
+        async fn chat(
+            &self,
+            _req: &ChatFormat,
+            _ctx: &BridgeContext,
+        ) -> Result<ChatResponse, BridgeError> {
+            Ok(ChatResponse {
+                id: String::new(),
+                model: String::new(),
+                message: ChatMessage::assistant(String::new()),
+                finish_reason: FinishReason::Stop,
+                usage: UsageStats::default(),
+            })
+        }
+        async fn chat_stream(
+            &self,
+            _req: &ChatFormat,
+            _ctx: &BridgeContext,
+        ) -> Result<ChatChunkStream, BridgeError> {
+            unreachable!("not exercised")
+        }
+    }
+
+    /// The three defaults name their capability in a typed field rather
+    /// than only in prose. Before #1093 the proxy read the sentence to
+    /// decide the status, so rewording it would have moved a 501 to a 500
+    /// with nothing to catch it — and this test would not have existed to
+    /// notice, because the message was the contract.
+    ///
+    /// The `Display` text is asserted too, because the three routes render
+    /// it into the client-facing 501 envelope.
+    #[tokio::test]
+    async fn the_optional_operations_default_to_a_typed_capability_gap() {
+        let b = ChatOnlyBridge;
+        let ctx = BridgeContext::new(
+            "req-1",
+            std::sync::Arc::new(
+                serde_json::from_str::<Model>(
+                    r#"{"display_name":"m","provider":"anthropic","model_name":"claude","provider_key_id":"pk"}"#,
+                )
+                .unwrap(),
+            ),
+            std::sync::Arc::new(
+                serde_json::from_str::<ProviderKey>(r#"{"display_name":"pk","secret":"s"}"#).unwrap(),
+            ),
+        );
+        let embed_req = EmbeddingRequest {
+            model: "m".into(),
+            input: vec!["hello".into()],
+            input_was_single: true,
+            encoding_format: None,
+            dimensions: None,
+        };
+
+        let cases: Vec<(BridgeError, BridgeCapability, &str)> = vec![
+            (
+                b.embed(&embed_req, &ctx).await.unwrap_err(),
+                BridgeCapability::Embeddings,
+                "this provider does not support embeddings",
+            ),
+            (
+                b.complete(&serde_json::json!({}), &ctx).await.unwrap_err(),
+                BridgeCapability::TextCompletions,
+                "this provider does not support text completions",
+            ),
+            (
+                b.generate_image(&serde_json::json!({}), &ctx)
+                    .await
+                    .unwrap_err(),
+                BridgeCapability::ImageGeneration,
+                "this provider does not support image generation",
+            ),
+        ];
+
+        for (err, capability, message) in cases {
+            assert!(
+                matches!(err, BridgeError::UnsupportedCapability(c) if c == capability),
+                "expected {capability:?}, got {err}"
+            );
+            assert_eq!(err.to_string(), message);
+            // The response shape the two non-route callers see is unchanged:
+            // this stays exactly what `Config` reported.
+            assert_eq!(err.http_status(), 500);
+            assert_eq!(err.error_type(), "config_error");
+            assert!(!err.reached_upstream());
+        }
+    }
 
     #[test]
     fn in_band_probe_parses_openai_string_code_envelope() {

--- a/crates/aisix-gateway/src/lib.rs
+++ b/crates/aisix-gateway/src/lib.rs
@@ -35,8 +35,8 @@ pub mod url_cache;
 
 pub use bridge::{
     capture_in_band_error, capture_upstream_error_http, content_type_is_json, parse_retry_after,
-    read_body_capped, response_is_json, truncate_lossy, Bridge, BridgeContext, BridgeError,
-    ChatChunkStream, UpstreamErrorView, UpstreamWire, MAX_UPSTREAM_ERROR_BODY_BYTES,
+    read_body_capped, response_is_json, truncate_lossy, Bridge, BridgeCapability, BridgeContext,
+    BridgeError, ChatChunkStream, UpstreamErrorView, UpstreamWire, MAX_UPSTREAM_ERROR_BODY_BYTES,
     MAX_UPSTREAM_ERROR_MESSAGE_BYTES,
 };
 pub use chat::{

--- a/crates/aisix-proxy/src/attempt.rs
+++ b/crates/aisix-proxy/src/attempt.rs
@@ -230,7 +230,11 @@ pub(crate) fn routing_error_class(err: &BridgeError) -> &'static str {
         BridgeError::UpstreamStatus { .. } => "upstream_status",
         BridgeError::UpstreamDecode(_) => "upstream_decode",
         BridgeError::UpstreamInBand { .. } => "upstream_in_band",
-        BridgeError::Config(_) => "config",
+        // Deliberately the same class `Config` reports: this variant was
+        // spelled as a `Config` until #1093, and giving it a class of its
+        // own would retire one series and create another for a failure that
+        // did not change.
+        BridgeError::Config(_) | BridgeError::UnsupportedCapability(_) => "config",
         BridgeError::InvalidUpstreamConfig(_) => "invalid_config",
         BridgeError::InvalidUpstreamCredentials(_) => "invalid_credentials",
         BridgeError::Transport(_) => "transport",
@@ -351,36 +355,23 @@ pub(crate) fn ms_since(started: Instant) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aisix_gateway::{UpstreamWire, MAX_UPSTREAM_ERROR_MESSAGE_BYTES};
+    use aisix_gateway::{BridgeCapability, UpstreamWire, MAX_UPSTREAM_ERROR_MESSAGE_BYTES};
 
-    /// The `aisix_deployment_*` families read as upstream health, so an
-    /// error raised while the request was still being assembled has to stay
-    /// out of them. Both matches are exhaustive, so a NEW variant is already
-    /// a compile error; this pins the classification of the existing ones,
-    /// which is what a well-meaning refactor would silently flip.
-    #[test]
-    fn only_errors_that_reached_the_provider_count_as_upstream_attempts() {
-        for err in [
-            BridgeError::Config("serialize request body: eof".into()),
-            BridgeError::InvalidUpstreamConfig("model.model_name missing".into()),
-            BridgeError::InvalidUpstreamCredentials("provider_key.api_key is empty".into()),
-        ] {
-            assert!(
-                !err.reached_upstream(),
-                "{err} is raised before the request is sent"
-            );
-            assert!(!attempt_reached_upstream(&ProxyError::Bridge(err)));
-        }
-
-        // A timeout or a refused connection IS upstream health: we tried to
-        // reach the provider and could not. Excluding these would hide the
-        // outage the family exists to show.
-        for err in [
+    /// One sample of every `BridgeError` variant.
+    ///
+    /// Hand-written, because the enum carries no reflection — but the
+    /// classification below is an EXHAUSTIVE match, so a variant added to
+    /// `BridgeError` stops this file compiling until someone decides which
+    /// side of the network boundary it sits on and which telemetry class it
+    /// reports. That is the decision this test exists to force. It does not
+    /// force the sample to be added here as well; the compile error is what
+    /// brings a reader to this function.
+    fn bridge_error_samples() -> Vec<BridgeError> {
+        vec![
             BridgeError::Timeout {
                 elapsed_ms: 7167,
                 cause: String::new(),
             },
-            BridgeError::Transport("connection refused".into()),
             BridgeError::upstream_status(502, "bad gateway"),
             BridgeError::UpstreamDecode("unparseable body".into()),
             BridgeError::UpstreamInBand {
@@ -389,15 +380,57 @@ mod tests {
                 parsed: None,
                 wire: UpstreamWire::Unknown,
             },
+            BridgeError::Transport("connection refused".into()),
             BridgeError::StreamAborted,
-        ] {
-            assert!(
-                err.reached_upstream(),
-                "{err} means the provider was contacted"
-            );
-            assert!(attempt_reached_upstream(&ProxyError::Bridge(err)));
-        }
+            BridgeError::Config("serialize request body: eof".into()),
+            BridgeError::UnsupportedCapability(BridgeCapability::Embeddings),
+            BridgeError::InvalidUpstreamConfig("model.model_name missing".into()),
+            BridgeError::InvalidUpstreamCredentials("provider_key.api_key is empty".into()),
+        ]
+    }
 
+    /// The `aisix_deployment_*` families read as upstream health, so an
+    /// error raised while the request was still being assembled has to stay
+    /// out of them — and `error_class` is a telemetry label, so a variant
+    /// silently minting a new series retires the one dashboards read.
+    #[test]
+    fn every_bridge_error_declares_its_side_of_the_network_and_its_class() {
+        for err in bridge_error_samples() {
+            let (reached, class) = match &err {
+                // A timeout or a refused connection IS upstream health: we
+                // tried to reach the provider and could not. Excluding these
+                // would hide the outage the family exists to show.
+                BridgeError::Timeout { .. } => (true, "timeout"),
+                BridgeError::UpstreamStatus { .. } => (true, "upstream_status"),
+                BridgeError::UpstreamDecode(_) => (true, "upstream_decode"),
+                BridgeError::UpstreamInBand { .. } => (true, "upstream_in_band"),
+                BridgeError::Transport(_) => (true, "transport"),
+                BridgeError::StreamAborted => (true, "stream_aborted"),
+                BridgeError::Config(_) => (false, "config"),
+                // Raised by the `Bridge` default impl itself, so no request
+                // was ever assembled — and it keeps the class `Config`
+                // reports, because until #1093 it WAS a `Config`. A class of
+                // its own would retire a series nothing else feeds.
+                BridgeError::UnsupportedCapability(_) => (false, "config"),
+                BridgeError::InvalidUpstreamConfig(_) => (false, "invalid_config"),
+                BridgeError::InvalidUpstreamCredentials(_) => (false, "invalid_credentials"),
+            };
+            assert_eq!(
+                routing_error_class(&err),
+                class,
+                "{err} reports the wrong attempt error_class"
+            );
+            assert_eq!(
+                err.reached_upstream(),
+                reached,
+                "{err} is on the wrong side of the network boundary"
+            );
+            assert_eq!(attempt_reached_upstream(&ProxyError::Bridge(err)), reached);
+        }
+    }
+
+    #[test]
+    fn only_errors_that_reached_the_provider_count_as_upstream_attempts() {
         // Only the output hook can fire inside a dispatch call, so the
         // provider had already answered — the attempt did reach it.
         assert!(attempt_reached_upstream(&ProxyError::ContentFiltered {

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -16,7 +16,9 @@
 //! 8. Call `bridge.complete(body, ctx)` → JSON response.
 //! 9. Providers that don't support completions return 501.
 
-use aisix_gateway::{BridgeError, ChatMessage, ChatResponse, FinishReason, UsageStats};
+use aisix_gateway::{
+    BridgeCapability, BridgeError, ChatMessage, ChatResponse, FinishReason, UsageStats,
+};
 use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, UsageEvent};
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -621,10 +623,10 @@ async fn dispatch(
                 captured_content,
             })
         }
-        Err(BridgeError::Config(msg)) if msg.contains("does not support text completions") => {
+        Err(e @ BridgeError::UnsupportedCapability(BridgeCapability::TextCompletions)) => {
             // No upstream call → no tokens to count; release the reservation.
             reservation.commit_tokens(0).await;
-            let env = ErrorEnvelope::new(msg, "not_implemented");
+            let env = ErrorEnvelope::new(e.to_string(), "not_implemented");
             Ok(CompletionDispatchSuccess {
                 response: (StatusCode::NOT_IMPLEMENTED, Json(env)).into_response(),
                 provider: provider_label,

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -2,7 +2,8 @@
 //!
 //! This endpoint is a thin passthrough to the provider's `/completions`
 //! surface. The upstream `model` field is rewritten to the provider's own
-//! model id; everything else in the request body is forwarded verbatim.
+//! model id, `stream: true` is refused, and everything else in the request
+//! body is forwarded verbatim.
 //!
 //! Flow:
 //! 1. [`AuthenticatedKey`] extractor — 401 if auth fails.
@@ -10,9 +11,10 @@
 //! 3. Validate `model` is present.
 //! 4. Resolve model name → `Model` in snapshot → 404 if absent.
 //! 5. Check `allowed_models` → 403 if denied.
-//! 6. Look up Bridge on Hub → 503 if not registered.
-//! 7. Call `bridge.complete(body, ctx)` → JSON response.
-//! 8. Providers that don't support completions return 501.
+//! 6. Refuse `stream: true` → 400, before any upstream call (#1093).
+//! 7. Look up Bridge on Hub → 503 if not registered.
+//! 8. Call `bridge.complete(body, ctx)` → JSON response.
+//! 9. Providers that don't support completions return 501.
 
 use aisix_gateway::{BridgeError, ChatMessage, ChatResponse, FinishReason, UsageStats};
 use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, UsageEvent};
@@ -313,6 +315,25 @@ async fn dispatch(
 
     // Client-IP allowlist gate (#557): reject before guardrails / upstream.
     crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;
+
+    // #1093: this route has no streaming relay, and the dispatch below reads
+    // the upstream answer as a single JSON document. Forwarding `stream` had
+    // the provider generate — and charge for — a response the gateway then
+    // failed to decode, so the caller got a 502 and no usage was recorded.
+    // Refuse it here, before the provider is contacted.
+    //
+    // Rejected AFTER model resolution so an unknown model still answers 404
+    // (matching the other JSON endpoints' precedence), and BEFORE the
+    // guardrail chain and the rate-limit reservation so a request that
+    // cannot be served burns neither — the same placement /v1/images/edits
+    // uses for its own `stream` refusal.
+    if body.get("stream").and_then(Value::as_bool) == Some(true) {
+        return Err(ProxyError::InvalidRequest(
+            "`stream` is not supported on /v1/completions; \
+             use /v1/chat/completions for streaming"
+                .into(),
+        ));
+    }
 
     // #545: /v1/completions must run input guardrails. Before this it
     // forwarded the user `prompt` to the upstream with no configured

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -15,7 +15,7 @@
 //! `"type": "not_implemented"`.
 
 use aisix_core::AppliedGuardrail;
-use aisix_gateway::{BridgeError, ChatFormat, ChatMessage, EmbeddingRequest};
+use aisix_gateway::{BridgeCapability, BridgeError, ChatFormat, ChatMessage, EmbeddingRequest};
 use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, UsageEvent};
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -540,7 +540,7 @@ async fn dispatch(
                 captured_content,
             })
         }
-        Err(BridgeError::Config(msg)) if msg.contains("does not support embeddings") => {
+        Err(e @ BridgeError::UnsupportedCapability(BridgeCapability::Embeddings)) => {
             // Provider doesn't implement embed → 501 Not Implemented.
             // Drop the reservation without committing — the request
             // didn't hit the upstream. No UsageEvent emission either
@@ -548,7 +548,7 @@ async fn dispatch(
             // chat.rs convention that we only attribute usage on a
             // real upstream completion).
             reservation.commit_tokens(0).await;
-            let env = ErrorEnvelope::new(msg, "not_implemented");
+            let env = ErrorEnvelope::new(e.to_string(), "not_implemented");
             Ok(EmbedDispatchSuccess {
                 response: (StatusCode::NOT_IMPLEMENTED, Json(env)).into_response(),
                 provider: provider.to_ascii_lowercase(),

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -11,7 +11,7 @@
 //! 8. Providers that don't support image generation return 501.
 
 use aisix_core::AppliedGuardrail;
-use aisix_gateway::BridgeError;
+use aisix_gateway::{BridgeCapability, BridgeError};
 use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, UsageEvent};
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -439,10 +439,10 @@ async fn dispatch(
                 captured_content,
             })
         }
-        Err(BridgeError::Config(msg)) if msg.contains("does not support image generation") => {
+        Err(e @ BridgeError::UnsupportedCapability(BridgeCapability::ImageGeneration)) => {
             // No upstream call → no tokens to count; release the reservation.
             reservation.commit_tokens(0).await;
-            let env = ErrorEnvelope::new(msg, "not_implemented");
+            let env = ErrorEnvelope::new(e.to_string(), "not_implemented");
             Ok(ImageDispatchSuccess {
                 response: (StatusCode::NOT_IMPLEMENTED, Json(env)).into_response(),
                 provider: provider_label,

--- a/crates/aisix-proxy/src/model_echo.rs
+++ b/crates/aisix-proxy/src/model_echo.rs
@@ -30,8 +30,9 @@
 //! changing — key order, whitespace, number spellings, escape choices —
 //! reaches the client exactly as the provider wrote it.
 //!
-//! Both are deliberately no-ops when the document carries no `model` at the
-//! selected path. A response that never had the field does not acquire one.
+//! All three are deliberately no-ops when the document carries no `model` at
+//! the selected path. A response that never had the field does not acquire
+//! one.
 
 use serde_json::Value;
 

--- a/crates/aisix-proxy/src/model_echo.rs
+++ b/crates/aisix-proxy/src/model_echo.rs
@@ -13,21 +13,22 @@
 //! which carries the upstream's own id. This module is where that difference
 //! is repaired, so the paths that use it cannot drift apart again.
 //!
-//! It is NOT yet the whole family. `/v1/rerank` (a Jina response carries a
-//! top-level `model`) and `/v1/realtime` (`session.created` / `session.updated`
-//! carry `session.model`) still hand the upstream id back — tracked as #1087
-//! and #1088. `/v1/fine_tuning/jobs` is deliberately outside it: its request
+//! `/v1/fine_tuning/jobs` is deliberately outside the family: its request
 //! half forwards the caller's `model` to the provider verbatim, so naming the
 //! upstream base model on both halves is the symmetric answer there (#1089).
 //!
-//! Two shapes, because a native path answers in two:
+//! Three shapes, because a native path answers in three:
 //!
 //! - [`restamp_body`] for a parsed JSON response.
-//! - [`restamp_sse_frame`] for one frame of a streamed response. It splices
-//!   the value through [`crate::json_splice`] rather than re-serialising the
-//!   frame, so every byte the gateway is not deliberately changing — key
-//!   order, whitespace, number spellings, escape choices — reaches the client
-//!   exactly as the provider wrote it.
+//! - [`restamp_json_bytes`] for a response the path relays as raw bytes
+//!   rather than re-serialising (`/v1/rerank`), and for one WebSocket text
+//!   frame (`/v1/realtime`).
+//! - [`restamp_sse_frame`] for one frame of a streamed response.
+//!
+//! The last two splice the value through [`crate::json_splice`] rather than
+//! re-serialising the document, so every byte the gateway is not deliberately
+//! changing — key order, whitespace, number spellings, escape choices —
+//! reaches the client exactly as the provider wrote it.
 //!
 //! Both are deliberately no-ops when the document carries no `model` at the
 //! selected path. A response that never had the field does not acquire one.
@@ -49,6 +50,48 @@ pub(crate) fn restamp_body(body: &mut Value, client_facing_model: &str) {
     }
 }
 
+/// Restamp the `model` value inside a raw JSON document, byte-preserving.
+///
+/// For the paths that relay the provider's own bytes instead of
+/// re-serialising a parsed body — `/v1/rerank`, and one `/v1/realtime`
+/// WebSocket text frame. Returns `None` when the document carries no value
+/// at the selected path, or when the scanner refuses it; a `None` caller
+/// forwards the original bytes.
+pub(crate) fn restamp_json_bytes(
+    doc: &[u8],
+    client_facing_model: &str,
+    selects_model: fn(&[PathSeg]) -> bool,
+) -> Option<Vec<u8>> {
+    splice_model_value(doc, selects_model, |_| {
+        Some(client_facing_model.to_string())
+    })
+}
+
+/// Splice new text into the `model` values `selects_model` picks out.
+///
+/// The one failure policy every caller shares: the scanner fails whole
+/// rather than half-rewriting, and a document it cannot read is forwarded
+/// verbatim — leaking the upstream id on one frame is a smaller harm than
+/// corrupting the stream.
+///
+/// `rewrite` sees the value as the document wrote it, so a caller that only
+/// wants to translate ONE name back (the realtime relay's client-to-upstream
+/// direction) answers `None` for every other and leaves those bytes alone.
+pub(crate) fn splice_model_value(
+    doc: &[u8],
+    selects_model: fn(&[PathSeg]) -> bool,
+    rewrite: impl FnMut(&str) -> Option<String>,
+) -> Option<Vec<u8>> {
+    match json_splice::rewrite_string_values(doc, selects_model, rewrite) {
+        Ok(Some(bytes)) => Some(bytes),
+        Ok(None) => None,
+        Err(error) => {
+            tracing::debug!(%error, "model restamp skipped; forwarding verbatim");
+            None
+        }
+    }
+}
+
 /// Restamp the `model` value inside one SSE frame's `data:` payload.
 ///
 /// Returns the rewritten frame, or `None` when the frame carries no value at
@@ -66,19 +109,7 @@ pub(crate) fn restamp_sse_frame(
     if payload == b"[DONE]" {
         return None;
     }
-    let spliced = match json_splice::rewrite_string_values(payload, selects_model, |_| {
-        Some(client_facing_model.to_string())
-    }) {
-        Ok(Some(bytes)) => bytes,
-        Ok(None) => return None,
-        Err(error) => {
-            // The scanner fails whole rather than half-rewriting. A frame it
-            // cannot read forwards verbatim: leaking the upstream id on one
-            // frame is a smaller harm than corrupting the stream.
-            tracing::debug!(%error, "sse frame model restamp skipped; forwarding verbatim");
-            return None;
-        }
-    };
+    let spliced = restamp_json_bytes(payload, client_facing_model, selects_model)?;
     let mut out = Vec::with_capacity(frame.len() - payload.len() + spliced.len());
     out.extend_from_slice(&frame[..range.start]);
     out.extend_from_slice(&spliced);
@@ -121,6 +152,34 @@ pub(crate) fn restamp_sse_buffer(
         None => out.extend_from_slice(rest),
     }
     out
+}
+
+/// A `model` at the document's TOP level.
+///
+/// The shape `/v1/rerank` answers in: among the supported rerank backends
+/// only Jina's response names a model, and it names it here. The Cohere and
+/// OpenAI-compatible shapes carry none, so the splice is a no-op on them
+/// rather than inventing the field.
+///
+/// Depth-exact, so a `model` nested inside a result or a `meta` block — not
+/// the caller-facing field — is left alone.
+pub(crate) fn top_level_model(path: &[PathSeg]) -> bool {
+    path.len() == 1 && path[0].is_key("model")
+}
+
+/// `session.model` on a Realtime `session.created` / `session.updated` frame.
+///
+/// Those two are the only Realtime server events that name a model: the
+/// Response object a `response.created` / `response.done` frame carries has
+/// no `model` field at all.
+///
+/// Depth-exact for a second reason here. A session's audio config can name a
+/// SEPARATE transcription model at
+/// `session.audio.input.transcription.model`, which the client chose itself
+/// and the gateway never aliased — restamping that one would rename a model
+/// the caller is entitled to see.
+pub(crate) fn realtime_session_model(path: &[PathSeg]) -> bool {
+    path.len() == 2 && path[0].is_key("session") && path[1].is_key("model")
 }
 
 /// `message.model` on an Anthropic `message_start` frame.
@@ -257,6 +316,99 @@ mod tests {
         );
         // Still no terminator invented for it.
         assert!(out.ends_with("}}"));
+    }
+
+    /// The first depth-1 predicate in production code (`/v1/rerank`). The
+    /// depth-2 ones above cannot exercise a top-level match, so this pins it
+    /// directly rather than assuming the walker offers a root-level value
+    /// the same way it offers a nested one.
+    #[test]
+    fn top_level_predicate_selects_the_root_model_only() {
+        // A Jina rerank response: the model is named at the root.
+        let body = br#"{"model":"jina-reranker-v2-base-multilingual","results":[{"index":0,"relevance_score":0.9}],"usage":{"total_tokens":11}}"#;
+        let out = restamp_json_bytes(body, "my-reranker", top_level_model)
+            .expect("a top-level `model` is selected");
+        let out = String::from_utf8(out).unwrap();
+        assert!(out.starts_with(r#"{"model":"my-reranker","results":"#));
+        // Everything outside the replaced value is byte-identical, the
+        // score's spelling included.
+        assert!(out.contains(r#""relevance_score":0.9"#));
+        assert!(out.ends_with(r#""usage":{"total_tokens":11}}"#));
+
+        // A Cohere-shape response names no model — nothing to rewrite, and
+        // the field is not invented.
+        assert!(restamp_json_bytes(
+            br#"{"id":"rr-1","results":[{"index":0}]}"#,
+            "my-reranker",
+            top_level_model,
+        )
+        .is_none());
+
+        // A `model` nested anywhere deeper is NOT the caller-facing field.
+        assert!(restamp_json_bytes(
+            br#"{"results":[{"model":"aux"}],"meta":{"model":"aux"}}"#,
+            "my-reranker",
+            top_level_model,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn realtime_predicate_selects_the_session_model_only() {
+        let frame = br#"{"type":"session.created","event_id":"e1","session":{"id":"sess_1","model":"gpt-realtime-2026-01-01","output_modalities":["audio"]}}"#;
+        let out = restamp_json_bytes(frame, "my-realtime", realtime_session_model)
+            .expect("session.created carries session.model");
+        let out = String::from_utf8(out).unwrap();
+        assert!(out.contains(r#""model":"my-realtime""#));
+        assert!(out.starts_with(r#"{"type":"session.created","event_id":"e1""#));
+        assert!(out.ends_with(r#""output_modalities":["audio"]}}"#));
+
+        // The transcription model the CLIENT configured sits deeper and is
+        // not an alias the gateway handed out — leave it as written.
+        assert!(restamp_json_bytes(
+            br#"{"type":"session.updated","session":{"audio":{"input":{"transcription":{"model":"gpt-4o-transcribe"}}}}}"#,
+            "my-realtime",
+            realtime_session_model,
+        )
+        .is_none());
+
+        // A `response.done` frame names no model at all.
+        assert!(restamp_json_bytes(
+            br#"{"type":"response.done","response":{"id":"resp_1","usage":{"input_tokens":9}}}"#,
+            "my-realtime",
+            realtime_session_model,
+        )
+        .is_none());
+    }
+
+    /// The reverse direction the realtime relay uses on its way UP: only the
+    /// alias the gateway handed out is translated back, so a client naming
+    /// anything else still reaches the upstream with its own words.
+    #[test]
+    fn splice_model_value_rewrites_only_what_the_closure_answers_for() {
+        let update = |model: &str| {
+            format!(
+                r#"{{"type":"session.update","session":{{"model":"{model}","voice":"alloy"}}}}"#
+            )
+        };
+        let translate = |v: &str| (v == "my-realtime").then(|| "gpt-realtime".to_string());
+
+        let out = splice_model_value(
+            update("my-realtime").as_bytes(),
+            realtime_session_model,
+            translate,
+        )
+        .expect("the alias is translated back");
+        assert!(String::from_utf8(out)
+            .unwrap()
+            .contains(r#""model":"gpt-realtime""#));
+
+        assert!(splice_model_value(
+            update("some-other-model").as_bytes(),
+            realtime_session_model,
+            translate,
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -532,8 +532,18 @@ fn restamp_session_model_in(
 ///
 /// The fast path matters: every audio delta is a text frame, and only two
 /// event types in the protocol carry a session at all.
+///
+/// It tests for a backslash as well as for the literal key, and that second
+/// condition is what makes it safe rather than merely quick. JSON lets a key
+/// be spelled with escapes, so `session` can also arrive as
+/// `\u0073ession` — the splice walker decodes keys and would match it, but a
+/// fast path looking only for the literal spelling would have skipped the
+/// frame before the walker ever saw it. An escape needs a backslash, so a
+/// frame carrying neither cannot name `session` at all, and skipping it is
+/// sound. (An audio delta is base64, which has no backslash, so the cheap
+/// case stays cheap.)
 fn splice_or_keep(text: String, splice: impl FnOnce(&[u8]) -> Option<Vec<u8>>) -> String {
-    if !text.contains("\"session\"") {
+    if !text.contains("\"session\"") && !text.contains('\\') {
         return text;
     }
     match splice(text.as_bytes()).map(String::from_utf8) {
@@ -1075,6 +1085,56 @@ fn emit_access_log(
 
 #[cfg(test)]
 mod tests {
+
+    /// JSON lets both a key and a string value be spelled with escapes, and
+    /// the two halves are handled in different places — so they are pinned
+    /// separately.
+    ///
+    /// The KEY half is the one that was broken: the splice walker decodes
+    /// keys and matches `"\u0073ession"` fine, but `splice_or_keep`'s fast
+    /// path tested only for the literal spelling and returned before the
+    /// walker ran, leaking the upstream model id.
+    #[test]
+    fn an_escaped_session_key_is_still_restamped() {
+        let frame = r#"{"type":"session.created","\u0073ession":{"model":"up-1"}}"#;
+        let out = restamp_session_model_out(frame.to_string(), "echo-realtime");
+        assert!(
+            out.contains(r#""model":"echo-realtime""#),
+            "the fast path must not skip an escaped key: {out}"
+        );
+        assert!(!out.contains("up-1"));
+    }
+
+    /// The VALUE half needs no special handling and this proves it rather
+    /// than assuming it: the walker offers the DECODED text to the rewrite
+    /// closure, so an alias spelled with escapes compares equal and is
+    /// translated back to the provider's own id.
+    #[test]
+    fn an_escaped_alias_value_still_translates_back_upstream() {
+        let frame = r#"{"type":"session.update","session":{"model":"echo-\u0072ealtime"}}"#;
+        let out = restamp_session_model_in(frame.to_string(), "echo-realtime", "gpt-realtime");
+        assert!(
+            out.contains(r#""model":"gpt-realtime""#),
+            "an escaped spelling of the alias is still the alias: {out}"
+        );
+    }
+
+    /// The fast path still skips the frames it exists for. An audio delta is
+    /// base64 with no backslash and no session, so it must come back as the
+    /// very same allocation-free string.
+    #[test]
+    fn an_audio_delta_takes_the_fast_path_unchanged() {
+        let frame =
+            r#"{"type":"response.output_audio.delta","delta":"UklGRiQAAABXQVZFZm10IBAAAAA="}"#;
+        assert_eq!(
+            restamp_session_model_out(frame.to_string(), "echo-realtime"),
+            frame
+        );
+        assert_eq!(
+            restamp_session_model_in(frame.to_string(), "echo-realtime", "gpt-realtime"),
+            frame
+        );
+    }
     use super::*;
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -511,8 +511,16 @@ fn restamp_session_model_out(text: String, client_facing_model: &str) -> String 
 /// names anything else reaches the provider with its own words, and gets the
 /// provider's own answer about it.
 ///
-/// This does not let a client SWITCH models mid-session: the model is fixed
-/// by the connect-time query parameter, and `session.update` cannot change it.
+/// Forwarding those other values verbatim is what this relay has always
+/// done, and this function does not change it — but note what it is and is
+/// not. The upstream session's model is fixed by the connect-time query
+/// parameter, and the Realtime protocol documents `model` as one of the two
+/// fields `session.update` cannot change, so a provider that follows the
+/// spec ignores whatever a client puts there. That is the PROVIDER's
+/// guarantee, not one the gateway enforces: against a permissive
+/// OpenAI-compatible server that did honour it, a caller could name a model
+/// the gateway attributed nothing to. Pre-existing either way, and out of
+/// scope here — do not read the passthrough as a check.
 fn restamp_session_model_in(
     text: String,
     client_facing_model: &str,

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -4,6 +4,9 @@
 //! Authenticates on connect, resolves the target Model from `?model=`,
 //! opens the provider WebSocket and relays frames bidirectionally.
 //!
+//! The relay is verbatim with one exception, `session.model` — see
+//! [`restamp_session_model_out`] and its mirror.
+//!
 //! ## Protocol scope
 //!
 //! v1 relays the **OpenAI Realtime wire protocol**: adapter `openai`
@@ -262,6 +265,9 @@ struct Prepared {
     upstream_request: tokio_tungstenite::tungstenite::handshake::client::Request,
     reservation: aisix_ratelimit::MultiReservation,
     requested_model: String,
+    /// Provider-side model id the upstream session was opened with. Only
+    /// [`restamp_session_model_in`] reads it — see there for why.
+    upstream_model: String,
     provider_label: String,
 }
 
@@ -395,6 +401,7 @@ async fn prepare(
         upstream_request,
         reservation,
         requested_model,
+        upstream_model,
         provider_label,
     })
 }
@@ -474,6 +481,67 @@ fn urlencode(s: &str) -> String {
     out
 }
 
+/// Restamp `session.model` on its way DOWN to the client.
+///
+/// `session.created` and `session.updated` are the only Realtime server
+/// events that name a model, and they name the one the provider is running —
+/// so a caller who connected with a gateway alias was told a different name
+/// than the one they addressed. That is the `model_echo` contract, applied on
+/// this surface (#1088).
+///
+/// A frame that names no model, or that the splice scanner refuses, is
+/// returned unchanged.
+fn restamp_session_model_out(text: String, client_facing_model: &str) -> String {
+    splice_or_keep(text, |bytes| {
+        crate::model_echo::restamp_json_bytes(
+            bytes,
+            client_facing_model,
+            crate::model_echo::realtime_session_model,
+        )
+    })
+}
+
+/// Translate `session.model` back on its way UP to the provider.
+///
+/// The mirror of [`restamp_session_model_out`], and it exists because of it.
+/// Realtime clients routinely take the `session` object the gateway just
+/// handed them, change one field and send the whole thing back as
+/// `session.update` — which now carries the gateway's alias where it used to
+/// carry the provider's own id. Only that alias is translated; a client that
+/// names anything else reaches the provider with its own words, and gets the
+/// provider's own answer about it.
+///
+/// This does not let a client SWITCH models mid-session: the model is fixed
+/// by the connect-time query parameter, and `session.update` cannot change it.
+fn restamp_session_model_in(
+    text: String,
+    client_facing_model: &str,
+    upstream_model: &str,
+) -> String {
+    splice_or_keep(text, |bytes| {
+        crate::model_echo::splice_model_value(
+            bytes,
+            crate::model_echo::realtime_session_model,
+            |named| (named == client_facing_model).then(|| upstream_model.to_string()),
+        )
+    })
+}
+
+/// Run a splice over one WebSocket text frame, keeping the original string
+/// whenever there is nothing to rewrite.
+///
+/// The fast path matters: every audio delta is a text frame, and only two
+/// event types in the protocol carry a session at all.
+fn splice_or_keep(text: String, splice: impl FnOnce(&[u8]) -> Option<Vec<u8>>) -> String {
+    if !text.contains("\"session\"") {
+        return text;
+    }
+    match splice(text.as_bytes()).map(String::from_utf8) {
+        Some(Ok(rewritten)) => rewritten,
+        _ => text,
+    }
+}
+
 /// Accumulated session usage harvested from upstream frames.
 #[derive(Default)]
 struct SessionUsage {
@@ -534,6 +602,7 @@ async fn run_session(
         upstream_request,
         reservation,
         requested_model,
+        upstream_model,
         provider_label,
     } = prep;
 
@@ -693,6 +762,7 @@ async fn run_session(
                             break;
                         }
                     }
+                    let text = restamp_session_model_in(text, &requested_model, &upstream_model);
                     if up_tx.send(TgMessage::Text(text)).await.is_err() {
                         break;
                     }
@@ -740,6 +810,7 @@ async fn run_session(
                             break;
                         }
                     }
+                    let text = restamp_session_model_out(text, &requested_model);
                     if client_tx.send(AxMessage::Text(text)).await.is_err() {
                         break;
                     }

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -3,7 +3,9 @@
 //! This endpoint proxies rerank requests to the upstream provider.
 //! The `model` field is resolved and authorised via the same path as
 //! chat completions. The body is forwarded verbatim after rewriting the
-//! `model` field to the upstream model name.
+//! `model` field to the upstream model name, and the response is relayed
+//! verbatim except for that same field, restamped back to the name the
+//! caller addressed (`model_echo`).
 //!
 //! Providers that support rerank natively (Cohere, Voyage, etc.) should
 //! be configured with a `base_url` pointing to their rerank endpoint root.
@@ -573,6 +575,24 @@ async fn dispatch(
             );
             (None, String::new())
         }
+    };
+
+    // #1087: echo the model name the CALLER addressed, not the id the
+    // upstream answered with (the `model_echo` contract). The request half
+    // already rewrote `model` to the upstream id, so without this the
+    // response half handed that id straight back. Among the supported
+    // rerank shapes only Jina's response names a model — Cohere's and the
+    // OpenAI-compatible one carry none, so this is a no-op there rather
+    // than inventing the field. Spliced rather than re-serialised so every
+    // other byte the provider wrote (relevance-score spellings included)
+    // still reaches the caller exactly as written.
+    let body_bytes = match crate::model_echo::restamp_json_bytes(
+        &body_bytes,
+        &model_name,
+        crate::model_echo::top_level_model,
+    ) {
+        Some(rewritten) => bytes::Bytes::from(rewritten),
+        None => body_bytes,
     };
 
     // Content capture (#700): the relayed response bytes are the JSON the

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -96,6 +96,20 @@ pub fn is_retryable(err: &BridgeError, retry_on_429: bool, fallback_on_statuses:
         // mistake — retrying or failing over won't help, same as a
         // non-429 4xx.
         BridgeError::InvalidUpstreamConfig(_) | BridgeError::InvalidUpstreamCredentials(_) => false,
+        // A capability the adapter simply does not implement. Static per
+        // adapter, so the same call answers the same way every time and a
+        // retry can only add latency to a refusal the caller is going to
+        // get anyway. Spelled as `Config` before #1093, which made it
+        // retryable and burned the whole budget before the 501 surfaced.
+        //
+        // There is no failover to preserve underneath this `false`. The
+        // three routes that can raise it — `/v1/completions`,
+        // `/v1/embeddings`, `/v1/images/generations` — dispatch through
+        // `retrying_dispatch`, which walks no candidates, and they refuse a
+        // routing model outright in `dispatch::require_provider`. The one
+        // loop that does fail over (chat's) only ever calls `chat` /
+        // `chat_stream`, which have no default impl to raise this.
+        BridgeError::UnsupportedCapability(_) => false,
         BridgeError::Timeout { .. }
         | BridgeError::Transport(_)
         | BridgeError::UpstreamDecode(_)
@@ -1166,6 +1180,7 @@ pub(crate) fn resolve_attempt_models(
 mod tests {
     use super::*;
     use aisix_core::{Routing, RoutingStrategy, RoutingTarget};
+    use aisix_gateway::BridgeCapability;
 
     fn r(
         strategy: RoutingStrategy,
@@ -1761,6 +1776,63 @@ mod tests {
             false,
             &[]
         ));
+        // #1093: the adapter simply does not implement this operation, and
+        // that is static — the same call answers the same way every time.
+        assert!(!is_retryable(
+            &BridgeError::UnsupportedCapability(BridgeCapability::TextCompletions),
+            false,
+            &[]
+        ));
+    }
+
+    /// The classifier answering `false` is only worth something if the loop
+    /// stops on it. This is the half that would go red if
+    /// `retrying_dispatch` ever consulted something other than
+    /// `is_retryable` — and the `Config` control is what shows the harness
+    /// can see a retry at all, so a mis-wired counter cannot pass by
+    /// reporting one call for both.
+    #[tokio::test(start_paused = true)]
+    async fn the_retry_loop_spends_no_attempt_on_a_capability_gap() {
+        let state = crate::ProxyState::new(
+            aisix_core::snapshot::SnapshotHandle::new(aisix_core::AisixSnapshot::new()),
+            std::sync::Arc::new(aisix_gateway::Hub::new()),
+            &aisix_core::ProxyConfig {
+                addr: "127.0.0.1:0".into(),
+                request_body_limit_bytes: 1_048_576,
+                tls: None,
+                real_ip: Default::default(),
+                request_id: Default::default(),
+                thread_per_core: None,
+                workers: None,
+                url_rewrites: Vec::new(),
+            },
+        );
+        let model = model_with_retries(Some(2));
+
+        let calls = std::cell::Cell::new(0u32);
+        let err = retrying_dispatch(&state, &model, "/v1/completions", || {
+            calls.set(calls.get() + 1);
+            async {
+                Err::<(), _>(BridgeError::UnsupportedCapability(
+                    BridgeCapability::TextCompletions,
+                ))
+            }
+        })
+        .await
+        .expect_err("the capability gap surfaces");
+        assert!(matches!(err, BridgeError::UnsupportedCapability(_)));
+        assert_eq!(calls.get(), 1, "a capability gap must not spend a retry");
+
+        // Control: the shape this used to have. Two configured retries mean
+        // three calls, which is the budget the 501 was burning before the
+        // variant was typed.
+        let calls = std::cell::Cell::new(0u32);
+        let _ = retrying_dispatch(&state, &model, "/v1/completions", || {
+            calls.set(calls.get() + 1);
+            async { Err::<(), _>(BridgeError::Config("serialize request body: eof".into())) }
+        })
+        .await;
+        assert_eq!(calls.get(), 3);
     }
 
     /// AISIX-Cloud#1222: in-band stream errors follow the same status

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -343,6 +343,52 @@ describe("client-facing model echo e2e: the response names what the caller asked
     expectAliasNotUpstreamId(await res.text(), "echo-completions");
   });
 
+  test("/v1/rerank: a Jina-shaped response echoes the alias", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    // Among the supported rerank backends only Jina's response names a
+    // model, and it names it at the top level. Cohere's and the
+    // OpenAI-compatible shape carry none, so they are covered by the
+    // byte-for-byte relay assertions in `rerank-e2e` rather than here.
+    const upstream = await startOpenAiUpstream({
+      nonStreamBody: {
+        model: UPSTREAM_REPORTED_MODEL,
+        results: [
+          { index: 2, relevance_score: 0.92, document: { text: "Paris" } },
+          { index: 0, relevance_score: 0.31, document: { text: "Berlin" } },
+        ],
+        usage: { total_tokens: 11 },
+      },
+    });
+    upstreams.push(upstream);
+    await seedAlias("echo-rerank", upstream, { provider: "jina" });
+
+    const res = await fetch(`${app.proxyUrl}/v1/rerank`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-rerank",
+        query: "What is the capital of France?",
+        documents: ["Berlin", "London", "Paris"],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expectAliasNotUpstreamId(text, "echo-rerank");
+    // The rest of the document is relayed as the provider wrote it — the
+    // scores above all, since a re-serialised body would silently reorder
+    // or re-spell them and break a RAG caller's ranking.
+    const body = JSON.parse(text) as {
+      results?: Array<{ index?: number; relevance_score?: number }>;
+      usage?: { total_tokens?: number };
+    };
+    expect(body.results?.[0]?.index).toBe(2);
+    expect(body.results?.[0]?.relevance_score).toBe(0.92);
+    expect(body.results?.[1]?.index).toBe(0);
+    expect(body.results?.[1]?.relevance_score).toBe(0.31);
+    expect(body.usage?.total_tokens).toBe(11);
+  });
+
   test("/v1/videos: the poll echoes the name the caller submitted under, not the wildcard row's", async (ctx) => {
     if (!etcdReachable || !app || !seed) return void ctx.skip();
 

--- a/tests/e2e/src/cases/completions-legacy-e2e.test.ts
+++ b/tests/e2e/src/cases/completions-legacy-e2e.test.ts
@@ -101,7 +101,27 @@ describe("legacy /v1/completions e2e: text-in / text-out passthrough", () => {
       key_hash: CALLER_KEY_HASH,
       allowed_models: ["completions-legacy-model"],
     });
-  });
+
+    // The caller key is seeded last, so it authenticating implies every
+    // earlier resource is in the snapshot (see this directory's AGENTS.md).
+    // Gating here rather than inside a test means each test does not depend
+    // on an earlier one having warmed the snapshot — an ordering dependency
+    // that passes locally and races the moment a test is run on its own.
+    // `/v1/models` is also not a request that exercises anything asserted
+    // below, so a broken dispatch surfaces as its own assertion rather than
+    // as a propagation timeout.
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+      });
+      if (res.status !== 200) {
+        await res.text();
+        return false;
+      }
+      const body = (await res.json()) as { data?: Array<{ id?: string }> };
+      return (body.data ?? []).some((m) => m.id === "completions-legacy-model");
+    });
+  }, 60_000);
 
   afterAll(async () => {
     await app?.exit();
@@ -230,23 +250,6 @@ describe("legacy /v1/completions e2e: text-in / text-out passthrough", () => {
         authorization: `Bearer ${CALLER_PLAINTEXT}`,
         "content-type": "application/json",
       };
-      await waitConfigPropagation(async () => {
-        try {
-          const r = await fetch(`${app!.proxyUrl}/v1/completions`, {
-            method: "POST",
-            headers: reqHeaders,
-            body: JSON.stringify({
-              model: "completions-legacy-model",
-              prompt: "ready-probe-stream",
-            }),
-          });
-          await r.text();
-          return r.status === 200;
-        } catch {
-          return false;
-        }
-      });
-
       const baseline = upstream.receivedRequests.length;
       const res = await fetch(`${app.proxyUrl}/v1/completions`, {
         method: "POST",

--- a/tests/e2e/src/cases/completions-legacy-e2e.test.ts
+++ b/tests/e2e/src/cases/completions-legacy-e2e.test.ts
@@ -266,10 +266,11 @@ describe("legacy /v1/completions e2e: text-in / text-out passthrough", () => {
         error?: { message?: string; type?: string };
       };
       expect(body.error?.type).toBe("invalid_request_error");
-      // The message names the endpoint that does stream, so a caller can
-      // act on it without reading the docs.
-      // Pinned whole, not by substring: this exact sentence is what the
-      // published docs quote, so a reworded message has to come here first.
+      // The message names the endpoint that does stream, so a caller can act
+      // on it without reading the docs. Pinned whole rather than by
+      // substring: this sentence is the endpoint's refusal contract, and a
+      // substring assertion would pass through a reword that changed what a
+      // caller is told to do next.
       expect(body.error?.message).toBe(
         "request payload is invalid: `stream` is not supported on " +
           "/v1/completions; use /v1/chat/completions for streaming",

--- a/tests/e2e/src/cases/completions-legacy-e2e.test.ts
+++ b/tests/e2e/src/cases/completions-legacy-e2e.test.ts
@@ -206,4 +206,119 @@ describe("legacy /v1/completions e2e: text-in / text-out passthrough", () => {
     },
     60_000,
   );
+
+  // #1093. `stream: true` used to be forwarded verbatim: the provider
+  // generated (and charged for) an SSE response, the dispatch path — which
+  // reads the upstream answer as a single JSON document — failed to decode
+  // it, and the caller got a 502 with no usage recorded. The upstream had
+  // already done the work.
+  //
+  // The route has no streaming relay, so the request is refused instead,
+  // and refused BEFORE the provider is contacted. That the upstream is
+  // never called is the property under test: a fix that returned 400 after
+  // dispatching would still have the caller paying for a refused request,
+  // and a status-only assertion could not tell the two apart.
+  test(
+    "POST /v1/completions with stream:true is refused without calling the upstream",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      const reqHeaders = {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      };
+      await waitConfigPropagation(async () => {
+        try {
+          const r = await fetch(`${app!.proxyUrl}/v1/completions`, {
+            method: "POST",
+            headers: reqHeaders,
+            body: JSON.stringify({
+              model: "completions-legacy-model",
+              prompt: "ready-probe-stream",
+            }),
+          });
+          await r.text();
+          return r.status === 200;
+        } catch {
+          return false;
+        }
+      });
+
+      const baseline = upstream.receivedRequests.length;
+      const res = await fetch(`${app.proxyUrl}/v1/completions`, {
+        method: "POST",
+        headers: reqHeaders,
+        body: JSON.stringify({
+          model: "completions-legacy-model",
+          prompt: PROMPT_TEXT,
+          stream: true,
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as {
+        error?: { message?: string; type?: string };
+      };
+      expect(body.error?.type).toBe("invalid_request_error");
+      // The message names the endpoint that does stream, so a caller can
+      // act on it without reading the docs.
+      expect(body.error?.message).toContain("`stream` is not supported");
+      expect(body.error?.message).toContain("/v1/chat/completions");
+
+      // The no-billing property: the provider was never asked.
+      expect(upstream.receivedRequests.slice(baseline)).toHaveLength(0);
+    },
+    60_000,
+  );
+
+  test(
+    "POST /v1/completions without stream still answers 200 with usage",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+
+      // The other half of the #1093 contract: the refusal is scoped to the
+      // streaming request. An over-broad guard — reading `stream` as
+      // "present" rather than "true" — would take the ordinary path down
+      // with it, and `stream: false` is what an SDK sends by default.
+      const reqHeaders = {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      };
+      const baseline = upstream.receivedRequests.length;
+      const res = await fetch(`${app.proxyUrl}/v1/completions`, {
+        method: "POST",
+        headers: reqHeaders,
+        body: JSON.stringify({
+          model: "completions-legacy-model",
+          prompt: PROMPT_TEXT,
+          stream: false,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        object?: string;
+        choices?: Array<{ text?: string }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+      };
+      expect(body.object).toBe("text_completion");
+      expect(body.choices?.[0]?.text).toBe(COMPLETION_TEXT);
+      expect(body.usage?.prompt_tokens).toBe(6);
+      expect(body.usage?.completion_tokens).toBe(7);
+      expect(body.usage?.total_tokens).toBe(13);
+
+      const sent = upstream.receivedRequests
+        .slice(baseline)
+        .filter((r) => r.path === "/v1/completions");
+      expect(sent).toHaveLength(1);
+      expect(JSON.parse(sent[0]!.body).stream).toBe(false);
+    },
+    60_000,
+  );
 });

--- a/tests/e2e/src/cases/completions-legacy-e2e.test.ts
+++ b/tests/e2e/src/cases/completions-legacy-e2e.test.ts
@@ -265,8 +265,12 @@ describe("legacy /v1/completions e2e: text-in / text-out passthrough", () => {
       expect(body.error?.type).toBe("invalid_request_error");
       // The message names the endpoint that does stream, so a caller can
       // act on it without reading the docs.
-      expect(body.error?.message).toContain("`stream` is not supported");
-      expect(body.error?.message).toContain("/v1/chat/completions");
+      // Pinned whole, not by substring: this exact sentence is what the
+      // published docs quote, so a reworded message has to come here first.
+      expect(body.error?.message).toBe(
+        "request payload is invalid: `stream` is not supported on " +
+          "/v1/completions; use /v1/chat/completions for streaming",
+      );
 
       // The no-billing property: the provider was never asked.
       expect(upstream.receivedRequests.slice(baseline)).toHaveLength(0);

--- a/tests/e2e/src/cases/realtime-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/realtime-model-echo-e2e.test.ts
@@ -1,0 +1,322 @@
+import { createHash } from "node:crypto";
+import { WebSocket as WsClient, WebSocketServer, type WebSocket as WsSocket } from "ws";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  waitConfigPropagation,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: `/v1/realtime` names the model the CALLER addressed (#1088).
+//
+// `session.created` and `session.updated` are the only Realtime server
+// events that carry a model, under `session.model`, and the relay used to
+// hand the provider's own value straight through — so a caller who
+// connected with a gateway alias was told a different model name than the
+// one they asked for. Same divergence #1086 removed from the HTTP native
+// passthrough paths.
+//
+// The scenario is the one an alias exists for: the operator configures
+// `model_name` (what to ask the provider for) and the provider answers with
+// a DIFFERENT id. Every frame below therefore reports
+// `UPSTREAM_REPORTED_MODEL`, which matches neither the caller's alias nor
+// the configured `model_name`.
+//
+// The reverse direction is covered too, because this fix creates the need
+// for it: a client that echoes the session object back as `session.update`
+// now sends the alias where it used to send the provider's id.
+
+const CALLER_PLAINTEXT = "sk-realtime-model-echo-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const ALIAS = "echo-realtime";
+/** What the operator configured as the upstream model id. */
+const CONFIGURED_MODEL_NAME = "gpt-realtime-mock";
+/** What the provider actually answers with — deliberately neither of the other two. */
+const UPSTREAM_REPORTED_MODEL = "gpt-realtime-2026-01-01";
+/**
+ * A SECOND model the client configures itself, nested inside the session's
+ * audio config. The gateway never aliased it, so restamping it would rename
+ * a model the caller is entitled to see under its real name.
+ */
+const CLIENT_TRANSCRIPTION_MODEL = "gpt-4o-transcribe";
+
+interface RealtimeUpstream {
+  port: number;
+  /** Every text frame the gateway relayed upstream. */
+  frames: string[];
+  close(): Promise<void>;
+}
+
+/**
+ * Mock OpenAI Realtime upstream: greets with `session.created`, answers a
+ * `session.update` with `session.updated`, and anything else with a
+ * `response.done`. Every session frame names `UPSTREAM_REPORTED_MODEL` at
+ * `session.model` and `CLIENT_TRANSCRIPTION_MODEL` deeper down.
+ */
+async function startRealtimeUpstream(): Promise<RealtimeUpstream> {
+  const frames: string[] = [];
+  const sessionObject = {
+    id: "sess_echo_01",
+    object: "realtime.session",
+    model: UPSTREAM_REPORTED_MODEL,
+    output_modalities: ["audio"],
+    audio: {
+      input: { transcription: { model: CLIENT_TRANSCRIPTION_MODEL } },
+    },
+  };
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  wss.on("connection", (socket: WsSocket) => {
+    socket.send(
+      JSON.stringify({
+        type: "session.created",
+        event_id: "ev_created",
+        session: sessionObject,
+      }),
+    );
+    socket.on("message", (data) => {
+      const text = data.toString();
+      frames.push(text);
+      const type = (JSON.parse(text) as { type?: string }).type;
+      if (type === "session.update") {
+        socket.send(
+          JSON.stringify({
+            type: "session.updated",
+            event_id: "ev_updated",
+            session: sessionObject,
+          }),
+        );
+        return;
+      }
+      socket.send(
+        JSON.stringify({
+          type: "response.done",
+          response: {
+            id: "resp_echo_01",
+            usage: { input_tokens: 9, output_tokens: 4 },
+          },
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve) => wss.on("listening", resolve));
+  const addr = wss.address();
+  if (addr === null || typeof addr === "string") throw new Error("no port");
+  return {
+    port: addr.port,
+    frames,
+    close: () =>
+      new Promise<void>((resolve, reject) => wss.close((e) => (e ? reject(e) : resolve()))),
+  };
+}
+
+/** Open a relay session: send frames, and await the next one the gateway delivers. */
+function session(app: SpawnedApp): {
+  send(frame: unknown): void;
+  next(): Promise<string>;
+  close(): void;
+  opened: Promise<void>;
+} {
+  const url = `${app.proxyUrl.replace("http://", "ws://")}/v1/realtime?model=${ALIAS}`;
+  const ws = new WsClient(url, {
+    headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+  });
+  const inbox: string[] = [];
+  const waiters: Array<(v: string) => void> = [];
+  ws.on("message", (d) => {
+    const text = d.toString();
+    const waiter = waiters.shift();
+    if (waiter) waiter(text);
+    else inbox.push(text);
+  });
+  return {
+    opened: new Promise<void>((resolve, reject) => {
+      ws.on("open", () => resolve());
+      ws.on("unexpected-response", (_q, res) =>
+        reject(new Error(`upgrade refused: ${res.statusCode}`)),
+      );
+      ws.on("error", (e) => reject(e));
+    }),
+    send: (frame) => ws.send(JSON.stringify(frame)),
+    next: () =>
+      new Promise<string>((resolve) => {
+        const buffered = inbox.shift();
+        if (buffered !== undefined) resolve(buffered);
+        else waiters.push(resolve);
+      }),
+    close: () => ws.terminate(),
+  };
+}
+
+describe("realtime model echo e2e: session frames name what the caller asked for", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: RealtimeUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    upstream = await startRealtimeUpstream();
+
+    const pk = await seed.createProviderKey({
+      display_name: "realtime-echo-pk",
+      secret: "sk-upstream-realtime",
+      api_base: `http://127.0.0.1:${upstream.port}/v1`,
+    });
+    await seed.createModel({
+      display_name: ALIAS,
+      provider: "openai",
+      model_name: CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+
+    // Gate on the DP snapshot: the WS upgrade authenticates against the same
+    // snapshot, and a handshake fired before the caller key propagates is
+    // rejected outright.
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+      });
+      if (res.status !== 200) {
+        await res.text();
+        return false;
+      }
+      const body = (await res.json()) as { data?: Array<{ id?: string }> };
+      return (body.data ?? []).some((m) => m.id === ALIAS);
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test(
+    "session.created and session.updated name the alias, not the upstream id",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) return void ctx.skip();
+
+      const s = session(app);
+      await s.opened;
+
+      const created = JSON.parse(await s.next()) as {
+        type?: string;
+        session?: {
+          model?: string;
+          id?: string;
+          audio?: { input?: { transcription?: { model?: string } } };
+        };
+      };
+      expect(created.type).toBe("session.created");
+      expect(created.session?.model).toBe(ALIAS);
+      // The alias is the whole point: neither the provider's own id nor the
+      // configured upstream name may reach the caller in that slot.
+      expect(created.session?.model).not.toBe(UPSTREAM_REPORTED_MODEL);
+      expect(created.session?.model).not.toBe(CONFIGURED_MODEL_NAME);
+      // Everything else in the session object relays as written — including
+      // the transcription model the CLIENT configured, which is a different
+      // model and was never aliased.
+      expect(created.session?.id).toBe("sess_echo_01");
+      expect(created.session?.audio?.input?.transcription?.model).toBe(
+        CLIENT_TRANSCRIPTION_MODEL,
+      );
+
+      s.send({ type: "session.update", session: { instructions: "hi" } });
+      const updated = JSON.parse(await s.next()) as {
+        type?: string;
+        session?: { model?: string };
+      };
+      expect(updated.type).toBe("session.updated");
+      expect(updated.session?.model).toBe(ALIAS);
+
+      s.close();
+    },
+    60_000,
+  );
+
+  test(
+    "a client that echoes the session back reaches the provider with the provider's own id",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) return void ctx.skip();
+
+      // The mirror of the fix above, and the reason it is needed: the
+      // gateway just told this client its model is `echo-realtime`, so the
+      // ordinary read-modify-write of the session object sends that name
+      // back up. Before the restamp the client would have echoed the
+      // provider's own id and the provider would have recognised it.
+      const s = session(app);
+      await s.opened;
+      const created = JSON.parse(await s.next()) as { session?: { model?: string } };
+      expect(created.session?.model).toBe(ALIAS);
+
+      const baseline = upstream.frames.length;
+      s.send({
+        type: "session.update",
+        session: { model: created.session?.model, instructions: "carry on" },
+      });
+      await s.next();
+
+      const relayed = JSON.parse(upstream.frames[baseline]!) as {
+        session?: { model?: string; instructions?: string };
+      };
+      expect(relayed.session?.model).toBe(CONFIGURED_MODEL_NAME);
+      expect(relayed.session?.instructions).toBe("carry on");
+
+      // Only the alias is translated. A client naming something else keeps
+      // its own words, so the provider answers about the model the client
+      // actually named rather than one the gateway substituted.
+      const otherBaseline = upstream.frames.length;
+      s.send({
+        type: "session.update",
+        session: { model: "some-other-model" },
+      });
+      await s.next();
+      const other = JSON.parse(upstream.frames[otherBaseline]!) as {
+        session?: { model?: string };
+      };
+      expect(other.session?.model).toBe("some-other-model");
+
+      s.close();
+    },
+    60_000,
+  );
+
+  test(
+    "frames that name no model relay byte-for-byte",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) return void ctx.skip();
+
+      // The Response object a `response.done` frame carries has no `model`
+      // field at all, so the relay must not acquire one — and the usage the
+      // session accounting reads off it must survive untouched.
+      const s = session(app);
+      await s.opened;
+      await s.next(); // session.created
+
+      s.send({ type: "response.create" });
+      const done = JSON.parse(await s.next()) as {
+        type?: string;
+        model?: unknown;
+        response?: { id?: string; model?: unknown; usage?: { input_tokens?: number } };
+      };
+      expect(done.type).toBe("response.done");
+      expect(done.response?.id).toBe("resp_echo_01");
+      expect(done.response?.usage?.input_tokens).toBe(9);
+      expect(done.model).toBeUndefined();
+      expect(done.response?.model).toBeUndefined();
+
+      s.close();
+    },
+    60_000,
+  );
+});

--- a/tests/e2e/src/cases/unsupported-capability-501-e2e.test.ts
+++ b/tests/e2e/src/cases/unsupported-capability-501-e2e.test.ts
@@ -1,0 +1,154 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: the three optional passthrough operations answer 501 when the
+// provider's adapter does not implement them.
+//
+// Each is produced by a `Bridge` default implementation, and until #1093
+// the route decided the status by searching the resulting error's MESSAGE
+// for a phrase. Nothing in the tree pinned the link, so rewording that
+// sentence would have turned every one of these 501s into a 500 silently.
+// These cases are that link, asserted from outside: a real gateway, a real
+// adapter that lacks the capability, and the status the caller gets.
+//
+// The Anthropic adapter is the one that keeps all three defaults. It is
+// reached here through the provider key, which is what selects the bridge —
+// the model's own `provider` only gates which routes will dispatch at all,
+// which is why the image case names `openai` there and still lands on the
+// Anthropic bridge.
+
+const CALLER_PLAINTEXT = "sk-unsupported-capability-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+const HEADERS = {
+  authorization: `Bearer ${CALLER_PLAINTEXT}`,
+  "content-type": "application/json",
+};
+
+/** Model whose bridge implements chat and nothing else. */
+const CHAT_ONLY = "capability-gap-model";
+/** Same bridge, but declared `provider: openai` so `/v1/images/generations` dispatches. */
+const CHAT_ONLY_IMAGES = "capability-gap-images";
+
+describe("unsupported capability e2e: an adapter that lacks the operation answers 501", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    // Never contacted — the refusal happens before any request is built.
+    // Seeded anyway so the configuration is an ordinary one and the 501
+    // cannot be an artefact of an unreachable upstream.
+    upstream = await startOpenAiUpstream({ nonStreamBody: { ok: true } });
+
+    const pk = await seed.createProviderKey({
+      display_name: "capability-gap-pk",
+      secret: "sk-anthropic-mock",
+      api_base: upstream.baseUrl,
+      provider: "anthropic",
+      adapter: "anthropic",
+    });
+    await seed.createModel({
+      display_name: CHAT_ONLY,
+      provider: "anthropic",
+      model_name: "claude-capability-mock",
+      provider_key_id: pk.id,
+    });
+    await seed.createModel({
+      display_name: CHAT_ONLY_IMAGES,
+      provider: "openai",
+      model_name: "claude-capability-mock",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      if (res.status !== 200) {
+        await res.text();
+        return false;
+      }
+      const body = (await res.json()) as { data?: Array<{ id?: string }> };
+      const ids = (body.data ?? []).map((m) => m.id);
+      return ids.includes(CHAT_ONLY) && ids.includes(CHAT_ONLY_IMAGES);
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  const cases: Array<{ route: string; model: string; body: unknown; capability: string }> = [
+    {
+      route: "/v1/completions",
+      model: CHAT_ONLY,
+      body: { prompt: "say ok" },
+      capability: "text completions",
+    },
+    {
+      route: "/v1/embeddings",
+      model: CHAT_ONLY,
+      body: { input: "say ok" },
+      capability: "embeddings",
+    },
+    {
+      route: "/v1/images/generations",
+      model: CHAT_ONLY_IMAGES,
+      body: { prompt: "a cardboard city" },
+      capability: "image generation",
+    },
+  ];
+
+  for (const c of cases) {
+    test(
+      `${c.route} answers 501 when the adapter does not implement it`,
+      async (ctx) => {
+        if (!etcdReachable || !app || !upstream) return void ctx.skip();
+
+        const baseline = upstream.receivedRequests.length;
+        const res = await fetch(`${app.proxyUrl}${c.route}`, {
+          method: "POST",
+          headers: HEADERS,
+          body: JSON.stringify({ model: c.model, ...(c.body as object) }),
+        });
+
+        expect(res.status).toBe(501);
+        const body = (await res.json()) as {
+          error?: { message?: string; type?: string };
+        };
+        expect(body.error?.type).toBe("not_implemented");
+        // The message names the capability, which is what tells an operator
+        // to point the alias at a different provider.
+        expect(body.error?.message).toBe(
+          `this provider does not support ${c.capability}`,
+        );
+
+        // No provider was contacted, so there is nothing to bill and
+        // nothing to retry.
+        expect(upstream.receivedRequests.slice(baseline)).toHaveLength(0);
+      },
+      60_000,
+    );
+  }
+});


### PR DESCRIPTION
Three reported defects on the native passthrough surfaces, plus one refactor that removes a status decision made by reading an error message.

## `/v1/completions` with `stream: true` billed the upstream, then 502'd the caller

`stream` was forwarded verbatim. The provider answered with SSE, the dispatch path — which reads the upstream answer as a single JSON document — failed to decode it, and the caller got:

```
502 {"error":{"message":"upstream returned an unparseable body: error decoding response body","type":"upstream_decode_error"}}
```

So the provider did the work and charged for it, the caller got an error, and no usage row was recorded.

This route has no streaming relay, and it is not getting one: the request is refused instead, **before the provider is contacted**, which is the point — the upstream must not bill for a request the gateway is going to fail. Callers who want to stream text generation use `/v1/chat/completions`.

```
400 {"error":{"message":"request payload is invalid: `stream` is not supported on /v1/completions; use /v1/chat/completions for streaming","type":"invalid_request_error"}}
```

The refusal sits after model resolution and the client-IP gate (so an unknown model still answers 404 and the error carries the attribution `resolve_model` recorded) and before the guardrail chain and the rate-limit reservation (so a request that cannot be served burns neither) — the same placement `/v1/images/edits` already uses for its own `stream` refusal. Non-streaming `/v1/completions` is unchanged; `stream: false` still dispatches.

## `/v1/rerank` handed back the upstream's model id

`response.model` names the model the **caller** addressed, never the provider's own id — the contract `render.rs` states and #1086 applied to the other native passthrough paths. `/v1/rerank` was left out of that PR because its cost was misjudged at the time, not because it is expensive.

Among the supported rerank backends this shows on Jina, whose response carries a top-level `model`; the Cohere and OpenAI-compatible shapes carry none, so the change is a no-op on those rather than inventing the field. The handler already parses the whole body to read usage before relaying it, so the value is spliced through `json_splice` and every other byte the provider wrote — key order, whitespace, relevance-score spellings — reaches the caller exactly as written.

This is the first depth-1 path predicate in production code (the two existing ones are depth-2), so it carries its own unit coverage rather than inheriting confidence from them.

## `/v1/realtime` relayed the upstream's model id in its session frames

`session.created` and `session.updated` carry the model under `session.model`, and it reached the client as the provider wrote it — so a caller who connected with a gateway alias was told a different model name.

Those two are the only Realtime server events that name a model. The Response object a `response.created` / `response.done` frame carries has no `model` field, so nothing else on the surface needed covering. The predicate is depth-exact for a second reason: a session's audio config can name a **separate** transcription model at `session.audio.input.transcription.model`, which the client chose itself and the gateway never aliased — restamping that one would rename a model the caller is entitled to see under its real name.

### The relay now translates that one name back on the way up

This half exists because of the half above. Realtime clients routinely read the session object, change a field, and send the whole thing back as `session.update` — which after this change carries the gateway's alias where it used to carry the provider's own id. Only the alias the gateway handed out is translated back; a client naming anything else reaches the provider with its own words and gets the provider's own answer about it.

It does not let a client switch models mid-session: the model is fixed by the connect-time query parameter, and `session.update` cannot change it.

## Typing the unsupported-capability error

`/v1/completions`, `/v1/embeddings` and `/v1/images/generations` each answer 501 when the provider's adapter does not implement the operation, and each recognised that case by matching a `BridgeError::Config` whose **message text** contained a phrase. Those messages are produced by the `Bridge` trait's default implementations several hundred lines away, and nothing connected the two: rewording either sentence turned a 501 into a 500 with nothing to go red.

`BridgeError::UnsupportedCapability(BridgeCapability)` replaces the string. The three defaults return it, the three routes match on it, and the capability is a closed enum rather than prose.

**Client-visible responses are unchanged.** The three routes still build the 501 inline (they answer it as a dispatch success, not through `ProxyError`) and still render the same sentence into it, now from the typed error's `Display`. The variant's entries in the central table are deliberately identical to `Config`'s — 500, `config_error`, attempt error class `config` — because two other callers of the `embed` default, the semantic router and the guardrail embedder, surface it through that table; mapping it to 501 there would change what they return, which is out of scope here.

### Behavior change

A capability gap is no longer retryable. It is static per adapter — the same call answers the same way every time — yet as a `Config` error it was retryable, so the model's whole retry budget was spent, with backoff between attempts, before the 501 reached the caller. There is no failover underneath that `false`: all three routes dispatch through `routing::retrying_dispatch`, which walks no candidates, and they refuse a routing model outright in `dispatch::require_provider`. The one loop that does fail over calls only `chat` / `chat_stream`, which have no default implementation that can raise this.

A client reading `model` off a `/v1/rerank` response, or `session.model` off a `/v1/realtime` session frame, now sees the gateway model name it asked for where it previously saw the provider's own id. `/v1/completions` with `stream: true` now answers 400 instead of 502.

## The sibling this does not fix

`/v1/images/generations` has the identical bug class and is **deferred to #1101**, not overlooked. It forwards `stream` verbatim and `generate_image` ends in `resp.json::<Value>()`, so `gpt-image-1`'s `partial_images` SSE fails to decode. It is worse there than it was here: the failure surfaces as `UpstreamDecode`, which is *retryable*, so one request re-runs the whole generation for the model's entire retry budget — N+1 billed image generations, then a 502.

It is split out rather than folded in because refusing is a client-visible status change (400 where callers get 502 today) on a route this effort's scope did not cover, and because the alternative — relaying partial-image SSE, which `/v1/images/edits` deferred rather than declined — is a live option there in a way it was not for `/v1/completions`. `/v1/images/edits` already refuses, so `/v1/images/generations` is the one endpoint in the family that neither relays a stream nor rejects one.

## Tests

- `completions-legacy-e2e`: `stream: true` returns 400 **and** the mock upstream received zero requests — the no-billing property is the thing under test, and a status-only assertion could not tell a pre-dispatch refusal from a post-dispatch one. Paired with a case pinning that `stream: false` still answers 200 with usage, so an over-broad guard reading "present" rather than "true" would not pass.
- `client-facing-model-echo-e2e`: a Jina-shaped upstream reporting an id matching neither the alias nor the configured `model_name`, matching the cases #1086 added, plus assertions that the scores relay untouched.
- `realtime-model-echo-e2e` (new): both session frames, the nested transcription model left alone, the reverse translation, a client naming a different model keeping its own words, and a `response.done` frame acquiring no `model`.
- `unsupported-capability-501-e2e` (new): one case per route, driving a real adapter that lacks the operation. This is the link that had no test — reverting one default impl to the untyped `Config` turns its case red with a 500.
- Unit: the depth-1 and depth-2 predicates' precision and byte preservation; each default impl returning the right capability and rendering the message the routes put on the wire; a retry-loop test with a `Config` control showing the budget is spent on one and not the other.
- `attempt.rs`'s variant-classifying test is now an exhaustive match, so a new `BridgeError` variant stops compiling until someone decides which side of the network boundary it sits on and which telemetry class it reports. It used to be two hand-written lists a new variant could sit outside of.

Every fix was mutation-checked locally: reverting each one turns its case red.

Fixes #1093
Fixes #1087
Fixes #1088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Model aliases are consistently shown in rerank responses and realtime session events, while provider model identifiers remain hidden.
  - Realtime model updates translate aliases correctly between clients and providers.
  - Unsupported embeddings, completions, and image generation capabilities return clear HTTP 501 errors without contacting the provider.

- **Bug Fixes**
  - Streaming requests to legacy completions are rejected with HTTP 400 guidance to use chat completions.
  - Unsupported capabilities no longer trigger unnecessary retries.
  - Response content and formatting remain intact when model names are rewritten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
