### PR TITLE
fix(proxy): scan every frame of a buffered SSE body, and refuse streamed image generations

### DIFF
--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -277,6 +277,29 @@ async fn dispatch(
     // Client-IP allowlist gate (#557): reject before guardrails / upstream.
     crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;
 
+    // #1101: partial-image SSE (`stream: true`) is not relayed on this
+    // route, and the dispatch below reads the upstream answer as a single
+    // JSON document. Forwarding `stream` had the provider generate — and
+    // charge for — a stream the gateway then failed to decode; that decode
+    // failure is retryable, and this route dispatches through
+    // `retrying_dispatch`, so ONE caller request re-ran the generation for
+    // the whole retry budget and still answered 502.
+    //
+    // Refuse it here, before the provider is contacted, and in the same
+    // words `/v1/images/edits` already uses — the two are one family and a
+    // caller should not have to learn two refusals. Unlike /v1/completions
+    // there is no streaming route to point at, so the message names none.
+    //
+    // Rejected AFTER model resolution so an unknown model still answers 404
+    // (matching the other JSON endpoints' precedence), and BEFORE the
+    // guardrail chain and the rate-limit reservation so a request that
+    // cannot be served burns neither.
+    if body.get("stream").and_then(Value::as_bool) == Some(true) {
+        return Err(ProxyError::InvalidRequest(
+            "`stream` is not supported on /v1/images/generations".into(),
+        ));
+    }
+
     // #545: /v1/images/generations must run input guardrails. Before this it
     // forwarded the user `prompt` with no configured content/DLP check, so a
     // block enforced on /v1/chat/completions was bypassable by switching

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -3388,8 +3388,12 @@ fn drain_anthropic_sse_frames(
     // tolerate `\r\n\r\n` defensively by normalising the search.
     while let Some(end) = find_frame_end(buf) {
         let frame: Vec<u8> = buf.drain(..end).collect();
-        if let Some(data) = extract_sse_data_line(&frame) {
-            if let Ok(json) = serde_json::from_slice::<Value>(data) {
+        // The frame's WHOLE payload, not just its first `data:` line: this
+        // is what feeds `response_text`, the text the end-of-stream output
+        // guardrail scans, and a payload split over several `data:` lines
+        // parses only once they are joined (#1100).
+        if let Some(payload) = crate::redact::frame_payload(&frame) {
+            if let Ok(json) = serde_json::from_str::<Value>(payload.trim()) {
                 update_anthropic_usage(acc, &json, attempt_started, first_token_seen);
             }
         }
@@ -3736,8 +3740,8 @@ where
             //
             // Its counts are as real as any other frame's, so read them
             // whether or not the fragment survives the seal below.
-            if let Some(data) = extract_sse_data_line(&tail) {
-                if let Ok(json) = serde_json::from_slice::<Value>(data) {
+            if let Some(payload) = crate::redact::frame_payload(&tail) {
+                if let Ok(json) = serde_json::from_str::<Value>(payload.trim()) {
                     update_anthropic_usage(
                         guard.usage(),
                         &json,
@@ -3772,41 +3776,6 @@ where
                     return;
                 }
                 held.extend_from_slice(&tail);
-                // #1091: seal what will actually be released. Held
-                // unterminated, this fragment was read by the block scan
-                // (which parses text out line by line) but handed back by
-                // the redaction pass as `trailing` and appended verbatim —
-                // so a maskable literal in the last frame went out unmasked.
-                // Sealed, it is an ordinary frame to both passes. Sealing
-                // `held` rather than the fragment alone is deliberate: the
-                // frames already in it are what say which line ending this
-                // upstream writes.
-                if let crate::redact::SseTailSeal::Dropped { dropped } =
-                    crate::redact::seal_buffered_sse(&mut held)
-                {
-                    // Not one parseable frame — nothing can extract its
-                    // text, so releasing it WOULD be the bypass.
-                    tracing::warn!(
-                        guardrail_hook = "output",
-                        dropped,
-                        "streaming /v1/messages passthrough ended on an SSE frame that \
-                         could not be scanned; dropping it rather than releasing it past \
-                         the output guardrail",
-                    );
-                    // When that fragment was the ENTIRE response, dropping it
-                    // silently would hand the caller an empty 200 and no signal at
-                    // all — and the scan is skipped too, since nothing ever
-                    // reached `response_text`. Refuse explicitly instead, the same
-                    // shape the frame-cap arm above uses.
-                    if held.is_empty() {
-                        guard.usage().guardrail_blocked = true;
-                        yield Ok(Bytes::from(guardrail_block_frame(
-                            None,
-                            Some(crate::error::TAG_UNSCANNABLE_BODY),
-                        )));
-                        return;
-                    }
-                }
             } else {
                 // Restamp on the way out, for the same reason the `/v1/responses`
                 // relay does: the upstream has ended, so this is a final frame it
@@ -3830,6 +3799,53 @@ where
                 yield Ok(Bytes::from(tail));
             }
         }
+        // #1091/#1100: seal what will actually be released, before either
+        // pass reads it. The block scan takes its text from the frames the
+        // drain loop parsed, while the redaction pass walks the held bytes
+        // as terminator-delimited frames — so anything the drain loop could
+        // not parse was in `held` having been read by neither. Sealing
+        // `held` whole (rather than the EOF fragment alone) is what makes
+        // the two agree: an unterminated final frame that parses gets the
+        // terminator its upstream left off, and a frame whose payload is
+        // not one JSON document is cut, since nothing can mask it.
+        let mut unscanned: Vec<String> = Vec::new();
+        if hold_policy.is_some() {
+            let seal = crate::redact::seal_buffered_sse(&mut held);
+            if let crate::redact::SseTailSeal::Dropped { dropped } = seal.tail {
+                tracing::warn!(
+                    guardrail_hook = "output",
+                    dropped,
+                    "streaming /v1/messages passthrough ended on an SSE frame that \
+                     could not be scanned; dropping it rather than releasing it past \
+                     the output guardrail",
+                );
+            }
+            if !seal.excised.is_empty() {
+                tracing::warn!(
+                    guardrail_hook = "output",
+                    frames = seal.excised.len(),
+                    dropped = seal.excised_bytes,
+                    "streaming /v1/messages passthrough carried SSE frames whose payload \
+                     is not one JSON document; dropping them rather than releasing them \
+                     past the output guardrail (their text is still scanned)",
+                );
+            }
+            // When the cut took the ENTIRE response, dropping it silently
+            // would hand the caller an empty 200 and no signal at all — and
+            // the scan below is skipped too, since nothing ever reached
+            // `response_text`. Refuse explicitly instead, the same shape the
+            // frame-cap arm above uses. A `held` that was empty to begin
+            // with is an empty upstream response and is left alone.
+            if held.is_empty() && seal.cut_anything() {
+                guard.usage().guardrail_blocked = true;
+                yield Ok(Bytes::from(guardrail_block_frame(
+                    None,
+                    Some(crate::error::TAG_UNSCANNABLE_BODY),
+                )));
+                return;
+            }
+            unscanned = seal.excised;
+        }
         // Upstream stream over. Record it before the scan below, which awaits
         // a remote provider and is a routine drop point for clients that close
         // on the terminal event. NOT the same as "all of it was forwarded":
@@ -3847,11 +3863,22 @@ where
             // Clone (not take) when content capture is on, so the assembled
             // response survives for the on_complete content capture below;
             // otherwise take it (nothing downstream reads it).
-            let text = if content_cap.is_some() {
+            let mut text = if content_cap.is_some() {
                 guard.usage().response_text.clone()
             } else {
                 std::mem::take(&mut guard.usage().response_text)
             };
+            // #1100: an excised frame is not released, but a forbidden
+            // literal inside it must still block the response — the block
+            // pass reads raw text, so it can scan a payload nothing could
+            // parse. Appended to the scanned copy only: it never reached
+            // the client, so it must not reach the captured content either.
+            for payload in &unscanned {
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(payload);
+            }
             if !text.is_empty() {
                 let synth = aisix_gateway::ChatResponse {
                     id: String::new(),

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -825,9 +825,11 @@ struct SseFrame {
 }
 
 impl SseFrame {
-    /// Re-render the frame: the first `data:` line is replaced with the
-    /// re-serialised payload (subsequent `data:` lines dropped); every
-    /// other line passes through untouched.
+    /// Re-render the frame: the first `data:` line carries the whole
+    /// re-serialised payload and the frame's other `data:` lines go with
+    /// it; every other line passes through untouched. Collapsing them is
+    /// not a loss — the payload is the lines joined with `\n`, and a
+    /// compact JSON document holds none, so one line says the same thing.
     fn render(&self) -> Vec<u8> {
         if !self.dirty {
             return self.raw.clone();
@@ -904,23 +906,59 @@ fn last_frame_end(raw: &[u8]) -> usize {
     end
 }
 
-/// The text of a frame's `data:` line, un-parsed (`None` = the frame
-/// carries no `data:` line at all — a comment or keepalive).
-fn frame_data_line(frame_raw: &[u8]) -> Option<String> {
-    String::from_utf8_lossy(frame_raw)
-        .split('\n')
-        .find(|l| l.starts_with("data:"))
-        .map(|l| l["data:".len()..].trim().to_owned())
+/// A frame's `data:` payload, un-parsed (`None` = the frame carries no
+/// `data:` line at all — a comment or keepalive).
+///
+/// A frame may carry SEVERAL `data:` lines, and the payload is all of them
+/// joined with `\n`; one leading space after the colon belongs to the
+/// framing, not the payload
+/// (<https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation>).
+/// Reading only the first line truncates the payload silently, which is
+/// how such a frame used to be invisible to the scan and rendered down to
+/// its first line by the redactor (#1100).
+pub(crate) fn frame_payload(frame_raw: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(frame_raw);
+    let mut lines = text.split('\n').filter_map(|l| {
+        let l = l.strip_suffix('\r').unwrap_or(l);
+        let l = l.strip_prefix("data:")?;
+        Some(l.strip_prefix(' ').unwrap_or(l))
+    });
+    let mut payload = lines.next()?.to_owned();
+    for l in lines {
+        payload.push('\n');
+        payload.push_str(l);
+    }
+    Some(payload)
 }
 
-/// Every `data:` line in a frame, un-parsed. A well-formed frame has at
-/// most one; more than one means the bytes are not one frame.
-fn frame_data_lines(frame_raw: &[u8]) -> Vec<String> {
-    String::from_utf8_lossy(frame_raw)
-        .split('\n')
-        .filter(|l| l.starts_with("data:"))
-        .map(|l| l["data:".len()..].trim().to_owned())
-        .collect()
+/// The `data:` payload of every frame in a buffered SSE body, in order,
+/// plus a trailing unterminated fragment's if there is one. Frames with no
+/// `data:` line are skipped.
+///
+/// The line-based block scans read this rather than raw lines, so the
+/// payload they scan is the payload the redaction pass rewrites — the two
+/// cannot disagree about what a frame carries (#1100).
+pub(crate) fn sse_frame_payloads(raw: &[u8]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = raw;
+    while let Some((pos, len)) = frame_terminator(rest) {
+        if let Some(p) = frame_payload(&rest[..pos]) {
+            out.push(p);
+        }
+        rest = &rest[pos + len..];
+    }
+    if let Some(p) = frame_payload(rest) {
+        out.push(p);
+    }
+    out
+}
+
+/// Whether a payload is one the passes can read: one JSON document, or
+/// nothing to read at all (empty, or the `[DONE]` sentinel — both are
+/// skipped by every scan).
+fn payload_scannable(payload: &str) -> bool {
+    let t = payload.trim();
+    t.is_empty() || t == "[DONE]" || serde_json::from_str::<Value>(t).is_ok()
 }
 
 /// Split a buffered SSE byte stream into frames on the blank-line
@@ -936,7 +974,8 @@ fn split_sse_frames(raw: &[u8]) -> (Vec<SseFrame>, &[u8]) {
         let frame_raw = &rest[..pos];
         frames.push(SseFrame {
             raw: frame_raw.to_vec(),
-            data: frame_data_line(frame_raw).and_then(|l| serde_json::from_str::<Value>(&l).ok()),
+            data: frame_payload(frame_raw)
+                .and_then(|l| serde_json::from_str::<Value>(l.trim()).ok()),
             term: if len == 4 { b"\r\n\r\n" } else { b"\n\n" },
             dirty: false,
         });
@@ -958,53 +997,91 @@ pub enum SseTailSeal {
     Dropped { dropped: usize },
 }
 
+/// What [`seal_buffered_sse`] did to a buffered body.
+#[derive(Debug)]
+pub struct BufferedSseSeal {
+    /// The trailing, unterminated fragment's disposition (#1091).
+    pub tail: SseTailSeal,
+    /// The payloads of terminated frames excised because they are not one
+    /// JSON document (#1100) — plain text, or several `data:` lines that
+    /// do not join into one.
+    ///
+    /// They are gone from the buffer, and the caller MUST fold them into
+    /// the text it hands the block scan: nothing can mask such a payload,
+    /// but a forbidden literal in one still has to block the response.
+    pub excised: Vec<String>,
+    /// How many bytes that excision removed (log detail).
+    pub excised_bytes: usize,
+}
+
+impl BufferedSseSeal {
+    /// Whether anything was removed from the buffer. A buffer left empty
+    /// by a cut has nothing scanned in it and must be refused; one that
+    /// was empty to begin with is just an empty upstream response.
+    pub fn cut_anything(&self) -> bool {
+        matches!(self.tail, SseTailSeal::Dropped { .. }) || !self.excised.is_empty()
+    }
+}
+
 /// Seal a fully-buffered SSE body so a guardrail scan and the redaction
-/// pass read the SAME frames (#1091).
+/// pass read the SAME frames, and so nothing in it reaches the client
+/// without having been read by one of them (#1091, #1100).
 ///
-/// A non-conformant upstream can end mid-frame. That fragment is where the
-/// two passes disagreed: the line-based block scan reads whatever lines it
-/// finds, while the frame-based redactor hands the fragment back as
-/// `trailing` and appends it verbatim — never masked. Either way something
-/// unscanned reaches the client.
+/// Two passes run over such a buffer and they used to disagree about what
+/// it contains: the line-based block scan reads whatever `data:` lines it
+/// finds and parses each one, while the frame-based redactor walks
+/// terminator-delimited frames. Wherever they disagreed, something
+/// unscanned reached the client. Both shapes of disagreement are resolved
+/// here, BEFORE either pass runs:
 ///
-/// So the fragment is resolved BEFORE either pass runs, exactly as the
-/// `/v1/messages` EOF tail is:
+/// - **The trailing fragment** (#1091) — a non-conformant upstream can end
+///   mid-frame. If it parses, or carries nothing a scan could read (no
+///   `data:` line at all, an empty payload, or the `[DONE]` sentinel), the
+///   terminator it left off is completed and it becomes an ordinary frame
+///   to both passes. If it does not, it is cut.
+/// - **A terminated frame whose payload is not one JSON document** (#1100)
+///   — plain text, or `data:` lines that do not join into one document.
+///   Neither pass could read it: the scan `continue`s past a line it
+///   cannot parse, and the redactor skips a frame with no parsed payload,
+///   so it was released byte-for-byte having been seen by nothing. Nothing
+///   can mask such a payload structurally, so it is excised and returned
+///   in [`BufferedSseSeal::excised`] for the caller's block scan to read.
 ///
-/// - it is ONE frame and it parses, or carries nothing a scan could read —
-///   no `data:` line at all (a comment / keepalive), an empty payload, or
-///   the `[DONE]` sentinel: complete the terminator the upstream left off. It is then an ordinary
-///   frame, scanned and maskable like every other one, and the client gets a
-///   frame it can actually parse.
-/// - it does not parse, or is not one frame at all (several `data:` lines
-///   with no blank line between them): nothing can extract its text, so
-///   releasing it WOULD be the bypass. It is cut, and the caller warns. A caller whose buffer
-///   is left empty by that cut has nothing scanned at all and must refuse
-///   (`unscannable_body`) rather than answer with an empty 200.
+/// A caller whose buffer is left empty by either cut has nothing scanned
+/// at all and must refuse (`unscannable_body`) rather than answer with an
+/// empty 200.
+///
+/// Note what is NOT cut: a frame carrying several `data:` lines that join
+/// into one JSON document is a well-formed frame, and is scanned and
+/// masked like any other. The payload is the lines joined with `\n` —
+/// reading only the first is the truncation #1100 is about, not a reason
+/// to drop the frame.
+pub fn seal_buffered_sse(buf: &mut Vec<u8>) -> BufferedSseSeal {
+    let tail = seal_sse_tail(buf);
+    let (excised, excised_bytes) = excise_unscannable_frames(buf);
+    BufferedSseSeal {
+        tail,
+        excised,
+        excised_bytes,
+    }
+}
+
+/// Resolve the unterminated trailing fragment (#1091). See
+/// [`seal_buffered_sse`].
 ///
 /// Pads by what is MISSING, not a fixed `\n\n`: a fragment that already
 /// ends in half its terminator needs only the other half, and a full pad
 /// would leave a stray blank line in the released bytes. The upstream's own
 /// line ending is matched, so a CRLF stream stays a CRLF stream.
-pub fn seal_buffered_sse(buf: &mut Vec<u8>) -> SseTailSeal {
+fn seal_sse_tail(buf: &mut Vec<u8>) -> SseTailSeal {
     let end = last_frame_end(buf);
     if end == buf.len() {
         return SseTailSeal::Terminated;
     }
-    let payloads = frame_data_lines(&buf[end..]);
-    // One frame carries one payload here. Several `data:` lines with no
-    // blank line between them are an upstream that never wrote its frame
-    // separators, and padding THAT into a single frame is worse than
-    // leaving it: the redactor renders a rewritten frame down to its first
-    // `data:` line, so masking would silently delete everything after it.
-    // Nothing can frame it, so nothing can scan it — cut it.
-    //
-    // Otherwise: an empty payload and the `[DONE]` sentinel carry no text
-    // (the scan passes skip both), so cutting one protects nothing and
-    // takes the terminal event the client is waiting for with it.
-    let scannable = payloads.len() <= 1
-        && payloads
-            .iter()
-            .all(|l| l.is_empty() || l == "[DONE]" || serde_json::from_str::<Value>(l).is_ok());
+    // An empty payload and the `[DONE]` sentinel carry no text (the scan
+    // passes skip both), so cutting one protects nothing and takes the
+    // terminal event the client is waiting for with it.
+    let scannable = frame_payload(&buf[end..]).is_none_or(|p| payload_scannable(&p));
     if !scannable {
         let dropped = buf.len() - end;
         buf.truncate(end);
@@ -1033,6 +1110,40 @@ pub fn seal_buffered_sse(buf: &mut Vec<u8>) -> SseTailSeal {
     };
     buf.extend_from_slice(pad);
     SseTailSeal::Completed { padded: pad.len() }
+}
+
+/// Cut every terminated frame whose payload is not one JSON document
+/// (#1100), returning those payloads and the bytes removed. See
+/// [`seal_buffered_sse`].
+///
+/// Runs AFTER the tail seal, so a fragment that was padded into a frame is
+/// judged by the same rule as the frames before it.
+fn excise_unscannable_frames(buf: &mut Vec<u8>) -> (Vec<String>, usize) {
+    let mut excised: Vec<String> = Vec::new();
+    let mut excised_bytes = 0usize;
+    let mut kept: Vec<u8> = Vec::with_capacity(buf.len());
+    let mut rest: &[u8] = buf;
+    while let Some((pos, len)) = frame_terminator(rest) {
+        match frame_payload(&rest[..pos]) {
+            // A frame with no `data:` line at all is a comment or a
+            // keepalive: there is nothing in it for a scan to read and
+            // nothing for a mask to rewrite, so it is not a bypass.
+            Some(p) if !payload_scannable(&p) => {
+                excised.push(p);
+                excised_bytes += pos + len;
+            }
+            _ => kept.extend_from_slice(&rest[..pos + len]),
+        }
+        rest = &rest[pos + len..];
+    }
+    if excised.is_empty() {
+        return (excised, 0);
+    }
+    // Empty after the tail seal, but appending it keeps this function
+    // correct on its own terms rather than on its caller's.
+    kept.extend_from_slice(rest);
+    *buf = kept;
+    (excised, excised_bytes)
 }
 
 /// Mask a fully-buffered Anthropic-native SSE response (the `/v1/messages`
@@ -1851,7 +1962,7 @@ mod tests {
         .as_bytes()
         .to_vec();
         assert_eq!(
-            seal_buffered_sse(&mut raw),
+            seal_buffered_sse(&mut raw).tail,
             SseTailSeal::Completed { padded: 2 }
         );
         let (out, counts) = redact_responses_sse(chain.as_ref(), &raw)
@@ -1874,7 +1985,7 @@ mod tests {
         .as_bytes()
         .to_vec();
         assert_eq!(
-            seal_buffered_sse(&mut raw),
+            seal_buffered_sse(&mut raw).tail,
             SseTailSeal::Completed { padded: 2 }
         );
         let (out, counts) = redact_anthropic_sse(chain.as_ref(), &raw)
@@ -1890,7 +2001,7 @@ mod tests {
     fn seal_leaves_a_terminated_body_byte_identical() {
         let raw = b"event: x\ndata: {\"a\":1}\n\n".to_vec();
         let mut sealed = raw.clone();
-        assert_eq!(seal_buffered_sse(&mut sealed), SseTailSeal::Terminated);
+        assert_eq!(seal_buffered_sse(&mut sealed).tail, SseTailSeal::Terminated);
         assert_eq!(sealed, raw);
     }
 
@@ -1899,7 +2010,7 @@ mod tests {
         // Nothing of the terminator written.
         let mut none = b"data: {\"a\":1}".to_vec();
         assert_eq!(
-            seal_buffered_sse(&mut none),
+            seal_buffered_sse(&mut none).tail,
             SseTailSeal::Completed { padded: 2 }
         );
         assert_eq!(none, b"data: {\"a\":1}\n\n");
@@ -1907,14 +2018,14 @@ mod tests {
         // fixed `\n\n` here would leave a stray blank line in the frames.
         let mut half = b"data: {\"a\":1}\n".to_vec();
         assert_eq!(
-            seal_buffered_sse(&mut half),
+            seal_buffered_sse(&mut half).tail,
             SseTailSeal::Completed { padded: 1 }
         );
         assert_eq!(half, b"data: {\"a\":1}\n\n");
         // A comment / keepalive carries nothing to scan, so it is kept.
         let mut comment = b"data: {\"a\":1}\n\n: ping".to_vec();
         assert_eq!(
-            seal_buffered_sse(&mut comment),
+            seal_buffered_sse(&mut comment).tail,
             SseTailSeal::Completed { padded: 2 }
         );
     }
@@ -1934,7 +2045,7 @@ mod tests {
         .as_bytes()
         .to_vec();
         let mut sealed = raw.clone();
-        assert_eq!(seal_buffered_sse(&mut sealed), SseTailSeal::Terminated);
+        assert_eq!(seal_buffered_sse(&mut sealed).tail, SseTailSeal::Terminated);
         assert_eq!(sealed, raw, "a terminated CRLF body must not be repadded");
         let (out, counts) = redact_responses_sse(chain.as_ref(), &sealed).unwrap();
         let out = String::from_utf8(out).unwrap();
@@ -1950,14 +2061,14 @@ mod tests {
     fn seal_matches_the_upstreams_own_line_ending() {
         let mut crlf = b"data: {\"a\":1}\r\n".to_vec();
         assert_eq!(
-            seal_buffered_sse(&mut crlf),
+            seal_buffered_sse(&mut crlf).tail,
             SseTailSeal::Completed { padded: 2 }
         );
         assert_eq!(crlf, b"data: {\"a\":1}\r\n\r\n");
         // Three quarters of a CRLF terminator written.
         let mut partial = b"data: {\"a\":1}\r\n\r".to_vec();
         assert_eq!(
-            seal_buffered_sse(&mut partial),
+            seal_buffered_sse(&mut partial).tail,
             SseTailSeal::Completed { padded: 1 }
         );
         assert_eq!(partial, b"data: {\"a\":1}\r\n\r\n");
@@ -1974,7 +2085,7 @@ mod tests {
         .as_bytes()
         .to_vec();
         assert_eq!(
-            seal_buffered_sse(&mut raw),
+            seal_buffered_sse(&mut raw).tail,
             SseTailSeal::Completed { padded: 4 }
         );
         assert!(raw.ends_with(b"\r\n\r\n"));
@@ -1986,7 +2097,7 @@ mod tests {
         // Half a payload line written: the CR is there, its LF is not.
         let mut half_line = b"data: {\"a\":1}\r\n\r\ndata: {\"b\":2}\r".to_vec();
         assert_eq!(
-            seal_buffered_sse(&mut half_line),
+            seal_buffered_sse(&mut half_line).tail,
             SseTailSeal::Completed { padded: 3 }
         );
         assert!(half_line.ends_with(b"data: {\"b\":2}\r\n\r\n"));
@@ -2006,7 +2117,7 @@ mod tests {
         .as_bytes()
         .to_vec();
         assert!(matches!(
-            seal_buffered_sse(&mut raw),
+            seal_buffered_sse(&mut raw).tail,
             SseTailSeal::Dropped { .. }
         ));
         // Nothing was scanned, so nothing is released — the caller refuses.
@@ -2071,7 +2182,7 @@ mod tests {
                 );
                 // And sealing is settled: a second pass changes nothing.
                 let once = buf.clone();
-                assert_eq!(seal_buffered_sse(&mut buf), SseTailSeal::Terminated);
+                assert_eq!(seal_buffered_sse(&mut buf).tail, SseTailSeal::Terminated);
                 assert_eq!(buf, once, "seal is not idempotent on {before:?}");
             }
             words = next;
@@ -2085,7 +2196,10 @@ mod tests {
         for tail in ["data: [DONE]", "data:"] {
             let mut raw = format!("data: {{\"a\":1}}\n\n{tail}").into_bytes();
             assert!(
-                matches!(seal_buffered_sse(&mut raw), SseTailSeal::Completed { .. }),
+                matches!(
+                    seal_buffered_sse(&mut raw).tail,
+                    SseTailSeal::Completed { .. }
+                ),
                 "cut {tail}",
             );
             assert!(String::from_utf8(raw)
@@ -2100,7 +2214,7 @@ mod tests {
         // scan it, so it must not be released.
         let mut raw = b"data: {\"a\":1}\n\ndata: {\"text\":\"SECRET".to_vec();
         assert_eq!(
-            seal_buffered_sse(&mut raw),
+            seal_buffered_sse(&mut raw).tail,
             SseTailSeal::Dropped { dropped: 21 },
         );
         assert_eq!(raw, b"data: {\"a\":1}\n\n");
@@ -2108,10 +2222,149 @@ mod tests {
         // refuses rather than answering with an empty 200.
         let mut only = b"data: {\"text\":\"SECRET".to_vec();
         assert!(matches!(
-            seal_buffered_sse(&mut only),
+            seal_buffered_sse(&mut only).tail,
             SseTailSeal::Dropped { .. }
         ));
         assert!(only.is_empty());
+    }
+
+    // #1100: the sibling of the fragment above, in the frames BEFORE it. A
+    // terminated frame whose payload is not one JSON document was read by
+    // neither pass — the scan `continue`d past a line it could not parse and
+    // the redactor skipped a frame with no parsed payload — so it went out
+    // byte-for-byte, seen by nothing. And a frame whose payload legitimately
+    // spans several `data:` lines lost every line after the first when the
+    // redactor rewrote it.
+
+    #[test]
+    fn a_frames_payload_is_all_of_its_data_lines_joined() {
+        // Split mid-document, which is exactly what the spec's `\n` join is
+        // for. Reading only the first line leaves neither half parseable.
+        let frame = b"event: x\ndata: {\"type\":\"content_block_delta\",\ndata: \"index\":0}";
+        assert_eq!(
+            frame_payload(frame).as_deref(),
+            Some("{\"type\":\"content_block_delta\",\n\"index\":0}"),
+        );
+        // One leading space belongs to the framing, the rest to the payload.
+        assert_eq!(frame_payload(b"data:  x").as_deref(), Some(" x"));
+        // No `data:` line at all: a comment or keepalive, nothing to read.
+        assert_eq!(frame_payload(b": ping"), None);
+    }
+
+    #[test]
+    fn anthropic_sse_masks_a_frame_whose_payload_spans_several_data_lines() {
+        let chain = both();
+        let mut raw = concat!(
+            "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello \"}}\n\n",
+            // One frame, one JSON document, written over two `data:` lines.
+            "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\n",
+            "data: \"delta\":{\"type\":\"text_delta\",\"text\":\"mail a@x.com\"}}\n\n",
+        )
+        .as_bytes()
+        .to_vec();
+        // Nothing to seal — every frame here is terminated — and nothing to
+        // excise either: the joined payload IS one JSON document.
+        let seal = seal_buffered_sse(&mut raw);
+        assert_eq!(seal.tail, SseTailSeal::Terminated);
+        assert!(seal.excised.is_empty(), "excised: {:?}", seal.excised);
+        let (out, counts) = redact_anthropic_sse(chain.as_ref(), &raw)
+            .expect("the whole payload must reach the redactor");
+        let out = String::from_utf8(out).unwrap();
+        assert!(!out.contains("a@x.com"), "left unmasked: {out}");
+        assert!(out.contains("[EMAIL_REDACTED]"), "out: {out}");
+        assert_eq!(counts.get("email"), Some(&1));
+        // The rewritten frame carries the whole document, re-serialised onto
+        // one `data:` line — the payload is preserved, not truncated to its
+        // first line.
+        assert!(out.contains("\"index\":0"), "second line dropped: {out}");
+        assert!(out.contains("\"text_delta\""), "second line dropped: {out}");
+    }
+
+    #[test]
+    fn responses_sse_masks_a_frame_whose_payload_spans_several_data_lines() {
+        let chain = both();
+        let mut raw = concat!(
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"item_id\":\"m\",\"delta\":\"hello \"}\n\n",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\n",
+            "data: \"item_id\":\"m\",\"delta\":\"mail a@x.com\"}\n\n",
+        )
+        .as_bytes()
+        .to_vec();
+        let seal = seal_buffered_sse(&mut raw);
+        assert!(seal.excised.is_empty(), "excised: {:?}", seal.excised);
+        let (out, counts) = redact_responses_sse(chain.as_ref(), &raw)
+            .expect("the whole payload must reach the redactor");
+        let out = String::from_utf8(out).unwrap();
+        assert!(!out.contains("a@x.com"), "left unmasked: {out}");
+        assert!(out.contains("[EMAIL_REDACTED]"), "out: {out}");
+        assert_eq!(counts.get("email"), Some(&1));
+        assert!(
+            out.contains("\"item_id\":\"m\""),
+            "second line dropped: {out}"
+        );
+    }
+
+    #[test]
+    fn seal_excises_a_terminated_frame_whose_payload_is_not_json() {
+        // Plain text in the middle of an otherwise well-formed stream. No
+        // pass could read it, so it used to be released having been scanned
+        // by nothing.
+        let mut raw = b"data: {\"a\":1}\n\ndata: my mail is a@x.com\n\ndata: [DONE]\n\n".to_vec();
+        let seal = seal_buffered_sse(&mut raw);
+        assert_eq!(seal.tail, SseTailSeal::Terminated);
+        // Handed back for the caller's block scan: nothing can mask it, but
+        // a forbidden literal in it still has to block the response.
+        assert_eq!(seal.excised, vec!["my mail is a@x.com".to_string()]);
+        assert_eq!(seal.excised_bytes, "data: my mail is a@x.com\n\n".len());
+        assert!(seal.cut_anything());
+        // ...and it is gone from what will be released, while its neighbours
+        // — including the frames with nothing to scan — are untouched.
+        assert_eq!(raw, b"data: {\"a\":1}\n\ndata: [DONE]\n\n");
+    }
+
+    #[test]
+    fn seal_excises_a_terminated_frame_whose_data_lines_do_not_join_into_one_document() {
+        // Two complete events run together with no blank line between them:
+        // not one frame, and the join is not one document either. Same rule
+        // as the tail shape, now applied wherever it appears.
+        let mut raw =
+            b"data: {\"a\":1}\n\ndata: {\"b\":2}\ndata: {\"c\":3}\n\ndata: [DONE]\n\n".to_vec();
+        let seal = seal_buffered_sse(&mut raw);
+        assert_eq!(
+            seal.excised,
+            vec!["{\"b\":2}\n{\"c\":3}".to_string()],
+            "raw: {}",
+            String::from_utf8_lossy(&raw),
+        );
+        assert_eq!(raw, b"data: {\"a\":1}\n\ndata: [DONE]\n\n");
+    }
+
+    #[test]
+    fn seal_can_excise_the_whole_buffer() {
+        // The caller refuses with `unscannable_body` rather than answering
+        // with an empty 200 — `cut_anything` is what tells it apart from an
+        // upstream that simply sent nothing.
+        let mut raw = b"data: not json at all\n\n".to_vec();
+        let seal = seal_buffered_sse(&mut raw);
+        assert!(raw.is_empty());
+        assert!(seal.cut_anything());
+
+        let mut empty = Vec::new();
+        let seal = seal_buffered_sse(&mut empty);
+        assert!(!seal.cut_anything(), "an empty body is not a cut");
+    }
+
+    #[test]
+    fn seal_keeps_frames_with_nothing_to_scan_and_crlf_frames() {
+        // A comment, a keepalive and an empty payload carry no text any pass
+        // reads, so excising them would cost the client its events and
+        // protect nothing. Framed CRLF, since that is the form the splitter
+        // used to miss entirely.
+        let raw = b": ping\r\n\r\ndata:\r\n\r\ndata: [DONE]\r\n\r\n".to_vec();
+        let mut sealed = raw.clone();
+        let seal = seal_buffered_sse(&mut sealed);
+        assert!(seal.excised.is_empty(), "excised: {:?}", seal.excised);
+        assert_eq!(sealed, raw);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -864,6 +864,14 @@ impl SseFrame {
         if out.ends_with('\n') {
             out.pop();
         }
+        // ...and, on a CRLF frame whose LAST line was a dropped `data:`
+        // line, the CR that line ending left behind. The frame's own
+        // terminator CR was split off with the frame, so anything trailing
+        // here belongs to a line that is no longer followed by one — it
+        // would reach the client as a lone CR before the separator.
+        if out.ends_with('\r') {
+            out.pop();
+        }
         out.into_bytes()
     }
 }
@@ -1024,8 +1032,8 @@ impl BufferedSseSeal {
 }
 
 /// Seal a fully-buffered SSE body so a guardrail scan and the redaction
-/// pass read the SAME frames, and so nothing in it reaches the client
-/// without having been read by one of them (#1091, #1100).
+/// pass read the SAME frames, and so no frame reaches the client whose
+/// payload neither of them could parse (#1091, #1100).
 ///
 /// Two passes run over such a buffer and they used to disagree about what
 /// it contains: the line-based block scan reads whatever `data:` lines it
@@ -1050,6 +1058,17 @@ impl BufferedSseSeal {
 /// A caller whose buffer is left empty by either cut has nothing scanned
 /// at all and must refuse (`unscannable_body`) rather than answer with an
 /// empty 200.
+///
+/// What this does NOT establish, and must not be read as establishing:
+/// that everything released was *understood*. The test here is whether a
+/// payload PARSES, because that is the most this layer can decide without
+/// knowing the route's event vocabulary. A frame carrying valid JSON of a
+/// `type` no pass models — and a 200 body that is not SSE at all, which an
+/// upstream ignoring `stream: true` will produce and which has no `data:`
+/// line to read — still travel through unread. Both predate #1100 and
+/// closing them would cut responses that reach clients today, so they are
+/// deliberately left; see #1100 for the reasoning. Do not build on a
+/// stronger invariant than the one stated above.
 ///
 /// Note what is NOT cut: a frame carrying several `data:` lines that join
 /// into one JSON document is a well-formed frame, and is scanned and
@@ -1119,15 +1138,33 @@ fn seal_sse_tail(buf: &mut Vec<u8>) -> SseTailSeal {
 /// Runs AFTER the tail seal, so a fragment that was padded into a frame is
 /// judged by the same rule as the frames before it.
 fn excise_unscannable_frames(buf: &mut Vec<u8>) -> (Vec<String>, usize) {
+    // A frame with no `data:` line at all is a comment or a keepalive:
+    // there is nothing in it for a scan to read and nothing for a mask to
+    // rewrite, so it is not a bypass.
+    let unscannable =
+        |frame: &[u8]| matches!(frame_payload(frame), Some(p) if !payload_scannable(&p));
+    // Look before copying. Every buffered response reaches this, and almost
+    // none of them has a frame to cut, so the common path must not rebuild
+    // the buffer to discover that.
+    let mut rest: &[u8] = buf;
+    let mut any = false;
+    while let Some((pos, len)) = frame_terminator(rest) {
+        if unscannable(&rest[..pos]) {
+            any = true;
+            break;
+        }
+        rest = &rest[pos + len..];
+    }
+    if !any {
+        return (Vec::new(), 0);
+    }
+
     let mut excised: Vec<String> = Vec::new();
     let mut excised_bytes = 0usize;
     let mut kept: Vec<u8> = Vec::with_capacity(buf.len());
     let mut rest: &[u8] = buf;
     while let Some((pos, len)) = frame_terminator(rest) {
         match frame_payload(&rest[..pos]) {
-            // A frame with no `data:` line at all is a comment or a
-            // keepalive: there is nothing in it for a scan to read and
-            // nothing for a mask to rewrite, so it is not a bypass.
             Some(p) if !payload_scannable(&p) => {
                 excised.push(p);
                 excised_bytes += pos + len;
@@ -1135,9 +1172,6 @@ fn excise_unscannable_frames(buf: &mut Vec<u8>) -> (Vec<String>, usize) {
             _ => kept.extend_from_slice(&rest[..pos + len]),
         }
         rest = &rest[pos + len..];
-    }
-    if excised.is_empty() {
-        return (excised, 0);
     }
     // Empty after the tail seal, but appending it keeps this function
     // correct on its own terms rather than on its caller's.
@@ -2247,6 +2281,13 @@ mod tests {
         );
         // One leading space belongs to the framing, the rest to the payload.
         assert_eq!(frame_payload(b"data:  x").as_deref(), Some(" x"));
+        // So does the CR of a CRLF line ending — the payload is the text
+        // between them. Only a continued payload can carry one: a frame's
+        // last line hands its CR to the terminator.
+        assert_eq!(
+            frame_payload(b"data: one\r\ndata: two").as_deref(),
+            Some("one\ntwo"),
+        );
         // No `data:` line at all: a comment or keepalive, nothing to read.
         assert_eq!(frame_payload(b": ping"), None);
     }
@@ -2365,6 +2406,49 @@ mod tests {
         let seal = seal_buffered_sse(&mut sealed);
         assert!(seal.excised.is_empty(), "excised: {:?}", seal.excised);
         assert_eq!(sealed, raw);
+        // `sealed == raw` alone would hold even if the splitter saw one
+        // unframed blob, since an empty excision returns the buffer
+        // untouched. Assert the framing itself: three CRLF frames, and the
+        // `\r` stripped from each payload rather than left in it.
+        assert_eq!(
+            sse_frame_payloads(&raw),
+            vec![String::new(), "[DONE]".to_string()],
+        );
+    }
+
+    #[test]
+    fn seal_excises_a_crlf_frame_and_leaves_its_neighbours_crlf() {
+        let mut crlf =
+            b"data: {\"a\":1}\r\n\r\ndata: not json\r\n\r\ndata: [DONE]\r\n\r\n".to_vec();
+        let seal = seal_buffered_sse(&mut crlf);
+        assert_eq!(seal.excised, vec!["not json".to_string()]);
+        assert_eq!(crlf, b"data: {\"a\":1}\r\n\r\ndata: [DONE]\r\n\r\n");
+    }
+
+    #[test]
+    fn anthropic_sse_masks_a_crlf_frame_whose_payload_spans_several_data_lines() {
+        // The CRLF half of the LF case above. The dropped `data:` line takes
+        // its line ending with it, so without care the CR of the line BEFORE
+        // the separator is left stranded and the client reads `...}\r` as
+        // the payload.
+        let chain = both();
+        let mut raw = concat!(
+            "event: content_block_delta\r\ndata: {\"type\":\"content_block_delta\",\"index\":0,\r\n",
+            "data: \"delta\":{\"type\":\"text_delta\",\"text\":\"mail a@x.com\"}}\r\n\r\n",
+        )
+        .as_bytes()
+        .to_vec();
+        let seal = seal_buffered_sse(&mut raw);
+        assert!(seal.excised.is_empty(), "excised: {:?}", seal.excised);
+        let (out, _) = redact_anthropic_sse(chain.as_ref(), &raw)
+            .expect("the whole payload must reach the redactor");
+        let out = String::from_utf8(out).unwrap();
+        assert!(!out.contains("a@x.com"), "left unmasked: {out}");
+        assert!(out.contains("[EMAIL_REDACTED]"), "out: {out}");
+        // A masked CRLF frame stays a well-formed CRLF frame: the payload
+        // ends at `}`, not at a stray CR.
+        assert!(out.ends_with("}\r\n\r\n"), "stray CR: {out:?}");
+        assert!(!out.contains("\r\r"), "stray CR: {out:?}");
     }
 
     #[test]

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1401,15 +1401,16 @@ async fn responses_to_target(
                         attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
                 }
             }
-            // #1091: an upstream that ends mid-frame leaves a fragment the
-            // two passes below read differently — the line-based scan sees
-            // it, the frame-based redactor appends it verbatim without ever
-            // masking it. Seal the buffer first, so both read the same
-            // frames: a parseable final frame gets the terminator its
-            // upstream left off, an unparseable one is cut.
-            if let crate::redact::SseTailSeal::Dropped { dropped } =
-                crate::redact::seal_buffered_sse(&mut buf)
-            {
+            // #1091/#1100: the two passes below read this buffer
+            // differently — the line-based scan reads `data:` lines it can
+            // parse, the frame-based redactor reads terminator-delimited
+            // frames whose payload parses. Seal it first, so both read the
+            // same frames and nothing in it can reach the client unread: a
+            // final frame missing only its terminator gets it, and a frame
+            // whose payload is not one JSON document is cut (its text still
+            // goes to the block scan below).
+            let seal = crate::redact::seal_buffered_sse(&mut buf);
+            if let crate::redact::SseTailSeal::Dropped { dropped } = seal.tail {
                 tracing::warn!(
                     guardrail_hook = "output",
                     model = %model.display_name,
@@ -1418,40 +1419,53 @@ async fn responses_to_target(
                      parsed; dropping it rather than releasing it past the output \
                      guardrail",
                 );
-                // Nothing else arrived: the whole response was that one
-                // unparseable frame. Dropping it silently would hand the
-                // caller an empty 200 with no signal, and there is no
-                // scanned content to release — refuse, the same shape the
-                // buffer-cap arm above and `/v1/messages` use.
-                if buf.is_empty() {
-                    return Ok(ResponseDispatchSuccess {
-                        response: crate::error::guardrail_block_error(
-                            "response",
-                            None,
-                            Some(crate::error::TAG_UNSCANNABLE_BODY),
-                        )
-                        .into_response(),
-                        provider: provider_label,
-                        usage: Some(ResponseUsage {
-                            upstream_ttft_ms,
-                            ..Default::default()
-                        }),
-                        model_id: model_id.to_string(),
-                        provider_key_id: provider_key_id.clone(),
-                        upstream_model: upstream_model.clone(),
-                        routing: RoutingTelemetry::default(),
-                        guardrail_blocked: true,
-                        usage_handled_by_stream: false,
-                        captured_content: match (&captured_prompt, content_cap) {
-                            (Some(prompt), Some(cap)) => {
-                                Some(CapturedContent::new(prompt, "", cap as usize))
-                            }
-                            _ => None,
-                        },
-                        output_redactions: crate::redact::RedactionCounts::new(),
-                        output_monitor_hits: Vec::new(),
-                    });
-                }
+            }
+            if !seal.excised.is_empty() {
+                tracing::warn!(
+                    guardrail_hook = "output",
+                    model = %model.display_name,
+                    frames = seal.excised.len(),
+                    dropped = seal.excised_bytes,
+                    "streaming /v1/responses carried SSE frames whose payload is not one \
+                     JSON document; dropping them rather than releasing them past the \
+                     output guardrail (their text is still scanned)",
+                );
+            }
+            // Nothing else arrived: the whole response was frames that
+            // could not be scanned. Dropping them silently would hand
+            // the caller an empty 200 with no signal, and there is no
+            // scanned content to release — refuse, the same shape the
+            // buffer-cap arm above and `/v1/messages` use. A buffer that
+            // was empty to begin with is an empty upstream response and
+            // is left alone.
+            if buf.is_empty() && seal.cut_anything() {
+                return Ok(ResponseDispatchSuccess {
+                    response: crate::error::guardrail_block_error(
+                        "response",
+                        None,
+                        Some(crate::error::TAG_UNSCANNABLE_BODY),
+                    )
+                    .into_response(),
+                    provider: provider_label,
+                    usage: Some(ResponseUsage {
+                        upstream_ttft_ms,
+                        ..Default::default()
+                    }),
+                    model_id: model_id.to_string(),
+                    provider_key_id: provider_key_id.clone(),
+                    upstream_model: upstream_model.clone(),
+                    routing: RoutingTelemetry::default(),
+                    guardrail_blocked: true,
+                    usage_handled_by_stream: false,
+                    captured_content: match (&captured_prompt, content_cap) {
+                        (Some(prompt), Some(cap)) => {
+                            Some(CapturedContent::new(prompt, "", cap as usize))
+                        }
+                        _ => None,
+                    },
+                    output_redactions: crate::redact::RedactionCounts::new(),
+                    output_monitor_hits: Vec::new(),
+                });
             }
             // #808: the whole SSE response is buffered here, so parse its
             // terminal event for usage and let the handler emit (the body is
@@ -1487,7 +1501,17 @@ async fn responses_to_target(
                     usage.usage_estimated = true;
                 }
             }
-            let out_text = responses_sse_output_text(&buf);
+            let mut out_text = responses_sse_output_text(&buf);
+            // #1100: an excised frame is not released, but a forbidden
+            // literal inside it must still block the response — the block
+            // pass reads raw text, so it can scan a payload nothing could
+            // parse.
+            for payload in &seal.excised {
+                if !out_text.is_empty() {
+                    out_text.push('\n');
+                }
+                out_text.push_str(payload);
+            }
             let synth = synth_chat_response(&upstream_model, out_text);
             let (verdict, hits) =
                 aisix_guardrails::Guardrail::check_output_non_segment_observed(chain, &synth).await;
@@ -3127,13 +3151,13 @@ fn responses_output_text(resp: &Value) -> String {
 /// `data:` JSON line drives the dispatch.
 /// <https://platform.openai.com/docs/api-reference/responses-streaming>
 fn responses_sse_output_text(bytes: &[u8]) -> String {
-    let text = String::from_utf8_lossy(bytes);
     let mut deltas = String::new();
-    for line in text.lines() {
-        let data = match line.strip_prefix("data:") {
-            Some(d) => d.trim(),
-            None => continue,
-        };
+    // Per FRAME, not per line: a frame's payload is all of its `data:`
+    // lines joined, so reading them one at a time both truncates such a
+    // payload and disagrees with the redaction pass about what the frame
+    // carries (#1100).
+    for payload in crate::redact::sse_frame_payloads(bytes) {
+        let data = payload.trim();
         if data.is_empty() || data == "[DONE]" {
             continue;
         }

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1405,10 +1405,11 @@ async fn responses_to_target(
             // differently — the line-based scan reads `data:` lines it can
             // parse, the frame-based redactor reads terminator-delimited
             // frames whose payload parses. Seal it first, so both read the
-            // same frames and nothing in it can reach the client unread: a
-            // final frame missing only its terminator gets it, and a frame
-            // whose payload is not one JSON document is cut (its text still
-            // goes to the block scan below).
+            // same frames and no frame reaches the client whose payload
+            // neither could parse: a final frame missing only its terminator
+            // gets it, and a frame whose payload is not one JSON document is
+            // cut (its text still goes to the block scan below). Parsing is
+            // the whole test — see `seal_buffered_sse` for what that leaves.
             let seal = crate::redact::seal_buffered_sse(&mut buf);
             if let crate::redact::SseTailSeal::Dropped { dropped } = seal.tail {
                 tracing::warn!(
@@ -2627,9 +2628,14 @@ fn has_complete_responses_sse_event(bytes: &[u8]) -> bool {
     let mut offset = 0;
     while let Some(end) = crate::messages::find_frame_end(&bytes[offset..]) {
         let frame = &bytes[offset..offset + end];
-        if crate::messages::extract_sse_data_line(frame)
-            .is_some_and(|data| data != b"[DONE]" && serde_json::from_slice::<Value>(data).is_ok())
-        {
+        // Whole payload, not the first `data:` line (#1100). Only COMPLETE
+        // frames count, so this walks them rather than taking the whole
+        // prefix: a partial frame can hold complete JSON without its
+        // terminator, and that must not stop the clock early.
+        if crate::redact::frame_payload(frame).is_some_and(|p| {
+            let p = p.trim();
+            p != "[DONE]" && serde_json::from_str::<Value>(p).is_ok()
+        }) {
             return true;
         }
         offset += end;
@@ -2642,13 +2648,13 @@ fn has_complete_responses_sse_event(bytes: &[u8]) -> bool {
 /// already holds the whole response. Returns `None` (skip emission, matching
 /// the non-streaming gate) when no terminal event carried a usage block.
 fn responses_sse_usage(bytes: &[u8]) -> Option<ResponseUsage> {
-    let text = String::from_utf8_lossy(bytes);
     let mut usage = None;
-    for line in text.lines() {
-        let data = match line.strip_prefix("data:") {
-            Some(d) => d.trim(),
-            None => continue,
-        };
+    // Per frame, like the scan and the redaction pass (#1100): a terminal
+    // event written over several `data:` lines parses only once they are
+    // joined, and reading one line at a time would bill it from the token
+    // estimator instead of the provider's own counters.
+    for payload in crate::redact::sse_frame_payloads(bytes) {
+        let data = payload.trim();
         if data.is_empty() || data == "[DONE]" {
             continue;
         }
@@ -2666,11 +2672,9 @@ fn responses_sse_usage(bytes: &[u8]) -> Option<ResponseUsage> {
 /// terminal frame reported no usage and therefore produced no
 /// [`ResponseUsage`] (AISIX-Cloud#1289).
 fn responses_sse_provider_request_id(bytes: &[u8]) -> String {
-    let text = String::from_utf8_lossy(bytes);
-    for line in text.lines() {
-        let Some(data) = line.strip_prefix("data:").map(str::trim) else {
-            continue;
-        };
+    // Same framing as everything else that reads this buffer (#1100).
+    for payload in crate::redact::sse_frame_payloads(bytes) {
+        let data = payload.trim();
         if data.is_empty() || data == "[DONE]" {
             continue;
         }

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -879,4 +879,267 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
     expect(text).toContain("[EMAIL_REDACTED]");
     expect(text.endsWith("\n\n")).toBe(true);
   });
+
+  // #1100. The sibling of the three cases above, in the frames BEFORE the
+  // fragment. A COMPLETE, terminated frame was scanned and masked only if
+  // its `data:` payload happened to be exactly one JSON document, and two
+  // shapes are not:
+  //
+  //   - a payload that is not JSON at all — the scan `continue`s past a line
+  //     it cannot parse and the redactor skips a frame with no parsed
+  //     payload, so it went out byte-for-byte having been read by nothing;
+  //   - a payload written over several `data:` lines, which the spec joins
+  //     with `\n` — only the first was read, so a literal on a later line was
+  //     never seen and a mask deleted every line after the first.
+  //
+  // Neither is reachable from the providers proxied today, which is why the
+  // upstreams below are hand-written frames.
+
+  test("/v1/responses: a terminated frame whose payload is not JSON is scanned, not released", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const snapshot = (status: string) =>
+      `"id":"resp_raw","object":"response","status":"${status}","model":"${UPSTREAM_REPORTED_MODEL}"`;
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: response.created\ndata: {"type":"response.created","response":{${snapshot("in_progress")}}}\n\n`,
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","item_id":"m","delta":"perfectly fine text"}\n\n`,
+        // Complete and terminated, but its payload is plain text. Both passes
+        // used to skip it, so the guardrail's literal rode out untouched in a
+        // 200.
+        `data: ABSOLUTELYFORBIDDENWORD arrived as plain text\n\n`,
+        `event: response.completed\ndata: {"type":"response.completed","response":{${snapshot("completed")},"usage":{"input_tokens":4,"output_tokens":3,"total_tokens":7}}}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+    });
+    upstreams.push(upstream);
+
+    const pk = await seed.createProviderKey({
+      display_name: "pk-echo-raw-frame",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "echo-raw-frame",
+      provider: "openai",
+      model_name: CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === "echo-raw-frame");
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-raw-frame",
+        input: "say something",
+        stream: true,
+      }),
+    });
+    // Blocked, not delivered: the block pass reads raw text, so a payload
+    // nothing can parse is still scanned. Pre-fix this was a 200 carrying the
+    // literal.
+    expect(res.status).toBe(422);
+    const text = await res.text();
+    expect(text).not.toContain("ABSOLUTELYFORBIDDENWORD");
+  });
+
+  test("/v1/responses: a frame whose payload spans several data lines is masked whole", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const snapshot = (status: string) =>
+      `"id":"resp_multiline","object":"response","status":"${status}","model":"${UPSTREAM_REPORTED_MODEL}"`;
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: response.created\ndata: {"type":"response.created","response":{${snapshot("in_progress")}}}\n\n`,
+        // ONE frame, ONE JSON document, two `data:` lines. The maskable
+        // literal is on the second — invisible while only the first was read.
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","item_id":"m",\ndata: "delta":"write to tail@example.com"}\n\n`,
+        `event: response.completed\ndata: {"type":"response.completed","response":{${snapshot("completed")},"usage":{"input_tokens":4,"output_tokens":3,"total_tokens":7}}}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+    });
+    upstreams.push(upstream);
+
+    const pk = await seed.createProviderKey({
+      display_name: "pk-echo-multiline",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "echo-multiline",
+      provider: "openai",
+      model_name: CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === "echo-multiline");
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-multiline",
+        input: "who do I write to",
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).not.toContain("tail@example.com");
+    expect(text).toContain("[EMAIL_REDACTED]");
+    // The second line's content survives the rewrite — the frame is
+    // re-emitted as the whole document, not truncated to its first line.
+    expect(text).toContain("write to [EMAIL_REDACTED]");
+    expect(text).toContain('"item_id":"m"');
+  });
+
+  test("/v1/messages hold-back: a terminated frame whose payload is not JSON is scanned, not released", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: message_start\ndata: {"type":"message_start","message":{"id":"msg_raw","type":"message","role":"assistant","model":"${UPSTREAM_REPORTED_MODEL}","content":[],"usage":{"input_tokens":4,"output_tokens":0}}}\n\n`,
+        `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"perfectly fine text"}}\n\n`,
+        `data: ABSOLUTELYFORBIDDENWORD arrived as plain text\n\n`,
+        `event: message_stop\ndata: {"type":"message_stop"}\n\n`,
+      ],
+    });
+    upstreams.push(upstream);
+
+    const pk = await seed.createProviderKey({
+      display_name: "pk-echo-raw-frame-anthropic",
+      secret: "sk-mock",
+      api_base: upstream.baseUrl,
+      provider: "anthropic",
+      adapter: "anthropic",
+    });
+    await seed.createModel({
+      display_name: "echo-raw-frame-anthropic",
+      provider: "anthropic",
+      model_name: CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === "echo-raw-frame-anthropic");
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-raw-frame-anthropic",
+        max_tokens: 16,
+        stream: true,
+        messages: [{ role: "user", content: "say something" }],
+      }),
+    });
+    // The stream committed its 200 before the scan; the block is in-band.
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("content_filter");
+    expect(text).not.toContain("ABSOLUTELYFORBIDDENWORD");
+    // Hold-back: nothing was forwarded before the verdict, so the frames
+    // that DID clear are withheld too.
+    expect(text).not.toContain("perfectly fine text");
+  });
+
+  test("/v1/messages hold-back: a frame whose payload spans several data lines is masked whole", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await startOpenAiUpstream({
+      rawStreamFrames: [
+        `event: message_start\ndata: {"type":"message_start","message":{"id":"msg_multiline","type":"message","role":"assistant","model":"${UPSTREAM_REPORTED_MODEL}","content":[],"usage":{"input_tokens":4,"output_tokens":0}}}\n\n`,
+        `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,\ndata: "delta":{"type":"text_delta","text":"write to tail@example.com"}}\n\n`,
+        `event: message_stop\ndata: {"type":"message_stop"}\n\n`,
+      ],
+    });
+    upstreams.push(upstream);
+
+    const pk = await seed.createProviderKey({
+      display_name: "pk-echo-multiline-anthropic",
+      secret: "sk-mock",
+      api_base: upstream.baseUrl,
+      provider: "anthropic",
+      adapter: "anthropic",
+    });
+    await seed.createModel({
+      display_name: "echo-multiline-anthropic",
+      provider: "anthropic",
+      model_name: CONFIGURED_MODEL_NAME,
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === "echo-multiline-anthropic");
+    });
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "echo-multiline-anthropic",
+        max_tokens: 16,
+        stream: true,
+        messages: [{ role: "user", content: "who do I write to" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).not.toContain("tail@example.com");
+    expect(text).toContain("[EMAIL_REDACTED]");
+    expect(text).toContain("write to [EMAIL_REDACTED]");
+    // The line the payload continued onto is still there.
+    expect(text).toContain('"text_delta"');
+  });
 });

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -956,6 +956,13 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
     expect(res.status).toBe(422);
     const text = await res.text();
     expect(text).not.toContain("ABSOLUTELYFORBIDDENWORD");
+    // Which refusal matters. `unscannable_body` — the arm for a buffer the
+    // cut emptied — is the same 422 and the same `content_filter` type, so
+    // a status-only assertion would still pass if the excised frame's text
+    // never reached the block scan. Only a keyword verdict names the
+    // guardrail; the unavailable arm names the tag instead.
+    expect(text).toContain("gr-model-echo-holdback");
+    expect(text).not.toContain("unscannable_body");
   });
 
   test("/v1/responses: a frame whose payload spans several data lines is masked whole", async (ctx) => {
@@ -1078,6 +1085,12 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
     const text = await res.text();
     expect(text).toContain("content_filter");
     expect(text).not.toContain("ABSOLUTELYFORBIDDENWORD");
+    // As on /v1/responses above: `unscannable_body` produces the same
+    // `content_filter` frame, so name the guardrail to pin that the block
+    // came from scanning the excised frame's text and not from the buffer
+    // having been emptied.
+    expect(text).toContain("gr-model-echo-holdback");
+    expect(text).not.toContain("unscannable_body");
     // Hold-back: nothing was forwarded before the verdict, so the frames
     // that DID clear are withheld too.
     expect(text).not.toContain("perfectly fine text");

--- a/tests/e2e/src/cases/images-generations-e2e.test.ts
+++ b/tests/e2e/src/cases/images-generations-e2e.test.ts
@@ -257,4 +257,91 @@ describe("images generations e2e: /v1/images/generations verbatim forward + mode
     // refuses for provider mismatch.
     expect(upstream.receivedRequests.length).toBe(upstreamHitsBefore);
   });
+
+  // #1101. `stream: true` used to be forwarded verbatim: the provider
+  // generated (and charged for) a partial-image SSE response, the dispatch
+  // path — which reads the upstream answer as a single JSON document —
+  // failed to decode it, and that decode failure is retryable. This route
+  // dispatches through `retrying_dispatch`, so ONE caller request re-ran the
+  // whole generation for the model's retry budget: the provider billed N+1
+  // image generations, no usage was recorded, and the caller got a 502.
+  //
+  // The route has no partial-image relay, so the request is refused instead,
+  // and refused BEFORE the provider is contacted. That the upstream is never
+  // called is the property under test — the billing was the harm, and a
+  // status-only assertion cannot tell "refused up front" from "refused after
+  // paying for N generations".
+  test("POST /v1/images/generations with stream:true is refused without calling the upstream", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const headers = {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    };
+    const baseline = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/images/generations`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "img-e2e",
+        prompt: "A cat sitting in a sunbeam",
+        stream: true,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error?: { message?: string; type?: string };
+    };
+    expect(body.error?.type).toBe("invalid_request_error");
+    // Pinned whole rather than by substring: this sentence is the
+    // endpoint's refusal contract, and it deliberately matches the one
+    // /v1/images/edits already gives, differing only in the route name.
+    expect(body.error?.message).toBe(
+      "request payload is invalid: `stream` is not supported on " +
+        "/v1/images/generations",
+    );
+
+    // The no-billing property: the provider was never asked, so the retry
+    // budget could not re-run the generation either.
+    expect(upstream.receivedRequests.slice(baseline)).toHaveLength(0);
+  });
+
+  test("POST /v1/images/generations with stream:false still reaches the upstream", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    // The other half of the contract: the refusal is scoped to a request
+    // that actually asked to stream. A guard reading `stream` as "present"
+    // rather than "true" would take the ordinary path down with it, and
+    // `stream: false` is what an SDK sends by default.
+    const headers = {
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+      "content-type": "application/json",
+    };
+    const baseline = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/images/generations`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "img-e2e",
+        prompt: "A cat sitting in a sunbeam",
+        stream: false,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data?: Array<{ url?: unknown }> };
+    expect(body.data?.[0]?.url).toBe("https://mock.example.com/img-1.png");
+    expect(
+      upstream.receivedRequests
+        .slice(baseline)
+        .filter((r) => r.path === "/v1/images/generations"),
+    ).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## #1100 — a buffered SSE frame that is not one JSON document

A block- or mask-capable output guardrail buffers a streamed response whole and runs two passes over it: a line-based block scan and a frame-based redaction pass. #1098 made them agree about the *unterminated trailing fragment*. This is the sibling in the frames before it.

A **terminated** frame was scanned and masked only if its `data:` payload happened to be exactly one JSON document. Two shapes are not, and both passes skipped both:

- **A payload that is not JSON.** `responses_sse_output_text` parses each `data:` line and `continue`s when it does not parse; `split_sse_frames` leaves that frame with no parsed payload and the redactor skips frames without one. So `data: my mail is a@x.com` in the middle of an otherwise well-formed stream was released byte-for-byte, seen by neither pass.
- **A payload written over several `data:` lines.** The payload is the lines joined with `\n`, but only the first was read — so a literal on a later line was never scanned, and a mask deleted every line after the first when the frame was re-rendered.

### The fix

Both are decided once, where the framing decision already lives.

`frame_payload` joins a frame's `data:` lines per the spec (one leading space after the colon belongs to the framing, `\r` to the line ending), and is now the single definition every pass reads: `split_sse_frames`, the `/v1/responses` block scan, and the `/v1/messages` frame parser that feeds `response_text`. A multi-line payload is therefore scanned whole and masked whole. A rewritten frame re-emits it on one `data:` line — the same payload, since a compact JSON document carries no newlines.

`seal_buffered_sse` then excises any terminated frame whose payload is *still* not one JSON document, and returns those payloads to the caller. Nothing can mask such a payload structurally, so it is not released; the block pass reads raw text, so it is still scanned and a forbidden literal in it still blocks the response. A cut that empties the buffer refuses with `unscannable_body`, exactly as #1098 already did for the tail — `cut_anything()` is what separates that from an upstream that simply sent nothing.

On `/v1/messages` the seal also moves out of the EOF-tail branch. It was only reached when the upstream left a fragment behind; an upstream that terminated its last frame properly left `buf` empty, so the held bytes reached both passes unsealed and #1100 could not have been fixed there at all.

Frames with nothing to scan are untouched: a comment or keepalive (no `data:` line), an empty payload and the `[DONE]` sentinel are kept, in LF and CRLF framing alike. Cutting one would cost the client its terminal event and protect nothing.

### Client-visible behaviour

Per shape, per route, behind a buffering output guardrail:

- **A terminated frame whose payload is not JSON** — `/v1/responses`: excised from the delivered body, and its text scanned, so a forbidden literal in it now yields 422 instead of a 200 carrying the literal. `/v1/messages` hold-back: same, signalled in-band as the route's terminal `content_filter` error event. If the excision empties the buffer, both refuse with `unscannable_body`.
- **A frame carrying several `data:` lines** — both routes: delivered, scanned whole and masked whole, re-emitted as one `data:` line carrying the entire document. Previously it was released unmasked, or truncated to its first line when some other frame was masked.

Nothing else changes. A body whose every frame is one JSON document is byte-identical to before, and the live-forward (non-buffered) relays are untouched.

Neither shape is reachable from the providers proxied today — model output arrives inside JSON delta events, one `data:` line per frame — so no currently-working response changes shape. What changes is that "everything released past a block-capable output guardrail was scanned" is now true as stated, with no exception.

## #1101 — `stream: true` on `/v1/images/generations`

`stream` was forwarded verbatim; the provider honours it with a partial-image SSE response, and the dispatch path reads the upstream answer as a single JSON document. The decode failure is retryable and this route dispatches through `retrying_dispatch`, so one caller request re-ran the whole generation for the model's retry budget: the provider billed N+1 generations, no usage row was recorded, and the caller got a 502.

There is no partial-image relay on this route, so the request is refused up front — after model resolution, so an unknown model still answers 404, and before the guardrail chain and the rate-limit reservation, so a request that cannot be served burns neither. That placement is the fix; the harm was the billing, not the status code.

The envelope is the one `/v1/images/edits` already produces, differing only in the route name — the two are one family and a caller should not have to learn two refusals:

- status `400`
- `error.type` = `invalid_request_error`
- `error.message` = ``request payload is invalid: `stream` is not supported on /v1/images/generations``

That is a deliberate divergence from the `/v1/completions` refusal shipped in #1099, which appends `use /v1/chat/completions for streaming`. Status and type are identical; only the pointer differs, and it is omitted because this family has no streaming route to point at. `UpstreamDecode` retryability is unchanged — that variant is shared with other routes and rejecting up front makes the retry moot here.

## Tests

- `redact.rs` unit tests: `frame_payload` joins the lines (and strips exactly one leading space); both redactors mask a frame whose payload spans two `data:` lines and keep its later lines; the seal excises a non-JSON frame and a run-together pair, hands their payloads back, leaves the neighbours and the nothing-to-scan frames alone, and can empty the buffer.
- e2e on **both** routes for **both** shapes, in `client-facing-model-echo-e2e.test.ts`: a terminated plain-text frame carrying the guardrail's literal, and a frame whose payload spans two `data:` lines carrying maskable PII.
- e2e for #1101 in `images-generations-e2e.test.ts`: the 400 envelope asserted whole **and** the mock upstream receiving nothing, plus `stream: false` still reaching the upstream so an over-broad guard cannot pass.
- Mutation-verified locally, each against the code it pins: reading only the first `data:` line; skipping the excision; excising but not scanning the excised text; removing the `stream` guard; widening it to "`stream` is present".

## Deferred, and why

Review found four siblings that are the same shape but not the same decision. None is a regression from this branch; each is recorded rather than folded in.

- **The invariant has two named exceptions, and they are in the doc comment, not implied away.** The test the seal applies is whether a payload *parses* — the most this layer can decide without knowing each route's event vocabulary. A frame carrying valid JSON of a `type` no pass models, and a 200 body that is not SSE at all (an upstream that ignores `stream: true` and answers with one JSON document, which has no `data:` line for either pass to read), still travel through unread. Both predate this work. Excising them would cut responses that reach clients today — every provider event type the gateway does not model would go with them — so they are stated in `seal_buffered_sse`'s doc rather than closed here.
- **`restamp_sse_frame` still reads only the first `data:` line** (`model_echo.rs` → `messages::extract_sse_data_range`). A `message_start` / `response.created` frame written over several `data:` lines does not parse, so the frame is forwarded unrestamped and the caller is told the upstream's model id. It needs a byte range to splice into, which a joined payload cannot provide, so it is a different change from this one.
- **The passthrough-route hold-back has both halves unfixed** (`passthrough_route.rs`, `frame_delta`). For the typed protocols only `Raw` folds an unparseable payload into the scanned text, yet the frame still reaches `pending` and is released once the scan clears. That is a third route family with no redaction pass, and folding raw payloads into a typed protocol's scan text changes what it blocks on.
- **`/v1/images/generations` needs the doc pair `/v1/images/edits` already has.** The image-editing page in both docs repos documents its own `stream=true` refusal; the image-generation page says nothing about `stream`. Unlike #1100 — whose shapes no proxied provider produces — `stream: true` is a parameter a caller sets directly, so this refusal is user-facing and owes an EN + ZH pair.

CodeRabbit's suggestion to extract the three `ResponseDispatchSuccess` refusal arms into one builder is declined: two of the three predate this branch and refactoring them is outside what this change touches.

Fixes #1100
Fixes #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
