### PR TITLE
fix(guardrails): read whole SSE frames, and settle where reasoning is in scope

### DIFF
--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -122,10 +122,20 @@ pub(crate) async fn read_body_capped(resp: &mut reqwest::Response, cap: usize) -
 ///     payload is serialized so neither a function name nor an argument
 ///     can hide a banned token, matching `ChatResponse::guardrail_output_text`
 ///     and `redact_chat_format`, which already cover this surface.
+///   * `extra["reasoning_content"]` — an assistant turn's reasoning
+///     replayed in history. It is the canonical slot every vendor
+///     spelling is normalised onto, and it travels upstream verbatim
+///     through `extra` like `tool_calls` do, so a payload parked there
+///     reaches the model unread otherwise. Reasoning the model GENERATES
+///     is a different question and stays out of the output scope — this
+///     helper only ever sees REQUEST messages (`check_input`); the output
+///     collectors read `ChatResponse::guardrail_output_text`.
 ///
 /// Non-text content blocks (image/audio) are out of scope — multimodal
-/// moderation is a separate feature. Every guardrail's input/output
-/// collector goes through this so the families can't drift.
+/// moderation is a separate feature. Every guardrail's input collector
+/// goes through this so the families can't drift, and `redact_chat_format`
+/// masks exactly this list — the two must stay in lockstep or a Mask rule
+/// reports a hit on text it then forwards unmasked.
 pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
     let mut parts: Vec<String> = Vec::new();
     let content = m.content_str();
@@ -144,6 +154,11 @@ pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
     if let Some(tool_calls) = m.extra.get("tool_calls") {
         if !tool_calls.is_null() {
             parts.push(tool_calls.to_string());
+        }
+    }
+    if let Some(reasoning) = m.extra.get("reasoning_content").and_then(|v| v.as_str()) {
+        if !reasoning.is_empty() {
+            parts.push(reasoning.to_string());
         }
     }
     parts.join("\n")
@@ -967,6 +982,26 @@ mod tests {
             scanned.contains("benign cover text") && scanned.contains("hidden payload"),
             "scan must cover both content and content_blocks, got {scanned:?}"
         );
+    }
+
+    /// Same bypass class again, via `extra["reasoning_content"]`: an
+    /// assistant turn's replayed reasoning is caller-supplied text that the
+    /// bridges forward upstream verbatim, so parking a payload there must
+    /// not be a way past a deny-list the same text trips in `content`.
+    #[test]
+    fn message_scan_text_scans_replayed_reasoning_content() {
+        let msg: ChatMessage = serde_json::from_value(serde_json::json!({
+            "role": "assistant",
+            "content": "nothing to see",
+            "reasoning_content": "hidden reasoning payload"
+        }))
+        .unwrap();
+        let scanned = message_scan_text(&msg);
+        assert!(
+            scanned.contains("hidden reasoning payload"),
+            "scan must cover replayed reasoning_content, got {scanned:?}",
+        );
+        assert!(scanned.contains("nothing to see"));
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/lib.rs
+++ b/crates/aisix-provider-anthropic/src/lib.rs
@@ -23,13 +23,16 @@ pub use bridge::{AnthropicBridge, ANTHROPIC_DEFAULT_BASE, ANTHROPIC_VERSION};
 /// outbound path:
 ///
 /// - [`parse_inbound_request`] turns the request body into
-///   `ChatFormat` so any Bridge can dispatch it.
+///   `ChatFormat` so any Bridge can dispatch it, and
+///   [`parse_inbound_request_for_scan`] does the same for the guardrail
+///   chain — the two differ only in whether an assistant turn's
+///   `thinking` blocks survive.
 /// - [`chat_response_into_anthropic_json`] renders the bridge's
 ///   `ChatResponse` back as Anthropic JSON.
 /// - [`AnthropicSseEncoder`] re-encodes the bridge's `ChatChunk`
 ///   stream as Anthropic typed SSE events.
 pub use wire::{
-    chat_response_into_anthropic_json, parse_inbound_request,
+    chat_response_into_anthropic_json, parse_inbound_request, parse_inbound_request_for_scan,
     translate_anthropic_tool_choice_to_openai, translate_anthropic_tools_to_openai,
     translate_extras_to_openai_shape, AnthropicInboundError, AnthropicSseEncoder,
     AnthropicSseEvent,

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -1532,7 +1532,7 @@ pub fn parse_inbound_request(
 /// carries only the provider's encrypted `data` blob — there is no
 /// plaintext in it for a scan to read, so it contributes nothing here (a
 /// Mask rule that would rewrite either block is refused outright rather
-/// than applied — see `redact::anthropic_masks_signed_reasoning`).
+/// than applied — see `redact::anthropic_request_masks_signed_reasoning`).
 pub fn parse_inbound_request_for_scan(
     body: &serde_json::Value,
 ) -> Result<ChatFormat, AnthropicInboundError> {

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -1488,16 +1488,60 @@ pub enum AnthropicInboundError {
     UnsupportedSystem,
 }
 
+/// What a parsed body is going to be used for.
+///
+/// The two answers differ in exactly one place — an assistant turn's
+/// `thinking` / `redacted_thinking` blocks — and that difference is the
+/// whole reason this enum exists. Dropping them is right for a body being
+/// bridged to a non-Anthropic upstream and wrong for a body being handed
+/// to the guardrail chain, so the two callers must not share one parse.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InboundUse {
+    /// The result is translated onto the OpenAI wire and sent upstream.
+    Dispatch,
+    /// The result is scan text for the input guardrail chain and is never
+    /// sent anywhere.
+    Scan,
+}
+
 /// Parse an Anthropic `POST /v1/messages` JSON body into the gateway's
-/// internal [`ChatFormat`]. The `system` field is folded into a leading
-/// system message. Message content blocks translate to their OpenAI
-/// equivalents (see the module comment above for the per-block map);
-/// a user message whose blocks include `tool_result`s expands into the
-/// preceding `role:"tool"` messages OpenAI expects. Unrecognized
-/// top-level keys (`metadata`, `tools`, `tool_choice`, etc.) flow into
-/// `ChatFormat::extra` for `translate_extras_to_openai_shape`.
+/// internal [`ChatFormat`], for **cross-provider dispatch**. The `system`
+/// field is folded into a leading system message. Message content blocks
+/// translate to their OpenAI equivalents (see the module comment above for
+/// the per-block map); a user message whose blocks include `tool_result`s
+/// expands into the preceding `role:"tool"` messages OpenAI expects.
+/// Unrecognized top-level keys (`metadata`, `tools`, `tool_choice`, etc.)
+/// flow into `ChatFormat::extra` for `translate_extras_to_openai_shape`.
+///
+/// Assistant `thinking` / `redacted_thinking` blocks are dropped, because
+/// they are not replayable on the OpenAI wire. Use
+/// [`parse_inbound_request_for_scan`] for a guardrail scan, where dropping
+/// them would leave caller-supplied text unread.
 pub fn parse_inbound_request(
     body: &serde_json::Value,
+) -> Result<ChatFormat, AnthropicInboundError> {
+    parse_inbound(body, InboundUse::Dispatch)
+}
+
+/// The same parse, for the **input guardrail scan**: an assistant turn's
+/// `thinking` blocks contribute their text.
+///
+/// Reasoning replayed by the caller is text entering the model like any
+/// other, so the scan has to see it; the dispatch parse still drops it, so
+/// what reaches a non-Anthropic upstream is unchanged. `redacted_thinking`
+/// carries only the provider's encrypted `data` blob — there is no
+/// plaintext in it for a scan to read, so it contributes nothing here (a
+/// Mask rule that would rewrite either block is refused outright rather
+/// than applied — see `redact::anthropic_masks_signed_reasoning`).
+pub fn parse_inbound_request_for_scan(
+    body: &serde_json::Value,
+) -> Result<ChatFormat, AnthropicInboundError> {
+    parse_inbound(body, InboundUse::Scan)
+}
+
+fn parse_inbound(
+    body: &serde_json::Value,
+    purpose: InboundUse,
 ) -> Result<ChatFormat, AnthropicInboundError> {
     use serde_json::Value;
     let obj = body.as_object().ok_or(AnthropicInboundError::NotAnObject)?;
@@ -1556,7 +1600,7 @@ pub fn parse_inbound_request(
                 translate_user_blocks(blocks, &mut messages);
             }
             ("assistant", Some(Value::Array(blocks))) => {
-                messages.push(translate_assistant_blocks(blocks));
+                messages.push(translate_assistant_blocks(blocks, purpose));
             }
             ("system", Some(Value::Array(blocks))) => {
                 messages.push(ChatMessage::system(concat_text_blocks(blocks)));
@@ -1790,9 +1834,10 @@ fn translate_user_blocks(blocks: &[serde_json::Value], out: &mut Vec<ChatMessage
 
 /// Collapse one Anthropic assistant message's content blocks into a
 /// ChatMessage: text concatenates, `tool_use` becomes OpenAI
-/// `tool_calls`, thinking blocks drop (non-replayable on the OpenAI
-/// wire — see the module comment).
-fn translate_assistant_blocks(blocks: &[serde_json::Value]) -> ChatMessage {
+/// `tool_calls`, thinking blocks drop for [`InboundUse::Dispatch`]
+/// (non-replayable on the OpenAI wire — see the module comment) and
+/// contribute their text for [`InboundUse::Scan`].
+fn translate_assistant_blocks(blocks: &[serde_json::Value], purpose: InboundUse) -> ChatMessage {
     use serde_json::Value;
     let mut text = String::new();
     let mut tool_calls: Vec<Value> = Vec::new();
@@ -1812,6 +1857,11 @@ fn translate_assistant_blocks(blocks: &[serde_json::Value]) -> ChatMessage {
                         "dropping malformed tool_use block (missing id/name) on \
                          cross-provider dispatch",
                     );
+                }
+            }
+            Some("thinking") if purpose == InboundUse::Scan => {
+                if let Some(t) = block.get("thinking").and_then(Value::as_str) {
+                    text.push_str(t);
                 }
             }
             Some("thinking") | Some("redacted_thinking") => {
@@ -5022,5 +5072,55 @@ mod tests {
         assert!(!serde_json::to_string(&chat.messages[0])
             .unwrap()
             .contains("secret chain"));
+    }
+
+    /// The scan parse is the other half of the pair above: the same body
+    /// that dispatches WITHOUT its thinking text must SCAN with it, or a
+    /// caller can park a payload in a replayed `thinking` block and reach
+    /// the model past a deny-list the same text trips in `content`.
+    #[test]
+    fn scan_parse_keeps_thinking_text_the_dispatch_parse_drops() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "messages": [{"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "secret chain", "signature": "sig"},
+                {"type": "redacted_thinking", "data": "opaque"},
+                {"type": "text", "text": "answer"},
+            ]}],
+        });
+        let scan = parse_inbound_request_for_scan(&body).unwrap();
+        assert_eq!(scan.messages[0].content_str(), "secret chainanswer");
+
+        // …and the dispatch parse is unchanged by that, which is the whole
+        // point of splitting them: what reaches a non-Anthropic upstream
+        // still carries no thinking block.
+        let dispatch = parse_inbound_request(&body).unwrap();
+        assert_eq!(dispatch.messages[0].content_str(), "answer");
+    }
+
+    /// The two parses differ ONLY on thinking blocks. Anything else that
+    /// diverged would mean the guardrail chain screened a request the
+    /// gateway did not actually dispatch.
+    #[test]
+    fn scan_and_dispatch_parses_agree_on_a_body_without_thinking() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "system": "be terse",
+            "max_tokens": 64,
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "text", "text": "look it up"},
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "42"},
+                ]},
+                {"role": "assistant", "content": [
+                    {"type": "text", "text": "answer"},
+                    {"type": "tool_use", "id": "t2", "name": "search", "input": {"q": "x"}},
+                ]},
+            ],
+        });
+        assert_eq!(
+            serde_json::to_value(parse_inbound_request_for_scan(&body).unwrap()).unwrap(),
+            serde_json::to_value(parse_inbound_request(&body).unwrap()).unwrap(),
+        );
     }
 }

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -1531,8 +1531,8 @@ pub fn parse_inbound_request(
 /// what reaches a non-Anthropic upstream is unchanged. `redacted_thinking`
 /// carries only the provider's encrypted `data` blob — there is no
 /// plaintext in it for a scan to read, so it contributes nothing here (a
-/// Mask rule that would rewrite either block is refused outright rather
-/// than applied — see `redact::anthropic_request_masks_signed_reasoning`).
+/// mask-action hit inside either block is forwarded unchanged — see
+/// `redact::redact_anthropic_content`).
 pub fn parse_inbound_request_for_scan(
     body: &serde_json::Value,
 ) -> Result<ChatFormat, AnthropicInboundError> {

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -328,22 +328,6 @@ async fn screen_input(
             unavailable.as_deref(),
         ));
     }
-    // Same refusal as `/v1/messages`: a mask that would have to rewrite a
-    // signed `thinking` block cannot be applied, so the request is refused
-    // rather than forwarded with the match still in it.
-    if crate::redact::anthropic_request_masks_signed_reasoning(&chain, body) {
-        tracing::warn!(
-            guardrail_hook = "input",
-            model = %model_name,
-            "mask-action guardrail matched inside a signed reasoning block on \
-             /v1/messages/count_tokens; refusing rather than forwarding it unmasked",
-        );
-        return Err(crate::error::guardrail_block_error(
-            "request",
-            None,
-            Some(crate::error::TAG_MASK_WRITEBACK_FAILED),
-        ));
-    }
     // Mask-action rules rewrite the body that is about to be forwarded.
     // Merged, not discarded: `/v1/messages` merges the same pass into the
     // counts its event reports (#932), and the two routes screen the same

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -301,12 +301,16 @@ async fn screen_input(
     let (verdict, monitor_hits) =
         aisix_guardrails::Guardrail::check_input_non_segment_observed(&chain, &chat).await;
     screening.monitor_hits = monitor_hits;
-    let verdict = crate::redact::moderate_body(
+    // Same scan-only submission as `/v1/messages` — the two routes screen
+    // the same body with the same chain and must reach the same verdict.
+    let signed_reasoning = crate::redact::anthropic_signed_reasoning_texts(body);
+    let verdict = crate::redact::moderate_body_scanning(
         &chain,
         crate::redact::Direction::Input,
         verdict,
         &mut screening.redactions,
         &mut Vec::new(),
+        signed_reasoning,
         |g| crate::redact::redact_anthropic_request(g, body),
     )
     .await;

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -309,7 +309,12 @@ async fn screen_input(
         crate::redact::Direction::Input,
         verdict,
         &mut screening.redactions,
-        &mut Vec::new(),
+        // The segment pass's monitor-mode observations belong on the same
+        // event as the non-segment ones above. A throwaway `Vec` here made
+        // this route report fewer monitor hits than `/v1/messages` for an
+        // identical body and chain — and the scan-only channel feeds this
+        // pass more text, so the gap would have widened.
+        &mut screening.monitor_hits,
         signed_reasoning,
         |g| crate::redact::redact_anthropic_request(g, body),
     )

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -282,7 +282,7 @@ async fn screen_input(
     }
     // Fail closed on a body the scanner cannot read — see the same arm in
     // `messages.rs`.
-    let chat = match aisix_provider_anthropic::parse_inbound_request(body) {
+    let chat = match aisix_provider_anthropic::parse_inbound_request_for_scan(body) {
         Ok(chat) => chat,
         Err(err) => {
             tracing::warn!(
@@ -326,6 +326,22 @@ async fn screen_input(
             "request",
             guardrail_name.as_deref(),
             unavailable.as_deref(),
+        ));
+    }
+    // Same refusal as `/v1/messages`: a mask that would have to rewrite a
+    // signed `thinking` block cannot be applied, so the request is refused
+    // rather than forwarded with the match still in it.
+    if crate::redact::anthropic_request_masks_signed_reasoning(&chain, body) {
+        tracing::warn!(
+            guardrail_hook = "input",
+            model = %model_name,
+            "mask-action guardrail matched inside a signed reasoning block on \
+             /v1/messages/count_tokens; refusing rather than forwarding it unmasked",
+        );
+        return Err(crate::error::guardrail_block_error(
+            "request",
+            None,
+            Some(crate::error::TAG_MASK_WRITEBACK_FAILED),
         ));
     }
     // Mask-action rules rewrite the body that is about to be forwarded.

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -608,6 +608,37 @@ pub(crate) fn upstream_body_is_sse(headers: &axum::http::HeaderMap) -> bool {
     !(essence == "application/json" || essence.ends_with("+json"))
 }
 
+/// Buffer a JSON response body under an optional deadline.
+///
+/// The relays attach reqwest's request-level timeout only when the REQUEST
+/// did not ask to stream, because that timeout bounds the body read too and
+/// would cut a real stream off mid-response. So when a `stream: true`
+/// request is answered with a JSON document — the case
+/// [`upstream_body_is_sse`] exists to detect — the buffered read it now
+/// takes has no deadline from that source, and the per-chunk read timeout
+/// that used to bound it lives only on the SSE branch. Pass the streaming
+/// budget here for that case; `None` where the request-level timeout is
+/// already in force.
+pub(crate) async fn json_body_within(
+    resp: reqwest::Response,
+    deadline: Option<std::time::Duration>,
+) -> Result<serde_json::Value, BridgeError> {
+    let read = resp.json::<serde_json::Value>();
+    match deadline {
+        Some(d) => tokio::time::timeout(d, read)
+            .await
+            .map_err(|_| BridgeError::Timeout {
+                elapsed_ms: d.as_millis() as u64,
+                cause: "upstream answered a streaming request with a JSON body that stalled"
+                    .to_string(),
+            })?
+            .map_err(|e| BridgeError::UpstreamDecode(e.to_string())),
+        None => read
+            .await
+            .map_err(|e| BridgeError::UpstreamDecode(e.to_string())),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -578,6 +578,33 @@ pub(crate) fn upstream_header_ctx<'a>(
         .with_client_headers(&client.headers)
 }
 
+/// Whether the upstream's 200 response body is an SSE stream, rather than
+/// the single JSON document an upstream that ignored `stream: true` sends.
+///
+/// The relays used to pick their streaming branch from the REQUEST's
+/// `stream` flag alone, so a JSON body answering a streaming request
+/// entered the SSE hold-back: it has no frames, so nothing scanned it, and
+/// the seal pass appended a `\n\n` frame terminator to a document that is
+/// not SSE before releasing it under the upstream's own content type.
+///
+/// Only an explicitly-JSON content type is treated as non-SSE. A missing
+/// or unrecognised one stays on the streaming path — a conforming SSE
+/// upstream labels itself `text/event-stream`, and a relay that guessed
+/// "not SSE" on an unfamiliar label would buffer a real stream to a
+/// `.json()` decode error.
+pub(crate) fn upstream_body_is_sse(headers: &axum::http::HeaderMap) -> bool {
+    let essence = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    !(essence == "application/json" || essence.ends_with("+json"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1561,5 +1588,44 @@ mod tests {
             let pk = pk_with_provider_and_adapter("vendor-without-specialized", Some("openai"));
             assert!(resolve_bridge(&hub, &pk).is_none());
         }
+    }
+
+    /// The relays used to pick their streaming branch from the REQUEST's
+    /// `stream` flag alone, so a JSON body answering `stream: true` entered
+    /// the SSE hold-back — unscanned, and released with a `\n\n` appended.
+    /// Only an explicitly-JSON content type routes such a body away from
+    /// the SSE path; everything else stays on it, so an SSE upstream with
+    /// an unfamiliar label is never buffered into a `.json()` decode error.
+    #[test]
+    fn only_a_json_content_type_says_the_upstream_did_not_stream() {
+        let ct = |v: &str| {
+            let mut h = axum::http::HeaderMap::new();
+            h.insert(
+                axum::http::header::CONTENT_TYPE,
+                axum::http::HeaderValue::from_str(v).unwrap(),
+            );
+            h
+        };
+        for json in [
+            "application/json",
+            "application/json; charset=utf-8",
+            "Application/JSON",
+            "application/vnd.openai+json",
+        ] {
+            assert!(!upstream_body_is_sse(&ct(json)), "{json} is not a stream");
+        }
+        for streamed in [
+            "text/event-stream",
+            "text/event-stream; charset=utf-8",
+            "application/octet-stream",
+            "text/plain",
+        ] {
+            assert!(
+                upstream_body_is_sse(&ct(streamed)),
+                "{streamed} stays on the streaming path"
+            );
+        }
+        // No content-type at all: stay on the streaming path.
+        assert!(upstream_body_is_sse(&axum::http::HeaderMap::new()));
     }
 }

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -591,10 +591,29 @@ pub(crate) fn upstream_header_ctx<'a>(
 /// has beside its streaming branch.
 ///
 /// Only an explicitly-JSON content type is treated as non-SSE. A missing
-/// or unrecognised one stays on the streaming path — a conforming SSE
-/// upstream labels itself `text/event-stream`, and a relay that guessed
-/// "not SSE" on an unfamiliar label would buffer a real stream to a
-/// `.json()` decode error.
+/// or unrecognised one stays on the streaming path.
+///
+/// **This deliberately differs from `passthrough_route`'s own `is_sse`,
+/// which requires an explicit `text/event-stream`.** They look like the
+/// same question and are not, because the populations differ: a passthrough
+/// route relays arbitrary REST traffic where most responses are genuinely
+/// not SSE, so "unknown means buffer" — the arm that scans — is right
+/// there. These typed relays have just asked an LLM provider to stream, so
+/// "unknown means stream" is right here, and the cost of being wrong is
+/// asymmetric. Guessing "not a stream" turns a working relay whose upstream
+/// merely mislabels its content type into a hard `502`, because the
+/// buffered arm then parses SSE text as JSON.
+///
+/// That mislabelling is not hypothetical: eight of this crate's own
+/// `/v1/messages` streaming tests produce it by accident. Their mock sets
+/// `text/event-stream` and then `set_body_string` overwrites the header
+/// with `text/plain` (wiremock `response_template.rs` sets `self.mime`), so
+/// they serve a real SSE body under the wrong label — and every one of them
+/// fails with a `502` if this predicate demands the correct one.
+///
+/// The bug this exists for — an upstream ignoring `stream: true` and
+/// answering with a JSON document — is caught by the JSON test alone, so
+/// the stricter rule would buy nothing for it and cost the above.
 pub(crate) fn upstream_body_is_sse(headers: &axum::http::HeaderMap) -> bool {
     let essence = headers
         .get(axum::http::header::CONTENT_TYPE)

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -581,11 +581,14 @@ pub(crate) fn upstream_header_ctx<'a>(
 /// Whether the upstream's 200 response body is an SSE stream, rather than
 /// the single JSON document an upstream that ignored `stream: true` sends.
 ///
-/// The relays used to pick their streaming branch from the REQUEST's
-/// `stream` flag alone, so a JSON body answering a streaming request
-/// entered the SSE hold-back: it has no frames, so nothing scanned it, and
-/// the seal pass appended a `\n\n` frame terminator to a document that is
-/// not SSE before releasing it under the upstream's own content type.
+/// `/v1/responses` and `/v1/messages` both pick their relay branch through
+/// this, and both used to pick it from the REQUEST's `stream` flag alone —
+/// so a JSON body answering a streaming request entered the SSE hold-back:
+/// it has no frames, so nothing scanned it, and the seal pass appended a
+/// `\n\n` frame terminator to a document that is not SSE before releasing
+/// it under the upstream's own content type. Such a body belongs on the
+/// non-streaming buffered scan+mask path each of those functions already
+/// has beside its streaming branch.
 ///
 /// Only an explicitly-JSON content type is treated as non-SSE. A missing
 /// or unrecognised one stays on the streaming path — a conforming SSE

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -614,6 +614,14 @@ pub(crate) fn upstream_header_ctx<'a>(
 /// The bug this exists for — an upstream ignoring `stream: true` and
 /// answering with a JSON document — is caught by the JSON test alone, so
 /// the stricter rule would buy nothing for it and cost the above.
+///
+/// A third sibling, `audio::is_event_stream`, is strict like the
+/// passthrough one even though `/v1/audio/transcriptions` is a typed relay
+/// that also just asked to stream. That is consistent, not an oversight:
+/// its non-stream arm relays opaque bytes rather than parsing them as
+/// JSON, so guessing wrong there costs nothing. The asymmetry here comes
+/// from the `.json()` on the other side of the branch, not from the
+/// question being asked.
 pub(crate) fn upstream_body_is_sse(headers: &axum::http::HeaderMap) -> bool {
     let essence = headers
         .get(axum::http::header::CONTENT_TYPE)

--- a/crates/aisix-proxy/src/error.rs
+++ b/crates/aisix-proxy/src/error.rs
@@ -860,7 +860,7 @@ struct AnthropicErrorBody {
 /// (The OpenAI envelope's inner `error.type` keeps the DP-stable
 /// strings per ai-gateway#327; that contract is unchanged on
 /// `/v1/chat/completions`.)
-fn anthropic_kind_from_status(status: StatusCode) -> &'static str {
+pub(crate) fn anthropic_kind_from_status(status: StatusCode) -> &'static str {
     match status.as_u16() {
         400 | 422 => "invalid_request_error",
         401 => "authentication_error",

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -636,7 +636,7 @@ async fn dispatch(
         // complete as the parser, and the parser lags the provider by
         // construction. `/mcp` already takes this arm on an unscannable
         // body; this is the same rule on the LLM side.
-        let chat = match aisix_provider_anthropic::parse_inbound_request(body) {
+        let chat = match aisix_provider_anthropic::parse_inbound_request_for_scan(body) {
             Ok(chat) => chat,
             Err(err) => {
                 tracing::warn!(
@@ -693,6 +693,25 @@ async fn dispatch(
                 "request",
                 guardrail_name.as_deref(),
                 unavailable.as_deref(),
+            )
+            .into());
+        }
+        // A Mask-action hit inside a signed `thinking` / `redacted_thinking`
+        // block has nowhere to go: rewriting the block invalidates the
+        // provider signature and the upstream rejects the replayed turn.
+        // The scan reads those blocks, so leaving the match in place would
+        // be a reported-but-unmasked dispatch — refuse instead.
+        if crate::redact::anthropic_request_masks_signed_reasoning(resolved_chain.as_ref(), body) {
+            tracing::warn!(
+                guardrail_hook = "input",
+                model = %model_name,
+                "mask-action guardrail matched inside a signed reasoning block on \
+                 /v1/messages; refusing rather than forwarding it unmasked",
+            );
+            return Err(crate::error::guardrail_block_error(
+                "request",
+                None,
+                Some(crate::error::TAG_MASK_WRITEBACK_FAILED),
             )
             .into());
         }
@@ -1306,6 +1325,16 @@ async fn anthropic_passthrough_dispatch(
         .unwrap_or("unknown")
         .to_ascii_lowercase();
 
+    // Pick the relay branch from what the upstream ACTUALLY sent, not from
+    // the request's `stream` flag. An upstream that ignores `stream: true`
+    // and answers with one JSON document used to enter the SSE branch
+    // anyway: with no frames in it nothing scanned it, and the hold-back's
+    // seal pass appended a `\n\n` frame terminator to a body that is not
+    // SSE before releasing it under the upstream's own content type. Such
+    // a response belongs on the non-streaming buffered scan+mask path
+    // below, which reads it as the JSON document it is.
+    let is_stream = is_stream && crate::dispatch::upstream_body_is_sse(upstream_resp.headers());
+
     if is_stream {
         // For SSE streaming: pass through the response body as a streaming
         // `text/event-stream` response.
@@ -1653,8 +1682,27 @@ async fn anthropic_passthrough_dispatch(
         let mut output_monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
         if !resolved_chain.is_empty() {
             if let Some(content) = json_body.get("content").and_then(|v| v.as_array()) {
+                // Generated reasoning is out of the output-guardrail scope
+                // on every other `/v1/messages` path — the streaming
+                // accumulator reads `delta.text` and `delta.partial_json`
+                // and never `delta.thinking`. The raw-array dump below was
+                // added for tool-use arguments and swept thinking text in
+                // with them, so the buffered path scanned more than the
+                // streaming one for the same response. Drop the two
+                // reasoning block types from the dump; everything the dump
+                // exists for (`tool_use` name/input, and any block shape
+                // the loop above cannot name) is untouched.
+                let scannable: Vec<&Value> = content
+                    .iter()
+                    .filter(|b| {
+                        !matches!(
+                            b.get("type").and_then(|v| v.as_str()),
+                            Some("thinking") | Some("redacted_thinking")
+                        )
+                    })
+                    .collect();
                 let mut out_text = String::new();
-                for block in content {
+                for block in &scannable {
                     if let Some(t) = block.get("text").and_then(|v| v.as_str()) {
                         if !out_text.is_empty() {
                             out_text.push('\n');
@@ -1665,7 +1713,7 @@ async fn anthropic_passthrough_dispatch(
                 if !out_text.is_empty() {
                     out_text.push('\n');
                 }
-                out_text.push_str(&Value::Array(content.clone()).to_string());
+                out_text.push_str(&serde_json::to_string(&scannable).unwrap_or_default());
 
                 let synth = aisix_gateway::ChatResponse {
                     id: String::new(),
@@ -2702,13 +2750,21 @@ fn build_anthropic_sse_stream(
 /// with serde_json so an operator-supplied guardrail name is JSON-escaped
 /// correctly; the message carries the firing guardrail's name (#519 B.4b)
 /// but never the matched-pattern detail (#153).
+///
+/// `error.type` is `invalid_request_error`, the same value the HTTP 422
+/// path renders for this refusal (`anthropic_kind_from_status`). It has to
+/// be: Anthropic's `error.type` is a closed enum in its SDK and carries no
+/// `content_filter` member, so emitting one made the streaming half of
+/// this endpoint disagree with the buffered half AND fail the SDK's typed
+/// parse. No `code` field either — the Anthropic envelope has none, and
+/// the caller reads WHICH guardrail fired from the message.
 fn guardrail_block_frame(guardrail_name: Option<&str>, unavailable: Option<&str>) -> String {
     format!(
         "event: error\ndata: {}\n\n",
         serde_json::json!({
             "type": "error",
             "error": {
-                "type": "content_filter",
+                "type": "invalid_request_error",
                 "message": crate::error::guardrail_block_message("response", guardrail_name, unavailable),
             }
         })
@@ -3430,19 +3486,18 @@ pub(crate) fn find_frame_end(buf: &[u8]) -> Option<usize> {
     None
 }
 
-/// Extract the `data:` payload bytes from one SSE frame. Returns the
-/// JSON slice (after `data:` and an optional leading space), or `None`
-/// if the frame has no data line. Only the first data line is read —
-/// Anthropic emits single-line data for the frames we care about.
-/// Shared with the `/v1/responses` streaming usage parser (#808).
-pub(crate) fn extract_sse_data_line(frame: &[u8]) -> Option<&[u8]> {
-    extract_sse_data_range(frame).map(|r| &frame[r])
-}
-
-/// The same payload as [`extract_sse_data_line`], as a range into
-/// `frame`. The restamp path needs the offsets so it can splice a value
-/// back into the frame without rebuilding the bytes around it
-/// (`model_echo::restamp_sse_frame`).
+/// The FIRST `data:` line of one SSE frame, as a range into `frame`
+/// (after `data:` and an optional leading space), or `None` if the frame
+/// has no data line.
+///
+/// First line only, and deliberately so: the restamp path is the one
+/// consumer, and it needs byte offsets so it can splice a value back into
+/// the frame without rebuilding the bytes around it
+/// (`model_echo::restamp_sse_frame`) — offsets a payload joined across
+/// several lines cannot supply. Every consumer that only READS a frame
+/// takes `redact::frame_payload` instead, which is the whole payload
+/// (#1100). A multi-`data:`-line frame therefore goes un-restamped rather
+/// than half-restamped; that gap is tracked in #1105.
 pub(crate) fn extract_sse_data_range(frame: &[u8]) -> Option<std::ops::Range<usize>> {
     let mut offset = 0usize;
     for line in frame.split(|&b| b == b'\n') {
@@ -5560,13 +5615,10 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
     /// `extract_sse_data_range` is what the model restamp splices into, so
     /// an off-by-one in its arithmetic would rewrite the wrong bytes. The
     /// range is checked against the payload it must select on every framing
-    /// variant a provider is allowed to emit. The `extract_sse_data_line`
-    /// assertion beside it is a cheap guard for the day someone gives that
-    /// accessor its own implementation again — today it delegates here, so
-    /// only the `want` table can actually catch a regression.
+    /// variant a provider is allowed to emit.
     #[test]
     fn extract_sse_data_range_selects_exactly_the_payload() {
-        use super::{extract_sse_data_line, extract_sse_data_range};
+        use super::extract_sse_data_range;
 
         for (frame, want) in [
             // Canonical: labelled event, LF terminators, one space after the colon.
@@ -5600,12 +5652,6 @@ event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
                 range.clone().map(|r| &frame[r]),
                 want,
                 "range selects the payload for {:?}",
-                String::from_utf8_lossy(frame),
-            );
-            assert_eq!(
-                extract_sse_data_line(frame),
-                want,
-                "the line accessor stays equivalent for {:?}",
                 String::from_utf8_lossy(frame),
             );
         }
@@ -6608,5 +6654,34 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
             "unscanned content must not be released: {streamed}"
         );
         assert_refused_not_abandoned(&event);
+    }
+
+    /// The two halves of `/v1/messages` must render the same refusal the
+    /// same way. The HTTP 422 path maps that status to
+    /// `invalid_request_error` (`anthropic_kind_from_status`), because
+    /// Anthropic's `error.type` is a closed enum with no `content_filter`
+    /// member — so the streaming terminal frame emitting `content_filter`
+    /// both disagreed with its own sibling and failed the SDK's typed
+    /// parse. The envelope carries no `code` either; Anthropic's shape has
+    /// none.
+    #[test]
+    fn streaming_block_frame_uses_a_legal_anthropic_error_type() {
+        let frame = super::guardrail_block_frame(Some("gr-block"), None);
+        let payload = frame
+            .strip_prefix("event: error\ndata: ")
+            .and_then(|r| r.strip_suffix("\n\n"))
+            .expect("an SSE error frame labelled `error`");
+        let v: serde_json::Value = serde_json::from_str(payload).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        assert!(v["error"]["message"].as_str().unwrap().contains("gr-block"));
+        assert!(v["error"].get("code").is_none());
+        assert_eq!(v["error"].as_object().unwrap().len(), 2);
+
+        // The same value the buffered half renders for this refusal.
+        assert_eq!(
+            v["error"]["type"].as_str().unwrap(),
+            crate::error::anthropic_kind_from_status(axum::http::StatusCode::UNPROCESSABLE_ENTITY),
+        );
     }
 }

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -696,25 +696,6 @@ async fn dispatch(
             )
             .into());
         }
-        // A Mask-action hit inside a signed `thinking` / `redacted_thinking`
-        // block has nowhere to go: rewriting the block invalidates the
-        // provider signature and the upstream rejects the replayed turn.
-        // The scan reads those blocks, so leaving the match in place would
-        // be a reported-but-unmasked dispatch — refuse instead.
-        if crate::redact::anthropic_request_masks_signed_reasoning(resolved_chain.as_ref(), body) {
-            tracing::warn!(
-                guardrail_hook = "input",
-                model = %model_name,
-                "mask-action guardrail matched inside a signed reasoning block on \
-                 /v1/messages; refusing rather than forwarding it unmasked",
-            );
-            return Err(crate::error::guardrail_block_error(
-                "request",
-                None,
-                Some(crate::error::TAG_MASK_WRITEBACK_FAILED),
-            )
-            .into());
-        }
         // #932: mask-action PII rules rewrite the Anthropic-native body in
         // place AFTER the block check passes — both the passthrough and the
         // cross-provider bridge forward from this body, so the masked text

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1329,6 +1329,12 @@ async fn anthropic_passthrough_dispatch(
     // request's `stream` flag — see `dispatch::upstream_body_is_sse`. A
     // JSON document answering `stream: true` takes the non-streaming
     // buffered scan+mask path below.
+    //
+    // That body needs its own deadline: the request-level timeout above was
+    // deliberately NOT attached for a streaming request, and the per-chunk
+    // read timeout lives on the SSE branch this response no longer takes,
+    // so without one a stalled JSON body would be held with no bound at all.
+    let buffered_body_deadline = if is_stream { timeouts.stream } else { None };
     let is_stream = is_stream && crate::dispatch::upstream_body_is_sse(upstream_resp.headers());
 
     if is_stream {
@@ -1648,18 +1654,18 @@ async fn anthropic_passthrough_dispatch(
         // failures cool down the target — a body the bridge can't
         // parse is a real upstream problem worth taking out of
         // rotation, not a caller bug.
-        let mut json_body: Value = upstream_resp
-            .json()
-            .await
-            .map_err(|e| {
-                crate::cooldown::note_failure(
-                    &state.runtime_status,
-                    model_id,
-                    model.cooldown.as_ref(),
-                    aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
-                )
-            })
-            .map_err(ProxyError::Bridge)?;
+        let mut json_body: Value =
+            crate::dispatch::json_body_within(upstream_resp, buffered_body_deadline)
+                .await
+                .map_err(|be| {
+                    crate::cooldown::note_failure(
+                        &state.runtime_status,
+                        model_id,
+                        model.cooldown.as_ref(),
+                        be,
+                    )
+                })
+                .map_err(ProxyError::Bridge)?;
 
         let mut metrics = anthropic_metrics_from_response_json(&json_body);
         // Token-estimation fallback (AISIX-Cloud#1074): an

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -662,12 +662,18 @@ async fn dispatch(
         // Segment pass: one Bedrock call over the body's text slots;
         // an ANONYMIZE disposition writes the masked text back into
         // the Anthropic-native body (#932 bedrock follow-up).
-        let verdict = crate::redact::moderate_body(
+        // Signed `thinking` blocks go in as SCAN-ONLY text: a segment
+        // kind's block rule must still fire on them, and the block itself
+        // must come back byte-identical (#1104). The walker below cannot
+        // carry them — it is also the write-back path.
+        let signed_reasoning = crate::redact::anthropic_signed_reasoning_texts(body);
+        let verdict = crate::redact::moderate_body_scanning(
             resolved_chain.as_ref(),
             crate::redact::Direction::Input,
             verdict,
             redactions_out,
             monitor_hits_out,
+            signed_reasoning,
             |g| crate::redact::redact_anthropic_request(g, body),
         )
         .await;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1325,14 +1325,10 @@ async fn anthropic_passthrough_dispatch(
         .unwrap_or("unknown")
         .to_ascii_lowercase();
 
-    // Pick the relay branch from what the upstream ACTUALLY sent, not from
-    // the request's `stream` flag. An upstream that ignores `stream: true`
-    // and answers with one JSON document used to enter the SSE branch
-    // anyway: with no frames in it nothing scanned it, and the hold-back's
-    // seal pass appended a `\n\n` frame terminator to a body that is not
-    // SSE before releasing it under the upstream's own content type. Such
-    // a response belongs on the non-streaming buffered scan+mask path
-    // below, which reads it as the JSON document it is.
+    // The relay branch follows what the upstream ACTUALLY sent, not the
+    // request's `stream` flag — see `dispatch::upstream_body_is_sse`. A
+    // JSON document answering `stream: true` takes the non-streaming
+    // buffered scan+mask path below.
     let is_stream = is_stream && crate::dispatch::upstream_body_is_sse(upstream_resp.headers());
 
     if is_stream {

--- a/crates/aisix-proxy/src/passthrough_route.rs
+++ b/crates/aisix-proxy/src/passthrough_route.rs
@@ -1239,15 +1239,31 @@ fn request_guardrail_text(protocol: PassthroughProtocol, body: &[u8]) -> String 
             })
             .unwrap_or_default(),
         // Responses API: `input` is either a bare string or an array of
-        // items whose `content` parts carry the text. `summary` rides
-        // alongside on a replayed `reasoning` item — caller-supplied text on
-        // the request side, and read by the typed route's scan
-        // (`responses::responses_item_text`), so it is read here too.
+        // items, and the text can sit in any of FOUR slots — the same four
+        // the typed route reads (`responses::responses_item_text`):
+        // `content` on a message, `output` on a tool result fed back,
+        // `reason` on an `mcp_approval_response`, and `summary` on a
+        // replayed `reasoning` item.
+        //
+        // All four, not just the common one: the raw-body fallback below
+        // fires only when the WHOLE extraction came back empty, so a body
+        // mixing a benign message item with a `function_call_output`
+        // produces non-empty text and the tool result is never scanned —
+        // while `/v1/responses` blocks that same body. A passthrough route
+        // must not enforce less than the typed route in front of the same
+        // envelope.
         PassthroughProtocol::OpenaiResponses => match v.get("input") {
             Some(serde_json::Value::String(t)) => t.clone(),
             Some(serde_json::Value::Array(items)) => items
                 .iter()
-                .flat_map(|i| [i.get("content"), i.get("summary")])
+                .flat_map(|i| {
+                    [
+                        i.get("content"),
+                        i.get("output"),
+                        i.get("reason"),
+                        i.get("summary"),
+                    ]
+                })
                 .flatten()
                 .map(content_text)
                 .filter(|t| !t.is_empty())
@@ -3198,7 +3214,9 @@ mod tests {
                     "type": "reasoning",
                     "summary": [{"type": "summary_text", "text": "SUMMARYSECRET"}],
                     "content": [{"type": "reasoning_text", "text": "REASONINGSECRET"}]
-                }
+                },
+                {"type": "function_call_output", "call_id": "c1", "output": "TOOLRESULTSECRET"},
+                {"type": "mcp_approval_response", "approve": true, "reason": "APPROVALSECRET"}
             ]
         })
         .to_string();
@@ -3207,6 +3225,13 @@ mod tests {
         assert!(scanned.contains("VISIBLE"), "got {scanned:?}");
         assert!(scanned.contains("REASONINGSECRET"), "got {scanned:?}");
         assert!(scanned.contains("SUMMARYSECRET"), "got {scanned:?}");
+        // The tool-result and approval slots too. These matter precisely
+        // because the items beside them yield text: the raw-body fallback
+        // fires only on a WHOLLY empty extraction, so a mixed body would
+        // otherwise carry them past the scan while `/v1/responses` blocks
+        // the same envelope.
+        assert!(scanned.contains("TOOLRESULTSECRET"), "got {scanned:?}");
+        assert!(scanned.contains("APPROVALSECRET"), "got {scanned:?}");
 
         let response = serde_json::json!({
             "output": [

--- a/crates/aisix-proxy/src/passthrough_route.rs
+++ b/crates/aisix-proxy/src/passthrough_route.rs
@@ -1081,15 +1081,22 @@ fn content_text(v: &serde_json::Value) -> String {
 }
 
 /// The text a guardrail scans from ONE chat-envelope message: its content
-/// plus the whole serialized `tool_calls` payload.
+/// plus the whole serialized `tool_calls` payload, and — on the request
+/// side only — an assistant turn's replayed `reasoning_content`.
 ///
 /// The tool-call half is what the typed endpoints scan (`message_scan_text`
 /// in the guardrails crate), and it is not optional: a request whose only
 /// sensitive text sits in a tool call's `arguments` would otherwise pass a
 /// deny-list that the same body sent to `/v1/chat/completions` trips.
 /// Serialising the whole payload means no function name or argument can
-/// escape inspection regardless of the provider-specific shape.
-fn message_scan_text(msg: &serde_json::Value) -> String {
+/// escape inspection regardless of the provider-specific shape. The same
+/// argument carries `reasoning_content`, which relays upstream verbatim.
+///
+/// `reasoning` splits the two callers because this helper reads BOTH the
+/// request's `messages[]` and the buffered response's `choices[].message`:
+/// caller-replayed reasoning is request text and in scope, while reasoning
+/// the model generated is out of the output-guardrail scope.
+fn message_scan_text(msg: &serde_json::Value, reasoning: bool) -> String {
     let mut parts: Vec<String> = Vec::new();
     let content = msg.get("content").map(content_text).unwrap_or_default();
     if !content.is_empty() {
@@ -1097,6 +1104,15 @@ fn message_scan_text(msg: &serde_json::Value) -> String {
     }
     if let Some(tool_calls) = msg.get("tool_calls").filter(|t| !t.is_null()) {
         parts.push(tool_calls.to_string());
+    }
+    if reasoning {
+        if let Some(r) = msg
+            .get("reasoning_content")
+            .and_then(|v| v.as_str())
+            .filter(|r| !r.is_empty())
+        {
+            parts.push(r.to_string());
+        }
     }
     parts.join("\n")
 }
@@ -1208,7 +1224,7 @@ fn request_guardrail_text(protocol: PassthroughProtocol, body: &[u8]) -> String 
             .and_then(|m| m.as_array())
             .map(|msgs| {
                 msgs.iter()
-                    .map(message_scan_text)
+                    .map(|m| message_scan_text(m, true))
                     .filter(|t| !t.is_empty())
                     .collect::<Vec<_>>()
                     .join("\n")
@@ -1284,7 +1300,9 @@ fn response_guardrail_text(protocol: PassthroughProtocol, body: &[u8]) -> String
     let texts: Vec<String> = choices
         .iter()
         .filter_map(|c| match protocol {
-            PassthroughProtocol::OpenaiChat => c.get("message").map(message_scan_text),
+            PassthroughProtocol::OpenaiChat => {
+                c.get("message").map(|m| message_scan_text(m, false))
+            }
             PassthroughProtocol::OpenaiCompletions => {
                 c.get("text").and_then(|t| t.as_str()).map(str::to_string)
             }
@@ -1606,18 +1624,26 @@ fn frame_delta(protocol: PassthroughProtocol, frame: &[u8]) -> (String, Option<P
             .get_or_insert_with(PassthroughUsage::default)
             .merge(found);
     };
-    for line in frame_text.lines() {
-        let Some(payload) = line.strip_prefix("data:").map(str::trim_start) else {
-            continue;
+    // ONE read and ONE parse per frame: a payload spread over several
+    // `data:` lines is one document joined with `\n`, so parsing each line
+    // independently produced N unparseable fragments — no usage read, and
+    // on a `Raw` stream the JSON source text pushed into the guardrail
+    // scan instead of the values (#1100). `frame_payload` also strips the
+    // per-line `\r` a CRLF-framed upstream leaves behind, and returns
+    // `None` for a comment-only frame (`: OPENROUTER PROCESSING`).
+    'payload: {
+        let Some(payload) = crate::redact::frame_payload(frame) else {
+            break 'payload;
         };
-        if payload == "[DONE]" {
-            continue;
+        let payload = payload.trim();
+        if payload.is_empty() || payload == "[DONE]" {
+            break 'payload;
         }
         let Ok(v) = serde_json::from_str::<serde_json::Value>(payload) else {
             if matches!(protocol, PassthroughProtocol::Raw) {
                 text.push_str(payload);
             }
-            continue;
+            break 'payload;
         };
         if let Some(u) = v.get("usage").and_then(usage_of) {
             merge(u);
@@ -2879,6 +2905,111 @@ mod tests {
 
 "#;
         assert_eq!(frame_delta(PassthroughProtocol::OpenaiChat, other).1, None);
+    }
+
+    /// A frame's payload is ALL of its `data:` lines joined with `\n`
+    /// (WHATWG SSE). Parsing each line on its own turns one document into
+    /// N unparseable fragments, so the frame's usage went unread and — on
+    /// a `Raw` stream — its JSON source text was pushed into the guardrail
+    /// scan instead of its values.
+    #[test]
+    fn a_payload_spread_over_several_data_lines_is_read_as_one_document() {
+        let frame = b"event: message_delta\ndata: {\"type\":\"message_delta\",\ndata: \"usage\":{\"output_tokens\":7,\"input_tokens\":12}}\n\n";
+        let (_, usage) = frame_delta(PassthroughProtocol::OpenaiChat, frame);
+        assert_eq!(
+            usage,
+            Some(PassthroughUsage {
+                prompt_tokens: 12,
+                completion_tokens: 7,
+                ..Default::default()
+            }),
+        );
+
+        // The `Raw` scan text is the payload's VALUES for a document that
+        // parses — never the raw JSON source, which is what a per-line read
+        // fell back to for each fragment.
+        let (text, _) = frame_delta(PassthroughProtocol::Raw, frame);
+        assert_eq!(
+            text,
+            "{\"type\":\"message_delta\",\n\"usage\":{\"output_tokens\":7,\"input_tokens\":12}}",
+        );
+    }
+
+    /// Framing varies per ENDPOINT, not per vendor: on one host
+    /// `/v1/audio/transcriptions` streams pure CRLF with `\r\n\r\n`
+    /// separators and no `event:` lines while `/v1/responses` on the same
+    /// host is pure LF. The `\r` belongs to the framing and must reach
+    /// neither the parser nor the scan text.
+    #[test]
+    fn a_crlf_framed_frame_reads_the_same_as_its_lf_twin() {
+        let crlf = b"data: {\"usage\":{\"prompt_tokens\":26,\"completion_tokens\":4}}\r\n\r\n";
+        let lf = b"data: {\"usage\":{\"prompt_tokens\":26,\"completion_tokens\":4}}\n\n";
+        assert_eq!(
+            frame_delta(PassthroughProtocol::Raw, crlf),
+            frame_delta(PassthroughProtocol::Raw, lf),
+        );
+        assert_eq!(
+            frame_delta(PassthroughProtocol::Raw, crlf).1,
+            Some(usage_dims(26, 4)),
+        );
+        // …and the frame splitter agrees about where such a frame ends.
+        let mut splitter = SseFrameSplitter::new();
+        assert_eq!(splitter.push(crlf), vec![crlf.to_vec()]);
+    }
+
+    /// A comment-only frame — the keepalive some relays emit while the
+    /// upstream thinks — carries no `data:` line at all. It must contribute
+    /// no usage and no scan text on every protocol, rather than being read
+    /// as an empty or unparseable payload.
+    #[test]
+    fn a_comment_only_frame_contributes_nothing() {
+        for frame in [
+            &b": OPENROUTER PROCESSING\n\n"[..],
+            &b": OPENROUTER PROCESSING\r\n\r\n"[..],
+            &b": keep-alive\nevent: ping\n\n"[..],
+        ] {
+            for protocol in [
+                PassthroughProtocol::Raw,
+                PassthroughProtocol::OpenaiChat,
+                PassthroughProtocol::OpenaiCompletions,
+                PassthroughProtocol::OpenaiResponses,
+            ] {
+                assert_eq!(
+                    frame_delta(protocol, frame),
+                    (String::new(), None),
+                    "{protocol:?} on {:?}",
+                    String::from_utf8_lossy(frame),
+                );
+            }
+        }
+    }
+
+    /// The `[DONE]` sentinel is not content, on either framing. A stream
+    /// that omits it entirely — OpenAI's Responses API sends none — is the
+    /// ordinary case, so nothing may depend on having seen one.
+    #[test]
+    fn the_done_sentinel_contributes_nothing_on_either_framing() {
+        for frame in [&b"data: [DONE]\n\n"[..], &b"data: [DONE]\r\n\r\n"[..]] {
+            assert_eq!(
+                frame_delta(PassthroughProtocol::Raw, frame),
+                (String::new(), None),
+            );
+        }
+    }
+
+    /// Reasoning replayed by the caller is REQUEST text and is scanned; the
+    /// same field on a buffered RESPONSE is generated reasoning and is out
+    /// of the output-guardrail scope. One helper, two answers.
+    #[test]
+    fn replayed_reasoning_is_request_scan_text_and_not_response_scan_text() {
+        let msg = serde_json::json!({
+            "role": "assistant",
+            "content": "visible",
+            "reasoning_content": "hidden reasoning payload",
+        });
+        assert!(message_scan_text(&msg, true).contains("hidden reasoning payload"));
+        assert!(!message_scan_text(&msg, false).contains("hidden reasoning payload"));
+        assert!(message_scan_text(&msg, false).contains("visible"));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/passthrough_route.rs
+++ b/crates/aisix-proxy/src/passthrough_route.rs
@@ -820,6 +820,14 @@ async fn dispatch(
 
     let status = upstream_resp.status();
     let resp_headers = upstream_resp.headers().clone();
+    // Explicit `text/event-stream` only. Deliberately STRICTER than
+    // `dispatch::upstream_body_is_sse`, which the typed relays use: a
+    // passthrough route carries arbitrary REST traffic where most responses
+    // are not SSE, so an unknown content type buffers — the arm that scans
+    // — here, while on a relay that has just asked an LLM to stream the
+    // same guess would 502 an upstream that merely mislabels itself. Not
+    // drift: see that function's doc comment for why the two populations
+    // take opposite defaults.
     let is_sse = resp_headers
         .get(header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())

--- a/crates/aisix-proxy/src/passthrough_route.rs
+++ b/crates/aisix-proxy/src/passthrough_route.rs
@@ -1231,12 +1231,17 @@ fn request_guardrail_text(protocol: PassthroughProtocol, body: &[u8]) -> String 
             })
             .unwrap_or_default(),
         // Responses API: `input` is either a bare string or an array of
-        // items whose `content` parts carry the text.
+        // items whose `content` parts carry the text. `summary` rides
+        // alongside on a replayed `reasoning` item — caller-supplied text on
+        // the request side, and read by the typed route's scan
+        // (`responses::responses_item_text`), so it is read here too.
         PassthroughProtocol::OpenaiResponses => match v.get("input") {
             Some(serde_json::Value::String(t)) => t.clone(),
             Some(serde_json::Value::Array(items)) => items
                 .iter()
-                .filter_map(|i| i.get("content").map(content_text))
+                .flat_map(|i| [i.get("content"), i.get("summary")])
+                .flatten()
+                .map(content_text)
                 .filter(|t| !t.is_empty())
                 .collect::<Vec<_>>()
                 .join("\n"),
@@ -1284,6 +1289,15 @@ fn response_guardrail_text(protocol: PassthroughProtocol, body: &[u8]) -> String
             .map(|items| {
                 items
                     .iter()
+                    // Generated reasoning is out of the output-guardrail
+                    // scope, and a `reasoning` item DOES carry `content[]`
+                    // with `text` parts — so reading `content` off every
+                    // item regardless of type sweeps it in. The typed
+                    // `/v1/responses` handler skips it for the same reason
+                    // (`responses::responses_output_text`); without this a
+                    // block rule matching only inside reasoning would refuse
+                    // a response here that the typed route allows.
+                    .filter(|i| i.get("type").and_then(|t| t.as_str()) != Some("reasoning"))
                     .filter_map(|i| i.get("content").map(content_text))
                     .filter(|t| !t.is_empty())
                     .collect::<Vec<_>>()
@@ -1640,9 +1654,16 @@ fn frame_delta(protocol: PassthroughProtocol, frame: &[u8]) -> (String, Option<P
             break 'payload;
         }
         let Ok(v) = serde_json::from_str::<serde_json::Value>(payload) else {
-            if matches!(protocol, PassthroughProtocol::Raw) {
-                text.push_str(payload);
-            }
+            // Unparseable joined payload — a non-conformant upstream that
+            // put two independent JSON documents on two `data:` lines, say.
+            // The frame is still FORWARDED, so scanning nothing here is a
+            // way past an output block rule. Fall back to the raw payload
+            // text on every protocol, not just `Raw`: over-scanning can only
+            // produce a false positive, while under-scanning a frame the
+            // client receives is the bypass. (Per-line parsing used to catch
+            // the two-document case incidentally; this covers it and every
+            // other shape that does not parse.)
+            text.push_str(payload);
             break 'payload;
         };
         if let Some(u) = v.get("usage").and_then(usage_of) {
@@ -2984,6 +3005,30 @@ mod tests {
         }
     }
 
+    /// A frame whose joined payload does not parse is still FORWARDED to
+    /// the client, so producing no scan text for it is a way past an output
+    /// block rule. Every protocol falls back to the raw payload text — the
+    /// worst case is a false positive, while the alternative is a bypass.
+    #[test]
+    fn an_unparseable_payload_still_yields_scan_text_on_every_protocol() {
+        // Two independent JSON documents on two `data:` lines: joined per
+        // the SSE spec this is one unparseable payload, and per-line parsing
+        // used to catch it only incidentally.
+        let frame = b"data: {\"choices\":[{\"delta\":{\"content\":\"BLOCKME\"}}]}\ndata: {\"choices\":[]}\n\n";
+        for protocol in [
+            PassthroughProtocol::Raw,
+            PassthroughProtocol::OpenaiChat,
+            PassthroughProtocol::OpenaiCompletions,
+            PassthroughProtocol::OpenaiResponses,
+        ] {
+            let (text, _) = frame_delta(protocol, frame);
+            assert!(
+                text.contains("BLOCKME"),
+                "{protocol:?} must still offer the forwarded bytes to the scan, got {text:?}",
+            );
+        }
+    }
+
     /// The `[DONE]` sentinel is not content, on either framing. A stream
     /// that omits it entirely — OpenAI's Responses API sends none — is the
     /// ordinary case, so nothing may depend on having seen one.
@@ -3126,6 +3171,57 @@ mod tests {
         let name = body_model_name(PassthroughProtocol::OpenaiResponses, hostile.as_bytes());
         assert_eq!(name.chars().count(), REQUESTED_MODEL_CAP);
         assert!(!name.contains('\0'));
+    }
+
+    /// The passthrough route reads the SAME Responses shapes the typed
+    /// `/v1/responses` handler does, in the same directions. Request:
+    /// a replayed `reasoning` item's `content` AND `summary` are
+    /// caller-supplied text and are scanned. Response: a generated
+    /// `reasoning` item is out of the output scope and must not be —
+    /// the walk reads `content` off every item regardless of type, so
+    /// without an explicit skip a block rule matching only inside
+    /// reasoning refuses a response the typed route allows.
+    #[test]
+    fn responses_passthrough_scans_replayed_reasoning_but_not_generated_reasoning() {
+        let request = serde_json::json!({
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "VISIBLE"}]},
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "SUMMARYSECRET"}],
+                    "content": [{"type": "reasoning_text", "text": "REASONINGSECRET"}]
+                }
+            ]
+        })
+        .to_string();
+        let scanned =
+            request_guardrail_text(PassthroughProtocol::OpenaiResponses, request.as_bytes());
+        assert!(scanned.contains("VISIBLE"), "got {scanned:?}");
+        assert!(scanned.contains("REASONINGSECRET"), "got {scanned:?}");
+        assert!(scanned.contains("SUMMARYSECRET"), "got {scanned:?}");
+
+        let response = serde_json::json!({
+            "output": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "SUMMARYSECRET"}],
+                    "content": [{"type": "reasoning_text", "text": "REASONINGSECRET"}]
+                },
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "the visible answer"}]
+                }
+            ]
+        })
+        .to_string();
+        let scanned =
+            response_guardrail_text(PassthroughProtocol::OpenaiResponses, response.as_bytes());
+        assert!(scanned.contains("the visible answer"), "got {scanned:?}");
+        assert!(!scanned.contains("REASONINGSECRET"), "got {scanned:?}");
+        // Not a raw-body fallback: the message item yielded text, so a
+        // green above means the reasoning item was skipped rather than the
+        // whole walk having come back empty.
+        assert!(!scanned.contains("\"output\""), "got {scanned:?}");
     }
 
     #[test]

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -437,13 +437,20 @@ pub fn redact_anthropic_request(chain: &dyn Guardrail, body: &mut Value) -> Reda
 /// rather than forward the match unmasked.
 ///
 /// An Anthropic `thinking` / `redacted_thinking` block is signed by the
-/// provider (`signature`, and the encrypted `data` of a redacted one). Any
-/// rewrite invalidates that signature and the upstream rejects the
-/// replayed turn, so a Mask-action hit inside one cannot be applied. The
-/// scan reads these blocks (`parse_inbound_request_for_scan`), so a Block
-/// rule still blocks normally; only the Mask action has nowhere to go, and
-/// silently leaving the match in place is the fail-open this exists to
-/// close. The same rule holds for any block carrying a `signature`.
+/// provider, so any rewrite invalidates that signature and the upstream
+/// rejects the replayed turn — a Mask-action hit inside one cannot be
+/// applied. The scan reads these blocks
+/// (`parse_inbound_request_for_scan`), so a Block rule still blocks
+/// normally; only the Mask action has nowhere to go, and silently leaving
+/// the match in place is the fail-open this exists to close. The same rule
+/// holds for any block carrying a `signature`.
+///
+/// Only the PLAINTEXT slots are probed. A `redacted_thinking` block's
+/// `data` is opaque provider ciphertext: the scan never reads it, so no
+/// mask can have reported a hit there and there is no fail-open to close —
+/// while running a detector over base64 would refuse ordinary requests on
+/// a coincidental match inside the ciphertext. Probing exactly what the
+/// scan reads is what keeps the two from disagreeing in either direction.
 ///
 /// Rewrites nothing — it asks the chain's input redactor whether the text
 /// WOULD change.
@@ -460,7 +467,7 @@ pub fn anthropic_request_masks_signed_reasoning(chain: &dyn Guardrail, body: &Va
         .flatten()
         .filter(|block| is_signed_reasoning_block(block))
         .any(|block| {
-            ["thinking", "data", "text"]
+            ["thinking", "text"]
                 .into_iter()
                 .filter_map(|k| block.get(k).and_then(Value::as_str))
                 .filter(|t| !t.is_empty())
@@ -1879,6 +1886,45 @@ mod tests {
             clean["messages"][0]["content"][1]["text"].as_str(),
             Some("mail [EMAIL_REDACTED]")
         );
+    }
+
+    /// A `redacted_thinking` block carries only the provider's opaque
+    /// ciphertext. The scan never reads it, so no mask can have reported a
+    /// hit there — and running a detector over the blob would refuse
+    /// ordinary requests whenever it happens to contain a matching span.
+    ///
+    /// The `data` below is a deliberately unmissable match rather than a
+    /// realistic blob: the claim under test is that this field is never
+    /// offered to a detector at all, so the value has to be one that WOULD
+    /// fire if it were. (A realistic base64 blob makes the test unable to
+    /// go red — its digit runs sit between alphanumerics, where the
+    /// boundary-anchored detectors do not match, so it would pass whether
+    /// or not the field is probed.)
+    #[test]
+    fn signed_reasoning_probe_ignores_opaque_ciphertext() {
+        let chain = both();
+        let body = json!({
+            "messages": [{"role": "assistant", "content": [
+                {"type": "redacted_thinking", "data": "RXJVUUtvVUJ a@x.com CkYIBBgCKkC"}
+            ]}]
+        });
+        assert!(!anthropic_request_masks_signed_reasoning(
+            chain.as_ref(),
+            &body
+        ));
+
+        // Control: the same chain DOES fire on a plaintext thinking block,
+        // so a green above means "this field is skipped", not "this chain
+        // matches nothing".
+        let plaintext = json!({
+            "messages": [{"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "a@x.com", "signature": "s"}
+            ]}]
+        });
+        assert!(anthropic_request_masks_signed_reasoning(
+            chain.as_ref(),
+            &plaintext
+        ));
     }
 
     /// An output-only chain must not make the request probe fire — it has

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -432,66 +432,28 @@ pub fn redact_anthropic_request(chain: &dyn Guardrail, body: &mut Value) -> Reda
     counts
 }
 
-/// Whether an input mask would have to rewrite a signed reasoning block
-/// to be honoured — in which case the caller must refuse the request
-/// rather than forward the match unmasked.
-///
-/// An Anthropic `thinking` / `redacted_thinking` block is signed by the
-/// provider, so any rewrite invalidates that signature and the upstream
-/// rejects the replayed turn — a Mask-action hit inside one cannot be
-/// applied. The scan reads these blocks
-/// (`parse_inbound_request_for_scan`), so a Block rule still blocks
-/// normally; only the Mask action has nowhere to go, and silently leaving
-/// the match in place is the fail-open this exists to close. The same rule
-/// holds for any block carrying a `signature`.
-///
-/// Only the PLAINTEXT slots are probed. A `redacted_thinking` block's
-/// `data` is opaque provider ciphertext: the scan never reads it, so no
-/// mask can have reported a hit there and there is no fail-open to close —
-/// while running a detector over base64 would refuse ordinary requests on
-/// a coincidental match inside the ciphertext. Probing exactly what the
-/// scan reads is what keeps the two from disagreeing in either direction.
-///
-/// Rewrites nothing — it asks the chain's input redactor whether the text
-/// WOULD change.
-pub fn anthropic_request_masks_signed_reasoning(chain: &dyn Guardrail, body: &Value) -> bool {
-    if !chain.redacts_input() {
-        return false;
-    }
-    let Some(messages) = body.get("messages").and_then(Value::as_array) else {
-        return false;
-    };
-    messages
-        .iter()
-        .filter_map(|m| m.get("content").and_then(Value::as_array))
-        .flatten()
-        .filter(|block| is_signed_reasoning_block(block))
-        .any(|block| {
-            ["thinking", "text"]
-                .into_iter()
-                .filter_map(|k| block.get(k).and_then(Value::as_str))
-                .filter(|t| !t.is_empty())
-                .any(|t| redact_str(chain, Direction::Input, t).is_some_and(|r| r.text != t))
-        })
-}
-
-/// A content block whose bytes the provider signed: Anthropic's two
-/// reasoning block types, plus anything else carrying a `signature`.
-fn is_signed_reasoning_block(block: &Value) -> bool {
-    matches!(
-        block.get("type").and_then(Value::as_str),
-        Some("thinking") | Some("redacted_thinking")
-    ) || block.get("signature").and_then(Value::as_str).is_some()
-}
-
 /// Anthropic `content` is either a bare string or an array of typed
 /// blocks. Rewrites `text` blocks, `tool_result` nested content, and
 /// `tool_use` input objects; leaves image/document blocks alone.
 ///
-/// `thinking` / `redacted_thinking` blocks are deliberately NOT rewritten
-/// — see [`anthropic_request_masks_signed_reasoning`], which is what the
-/// handlers consult before masking so a hit there refuses the request
-/// instead of travelling upstream unmasked.
+/// **Deliberate exception to "no write-back channel means block".** A
+/// `thinking` / `redacted_thinking` block is signed by the provider, so it
+/// can be neither rewritten (the signature would no longer verify and the
+/// upstream rejects the replayed turn) nor, per the ruling on #1104,
+/// blocked. A mask-action hit inside one is FORWARDED UNCHANGED, for every
+/// guardrail kind — including the kinds that otherwise turn an unmaskable
+/// result into a blocking verdict.
+///
+/// Why refusing it buys nothing: the same bytes already left the gateway.
+/// Generated reasoning is out of the OUTPUT scope by design, so this block
+/// is one the gateway itself handed to the client, unmasked, on the
+/// previous turn. Blocking the replay protects nothing that was not already
+/// disclosed, and it denies service permanently, because a client following
+/// Anthropic's extended-thinking protocol re-sends the block every turn.
+///
+/// BLOCK-action rules are unaffected and still fire on thinking content —
+/// the scan reads it (`parse_inbound_request_for_scan`); only the mask has
+/// nowhere to write.
 fn redact_anthropic_content(
     chain: &dyn Guardrail,
     dir: Direction,
@@ -613,8 +575,8 @@ fn redact_responses_item(
         // match still in it — the mask has to reach the same slots the scan
         // does. Neither slot carries a provider signature, so rewriting one
         // is not replay-breaking; the Anthropic `thinking` block is the
-        // signed case and is refused instead
-        // (`anthropic_request_masks_signed_reasoning`).
+        // signed case and is forwarded unchanged instead (see
+        // `redact_anthropic_content`).
         //
         // NOT closed here: a reasoning item's `encrypted_content` is
         // forwarded verbatim and is neither scanned nor rewritten, so on a
@@ -1841,12 +1803,14 @@ mod tests {
         );
     }
 
-    /// C4: a Mask hit inside a signed Anthropic `thinking` block cannot be
-    /// honoured — rewriting invalidates the signature — so the handler has
-    /// to refuse. This is the probe it refuses on; the block itself stays
-    /// untouched by the mask pass.
+    /// A mask-action hit inside a signed `thinking` / `redacted_thinking`
+    /// block is FORWARDED UNCHANGED — the deliberate exception to "no
+    /// write-back channel means block" (#1104). The block is byte-identical
+    /// afterwards, and the ordinary block beside it still masks, so this
+    /// pins an exception for the signed block rather than an exemption for
+    /// the whole message.
     #[test]
-    fn signed_reasoning_mask_is_reported_and_never_applied() {
+    fn signed_reasoning_is_forwarded_unchanged_while_its_neighbours_mask() {
         let chain = both();
         let mut body = json!({
             "model": "m",
@@ -1854,101 +1818,56 @@ mod tests {
                 {"role": "user", "content": "hi"},
                 {"role": "assistant", "content": [
                     {"type": "thinking", "thinking": "mail a@x.com", "signature": "sig-abc"},
-                    {"type": "text", "text": "sure"}
+                    {"type": "redacted_thinking", "data": "opaque a@x.com blob"},
+                    {"type": "text", "text": "also mail a@x.com"}
                 ]}
             ]
         });
-        assert!(anthropic_request_masks_signed_reasoning(
-            chain.as_ref(),
-            &body
-        ));
-        let before = body["messages"][1]["content"][0].clone();
+        let before = body["messages"][1]["content"].clone();
         redact_anthropic_request(chain.as_ref(), &mut body);
+
         assert_eq!(
-            body["messages"][1]["content"][0], before,
-            "the signed block is never rewritten",
+            body["messages"][1]["content"][0], before[0],
+            "the signed thinking block is byte-identical",
+        );
+        assert_eq!(
+            body["messages"][1]["content"][1], before[1],
+            "so is the redacted_thinking block",
+        );
+        assert_eq!(
+            body["messages"][1]["content"][2]["text"].as_str(),
+            Some("also mail [EMAIL_REDACTED]"),
+            "the mask is demonstrably running on this very request",
         );
     }
 
-    /// The probe must not fire on a body the mask can honour, or every
-    /// thinking-carrying request would 422. Two negatives: a thinking block
-    /// with nothing to mask, and a maskable literal in an ordinary `text`
-    /// block beside one.
+    /// The exception is for the MASK only. A block-action rule still fires
+    /// on thinking content, because the scan reads it — otherwise the
+    /// exception would have turned a signed block into a channel any
+    /// forbidden text could travel through.
     #[test]
-    fn signed_reasoning_probe_is_quiet_when_the_mask_has_somewhere_to_go() {
-        let chain = both();
-        let clean = json!({
+    fn a_block_rule_still_fires_on_thinking_content() {
+        use aisix_guardrails::{KeywordBlocklist, KeywordRule};
+
+        let chain: Arc<dyn Guardrail> = Arc::new(GuardrailChain::new(vec![Arc::new(
+            KeywordBlocklist::input_only(vec![KeywordRule::literal("FORBIDDENTHOUGHT")]),
+        )]));
+
+        let body = json!({
+            "model": "claude",
             "messages": [{"role": "assistant", "content": [
-                {"type": "thinking", "thinking": "nothing sensitive here", "signature": "s"},
-                {"type": "text", "text": "mail a@x.com"}
+                {"type": "thinking", "thinking": "I will FORBIDDENTHOUGHT now", "signature": "s"}
             ]}]
         });
-        assert!(!anthropic_request_masks_signed_reasoning(
+        let chat = aisix_provider_anthropic::parse_inbound_request_for_scan(&body).unwrap();
+        let verdict = futures::executor::block_on(aisix_guardrails::Guardrail::check_input(
             chain.as_ref(),
-            &clean
+            &chat,
         ));
-        // …and that ordinary block still masks normally.
-        let mut clean = clean;
-        redact_anthropic_request(chain.as_ref(), &mut clean);
-        assert_eq!(
-            clean["messages"][0]["content"][1]["text"].as_str(),
-            Some("mail [EMAIL_REDACTED]")
+        assert!(
+            matches!(verdict, aisix_guardrails::GuardrailVerdict::Block { .. }),
+            "a block rule must still reach thinking text, got {verdict:?}",
         );
-    }
-
-    /// A `redacted_thinking` block carries only the provider's opaque
-    /// ciphertext. The scan never reads it, so no mask can have reported a
-    /// hit there — and running a detector over the blob would refuse
-    /// ordinary requests whenever it happens to contain a matching span.
-    ///
-    /// The `data` below is a deliberately unmissable match rather than a
-    /// realistic blob: the claim under test is that this field is never
-    /// offered to a detector at all, so the value has to be one that WOULD
-    /// fire if it were. (A realistic base64 blob makes the test unable to
-    /// go red — its digit runs sit between alphanumerics, where the
-    /// boundary-anchored detectors do not match, so it would pass whether
-    /// or not the field is probed.)
-    #[test]
-    fn signed_reasoning_probe_ignores_opaque_ciphertext() {
-        let chain = both();
-        let body = json!({
-            "messages": [{"role": "assistant", "content": [
-                {"type": "redacted_thinking", "data": "RXJVUUtvVUJ a@x.com CkYIBBgCKkC"}
-            ]}]
-        });
-        assert!(!anthropic_request_masks_signed_reasoning(
-            chain.as_ref(),
-            &body
-        ));
-
-        // Control: the same chain DOES fire on a plaintext thinking block,
-        // so a green above means "this field is skipped", not "this chain
-        // matches nothing".
-        let plaintext = json!({
-            "messages": [{"role": "assistant", "content": [
-                {"type": "thinking", "thinking": "a@x.com", "signature": "s"}
-            ]}]
-        });
-        assert!(anthropic_request_masks_signed_reasoning(
-            chain.as_ref(),
-            &plaintext
-        ));
-    }
-
-    /// An output-only chain must not make the request probe fire — it has
-    /// no input redactor to ask.
-    #[test]
-    fn signed_reasoning_probe_ignores_an_output_only_chain() {
-        let out_only = mask_chain(aisix_core::models::GuardrailHookPoint::Output);
-        let body = json!({
-            "messages": [{"role": "assistant", "content": [
-                {"type": "thinking", "thinking": "mail a@x.com", "signature": "s"}
-            ]}]
-        });
-        assert!(!anthropic_request_masks_signed_reasoning(
-            out_only.as_ref(),
-            &body
-        ));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -613,8 +613,16 @@ fn redact_responses_item(
         // match still in it — the mask has to reach the same slots the scan
         // does. Neither slot carries a provider signature, so rewriting one
         // is not replay-breaking; the Anthropic `thinking` block is the
-        // signed case and is refused instead (`anthropic_masks_signed_
-        // reasoning`).
+        // signed case and is refused instead
+        // (`anthropic_request_masks_signed_reasoning`).
+        //
+        // NOT closed here: a reasoning item's `encrypted_content` is
+        // forwarded verbatim and is neither scanned nor rewritten, so on a
+        // request that replays one the masked `text` is a readable copy
+        // while the provider still receives the original. Masking it is not
+        // possible (it is provider ciphertext) and refusing on it is the
+        // open question this arm's Anthropic sibling raises — do not read
+        // this arm as closing the `/v1/responses` side.
         //
         // Input only. Reasoning the model GENERATES is out of
         // output-guardrail scope, so this arm must not fire on

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -347,8 +347,13 @@ pub fn redact_json_encoded(
 /// Mask the request messages of a normalised [`ChatFormat`] in place:
 /// the flat `content` string and the `text` field of typed content
 /// blocks — the same surface `check_input` scans (`message_scan_text`).
-/// Tool-call arguments replayed in history are covered too (they reach
-/// the upstream verbatim). Returns the merged counts (empty = untouched).
+/// Tool-call arguments and replayed `reasoning_content` are covered too
+/// (both reach the upstream verbatim through `extra`). Returns the merged
+/// counts (empty = untouched).
+///
+/// This list and `message_scan_text`'s must stay equal: a slot the scan
+/// reads but this does not is a Mask rule that reports a hit and then
+/// dispatches the match unmasked.
 pub fn redact_chat_format(chain: &dyn Guardrail, req: &mut ChatFormat) -> RedactionCounts {
     let mut counts = RedactionCounts::new();
     if !chain.redacts_input() {
@@ -371,6 +376,13 @@ pub fn redact_chat_format(chain: &dyn Guardrail, req: &mut ChatFormat) -> Redact
         // verbatim through `extra`, so mask them like fresh content.
         if let Some(tool_calls) = msg.extra.get_mut("tool_calls") {
             redact_tool_call_arguments(chain, Direction::Input, tool_calls, &mut counts);
+        }
+        // Same reason for replayed reasoning: `reasoning_content` is the
+        // canonical slot the provider overrides normalise every vendor
+        // spelling onto, and it rides `extra` to the upstream untouched.
+        // Nothing signs it on this wire, so masking it is safe.
+        if let Some(reasoning @ Value::String(_)) = msg.extra.get_mut("reasoning_content") {
+            apply_to_value_string(chain, Direction::Input, reasoning, &mut counts);
         }
     }
     counts
@@ -420,9 +432,59 @@ pub fn redact_anthropic_request(chain: &dyn Guardrail, body: &mut Value) -> Reda
     counts
 }
 
+/// Whether an input mask would have to rewrite a signed reasoning block
+/// to be honoured — in which case the caller must refuse the request
+/// rather than forward the match unmasked.
+///
+/// An Anthropic `thinking` / `redacted_thinking` block is signed by the
+/// provider (`signature`, and the encrypted `data` of a redacted one). Any
+/// rewrite invalidates that signature and the upstream rejects the
+/// replayed turn, so a Mask-action hit inside one cannot be applied. The
+/// scan reads these blocks (`parse_inbound_request_for_scan`), so a Block
+/// rule still blocks normally; only the Mask action has nowhere to go, and
+/// silently leaving the match in place is the fail-open this exists to
+/// close. The same rule holds for any block carrying a `signature`.
+///
+/// Rewrites nothing — it asks the chain's input redactor whether the text
+/// WOULD change.
+pub fn anthropic_request_masks_signed_reasoning(chain: &dyn Guardrail, body: &Value) -> bool {
+    if !chain.redacts_input() {
+        return false;
+    }
+    let Some(messages) = body.get("messages").and_then(Value::as_array) else {
+        return false;
+    };
+    messages
+        .iter()
+        .filter_map(|m| m.get("content").and_then(Value::as_array))
+        .flatten()
+        .filter(|block| is_signed_reasoning_block(block))
+        .any(|block| {
+            ["thinking", "data", "text"]
+                .into_iter()
+                .filter_map(|k| block.get(k).and_then(Value::as_str))
+                .filter(|t| !t.is_empty())
+                .any(|t| redact_str(chain, Direction::Input, t).is_some_and(|r| r.text != t))
+        })
+}
+
+/// A content block whose bytes the provider signed: Anthropic's two
+/// reasoning block types, plus anything else carrying a `signature`.
+fn is_signed_reasoning_block(block: &Value) -> bool {
+    matches!(
+        block.get("type").and_then(Value::as_str),
+        Some("thinking") | Some("redacted_thinking")
+    ) || block.get("signature").and_then(Value::as_str).is_some()
+}
+
 /// Anthropic `content` is either a bare string or an array of typed
 /// blocks. Rewrites `text` blocks, `tool_result` nested content, and
 /// `tool_use` input objects; leaves image/document blocks alone.
+///
+/// `thinking` / `redacted_thinking` blocks are deliberately NOT rewritten
+/// — see [`anthropic_request_masks_signed_reasoning`], which is what the
+/// handlers consult before masking so a hit there refuses the request
+/// instead of travelling upstream unmasked.
 fn redact_anthropic_content(
     chain: &dyn Guardrail,
     dir: Direction,
@@ -535,6 +597,30 @@ fn redact_responses_item(
         Some("function_call_output") => {
             if let Some(output) = item.get_mut("output") {
                 apply_to_value_string(chain, dir, output, counts);
+            }
+        }
+        // A `reasoning` item replayed on the REQUEST. Its `content[].text`
+        // and `summary[].text` are both read by the scan
+        // (`responses::responses_item_text`), so a Mask rule matching there
+        // reported a hit, returned Allow, and dispatched the body with the
+        // match still in it — the mask has to reach the same slots the scan
+        // does. Neither slot carries a provider signature, so rewriting one
+        // is not replay-breaking; the Anthropic `thinking` block is the
+        // signed case and is refused instead (`anthropic_masks_signed_
+        // reasoning`).
+        //
+        // Input only. Reasoning the model GENERATES is out of
+        // output-guardrail scope, so this arm must not fire on
+        // `redact_responses_response`.
+        Some("reasoning") if dir == Direction::Input => {
+            for key in ["content", "summary"] {
+                if let Some(Value::Array(parts)) = item.get_mut(key) {
+                    for part in parts {
+                        if let Some(text) = part.get_mut("text") {
+                            apply_to_value_string(chain, dir, text, counts);
+                        }
+                    }
+                }
             }
         }
         _ => {}
@@ -1063,12 +1149,17 @@ impl BufferedSseSeal {
 /// that everything released was *understood*. The test here is whether a
 /// payload PARSES, because that is the most this layer can decide without
 /// knowing the route's event vocabulary. A frame carrying valid JSON of a
-/// `type` no pass models — and a 200 body that is not SSE at all, which an
-/// upstream ignoring `stream: true` will produce and which has no `data:`
-/// line to read — still travel through unread. Both predate #1100 and
-/// closing them would cut responses that reach clients today, so they are
-/// deliberately left; see #1100 for the reasoning. Do not build on a
+/// `type` no pass models still travels through unread; that predates #1100
+/// and closing it would cut responses that reach clients today, so it is
+/// deliberately left (see #1100 for the reasoning). Do not build on a
 /// stronger invariant than the one stated above.
+///
+/// A 200 body that is not SSE at all — what an upstream ignoring
+/// `stream: true` returns — used to reach here too, and was released with
+/// a `\n\n` appended to it. It no longer does: `/v1/responses` and
+/// `/v1/messages` choose their relay branch from the upstream's own
+/// content type (`dispatch::upstream_body_is_sse`), so such a body takes
+/// the non-streaming buffered scan+mask path instead of this one.
 ///
 /// Note what is NOT cut: a frame carrying several `data:` lines that join
 /// into one JSON document is a well-formed frame, and is scanned and
@@ -1636,6 +1727,174 @@ mod tests {
 
     fn both() -> Arc<dyn Guardrail> {
         mask_chain(aisix_core::models::GuardrailHookPoint::Both)
+    }
+
+    /// `message_scan_text` reads `extra["reasoning_content"]`, so this
+    /// must rewrite it or a Mask rule reports a hit on reasoning it then
+    /// forwards to the upstream verbatim. Nothing on the OpenAI wire signs
+    /// this slot, so rewriting it is safe — unlike the Anthropic `thinking`
+    /// block below.
+    #[test]
+    fn chat_format_masks_replayed_reasoning_content() {
+        let chain = both();
+        let mut req: ChatFormat = serde_json::from_value(json!({
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "who?"},
+                {
+                    "role": "assistant",
+                    "content": "checking",
+                    "reasoning_content": "the user meant a@x.com I think"
+                }
+            ]
+        }))
+        .unwrap();
+        let counts = redact_chat_format(chain.as_ref(), &mut req);
+        assert_eq!(
+            req.messages[1]
+                .extra
+                .get("reasoning_content")
+                .and_then(Value::as_str),
+            Some("the user meant [EMAIL_REDACTED] I think"),
+        );
+        assert!(!counts.is_empty());
+    }
+
+    /// C1: the `/v1/responses` scan reads a `reasoning` item's
+    /// `content[].text` AND `summary[].text`, so the request mask has to
+    /// reach both — otherwise a Mask rule matching there reported a hit,
+    /// returned Allow, and dispatched the body with the match intact.
+    #[test]
+    fn responses_request_masks_reasoning_content_and_summary() {
+        let chain = both();
+        let mut body = json!({
+            "model": "m",
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [{"type": "summary_text", "text": "ask a@x.com"}],
+                    "content": [{"type": "reasoning_text", "text": "or call 13800138000"}]
+                }
+            ]
+        });
+        let counts = redact_responses_request(chain.as_ref(), &mut body);
+        let item = &body["input"][1];
+        assert_eq!(
+            item["summary"][0]["text"].as_str(),
+            Some("ask [EMAIL_REDACTED]")
+        );
+        assert_eq!(
+            item["content"][0]["text"].as_str(),
+            Some("or call [CHINA_MOBILE_REDACTED]")
+        );
+        assert!(!counts.is_empty());
+    }
+
+    /// The mirror of the test above, and the reason the arm is gated on
+    /// `Direction::Input`: reasoning the model GENERATED is out of the
+    /// output-guardrail scope, so the response mask must leave a
+    /// `reasoning` item in `output[]` byte-identical.
+    #[test]
+    fn responses_response_leaves_generated_reasoning_alone() {
+        let chain = both();
+        let mut body = json!({
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [{"type": "summary_text", "text": "ask a@x.com"}],
+                    "content": [{"type": "reasoning_text", "text": "or call 13800138000"}]
+                },
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "reply to b@y.org"}]
+                }
+            ]
+        });
+        let before = body["output"][0].clone();
+        redact_responses_response(chain.as_ref(), &mut body);
+        assert_eq!(
+            body["output"][0], before,
+            "generated reasoning is untouched"
+        );
+        assert_eq!(
+            body["output"][1]["content"][0]["text"].as_str(),
+            Some("reply to [EMAIL_REDACTED]"),
+            "the message item is still masked",
+        );
+    }
+
+    /// C4: a Mask hit inside a signed Anthropic `thinking` block cannot be
+    /// honoured — rewriting invalidates the signature — so the handler has
+    /// to refuse. This is the probe it refuses on; the block itself stays
+    /// untouched by the mask pass.
+    #[test]
+    fn signed_reasoning_mask_is_reported_and_never_applied() {
+        let chain = both();
+        let mut body = json!({
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": [
+                    {"type": "thinking", "thinking": "mail a@x.com", "signature": "sig-abc"},
+                    {"type": "text", "text": "sure"}
+                ]}
+            ]
+        });
+        assert!(anthropic_request_masks_signed_reasoning(
+            chain.as_ref(),
+            &body
+        ));
+        let before = body["messages"][1]["content"][0].clone();
+        redact_anthropic_request(chain.as_ref(), &mut body);
+        assert_eq!(
+            body["messages"][1]["content"][0], before,
+            "the signed block is never rewritten",
+        );
+    }
+
+    /// The probe must not fire on a body the mask can honour, or every
+    /// thinking-carrying request would 422. Two negatives: a thinking block
+    /// with nothing to mask, and a maskable literal in an ordinary `text`
+    /// block beside one.
+    #[test]
+    fn signed_reasoning_probe_is_quiet_when_the_mask_has_somewhere_to_go() {
+        let chain = both();
+        let clean = json!({
+            "messages": [{"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "nothing sensitive here", "signature": "s"},
+                {"type": "text", "text": "mail a@x.com"}
+            ]}]
+        });
+        assert!(!anthropic_request_masks_signed_reasoning(
+            chain.as_ref(),
+            &clean
+        ));
+        // …and that ordinary block still masks normally.
+        let mut clean = clean;
+        redact_anthropic_request(chain.as_ref(), &mut clean);
+        assert_eq!(
+            clean["messages"][0]["content"][1]["text"].as_str(),
+            Some("mail [EMAIL_REDACTED]")
+        );
+    }
+
+    /// An output-only chain must not make the request probe fire — it has
+    /// no input redactor to ask.
+    #[test]
+    fn signed_reasoning_probe_ignores_an_output_only_chain() {
+        let out_only = mask_chain(aisix_core::models::GuardrailHookPoint::Output);
+        let body = json!({
+            "messages": [{"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "mail a@x.com", "signature": "s"}
+            ]}]
+        });
+        assert!(!anthropic_request_masks_signed_reasoning(
+            out_only.as_ref(),
+            &body
+        ));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -204,6 +204,43 @@ pub async fn moderate_body(
     non_segment_verdict: aisix_guardrails::GuardrailVerdict,
     counts_out: &mut RedactionCounts,
     monitor_hits_out: &mut Vec<aisix_core::models::GuardrailMonitorHit>,
+    walk: impl FnMut(&dyn Guardrail) -> RedactionCounts,
+) -> aisix_guardrails::GuardrailVerdict {
+    moderate_body_scanning(
+        chain,
+        dir,
+        non_segment_verdict,
+        counts_out,
+        monitor_hits_out,
+        Vec::new(),
+        walk,
+    )
+    .await
+}
+
+/// [`moderate_body`] plus text that must be SCANNED but must never be
+/// written back.
+///
+/// The walker is both the collect pass and the apply pass, so a slot it
+/// offers is a slot the provider may rewrite. That makes it the wrong place
+/// for a signed Anthropic `thinking` block: the block has to reach the
+/// screening call (an operator's block rule must still fire on it) and must
+/// come back byte-identical (#1104). `scan_only` is appended after the
+/// collected slots and truncated off the masked reply before the apply
+/// walk, so those texts are judged and never rewritten.
+///
+/// Without it the segment kinds — `bedrock`, `presidio`, `lakera`,
+/// `aliyun_ai_guardrail`, `custom` — never saw thinking content at all on
+/// `/v1/messages`: they answer `Allow` from `check_input_non_segment` by
+/// design and take their real verdict from this pass, so a block policy on
+/// any of them was bypassable by moving the text into a thinking block.
+pub async fn moderate_body_scanning(
+    chain: &dyn Guardrail,
+    dir: Direction,
+    non_segment_verdict: aisix_guardrails::GuardrailVerdict,
+    counts_out: &mut RedactionCounts,
+    monitor_hits_out: &mut Vec<aisix_core::models::GuardrailMonitorHit>,
+    scan_only: Vec<String>,
     mut walk: impl FnMut(&dyn Guardrail) -> RedactionCounts,
 ) -> aisix_guardrails::GuardrailVerdict {
     if non_segment_verdict.is_block() || !chain.moderates_segments() {
@@ -211,7 +248,11 @@ pub async fn moderate_body(
     }
     let collector = SegmentCollector::default();
     walk(&collector);
-    let texts = collector.take();
+    let mut texts = collector.take();
+    // Everything past here is judged but unwritable; the apply walk only
+    // ever offers the first `writable` slots back.
+    let writable = texts.len();
+    texts.extend(scan_only);
     // The pass runs even with zero collected slots. "Nothing to scan" is
     // not "nothing to decide": a segment-moderating member may hold a
     // verdict that does not depend on the text (a `kind: custom` policy
@@ -226,7 +267,15 @@ pub async fn moderate_body(
     };
     monitor_hits_out.append(&mut outcome.monitor_hits);
     if !outcome.verdict.is_block() {
-        if let Some(masked) = outcome.masked {
+        if let Some(mut masked) = outcome.masked {
+            // Drop the scan-only tail. The applier is positional and the
+            // walk offers only the first `writable` slots, so slots 0..n
+            // land correctly either way — this is not what keeps the signed
+            // block unwritten (the walk never offering it is). What it
+            // buys: without it `warn_if_misaligned` fires on every request
+            // that carries a thinking block, reporting a drift that did not
+            // happen and training operators to ignore a real one.
+            masked.truncate(writable);
             let applier = SegmentApplier::new(masked);
             // Marker counts are plumbing (see SEGMENT_APPLY_MARKER) —
             // discard them; the provider counts below are the real ones.
@@ -486,6 +535,35 @@ fn redact_anthropic_content(
         }
         _ => {}
     }
+}
+
+/// The plaintext of every signed reasoning block in an Anthropic request,
+/// for SCAN-ONLY submission to the segment pass
+/// ([`moderate_body_scanning`]).
+///
+/// Deliberately not part of `redact_anthropic_content`'s walk: that walk is
+/// also the write-back path, and a signed `thinking` block must be
+/// forwarded byte-identical (#1104). Collecting it here is what lets a
+/// segment-moderating kind — `bedrock`, `presidio`, `lakera`,
+/// `aliyun_ai_guardrail`, `custom` — judge the text without being handed a
+/// slot it could rewrite.
+///
+/// `redacted_thinking` carries only provider ciphertext under `data`, so
+/// there is no plaintext in it to screen.
+pub fn anthropic_signed_reasoning_texts(body: &Value) -> Vec<String> {
+    body.get("messages")
+        .and_then(Value::as_array)
+        .map(|msgs| {
+            msgs.iter()
+                .filter_map(|m| m.get("content").and_then(Value::as_array))
+                .flatten()
+                .filter(|b| b.get("type").and_then(Value::as_str) == Some("thinking"))
+                .filter_map(|b| b.get("thinking").and_then(Value::as_str))
+                .filter(|t| !t.is_empty())
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Mask an Anthropic-native `/v1/messages` RESPONSE body in place (the
@@ -1867,6 +1945,153 @@ mod tests {
         assert!(
             matches!(verdict, aisix_guardrails::GuardrailVerdict::Block { .. }),
             "a block rule must still reach thinking text, got {verdict:?}",
+        );
+    }
+
+    /// The FIVE segment-moderating kinds — `bedrock`, `presidio`, `lakera`,
+    /// `aliyun_ai_guardrail`, `custom` — answer `Allow` from
+    /// `check_input_non_segment` by design and take their real verdict from
+    /// the segment pass. That pass walks the redactor, which never offers a
+    /// signed `thinking` block, so before the scan-only channel existed a
+    /// block policy on any of those kinds was bypassable by moving the text
+    /// into a thinking block. The keyword test above cannot see this: keyword
+    /// is not a segment moderator.
+    #[tokio::test]
+    async fn a_segment_kind_sees_thinking_text_and_can_block_on_it() {
+        use aisix_guardrails::{GuardrailVerdict, SegmentsOutcome};
+        use std::sync::Mutex;
+
+        /// Records what the segment pass was offered, and blocks on a
+        /// literal — the shape a Presidio/Bedrock/custom block policy has.
+        struct RecordingSegmenter {
+            seen: Mutex<Vec<String>>,
+        }
+        #[async_trait::async_trait]
+        impl Guardrail for RecordingSegmenter {
+            fn name(&self) -> &'static str {
+                "recording-segmenter"
+            }
+            fn moderates_segments(&self) -> bool {
+                true
+            }
+            async fn moderate_input_segments(&self, texts: &[String]) -> SegmentsOutcome {
+                *self.seen.lock().unwrap() = texts.to_vec();
+                let hit = texts.iter().any(|t| t.contains("FORBIDDENTHOUGHT"));
+                SegmentsOutcome {
+                    verdict: if hit {
+                        GuardrailVerdict::block("segment block".to_string())
+                    } else {
+                        GuardrailVerdict::Allow
+                    },
+                    masked: None,
+                    counts: Default::default(),
+                    monitor_hits: Vec::new(),
+                }
+            }
+        }
+
+        let seg = Arc::new(RecordingSegmenter {
+            seen: Mutex::new(Vec::new()),
+        });
+        let chain: Arc<dyn Guardrail> = Arc::new(GuardrailChain::new(vec![seg.clone()]));
+
+        let mut body = json!({
+            "model": "claude",
+            "messages": [
+                {"role": "user", "content": "benign question"},
+                {"role": "assistant", "content": [
+                    {"type": "thinking", "thinking": "I will FORBIDDENTHOUGHT now", "signature": "s"}
+                ]}
+            ]
+        });
+        let before = body.clone();
+
+        let mut counts = RedactionCounts::new();
+        let mut hits = Vec::new();
+        let verdict = moderate_body_scanning(
+            chain.as_ref(),
+            Direction::Input,
+            GuardrailVerdict::Allow,
+            &mut counts,
+            &mut hits,
+            anthropic_signed_reasoning_texts(&body),
+            |g| redact_anthropic_request(g, &mut body),
+        )
+        .await;
+
+        let seen = seg.seen.lock().unwrap().clone();
+        assert!(
+            seen.iter().any(|t| t.contains("FORBIDDENTHOUGHT")),
+            "the segment pass must be offered the thinking text, got {seen:?}",
+        );
+        assert!(
+            matches!(verdict, GuardrailVerdict::Block { .. }),
+            "a segment kind's block rule must fire on thinking content, got {verdict:?}",
+        );
+        assert_eq!(body, before, "and the body is never rewritten");
+    }
+
+    /// The scan-only text is judged but never written back: a segment kind
+    /// that masks every slot it was offered must not have that mask land on
+    /// the signed block, and must still land on the ordinary ones. (What
+    /// enforces that is the walk not offering the block — see the note on
+    /// `masked.truncate`, which is about log truthfulness, not this.)
+    #[tokio::test]
+    async fn a_segment_masks_ordinary_slots_but_never_the_signed_block() {
+        use aisix_guardrails::{GuardrailVerdict, SegmentsOutcome};
+
+        struct MaskEverything;
+        #[async_trait::async_trait]
+        impl Guardrail for MaskEverything {
+            fn name(&self) -> &'static str {
+                "mask-everything"
+            }
+            fn moderates_segments(&self) -> bool {
+                true
+            }
+            async fn moderate_input_segments(&self, texts: &[String]) -> SegmentsOutcome {
+                SegmentsOutcome {
+                    verdict: GuardrailVerdict::Allow,
+                    masked: Some(texts.iter().map(|_| "MASKED".to_owned()).collect()),
+                    counts: std::collections::BTreeMap::from([("X".to_owned(), 1)]),
+                    monitor_hits: Vec::new(),
+                }
+            }
+        }
+
+        let chain: Arc<dyn Guardrail> =
+            Arc::new(GuardrailChain::new(vec![Arc::new(MaskEverything)]));
+        let mut body = json!({
+            "model": "claude",
+            "messages": [{"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "secret chain", "signature": "s"},
+                {"type": "text", "text": "ordinary text"}
+            ]}]
+        });
+
+        let mut counts = RedactionCounts::new();
+        let mut hits = Vec::new();
+        moderate_body_scanning(
+            chain.as_ref(),
+            Direction::Input,
+            GuardrailVerdict::Allow,
+            &mut counts,
+            &mut hits,
+            anthropic_signed_reasoning_texts(&body),
+            |g| redact_anthropic_request(g, &mut body),
+        )
+        .await;
+
+        let blocks = &body["messages"][0]["content"];
+        assert_eq!(
+            blocks[0]["thinking"].as_str(),
+            Some("secret chain"),
+            "the signed block is byte-identical even under a mask-everything segmenter",
+        );
+        assert_eq!(
+            blocks[1]["text"].as_str(),
+            Some("MASKED"),
+            "…while the ordinary slot beside it is rewritten",
         );
     }
 

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1271,6 +1271,12 @@ async fn responses_to_target(
     // request's `stream` flag — see `dispatch::upstream_body_is_sse`. A
     // JSON document answering `stream: true` takes the non-streaming
     // buffered scan+mask path below.
+    //
+    // That body needs its own deadline: the request-level timeout above was
+    // deliberately NOT attached for a streaming request, and the per-chunk
+    // read timeout lives on the SSE branch this response no longer takes,
+    // so without one a stalled JSON body would be held with no bound at all.
+    let buffered_body_deadline = if is_stream { timeouts.stream } else { None };
     let is_stream = is_stream && crate::dispatch::upstream_body_is_sse(upstream_resp.headers());
 
     if is_stream {
@@ -1887,18 +1893,18 @@ async fn responses_to_target(
             captured_content: None,
         })
     } else {
-        let json_body: Value = upstream_resp
-            .json()
-            .await
-            .map_err(|e| {
-                crate::cooldown::note_failure(
-                    &state.runtime_status,
-                    model_id,
-                    model.cooldown.as_ref(),
-                    aisix_gateway::BridgeError::UpstreamDecode(e.to_string()),
-                )
-            })
-            .map_err(ProxyError::Bridge)?;
+        let json_body: Value =
+            crate::dispatch::json_body_within(upstream_resp, buffered_body_deadline)
+                .await
+                .map_err(|be| {
+                    crate::cooldown::note_failure(
+                        &state.runtime_status,
+                        model_id,
+                        model.cooldown.as_ref(),
+                        be,
+                    )
+                })
+                .map_err(ProxyError::Bridge)?;
 
         // Extract the upstream-reported usage block for telemetry
         // emission. Pulled here (before the response is moved into

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1267,14 +1267,10 @@ async fn responses_to_target(
         .unwrap_or("unknown")
         .to_ascii_lowercase();
 
-    // Pick the relay branch from what the upstream ACTUALLY sent, not from
-    // the request's `stream` flag. An upstream that ignores `stream: true`
-    // and answers with one JSON document used to enter the SSE branch
-    // anyway: with no frames in it nothing scanned it, and the hold-back's
-    // seal pass appended a `\n\n` frame terminator to a body that is not
-    // SSE before releasing it under the upstream's own content type. Such
-    // a response belongs on the non-streaming buffered scan+mask path
-    // below, which reads it as the JSON document it is.
+    // The relay branch follows what the upstream ACTUALLY sent, not the
+    // request's `stream` flag — see `dispatch::upstream_body_is_sse`. A
+    // JSON document answering `stream: true` takes the non-streaming
+    // buffered scan+mask path below.
     let is_stream = is_stream && crate::dispatch::upstream_body_is_sse(upstream_resp.headers());
 
     if is_stream {

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1001,7 +1001,15 @@ fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
 /// - `content` — message items;
 /// - `output` — tool-result items (`function_call_output`,
 ///   `custom_tool_call_output`, `*_call_output`) the caller feeds back;
-/// - `reason` — an `mcp_approval_response` justification.
+/// - `reason` — an `mcp_approval_response` justification;
+/// - `summary` — a `reasoning` item's summary parts.
+///
+/// A `reasoning` item's `content[]` parts are covered by the `content`
+/// key above. Reasoning replayed on the REQUEST is caller-supplied text
+/// entering the model like any other, so it is scanned — and masked, at
+/// the same two slots (`redact::redact_responses_item`). Reasoning the
+/// model GENERATES is a separate question and stays out of the
+/// output-guardrail scope.
 ///
 /// All are user-controlled content entering the model — the
 /// `/v1/chat/completions` equivalent (a `role:"tool"` message) is
@@ -1013,13 +1021,18 @@ fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
 /// kind). Reading a key absent on other item types is a harmless no-op.
 /// <https://platform.openai.com/docs/api-reference/responses/create>
 fn responses_item_text(item: &Value) -> String {
-    [item.get("content"), item.get("output"), item.get("reason")]
-        .into_iter()
-        .flatten()
-        .map(responses_value_text)
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n")
+    [
+        item.get("content"),
+        item.get("output"),
+        item.get("reason"),
+        item.get("summary"),
+    ]
+    .into_iter()
+    .flatten()
+    .map(responses_value_text)
+    .filter(|s| !s.is_empty())
+    .collect::<Vec<_>>()
+    .join("\n")
 }
 
 /// Plain text of one Responses-API content slot: a bare string, or the
@@ -1253,6 +1266,16 @@ async fn responses_to_target(
         .as_deref()
         .unwrap_or("unknown")
         .to_ascii_lowercase();
+
+    // Pick the relay branch from what the upstream ACTUALLY sent, not from
+    // the request's `stream` flag. An upstream that ignores `stream: true`
+    // and answers with one JSON document used to enter the SSE branch
+    // anyway: with no frames in it nothing scanned it, and the hold-back's
+    // seal pass appended a `\n\n` frame terminator to a body that is not
+    // SSE before releasing it under the upstream's own content type. Such
+    // a response belongs on the non-streaming buffered scan+mask path
+    // below, which reads it as the JSON document it is.
+    let is_stream = is_stream && crate::dispatch::upstream_body_is_sse(upstream_resp.headers());
 
     if is_stream {
         let headers = upstream_resp.headers().clone();
@@ -2725,11 +2748,19 @@ fn drain_responses_sse_frames(
             Some(rewritten) => out.extend_from_slice(&rewritten),
             None => out.extend_from_slice(&frame),
         }
-        if let Some(data) = crate::messages::extract_sse_data_line(&frame) {
-            if data == b"[DONE]" {
+        // Whole payload, not the first `data:` line (#1100): a frame whose
+        // JSON is written over several `data:` lines parses only once they
+        // are joined. Reading one line at a time leaves the terminal
+        // `response.completed` unparseable, and the buffered path then
+        // bills the request from the token estimator instead of the
+        // provider's own counters. This site only READS the frame — the
+        // bytes forwarded to the client are `frame` itself.
+        if let Some(payload) = crate::redact::frame_payload(&frame) {
+            let data = payload.trim();
+            if data == "[DONE]" {
                 continue;
             }
-            if let Ok(json) = serde_json::from_slice::<Value>(data) {
+            if let Ok(json) = serde_json::from_str::<Value>(data) {
                 // First parsed frame of ANY type (`response.created`
                 // included) → upstream TTFT. The industry convention
                 // (LiteLLM, caller-side gateways) stamps the same event, so
@@ -3109,9 +3140,13 @@ where
 ///   surface scans tool-call output too (`ChatResponse::guardrail_output_text`,
 ///   the #448 fix); this keeps the surfaces symmetric.
 ///
-/// Reasoning items are intentionally excluded (out of output-guardrail
-/// scope, matching the chat surface) — they carry `summary`, not `content`
-/// / `arguments`, so they're naturally skipped.
+/// Reasoning items are excluded (out of output-guardrail scope, matching
+/// the chat surface). That used to be left to the shape — the comment here
+/// said they carry `summary`, not `content`, so they are naturally
+/// skipped — but a reasoning item DOES carry `content[]` with `text`
+/// parts, and the walk below reads `content` off every item regardless of
+/// type, so generated reasoning was reaching the output scan. The skip is
+/// explicit now.
 /// <https://platform.openai.com/docs/api-reference/responses/object>
 fn responses_output_text(resp: &Value) -> String {
     let Some(items) = resp.get("output").and_then(|v| v.as_array()) else {
@@ -3119,6 +3154,9 @@ fn responses_output_text(resp: &Value) -> String {
     };
     let mut parts: Vec<&str> = Vec::new();
     for it in items {
+        if it.get("type").and_then(|t| t.as_str()) == Some("reasoning") {
+            continue;
+        }
         if let Some(content) = it.get("content").and_then(|c| c.as_array()) {
             parts.extend(
                 content
@@ -6452,5 +6490,112 @@ data: [DONE]\n\n";
             .expect("usage_sink sender dropped");
         // Two spans: the delta frame and the terminal event's repeat.
         assert_masked_by_eda(&event, 2);
+    }
+
+    /// The live `/v1/responses` relay reads each frame to find the terminal
+    /// event's usage. Reading only the FIRST `data:` line left a terminal
+    /// frame written over several lines unparseable, and the counters then
+    /// came from the local token estimator instead of the provider — which
+    /// is invisible unless the assertion pins the exact numbers, because
+    /// "usage exists" is true either way.
+    #[test]
+    fn drain_reads_a_terminal_frame_spread_over_several_data_lines() {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(
+            b"event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_ml\"}}\n\n",
+        );
+        // ONE frame, ONE JSON document, three `data:` lines.
+        buf.extend_from_slice(
+            b"event: response.completed\ndata: {\"type\":\"response.completed\",\ndata: \"response\":{\"id\":\"resp_ml\",\"usage\":\n\
+              data: {\"input_tokens\":4321,\"output_tokens\":765,\"total_tokens\":5086}}}\n\n",
+        );
+        let mut acc = None;
+        let mut out = Vec::new();
+        let mut first = false;
+        super::drain_responses_sse_frames(
+            &mut buf,
+            &mut acc,
+            None,
+            std::time::Instant::now(),
+            &mut first,
+            "client-facing",
+            &mut out,
+        );
+        let usage = acc.expect("the terminal frame must be parsed");
+        assert_eq!(usage.prompt_tokens, 4321);
+        assert_eq!(usage.completion_tokens, 765);
+        assert_eq!(usage.provider_request_id, "resp_ml");
+    }
+
+    /// The same drain on a CRLF-framed stream with no `[DONE]` sentinel —
+    /// what OpenAI's Responses API actually sends — must read identically.
+    #[test]
+    fn drain_reads_a_crlf_framed_stream_with_no_done_sentinel() {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(b": keep-alive\r\n\r\n");
+        buf.extend_from_slice(
+            b"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_crlf\",\"usage\":{\"input_tokens\":11,\"output_tokens\":3,\"total_tokens\":14}}}\r\n\r\n",
+        );
+        let mut acc = None;
+        let mut out = Vec::new();
+        let mut first = false;
+        super::drain_responses_sse_frames(
+            &mut buf,
+            &mut acc,
+            None,
+            std::time::Instant::now(),
+            &mut first,
+            "client-facing",
+            &mut out,
+        );
+        let usage = acc.expect("a CRLF terminal frame must be parsed");
+        assert_eq!(usage.prompt_tokens, 11);
+        assert_eq!(usage.completion_tokens, 3);
+        assert!(buf.is_empty(), "both complete frames were drained");
+    }
+
+    /// Generated reasoning is out of the output-guardrail scope. A
+    /// `reasoning` item DOES carry `content[]` with `text` parts, and the
+    /// walk reads `content` off every item regardless of type — so without
+    /// an explicit skip the model's own reasoning reached the output scan
+    /// on this surface while the chat and `/v1/messages` surfaces excluded
+    /// it.
+    #[test]
+    fn responses_output_scan_excludes_generated_reasoning() {
+        let resp = serde_json::json!({
+            "output": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "SUMMARYSECRET"}],
+                    "content": [{"type": "reasoning_text", "text": "REASONINGSECRET"}]
+                },
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "the visible answer"}]
+                },
+                {"type": "function_call", "name": "lookup", "arguments": "{\"q\":\"argtext\"}"}
+            ]
+        });
+        let scanned = super::responses_output_text(&resp);
+        assert!(!scanned.contains("REASONINGSECRET"), "got {scanned:?}");
+        assert!(!scanned.contains("SUMMARYSECRET"), "got {scanned:?}");
+        // The tool-call coverage the walk exists for is untouched.
+        assert!(scanned.contains("the visible answer"));
+        assert!(scanned.contains("lookup") && scanned.contains("argtext"));
+    }
+
+    /// The request side is the mirror: a `reasoning` item replayed by the
+    /// caller is text entering the model, and both slots the mask rewrites
+    /// have to be slots the scan reads.
+    #[test]
+    fn responses_input_scan_covers_replayed_reasoning_content_and_summary() {
+        let item = serde_json::json!({
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "SUMMARYSECRET"}],
+            "content": [{"type": "reasoning_text", "text": "REASONINGSECRET"}]
+        });
+        let scanned = super::responses_item_text(&item);
+        assert!(scanned.contains("REASONINGSECRET"), "got {scanned:?}");
+        assert!(scanned.contains("SUMMARYSECRET"), "got {scanned:?}");
     }
 }

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -1136,12 +1136,10 @@ pub fn build_responses_bridge_stream(
                     }
                 }
                 Err(e) => {
-                    let frame = format!(
-                        "event: error\ndata: {{\"type\":\"error\",\"code\":\"{}\",\"message\":{}}}\n\n",
+                    yield Ok(bytes::Bytes::from(upstream_error_frame(
                         e.error_type(),
-                        serde_json::to_string(&e.to_string()).unwrap_or_else(|_| "\"error\"".into()),
-                    );
-                    yield Ok(bytes::Bytes::from(frame));
+                        &e.to_string(),
+                    )));
                     return;
                 }
             }
@@ -1352,15 +1350,32 @@ pub fn build_responses_bridge_stream(
     ))
 }
 
+/// Responses-API SSE `error` frame for an upstream failure mid-stream.
+///
+/// Same envelope as [`guardrail_error_frame`] — the two are the only SSE
+/// errors this relay emits and a client should not have to branch on which
+/// one it got to find the error type.
+fn upstream_error_frame(error_type: &str, message: &str) -> String {
+    format!(
+        "event: error\ndata: {}\n\n",
+        json!({
+            "error": {
+                "type": error_type,
+                "message": message,
+            }
+        })
+    )
+}
+
 /// Responses-API SSE `error` frame for an output-guardrail block. Carries the
 /// firing guardrail's name (#519 B.4b) but never the matched-pattern detail.
 ///
-/// Nested under `error`, like every other SSE error this crate emits (the
-/// chat relay's `error_frame_payload`, the passthrough route's frame of
-/// the same name): a flat `{type, code, message}` was the odd one out, so
-/// a client branching on `error.type` saw nothing on this surface alone.
-/// `content_filter` moves onto `error.type`, which is the key that carries
-/// it everywhere else; the `event: error` line already names the event.
+/// Nested under `error`, matching the chat relay's `error_frame_payload`
+/// and the passthrough route's frame of the same name: a flat
+/// `{type, code, message}` left a client branching on `error.type` with
+/// nothing on this surface. `content_filter` moves onto `error.type`, the
+/// key that carries it everywhere else; the `event: error` line already
+/// names the event.
 fn guardrail_error_frame(guardrail_name: Option<&str>, unavailable: Option<&str>) -> String {
     format!(
         "event: error\ndata: {}\n\n",
@@ -1831,25 +1846,41 @@ mod tests {
         );
     }
 
-    /// Every SSE error this crate emits nests under an `error` object —
-    /// the chat relay's `error_frame_payload` and the passthrough route's
-    /// frame of the same name both do. This one was flat
-    /// (`{type, code, message}`), so a client branching on `error.type`
-    /// saw nothing on the `/v1/responses` bridge alone.
+    /// The chat relay's `error_frame_payload` and the passthrough route's
+    /// frame of the same name both nest under an `error` object. BOTH of
+    /// this relay's error frames were flat (`{type, code, message}`), so a
+    /// client branching on `error.type` saw nothing on the
+    /// `/v1/responses` bridge whichever failure it hit.
     #[test]
-    fn guardrail_error_frame_nests_under_error_like_every_other_sse_error() {
-        let frame = guardrail_error_frame(Some("gr-block"), None);
-        let payload = frame
-            .strip_prefix("event: error\ndata: ")
-            .and_then(|r| r.strip_suffix("\n\n"))
-            .expect("an SSE error frame labelled `error`");
-        let v: serde_json::Value = serde_json::from_str(payload).unwrap();
-        assert_eq!(v["error"]["type"], "content_filter");
-        assert!(v["error"]["message"].as_str().unwrap().contains("gr-block"));
-        // The flat keys are gone: `type` and `code` at the top level were
-        // the divergence.
-        assert!(v.get("type").is_none());
-        assert!(v.get("code").is_none());
-        assert_eq!(v.as_object().unwrap().len(), 1);
+    fn both_sse_error_frames_nest_under_error() {
+        let payload_of = |frame: &str| -> serde_json::Value {
+            let body = frame
+                .strip_prefix("event: error\ndata: ")
+                .and_then(|r| r.strip_suffix("\n\n"))
+                .expect("an SSE error frame labelled `error`")
+                .to_owned();
+            serde_json::from_str(&body).expect("one JSON document")
+        };
+
+        let block = payload_of(&guardrail_error_frame(Some("gr-block"), None));
+        assert_eq!(block["error"]["type"], "content_filter");
+        assert!(block["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("gr-block"));
+
+        // The upstream-failure frame on the same stream, same envelope. Its
+        // message is JSON-escaped through serde rather than interpolated.
+        let upstream = payload_of(&upstream_error_frame("upstream_error", "boom \"quoted\""));
+        assert_eq!(upstream["error"]["type"], "upstream_error");
+        assert_eq!(upstream["error"]["message"], "boom \"quoted\"");
+
+        // The flat keys are gone from both: `type` and `code` at the top
+        // level were the divergence.
+        for v in [&block, &upstream] {
+            assert!(v.get("type").is_none());
+            assert!(v.get("code").is_none());
+            assert_eq!(v.as_object().unwrap().len(), 1);
+        }
     }
 }

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -1354,13 +1354,21 @@ pub fn build_responses_bridge_stream(
 
 /// Responses-API SSE `error` frame for an output-guardrail block. Carries the
 /// firing guardrail's name (#519 B.4b) but never the matched-pattern detail.
+///
+/// Nested under `error`, like every other SSE error this crate emits (the
+/// chat relay's `error_frame_payload`, the passthrough route's frame of
+/// the same name): a flat `{type, code, message}` was the odd one out, so
+/// a client branching on `error.type` saw nothing on this surface alone.
+/// `content_filter` moves onto `error.type`, which is the key that carries
+/// it everywhere else; the `event: error` line already names the event.
 fn guardrail_error_frame(guardrail_name: Option<&str>, unavailable: Option<&str>) -> String {
     format!(
         "event: error\ndata: {}\n\n",
         json!({
-            "type": "error",
-            "code": "content_filter",
-            "message": crate::error::guardrail_block_message("response", guardrail_name, unavailable),
+            "error": {
+                "type": "content_filter",
+                "message": crate::error::guardrail_block_message("response", guardrail_name, unavailable),
+            }
         })
     )
 }
@@ -1821,5 +1829,27 @@ mod tests {
             completed.data["response"]["incomplete_details"]["reason"],
             "max_output_tokens"
         );
+    }
+
+    /// Every SSE error this crate emits nests under an `error` object —
+    /// the chat relay's `error_frame_payload` and the passthrough route's
+    /// frame of the same name both do. This one was flat
+    /// (`{type, code, message}`), so a client branching on `error.type`
+    /// saw nothing on the `/v1/responses` bridge alone.
+    #[test]
+    fn guardrail_error_frame_nests_under_error_like_every_other_sse_error() {
+        let frame = guardrail_error_frame(Some("gr-block"), None);
+        let payload = frame
+            .strip_prefix("event: error\ndata: ")
+            .and_then(|r| r.strip_suffix("\n\n"))
+            .expect("an SSE error frame labelled `error`");
+        let v: serde_json::Value = serde_json::from_str(payload).unwrap();
+        assert_eq!(v["error"]["type"], "content_filter");
+        assert!(v["error"]["message"].as_str().unwrap().contains("gr-block"));
+        // The flat keys are gone: `type` and `code` at the top level were
+        // the divergence.
+        assert!(v.get("type").is_none());
+        assert!(v.get("code").is_none());
+        assert_eq!(v.as_object().unwrap().len(), 1);
     }
 }

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -477,6 +477,16 @@ impl ResponsesSseEncoder {
         }
     }
 
+    /// Take the next `sequence_number` for an event this relay emits
+    /// outside the state machine — the terminal `error` frames. They are
+    /// part of the same numbered event stream a client is reading, so they
+    /// must continue its numbering rather than restart or repeat it.
+    pub fn take_sequence_number(&mut self) -> u64 {
+        let seq = self.sequence_number;
+        self.sequence_number += 1;
+        seq
+    }
+
     /// Build one event, stamping `type` + `sequence_number`.
     fn event(&mut self, event_type: &'static str, mut data: Value) -> ResponsesSseEvent {
         let seq = self.sequence_number;
@@ -1137,6 +1147,7 @@ pub fn build_responses_bridge_stream(
                 }
                 Err(e) => {
                     yield Ok(bytes::Bytes::from(upstream_error_frame(
+                        encoder.take_sequence_number(),
                         e.error_type(),
                         &e.to_string(),
                     )));
@@ -1180,7 +1191,7 @@ pub fn build_responses_bridge_stream(
                 "streaming /v1/responses (cross-provider) output exceeded buffer cap; failing closed",
             );
             guard.comp().guardrail_blocked = true;
-            yield Ok(bytes::Bytes::from(guardrail_error_frame(None, Some(crate::error::TAG_OUTPUT_BUFFER_EXCEEDED))));
+            yield Ok(bytes::Bytes::from(guardrail_error_frame(encoder.take_sequence_number(), None, Some(crate::error::TAG_OUTPUT_BUFFER_EXCEEDED))));
             return;
         }
 
@@ -1302,7 +1313,7 @@ pub fn build_responses_bridge_stream(
                     "guardrail blocked streaming /v1/responses (cross-provider) response",
                 );
                 guard.comp().guardrail_blocked = true;
-                yield Ok(bytes::Bytes::from(guardrail_error_frame(guardrail_name.as_deref(), unavailable.as_deref())));
+                yield Ok(bytes::Bytes::from(guardrail_error_frame(encoder.take_sequence_number(), guardrail_name.as_deref(), unavailable.as_deref())));
                 return;
             }
             if seg_rewrote {
@@ -1350,41 +1361,51 @@ pub fn build_responses_bridge_stream(
     ))
 }
 
-/// Responses-API SSE `error` frame for an upstream failure mid-stream.
+/// The Responses-API `error` event, as the API itself defines it — FLAT,
+/// with the discriminant on the top-level `type`.
 ///
-/// Same envelope as [`guardrail_error_frame`] — the two are the only SSE
-/// errors this relay emits and a client should not have to branch on which
-/// one it got to find the error type.
-fn upstream_error_frame(error_type: &str, message: &str) -> String {
+/// Every OTHER SSE error this crate emits nests under an `error` object,
+/// and this one deliberately does not, because each surface matches its own
+/// protocol rather than the crate's internal habit. The Responses event
+/// stream is a union discriminated on `type`, and the official SDKs parse
+/// it that way — `openai-python`'s `ResponseErrorEvent` is
+/// `{type: Literal["error"], code, message, param, sequence_number}`,
+/// generated from OpenAI's own OpenAPI spec. Nesting the payload would hand
+/// a `responses.stream()` client an event it cannot classify at all. (The
+/// mirror-image argument is why the Anthropic surface uses Anthropic's
+/// closed `error.type` enum instead of ours.)
+///
+/// `sequence_number` continues the encoder's own numbering, so the error is
+/// an ordinary member of the stream a client has been counting.
+fn responses_error_frame(seq: u64, code: &str, message: &str) -> String {
     format!(
         "event: error\ndata: {}\n\n",
         json!({
-            "error": {
-                "type": error_type,
-                "message": message,
-            }
+            "type": "error",
+            "code": code,
+            "message": message,
+            "param": Value::Null,
+            "sequence_number": seq,
         })
     )
 }
 
+/// Responses-API SSE `error` frame for an upstream failure mid-relay.
+fn upstream_error_frame(seq: u64, error_type: &str, message: &str) -> String {
+    responses_error_frame(seq, error_type, message)
+}
+
 /// Responses-API SSE `error` frame for an output-guardrail block. Carries the
 /// firing guardrail's name (#519 B.4b) but never the matched-pattern detail.
-///
-/// Nested under `error`, matching the chat relay's `error_frame_payload`
-/// and the passthrough route's frame of the same name: a flat
-/// `{type, code, message}` left a client branching on `error.type` with
-/// nothing on this surface. `content_filter` moves onto `error.type`, the
-/// key that carries it everywhere else; the `event: error` line already
-/// names the event.
-fn guardrail_error_frame(guardrail_name: Option<&str>, unavailable: Option<&str>) -> String {
-    format!(
-        "event: error\ndata: {}\n\n",
-        json!({
-            "error": {
-                "type": "content_filter",
-                "message": crate::error::guardrail_block_message("response", guardrail_name, unavailable),
-            }
-        })
+fn guardrail_error_frame(
+    seq: u64,
+    guardrail_name: Option<&str>,
+    unavailable: Option<&str>,
+) -> String {
+    responses_error_frame(
+        seq,
+        "content_filter",
+        &crate::error::guardrail_block_message("response", guardrail_name, unavailable),
     )
 }
 
@@ -1846,13 +1867,16 @@ mod tests {
         );
     }
 
-    /// The chat relay's `error_frame_payload` and the passthrough route's
-    /// frame of the same name both nest under an `error` object. BOTH of
-    /// this relay's error frames were flat (`{type, code, message}`), so a
-    /// client branching on `error.type` saw nothing on the
-    /// `/v1/responses` bridge whichever failure it hit.
+    /// The Responses API defines its `error` event FLAT, discriminated on
+    /// the top-level `type`, and the official SDKs parse it that way —
+    /// `openai-python`'s `ResponseErrorEvent` is
+    /// `{type, code, message, param, sequence_number}`. Nesting it under an
+    /// `error` object (which is what every other SSE error in this crate
+    /// does) would hand a `responses.stream()` client an event it cannot
+    /// classify. Both of this relay's error frames are checked, because a
+    /// client should not have to know which failure it hit.
     #[test]
-    fn both_sse_error_frames_nest_under_error() {
+    fn both_sse_error_frames_match_the_responses_api_error_event() {
         let payload_of = |frame: &str| -> serde_json::Value {
             let body = frame
                 .strip_prefix("event: error\ndata: ")
@@ -1862,25 +1886,37 @@ mod tests {
             serde_json::from_str(&body).expect("one JSON document")
         };
 
-        let block = payload_of(&guardrail_error_frame(Some("gr-block"), None));
-        assert_eq!(block["error"]["type"], "content_filter");
-        assert!(block["error"]["message"]
-            .as_str()
-            .unwrap()
-            .contains("gr-block"));
+        let block = payload_of(&guardrail_error_frame(7, Some("gr-block"), None));
+        assert_eq!(block["type"], "error");
+        assert_eq!(block["code"], "content_filter");
+        assert!(block["message"].as_str().unwrap().contains("gr-block"));
+        assert_eq!(block["param"], serde_json::Value::Null);
+        assert_eq!(block["sequence_number"], 7);
 
         // The upstream-failure frame on the same stream, same envelope. Its
         // message is JSON-escaped through serde rather than interpolated.
-        let upstream = payload_of(&upstream_error_frame("upstream_error", "boom \"quoted\""));
-        assert_eq!(upstream["error"]["type"], "upstream_error");
-        assert_eq!(upstream["error"]["message"], "boom \"quoted\"");
+        let upstream = payload_of(&upstream_error_frame(
+            8,
+            "upstream_error",
+            "boom \"quoted\"",
+        ));
+        assert_eq!(upstream["type"], "error");
+        assert_eq!(upstream["code"], "upstream_error");
+        assert_eq!(upstream["message"], "boom \"quoted\"");
+        assert_eq!(upstream["sequence_number"], 8);
 
-        // The flat keys are gone from both: `type` and `code` at the top
-        // level were the divergence.
+        // Exactly the SDK's field set, and nothing nested: an `error` key
+        // here is the shape this deliberately does NOT use.
         for v in [&block, &upstream] {
-            assert!(v.get("type").is_none());
-            assert!(v.get("code").is_none());
-            assert_eq!(v.as_object().unwrap().len(), 1);
+            assert!(v.get("error").is_none());
+            let keys: std::collections::BTreeSet<&str> =
+                v.as_object().unwrap().keys().map(String::as_str).collect();
+            assert_eq!(
+                keys,
+                ["code", "message", "param", "sequence_number", "type"]
+                    .into_iter()
+                    .collect::<std::collections::BTreeSet<_>>(),
+            );
         }
     }
 }

--- a/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
+++ b/tests/e2e/src/cases/client-facing-model-echo-e2e.test.ts
@@ -1083,12 +1083,16 @@ describe("client-facing model echo e2e: a buffering output guardrail keeps the a
     // The stream committed its 200 before the scan; the block is in-band.
     expect(res.status).toBe(200);
     const text = await res.text();
-    expect(text).toContain("content_filter");
+    // The Anthropic-shape terminal error frame. `error.type` is
+    // `invalid_request_error` here, matching this endpoint's HTTP 422 half —
+    // Anthropic's error-type enum has no `content_filter` member.
+    expect(text).toContain("event: error");
+    expect(text).toContain('"type":"invalid_request_error"');
     expect(text).not.toContain("ABSOLUTELYFORBIDDENWORD");
     // As on /v1/responses above: `unscannable_body` produces the same
-    // `content_filter` frame, so name the guardrail to pin that the block
-    // came from scanning the excised frame's text and not from the buffer
-    // having been emptied.
+    // error frame, so name the guardrail to pin that the block came from
+    // scanning the excised frame's text and not from the buffer having been
+    // emptied.
     expect(text).toContain("gr-model-echo-holdback");
     expect(text).not.toContain("unscannable_body");
     // Hold-back: nothing was forwarded before the verdict, so the frames

--- a/tests/e2e/src/cases/messages-streaming-output-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-streaming-output-guardrail-e2e.test.ts
@@ -15,7 +15,7 @@ import {
 // blocked response is signalled with a terminal `error` event (mirroring
 // /v1/chat/completions and the common streaming-guardrail pattern). We stream
 // Anthropic SSE whose text_delta carries a forbidden token and require
-// the response to end with a content_filter error event.
+// the response to end with an Anthropic-shape `error` event.
 
 const CALLER = "sk-msgstream-gr-caller";
 const HASH = createHash("sha256").update(CALLER).digest("hex");
@@ -83,7 +83,7 @@ describe("streaming /v1/messages output guardrail (#448)", () => {
       }),
     });
 
-  test("a forbidden streamed response ends with a content_filter error event", async (ctx) => {
+  test("a forbidden streamed response ends with an anthropic-shape error event", async (ctx) => {
     if (!etcdReachable || !app || !upstream) {
       ctx.skip();
       return;
@@ -91,7 +91,7 @@ describe("streaming /v1/messages output guardrail (#448)", () => {
     await waitConfigPropagation(async () => {
       const r = await stream();
       const b = await r.text();
-      return b.includes("content_filter");
+      return b.includes("event: error");
     });
 
     const res = await stream();
@@ -102,6 +102,18 @@ describe("streaming /v1/messages output guardrail (#448)", () => {
     // response until it scans clean — the matched content must NOT reach
     // the wire (pre-fix it was forwarded verbatim before the error frame).
     expect(body, "hold-back keeps the matched content off the wire").not.toContain(FORBIDDEN);
-    expect(body, "stream must end with a content_filter error event").toContain("content_filter");
+    // The terminal frame carries `error.type = "invalid_request_error"` —
+    // the same value the HTTP 422 half of this endpoint renders. Anthropic's
+    // `error.type` is a closed enum with no `content_filter` member, so the
+    // two halves had been disagreeing and the SDK's typed parse rejected the
+    // streaming one.
+    expect(body, "stream must end with an SSE error event").toContain("event: error");
+    const frame = body.slice(body.lastIndexOf("event: error"));
+    const payload = JSON.parse(
+      frame.slice(frame.indexOf("data: ") + "data: ".length, frame.indexOf("\n\n")),
+    ) as { type: string; error: { type: string; message: string } };
+    expect(payload.type).toBe("error");
+    expect(payload.error.type).toBe("invalid_request_error");
+    expect(payload.error).not.toHaveProperty("code");
   });
 });

--- a/tests/e2e/src/cases/messages-streaming-toolcall-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/messages-streaming-toolcall-guardrail-e2e.test.ts
@@ -14,8 +14,8 @@ import {
 // payloads (#448 #22). Anthropic streams tool_use args as input_json_delta
 // (and the name in content_block_start), with no text_delta. The
 // passthrough end-of-stream guardrail must scan that too — a forbidden
-// token in the tool arguments must trigger a terminal content_filter
-// error, matching the non-streaming path.
+// token in the tool arguments must trigger a terminal Anthropic-shape
+// error event, matching the non-streaming path.
 
 const CALLER = "sk-msgtool-gr-caller";
 const HASH = createHash("sha256").update(CALLER).digest("hex");
@@ -78,18 +78,21 @@ describe("streaming /v1/messages tool_use output guardrail (#448)", () => {
       body: JSON.stringify({ model: "msgtool-gr", max_tokens: 64, stream: true, messages: [{ role: "user", content: "go" }] }),
     });
 
-  test("forbidden tool_use arguments in a stream trigger a content_filter error", async (ctx) => {
+  test("forbidden tool_use arguments in a stream trigger a terminal error event", async (ctx) => {
     if (!etcdReachable || !app || !upstream) {
       ctx.skip();
       return;
     }
-    await waitConfigPropagation(async () => (await stream().then((r) => r.text())).includes("content_filter"));
+    await waitConfigPropagation(async () => (await stream().then((r) => r.text())).includes("event: error"));
 
     const body = await stream().then((r) => r.text());
     // #932 / #466-class: keyword output guardrails carry the BufferFull
     // hold-back policy, so the tool_use arguments are withheld until the
     // end-of-stream scan — the matched content must NOT reach the wire.
     expect(body, "hold-back keeps the matched arguments off the wire").not.toContain(FORBIDDEN);
-    expect(body, "stream must end with a content_filter error event").toContain("content_filter");
+    // `error.type` matches the HTTP 422 half of this endpoint; Anthropic's
+    // error-type enum has no `content_filter` member.
+    expect(body, "stream must end with an SSE error event").toContain("event: error");
+    expect(body).toContain('"type":"invalid_request_error"');
   });
 });

--- a/tests/e2e/src/cases/sse-frames-and-reasoning-scope-e2e.test.ts
+++ b/tests/e2e/src/cases/sse-frames-and-reasoning-scope-e2e.test.ts
@@ -398,7 +398,7 @@ describe("sse frames + reasoning scope e2e (#1103/#1104)", () => {
     expect(upstream.receivedRequests.length).toBe(before);
   });
 
-  test("/v1/messages: a mask hit inside a signed thinking block refuses rather than dispatching it unmasked", async (ctx) => {
+  test("/v1/messages: a mask hit inside a signed thinking block is forwarded unchanged", async (ctx) => {
     if (!etcdReachable || !app || !seed) return void ctx.skip();
 
     const upstream = await upstreamWith({
@@ -413,7 +413,6 @@ describe("sse frames + reasoning scope e2e (#1103/#1104)", () => {
     });
     await seedScenario("thinking-request-mask", upstream, "anthropic", [maskGuardrailId]);
 
-    const before = upstream.receivedRequests.length;
     const res = await fetch(`${app.proxyUrl}/v1/messages`, {
       method: "POST",
       headers: HEADERS,
@@ -426,40 +425,80 @@ describe("sse frames + reasoning scope e2e (#1103/#1104)", () => {
             role: "assistant",
             content: [
               { type: "thinking", thinking: `write to ${EMAIL}`, signature: "sig-abc" },
-              { type: "text", text: "nothing to see" },
+              { type: "text", text: `and also ${EMAIL}` },
             ],
           },
           { role: "user", content: "go on" },
         ],
       }),
     });
-    // Rewriting a signed block invalidates its signature and the upstream
-    // rejects the replayed turn, so the mask cannot be honoured — and
-    // forwarding the match unmasked is exactly the fail-open the scan
-    // coverage would otherwise create. Refuse, and say why.
-    expect(res.status).toBe(422);
-    const body = await res.text();
-    expect(body).toContain("mask_writeback_failed");
-    expect(body).not.toContain(EMAIL);
-    expect(upstream.receivedRequests.length).toBe(before);
 
-    // The ordinary (unsigned) case still masks and dispatches — the refusal
-    // is specific to the signed slot, not a blanket rejection of any
-    // request whose history mentions an email.
-    const ok = await fetch(`${app.proxyUrl}/v1/messages`, {
+    // The deliberate exception to "no write-back channel means block": the
+    // signed block cannot be rewritten without invalidating its signature,
+    // and refusing the replay protects nothing, because the gateway itself
+    // emitted that block unmasked on the previous turn (generated reasoning
+    // is out of the output scope). So it is forwarded as-is.
+    expect(res.status).toBe(200);
+    await res.text();
+
+    const dispatched = JSON.parse(upstream.receivedRequests.at(-1)!.body) as {
+      messages: Array<{ content: Array<Record<string, unknown>> }>;
+    };
+    const assistant = dispatched.messages[1].content;
+    expect(assistant[0]).toEqual({
+      type: "thinking",
+      thinking: `write to ${EMAIL}`,
+      signature: "sig-abc",
+    });
+    // …and the ordinary text block beside it in the SAME message is still
+    // masked, so this pins an exception for the signed block rather than an
+    // exemption for the whole request.
+    expect(assistant[1]).toEqual({ type: "text", text: `and also ${MASKED}` });
+  });
+
+  test("/v1/messages: a block rule still fires on thinking content", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await upstreamWith({
+      nonStreamBody: {
+        id: "msg_thinking_blockrule",
+        type: "message",
+        role: "assistant",
+        model: "upstream-model-x",
+        content: [{ type: "text", text: "ok" }],
+        usage: { input_tokens: 3, output_tokens: 1 },
+      },
+    });
+    await seedScenario("thinking-mask-vs-block", upstream, "anthropic", [blockGuardrailId]);
+
+    const before = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
       method: "POST",
       headers: HEADERS,
       body: JSON.stringify({
-        model: "thinking-request-mask",
+        model: "thinking-mask-vs-block",
         max_tokens: 16,
-        messages: [{ role: "user", content: `write to ${EMAIL}` }],
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "thinking",
+                thinking: `I will ${BLOCKED} quietly`,
+                signature: "sig-abc",
+              },
+            ],
+          },
+          { role: "user", content: "go on" },
+        ],
       }),
     });
-    expect(ok.status).toBe(200);
-    await ok.text();
-    const dispatched = upstream.receivedRequests.at(-1)!.body;
-    expect(dispatched).toContain(MASKED);
-    expect(dispatched).not.toContain(EMAIL);
+    // The mask exception is for the MASK only. A block rule still reaches
+    // thinking text, or the exemption would have opened a channel any
+    // forbidden content could travel through.
+    expect(res.status).toBe(422);
+    expect(await res.text()).not.toContain(BLOCKED);
+    expect(upstream.receivedRequests.length).toBe(before);
   });
 
   // ── 3. generated reasoning stays out of the OUTPUT scope ───────────

--- a/tests/e2e/src/cases/sse-frames-and-reasoning-scope-e2e.test.ts
+++ b/tests/e2e/src/cases/sse-frames-and-reasoning-scope-e2e.test.ts
@@ -1,0 +1,704 @@
+import { createHash, randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { startMockSls, waitForSlsLog, type MockSls } from "../harness/sls-mock.js";
+
+// E2E for the SSE frame-reading and reasoning-scope contract (#1103 / #1104).
+//
+// Four things are pinned here, all of them invisible to a response-content
+// assertion and all of them silent when broken:
+//
+//  1. A frame's payload is ALL of its `data:` lines joined, so a terminal
+//     `response.completed` written over several lines must still be read as
+//     the provider's own usage. Reading the first line alone did not produce
+//     "no usage" — a local token estimator filled the counters in — so the
+//     assertion has to name the exact numbers AND the absence of the
+//     `usage_estimated` flag.
+//  2. Reasoning replayed by the CALLER is request text: it is scanned, and a
+//     mask that reports a hit there has to actually rewrite the dispatched
+//     body. Where the block is signed by the provider (Anthropic `thinking`),
+//     a rewrite would invalidate the signature, so the request is refused
+//     instead of forwarded with the match still in it.
+//  3. Reasoning the MODEL generates stays out of the output-guardrail scope,
+//     on every `/v1/messages` and `/v1/responses` shape — neither scanned nor
+//     rewritten.
+//  4. A 200 that is not SSE at all, from an upstream that ignored
+//     `stream: true`, takes the buffered scan+mask path rather than the SSE
+//     hold-back, which used to release it unscanned with `\n\n` appended.
+
+const CALLER = "sk-sse-reasoning-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER).digest("hex");
+const HEADERS = {
+  "content-type": "application/json",
+  authorization: `Bearer ${CALLER}`,
+};
+
+// Distinct from any PII pattern: this is the literal a BLOCK rule fires on.
+const BLOCKED = "ABSOLUTELYFORBIDDENWORD";
+// Masked by the `email` detector, so its presence or absence in a body says
+// whether the mask reached that slot.
+const EMAIL = "leak@example.com";
+const MASKED = "[EMAIL_REDACTED]";
+
+const SLS_PROJECT = "aisix-e2e-obs";
+const LOGSTORE = "sse-reasoning-events";
+const CREDENTIAL_REF = "mock";
+
+// The provider's own counters on a terminal frame written over three
+// `data:` lines. Deliberately far from anything the local estimator could
+// produce for these prompts, so the numbers alone identify which side the
+// usage came from.
+const PROVIDER_PROMPT_TOKENS = 4321;
+const PROVIDER_COMPLETION_TOKENS = 765;
+
+describe("sse frames + reasoning scope e2e (#1103/#1104)", () => {
+  let app: SpawnedApp | undefined;
+  let sls: MockSls | undefined;
+  let seed: SeedClient | undefined;
+  let etcd: EtcdClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  /** Attach a guardrail to one model only, the way cp-api projects it. */
+  async function attachToModel(guardrailId: string, modelId: string): Promise<void> {
+    await etcd!.put(
+      `${app!.etcdPrefix}/guardrail_attachments/${randomUUID()}`,
+      JSON.stringify({
+        guardrail_id: guardrailId,
+        env_id: randomUUID(),
+        scope_type: "model",
+        scope_id: modelId,
+        priority: 0,
+        enabled: true,
+      }),
+    );
+  }
+
+  /**
+   * Seed one scenario: a provider key, the model under test, its guardrail
+   * attachments, and — written LAST — a sentinel model the readiness gate
+   * waits on.
+   *
+   * The sentinel is what makes the gate sound. etcd watch events apply in
+   * revision order, so seeing the sentinel in `GET /v1/models` proves every
+   * earlier write landed, attachments included. Gating on the model under
+   * test instead would prove nothing about the attachment written after it,
+   * and gating on the behaviour under test would turn an assertion failure
+   * into a 30s timeout.
+   */
+  async function seedScenario(
+    display: string,
+    upstream: OpenAiUpstream,
+    protocol: "openai" | "anthropic",
+    guardrailIds: string[] = [],
+  ): Promise<void> {
+    const pk = await seed!.createProviderKey(
+      protocol === "anthropic"
+        ? {
+            display_name: `${display}-pk`,
+            secret: "sk-mock",
+            api_base: upstream.baseUrl,
+            provider: "anthropic",
+            adapter: "anthropic",
+          }
+        : {
+            display_name: `${display}-pk`,
+            secret: "sk-mock",
+            api_base: `${upstream.baseUrl}/v1`,
+          },
+    );
+    const model = await seed!.createModel({
+      display_name: display,
+      provider: protocol,
+      model_name: "upstream-model-x",
+      provider_key_id: pk.id,
+    });
+    for (const id of guardrailIds) await attachToModel(id, model.id);
+    await seed!.createModel({
+      display_name: `${display}-gate`,
+      provider: protocol,
+      model_name: "upstream-model-x",
+      provider_key_id: pk.id,
+    });
+    await waitConfigPropagation(async () => {
+      const r = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: HEADERS.authorization },
+      });
+      if (r.status !== 200) {
+        await r.text();
+        return false;
+      }
+      const j = (await r.json()) as { data?: Array<{ id?: string }> };
+      return !!j.data?.some((m) => m.id === `${display}-gate`);
+    });
+  }
+
+  async function upstreamWith(
+    opts: Parameters<typeof startOpenAiUpstream>[0],
+  ): Promise<OpenAiUpstream> {
+    const u = await startOpenAiUpstream(opts);
+    upstreams.push(u);
+    return u;
+  }
+
+  let maskGuardrailId = "";
+  let blockGuardrailId = "";
+
+  beforeAll(async () => {
+    etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    sls = await startMockSls();
+    app = await spawnApp({
+      extraEnv: {
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_ID`]: "mock-akid",
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_SECRET`]: "mock-secret",
+      },
+    });
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    await seed.createObservabilityExporter({
+      name: "sse-reasoning-sls",
+      enabled: true,
+      kind: "aliyun_sls",
+      endpoint: sls.url,
+      project: SLS_PROJECT,
+      logstore: LOGSTORE,
+      credential_ref: CREDENTIAL_REF,
+      content_mode: "metadata_only",
+    });
+
+    // Two guardrails, each attached per model below so one file can hold
+    // both a guarded and an unguarded relay.
+    const mask = await seed.createGuardrail(
+      {
+        name: "sse-reasoning-mask",
+        enabled: true,
+        hook_point: "both",
+        kind: "pii",
+        detectors: [{ type: "email", action: "mask" }],
+      },
+      { attach: false },
+    );
+    maskGuardrailId = mask.id;
+
+    const block = await seed.createGuardrail(
+      {
+        name: "sse-reasoning-block",
+        enabled: true,
+        hook_point: "both",
+        kind: "keyword",
+        patterns: [{ kind: "literal", value: BLOCKED }],
+      },
+      { attach: false },
+    );
+    blockGuardrailId = block.id;
+
+    await seed.createApiKey({ key_hash: CALLER_KEY_HASH, allowed_models: ["*"] });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await sls?.close();
+    for (const u of upstreams) await u.close();
+  });
+
+  // ── 1. whole-frame reads ───────────────────────────────────────────
+
+  test("/v1/responses live relay: a terminal frame split over several data lines still bills the provider's own counters", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !sls) return void ctx.skip();
+
+    // ONE frame, ONE JSON document, three `data:` lines — a shape the SSE
+    // spec allows and some relays emit. No output guardrail on this model,
+    // so the verbatim live relay reads the stream, which is the path that
+    // used to stop at the first `data:` line.
+    const upstream = await upstreamWith({
+      rawStreamFrames: [
+        `event: response.created\ndata: {"type":"response.created","response":{"id":"resp_split","object":"response","status":"in_progress","model":"upstream-model-x"}}\n\n`,
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","item_id":"m","delta":"hello"}\n\n`,
+        `event: response.completed\ndata: {"type":"response.completed",\ndata: "response":{"id":"resp_split","object":"response","status":"completed","model":"upstream-model-x",\ndata: "usage":{"input_tokens":${PROVIDER_PROMPT_TOKENS},"output_tokens":${PROVIDER_COMPLETION_TOKENS},"total_tokens":${PROVIDER_PROMPT_TOKENS + PROVIDER_COMPLETION_TOKENS}}}}\n\n`,
+      ],
+    });
+    await seedScenario("split-frame-usage", upstream, "openai");
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "split-frame-usage",
+        input: "hi",
+        stream: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    // The whole document reaches the caller, not just its first line.
+    const text = await res.text();
+    expect(text).toContain(`"input_tokens":${PROVIDER_PROMPT_TOKENS}`);
+
+    const log = await waitForSlsLog(
+      sls,
+      LOGSTORE,
+      (l) => l.get("requested_model") === "split-frame-usage",
+      "usage row for the split terminal frame",
+      15_000,
+    );
+    // The trap: on the broken read the counters are NOT absent — the local
+    // estimator fills them — so "usage exists" passes either way. Only the
+    // provider's exact numbers, plus the absence of the estimated flag,
+    // tell the two apart.
+    expect(log.get("prompt_tokens")).toBe(String(PROVIDER_PROMPT_TOKENS));
+    expect(log.get("completion_tokens")).toBe(String(PROVIDER_COMPLETION_TOKENS));
+    expect(log.get("usage_estimated")).not.toBe("true");
+    // The provider's own call id rides the same frame.
+    expect(log.get("provider_request_id")).toBe("resp_split");
+  });
+
+  test("/v1/responses live relay: a CRLF-framed stream with no [DONE] sentinel bills the same", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !sls) return void ctx.skip();
+
+    // Framing varies per endpoint, not per vendor: on one host
+    // `/v1/audio/transcriptions` is pure CRLF while `/v1/responses` is pure
+    // LF, and the Responses API sends no `[DONE]`. A comment-only frame
+    // (zero `data:` lines) leads, as some relays emit while the model
+    // thinks.
+    const upstream = await upstreamWith({
+      rawStreamFrames: [
+        `: keep-alive\r\n\r\n`,
+        `data: {"type":"response.created","response":{"id":"resp_crlf","object":"response","status":"in_progress","model":"upstream-model-x"}}\r\n\r\n`,
+        `data: {"type":"response.completed","response":{"id":"resp_crlf","object":"response","status":"completed","model":"upstream-model-x","usage":{"input_tokens":${PROVIDER_PROMPT_TOKENS},"output_tokens":${PROVIDER_COMPLETION_TOKENS},"total_tokens":${PROVIDER_PROMPT_TOKENS + PROVIDER_COMPLETION_TOKENS}}}}\r\n\r\n`,
+      ],
+    });
+    await seedScenario("crlf-frame-usage", upstream, "openai");
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({ model: "crlf-frame-usage", input: "hi", stream: true }),
+    });
+    expect(res.status).toBe(200);
+    await res.text();
+
+    const log = await waitForSlsLog(
+      sls,
+      LOGSTORE,
+      (l) => l.get("requested_model") === "crlf-frame-usage",
+      "usage row for the CRLF stream",
+      15_000,
+    );
+    expect(log.get("prompt_tokens")).toBe(String(PROVIDER_PROMPT_TOKENS));
+    expect(log.get("completion_tokens")).toBe(String(PROVIDER_COMPLETION_TOKENS));
+    expect(log.get("usage_estimated")).not.toBe("true");
+  });
+
+  // ── 2. request-side reasoning is scanned AND masked ────────────────
+
+  test("/v1/responses: a mask hit inside a replayed reasoning item rewrites the DISPATCHED body", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await upstreamWith({
+      nonStreamBody: {
+        id: "resp_reason_req",
+        object: "response",
+        status: "completed",
+        model: "upstream-model-x",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "ok" }],
+          },
+        ],
+        usage: { input_tokens: 3, output_tokens: 1, total_tokens: 4 },
+      },
+    });
+    await seedScenario("reasoning-request-mask", upstream, "openai", [maskGuardrailId]);
+
+    const before = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "reasoning-request-mask",
+        input: [
+          { role: "user", content: [{ type: "input_text", text: "carry on" }] },
+          {
+            type: "reasoning",
+            id: "rs_replayed",
+            summary: [{ type: "summary_text", text: `summary says ${EMAIL}` }],
+            content: [{ type: "reasoning_text", text: `content says ${EMAIL}` }],
+          },
+        ],
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    // The point of the test: a Mask verdict that REPORTS a hit but leaves
+    // the dispatched body untouched is the fail-open this closes, so the
+    // assertion is on what the upstream received, never on the verdict.
+    expect(upstream.receivedRequests.length).toBe(before + 1);
+    const dispatched = upstream.receivedRequests.at(-1)!.body;
+    expect(dispatched).not.toContain(EMAIL);
+    expect(dispatched).toContain("summary says " + MASKED);
+    expect(dispatched).toContain("content says " + MASKED);
+  });
+
+  test("/v1/messages: a blocked literal inside a replayed thinking block is refused", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await upstreamWith({
+      nonStreamBody: {
+        id: "msg_thinking_block",
+        type: "message",
+        role: "assistant",
+        model: "upstream-model-x",
+        content: [{ type: "text", text: "ok" }],
+        usage: { input_tokens: 3, output_tokens: 1 },
+      },
+    });
+    await seedScenario("thinking-request-block", upstream, "anthropic", [blockGuardrailId]);
+
+    const before = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "thinking-request-block",
+        max_tokens: 16,
+        messages: [
+          { role: "user", content: "what did you decide" },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "thinking",
+                thinking: `I will now ${BLOCKED} quietly`,
+                signature: "sig-abc",
+              },
+              { type: "text", text: "nothing to see" },
+            ],
+          },
+          { role: "user", content: "go on" },
+        ],
+      }),
+    });
+    // The scan parse keeps thinking text the dispatch parse drops, so the
+    // block fires. Pre-fix the payload was invisible and the turn reached
+    // the upstream.
+    expect(res.status).toBe(422);
+    expect(await res.text()).not.toContain(BLOCKED);
+    expect(upstream.receivedRequests.length).toBe(before);
+  });
+
+  test("/v1/messages: a mask hit inside a signed thinking block refuses rather than dispatching it unmasked", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await upstreamWith({
+      nonStreamBody: {
+        id: "msg_thinking_mask",
+        type: "message",
+        role: "assistant",
+        model: "upstream-model-x",
+        content: [{ type: "text", text: "ok" }],
+        usage: { input_tokens: 3, output_tokens: 1 },
+      },
+    });
+    await seedScenario("thinking-request-mask", upstream, "anthropic", [maskGuardrailId]);
+
+    const before = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "thinking-request-mask",
+        max_tokens: 16,
+        messages: [
+          { role: "user", content: "what did you decide" },
+          {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: `write to ${EMAIL}`, signature: "sig-abc" },
+              { type: "text", text: "nothing to see" },
+            ],
+          },
+          { role: "user", content: "go on" },
+        ],
+      }),
+    });
+    // Rewriting a signed block invalidates its signature and the upstream
+    // rejects the replayed turn, so the mask cannot be honoured — and
+    // forwarding the match unmasked is exactly the fail-open the scan
+    // coverage would otherwise create. Refuse, and say why.
+    expect(res.status).toBe(422);
+    const body = await res.text();
+    expect(body).toContain("mask_writeback_failed");
+    expect(body).not.toContain(EMAIL);
+    expect(upstream.receivedRequests.length).toBe(before);
+
+    // The ordinary (unsigned) case still masks and dispatches — the refusal
+    // is specific to the signed slot, not a blanket rejection of any
+    // request whose history mentions an email.
+    const ok = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "thinking-request-mask",
+        max_tokens: 16,
+        messages: [{ role: "user", content: `write to ${EMAIL}` }],
+      }),
+    });
+    expect(ok.status).toBe(200);
+    await ok.text();
+    const dispatched = upstream.receivedRequests.at(-1)!.body;
+    expect(dispatched).toContain(MASKED);
+    expect(dispatched).not.toContain(EMAIL);
+  });
+
+  // ── 3. generated reasoning stays out of the OUTPUT scope ───────────
+
+  test("/v1/messages buffered: generated thinking is neither scanned nor masked", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await upstreamWith({
+      nonStreamBody: {
+        id: "msg_out_thinking",
+        type: "message",
+        role: "assistant",
+        model: "upstream-model-x",
+        content: [
+          {
+            type: "thinking",
+            thinking: `internally I considered ${BLOCKED} and ${EMAIL}`,
+            signature: "sig-out",
+          },
+          { type: "text", text: `you can reach us at ${EMAIL}` },
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "lookup",
+            input: { q: "argument text" },
+          },
+        ],
+        usage: { input_tokens: 3, output_tokens: 9 },
+      },
+    });
+    await seedScenario("thinking-output-scope", upstream, "anthropic", [
+      maskGuardrailId,
+      blockGuardrailId,
+    ]);
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "thinking-output-scope",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    // NOT blocked: the raw-content dump the output scan takes for tool-use
+    // arguments used to sweep the thinking text in with them, so a block
+    // rule matching only inside reasoning refused a response that is out of
+    // the output scope.
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    const parsed = JSON.parse(body) as {
+      content: Array<Record<string, unknown>>;
+    };
+
+    // Not rewritten: the signed block reaches the caller byte-for-byte,
+    // literal email and all.
+    expect(parsed.content[0]).toEqual({
+      type: "thinking",
+      thinking: `internally I considered ${BLOCKED} and ${EMAIL}`,
+      signature: "sig-out",
+    });
+    // …while everything the output scan and mask DO cover still works:
+    // the text block is masked, and tool-use arguments are still scanned.
+    expect(parsed.content[1]).toEqual({
+      type: "text",
+      text: `you can reach us at ${MASKED}`,
+    });
+    expect(body).toContain("argument text");
+  });
+
+  test("/v1/messages streaming: generated thinking deltas are neither scanned nor masked", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await upstreamWith({
+      rawStreamFrames: [
+        `event: message_start\ndata: {"type":"message_start","message":{"id":"msg_stream_thinking","type":"message","role":"assistant","model":"upstream-model-x","content":[],"usage":{"input_tokens":3,"output_tokens":0}}}\n\n`,
+        `event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}\n\n`,
+        `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"considering ${BLOCKED} and ${EMAIL}"}}\n\n`,
+        `event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n`,
+        `event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n`,
+        `event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"reach us at ${EMAIL}"}}\n\n`,
+        `event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n`,
+        `event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9}}\n\n`,
+        `event: message_stop\ndata: {"type":"message_stop"}\n\n`,
+      ],
+    });
+    await seedScenario("thinking-stream-output-scope", upstream, "anthropic", [
+      maskGuardrailId,
+      blockGuardrailId,
+    ]);
+
+    const r = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "thinking-stream-output-scope",
+        max_tokens: 16,
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    expect(r.status).toBe(200);
+    const text = await r.text();
+
+    // The block rule never sees the thinking delta, so the stream is not
+    // terminated with an error frame…
+    expect(text).not.toContain("content_filter");
+    // …the thinking delta reaches the caller unrewritten…
+    expect(text).toContain(`considering ${BLOCKED} and ${EMAIL}`);
+    // …and the text delta beside it is masked, which is what proves the
+    // output mask ran at all.
+    expect(text).toContain(`reach us at ${MASKED}`);
+  });
+
+  test("/v1/responses buffered: generated reasoning is neither scanned nor masked", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    // BLOCKED sits in BOTH reasoning slots. `content[]` is the one that
+    // matters: the output walk reads `content` off every item regardless of
+    // type, so without an explicit skip a reasoning item's text reached the
+    // output scan on this surface alone.
+    const reasoningItem = `{"type":"reasoning","id":"rs_out","summary":[{"type":"summary_text","text":"considering ${BLOCKED} and ${EMAIL}"}],"content":[{"type":"reasoning_text","text":"also ${BLOCKED} and ${EMAIL}"}]}`;
+    const messageItem = `{"type":"message","id":"m","role":"assistant","content":[{"type":"output_text","text":"reach us at ${EMAIL}"}]}`;
+    const upstream = await upstreamWith({
+      rawStreamFrames: [
+        `event: response.created\ndata: {"type":"response.created","response":{"id":"resp_out_reasoning","object":"response","status":"in_progress","model":"upstream-model-x"}}\n\n`,
+        `event: response.reasoning_summary_text.delta\ndata: {"type":"response.reasoning_summary_text.delta","item_id":"rs_out","delta":"considering ${BLOCKED} and ${EMAIL}"}\n\n`,
+        `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","item_id":"m","delta":"reach us at ${EMAIL}"}\n\n`,
+        `event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_out_reasoning","object":"response","status":"completed","model":"upstream-model-x","output":[${reasoningItem},${messageItem}],"usage":{"input_tokens":3,"output_tokens":9,"total_tokens":12}}}\n\n`,
+      ],
+    });
+    await seedScenario("reasoning-output-scope", upstream, "openai", [
+      maskGuardrailId,
+      blockGuardrailId,
+    ]);
+
+    const r = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "reasoning-output-scope",
+        input: "hello",
+        stream: true,
+      }),
+    });
+    expect(r.status).toBe(200);
+    const text = await r.text();
+
+    // Not blocked by the literal that appears only inside reasoning…
+    expect(text).not.toContain("content_filter");
+    // …the reasoning summary and content survive the output mask…
+    expect(text).toContain(`considering ${BLOCKED} and ${EMAIL}`);
+    expect(text).toContain(`also ${BLOCKED} and ${EMAIL}`);
+    // …and the assistant text beside them is masked.
+    expect(text).toContain(`reach us at ${MASKED}`);
+  });
+
+  // ── 4. a non-SSE body answering a streaming request ────────────────
+
+  test("/v1/responses: a JSON body answering stream:true takes the buffered scan+mask path", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    // The mock replies with a JSON document regardless of the request's
+    // `stream` flag — an upstream that ignores it, which is what this arm
+    // exists for.
+    const upstream = await upstreamWith({
+      nonStreamBody: {
+        id: "resp_not_sse",
+        object: "response",
+        status: "completed",
+        model: "upstream-model-x",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: `reach us at ${EMAIL}` }],
+          },
+        ],
+        usage: { input_tokens: 3, output_tokens: 5, total_tokens: 8 },
+      },
+    });
+    await seedScenario("responses-not-sse", upstream, "openai", [maskGuardrailId]);
+
+    const res = await fetch(`${app.proxyUrl}/v1/responses`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "responses-not-sse",
+        input: "hello",
+        stream: true,
+      }),
+    });
+    const text = await res.text();
+
+    expect(res.status).toBe(200);
+    // Scanned and masked, as the non-streaming body it actually is. On the
+    // request-flag branch it entered the SSE hold-back, where a body with
+    // no frames was seen by nothing.
+    expect(text).toContain(MASKED);
+    expect(text).not.toContain(EMAIL);
+    // …and released as itself: no `\n\n` frame terminator appended to a
+    // document that is not SSE, and not relabelled as a stream.
+    expect(text.endsWith("\n\n")).toBe(false);
+    expect(() => JSON.parse(text)).not.toThrow();
+    expect(res.headers.get("content-type") ?? "").toContain("application/json");
+  });
+
+  test("/v1/messages: a JSON body answering stream:true takes the buffered scan+mask path", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await upstreamWith({
+      nonStreamBody: {
+        id: "msg_not_sse",
+        type: "message",
+        role: "assistant",
+        model: "upstream-model-x",
+        content: [{ type: "text", text: `reach us at ${EMAIL}` }],
+        usage: { input_tokens: 3, output_tokens: 5 },
+      },
+    });
+    await seedScenario("messages-not-sse", upstream, "anthropic", [maskGuardrailId]);
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "messages-not-sse",
+        max_tokens: 16,
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    const text = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(text).toContain(MASKED);
+    expect(text).not.toContain(EMAIL);
+    expect(text.endsWith("\n\n")).toBe(false);
+    expect(() => JSON.parse(text)).not.toThrow();
+  });
+});

--- a/tests/e2e/src/cases/sse-frames-and-reasoning-scope-e2e.test.ts
+++ b/tests/e2e/src/cases/sse-frames-and-reasoning-scope-e2e.test.ts
@@ -25,8 +25,10 @@ import { startMockSls, waitForSlsLog, type MockSls } from "../harness/sls-mock.j
 //  2. Reasoning replayed by the CALLER is request text: it is scanned, and a
 //     mask that reports a hit there has to actually rewrite the dispatched
 //     body. Where the block is signed by the provider (Anthropic `thinking`),
-//     a rewrite would invalidate the signature, so the request is refused
-//     instead of forwarded with the match still in it.
+//     a rewrite would invalidate the signature and refusing the replay
+//     protects nothing already disclosed, so the block is forwarded
+//     unchanged while its unsigned neighbours still mask (#1104). A block
+//     rule still fires on it.
 //  3. Reasoning the MODEL generates stays out of the output-guardrail scope,
 //     on every `/v1/messages` and `/v1/responses` shape — neither scanned nor
 //     rewritten.
@@ -151,6 +153,7 @@ describe("sse frames + reasoning scope e2e (#1103/#1104)", () => {
 
   let maskGuardrailId = "";
   let blockGuardrailId = "";
+  let segmentGuardrailId = "";
 
   beforeAll(async () => {
     etcd = new EtcdClient();
@@ -202,6 +205,34 @@ describe("sse frames + reasoning scope e2e (#1103/#1104)", () => {
       { attach: false },
     );
     blockGuardrailId = block.id;
+
+    // A `custom` script is a SEGMENT-moderating kind: it answers `Allow`
+    // from the non-segment check by design and takes its real verdict from
+    // the segment pass, which walks the redactor. That walk never offers a
+    // signed thinking block, so a block policy on any segment kind
+    // (`custom`, `bedrock`, `presidio`, `lakera`, `aliyun_ai_guardrail`)
+    // used to be bypassable by moving the text into one. Self-contained on
+    // purpose — no screening service, so the case tests our plumbing.
+    const seg = await seed.createGuardrail(
+      {
+        name: "sse-reasoning-segment-block",
+        enabled: true,
+        hook_point: "input",
+        fail_open: false,
+        kind: "custom",
+        timeout_ms: 5000,
+        script: `
+export async function checkInput(ctx) {
+  if (ctx.text.includes("${BLOCKED}")) {
+    return { action: "block", reason_code: "segment_thinking_scan" };
+  }
+  return { action: "none" };
+}
+`,
+      },
+      { attach: false },
+    );
+    segmentGuardrailId = seg.id;
 
     await seed.createApiKey({ key_hash: CALLER_KEY_HASH, allowed_models: ["*"] });
   });
@@ -496,6 +527,53 @@ describe("sse frames + reasoning scope e2e (#1103/#1104)", () => {
     // The mask exception is for the MASK only. A block rule still reaches
     // thinking text, or the exemption would have opened a channel any
     // forbidden content could travel through.
+    expect(res.status).toBe(422);
+    expect(await res.text()).not.toContain(BLOCKED);
+    expect(upstream.receivedRequests.length).toBe(before);
+  });
+
+  test("/v1/messages: a SEGMENT-kind block rule also fires on thinking content", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await upstreamWith({
+      nonStreamBody: {
+        id: "msg_segment_block",
+        type: "message",
+        role: "assistant",
+        model: "upstream-model-x",
+        content: [{ type: "text", text: "ok" }],
+        usage: { input_tokens: 3, output_tokens: 1 },
+      },
+    });
+    await seedScenario("thinking-segment-block", upstream, "anthropic", [segmentGuardrailId]);
+
+    const before = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "thinking-segment-block",
+        max_tokens: 16,
+        messages: [
+          { role: "user", content: "benign question" },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "thinking",
+                thinking: `I will ${BLOCKED} quietly`,
+                signature: "sig-abc",
+              },
+            ],
+          },
+          { role: "user", content: "go on" },
+        ],
+      }),
+    });
+
+    // The keyword case above cannot see this: keyword is not a segment
+    // moderator, so it took a different route to the same text. A segment
+    // kind reaches thinking only through the scan-only channel.
     expect(res.status).toBe(422);
     expect(await res.text()).not.toContain(BLOCKED);
     expect(upstream.receivedRequests.length).toBe(before);

--- a/tests/e2e/src/cases/sse-frames-and-reasoning-scope-e2e.test.ts
+++ b/tests/e2e/src/cases/sse-frames-and-reasoning-scope-e2e.test.ts
@@ -523,12 +523,61 @@ describe("sse frames + reasoning scope e2e (#1103/#1104)", () => {
       signature: "sig-out",
     });
     // …while everything the output scan and mask DO cover still works:
-    // the text block is masked, and tool-use arguments are still scanned.
+    // the text block is masked.
     expect(parsed.content[1]).toEqual({
       type: "text",
       text: `you can reach us at ${MASKED}`,
     });
     expect(body).toContain("argument text");
+  });
+
+  /// The raw-array dump this change filters is the one #448 added so
+  /// tool-use arguments reach the output scan. Dropping the reasoning
+  /// blocks must not drop that: a blocked literal inside `tool_use.input`
+  /// still has to refuse the response. Asserting the argument text merely
+  /// ARRIVES proves nothing — it is part of the upstream body and is
+  /// delivered verbatim whether or not the dump still feeds the scan.
+  test("/v1/messages buffered: tool-use arguments are still scanned after the reasoning filter", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return void ctx.skip();
+
+    const upstream = await upstreamWith({
+      nonStreamBody: {
+        id: "msg_out_tooluse",
+        type: "message",
+        role: "assistant",
+        model: "upstream-model-x",
+        content: [
+          {
+            type: "thinking",
+            thinking: "nothing interesting in here",
+            signature: "sig-out",
+          },
+          { type: "text", text: "calling the tool" },
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "lookup",
+            input: { q: `argument carrying ${BLOCKED}` },
+          },
+        ],
+        usage: { input_tokens: 3, output_tokens: 9 },
+      },
+    });
+    await seedScenario("tooluse-output-scan", upstream, "anthropic", [blockGuardrailId]);
+
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        model: "tooluse-output-scan",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    expect(res.status).toBe(422);
+    const body = await res.text();
+    expect(body).not.toContain(BLOCKED);
+    expect(body).not.toContain("argument carrying");
   });
 
   test("/v1/messages streaming: generated thinking deltas are neither scanned nor masked", async (ctx) => {
@@ -566,8 +615,12 @@ describe("sse frames + reasoning scope e2e (#1103/#1104)", () => {
     const text = await r.text();
 
     // The block rule never sees the thinking delta, so the stream is not
-    // terminated with an error frame…
-    expect(text).not.toContain("content_filter");
+    // terminated with an error frame. Assert the shape this endpoint
+    // ACTUALLY emits: since the terminal frame moved to
+    // `invalid_request_error`, a `content_filter` assertion here could never
+    // go red no matter what the guardrail did.
+    expect(text).not.toContain("event: error");
+    expect(text).not.toContain('"type":"invalid_request_error"');
     // …the thinking delta reaches the caller unrewritten…
     expect(text).toContain(`considering ${BLOCKED} and ${EMAIL}`);
     // …and the text delta beside it is masked, which is what proves the
@@ -609,8 +662,12 @@ describe("sse frames + reasoning scope e2e (#1103/#1104)", () => {
     expect(r.status).toBe(200);
     const text = await r.text();
 
-    // Not blocked by the literal that appears only inside reasoning…
-    expect(text).not.toContain("content_filter");
+    // Not blocked by the literal that appears only inside reasoning. This
+    // surface refuses with an HTTP 422 rather than an in-band frame, so the
+    // `r.status` assertion above is the real check — a `content_filter`
+    // substring assertion here could never go red, because `responses.rs`
+    // has no error-frame producer at all on the verbatim hold-back path.
+    expect(text).not.toContain("guardrail");
     // …the reasoning summary and content survive the output mask…
     expect(text).toContain(`considering ${BLOCKED} and ${EMAIL}`);
     expect(text).toContain(`also ${BLOCKED} and ${EMAIL}`);


### PR DESCRIPTION
Six related defects on the SSE relay and guardrail paths. All of them are silent: nothing errors, the gateway keeps answering 200, and enforcement or metering quietly weakens.

## Whole-frame SSE reads

A frame's payload is every one of its `data:` lines joined with `\n`, and two readers still stopped at the first.

`drain_responses_sse_frames` could not parse a terminal `response.completed` written over several lines, so the local token estimator filled the counters in — the request billed *estimated* tokens while still reporting usage, which is indistinguishable from working code unless a test names the provider's exact numbers.

`frame_delta` on the passthrough route parsed each `data:` line independently, turning one document into N unparseable fragments: no usage read, and on an opaque stream the JSON *source text* was pushed into the guardrail scan instead of the values.

Both now take `redact::frame_payload`. A frame whose joined payload does not parse still yields its raw text to the scan on **every** protocol — the frame is forwarded either way, so scanning nothing for it would be a way past an output block rule. `model_echo::restamp_sse_frame` deliberately keeps its first-line read: it needs byte offsets into the original buffer that a joined payload cannot supply (#1105).

## Framing audit

Every SSE splitter and frame reader in the crate is now covered against the three shapes real upstreams produce: pure-CRLF framing with `\r\n\r\n` separators and no `event:` lines (framing varies per *endpoint*, not per vendor — the same host streams transcriptions in CRLF and responses in LF); a stream with no `[DONE]` sentinel; and comment-only frames carrying zero `data:` lines. The splitters were already right — they had no tests saying so, and now they do.

## Request-side reasoning is in scope

Reasoning replayed by the **caller** is text entering the model like any other. Three surfaces read it without masking it, so a Mask rule reported a hit, returned Allow, and dispatched the match untouched:

- **`/v1/responses`** scanned a `reasoning` item's `content[].text` while the mask walked past it. Both `content[].text` and `summary[].text` are now scanned and masked.
- **`/v1/chat/completions`** never read `reasoning_content` at all — the canonical slot every vendor spelling is normalised onto, and one that relays upstream verbatim. Added to `message_scan_text`, `redact_chat_format`, and the passthrough route's request scan.
- **`/v1/messages`** dropped `thinking` blocks before the scan saw them, because the scan shared one parse with the cross-provider dispatch bridge — where dropping them is correct. They are now two parses that differ in exactly that.

## A signed thinking block is forwarded unchanged

A mask-action hit inside an Anthropic `thinking` / `redacted_thinking` block is **forwarded unchanged** — not rewritten, not blocked — for every guardrail kind, including the kinds that otherwise turn an unmaskable result into a blocking verdict.

This is a deliberate, narrow exception to "no write-back channel means a blocking verdict", and it is written as one on `redact_anthropic_content` rather than left to be inferred. The reason refusing buys nothing: the same bytes already left through the response. Generated reasoning is out of the output scope by design, so the block being replayed is one the gateway itself handed to the client unmasked on the previous turn. Blocking it protects nothing that was not already disclosed, and it denies service permanently — a client following Anthropic's extended-thinking protocol re-sends the block every turn, so the conversation and `count_tokens` with it would 422 forever with no caller-side remedy.

Block-action rules are unaffected and still fire on thinking content. That needed work on two fronts, not one: the seven kinds that answer through `check_input` get the text from the scan parse, while `bedrock`, `presidio`, `lakera`, `aliyun_ai_guardrail` and `custom` report `moderates_segments()` and take their verdict from the segment pass — which reads the redaction walker, and the walker deliberately does not offer a signed block. Those five therefore saw no thinking content at all, and a block policy on any of them was bypassable by moving the text into a thinking block.

`moderate_body_scanning` adds a scan-only channel for exactly this: texts appended after the collected slots and truncated off the masked reply before the apply walk, so they are judged and can never be written back. Both constraints then hold together — the block rule fires, and the block still reaches the upstream byte-identical.

## Response-side reasoning stays out, and is pinned

The posture is unchanged, but two paths were including generated reasoning by accident: the buffered `/v1/messages` output scan serialises the whole content array (added for tool-use arguments) and swept thinking text in with it, and `responses_output_text` reads `content` off every output item regardless of type — a reasoning item carries one. Both now skip the reasoning shapes, which is what their own doc comments already claimed. The passthrough route's Responses output scan had the identical gap and is fixed with them. Tests pin both directions on buffered `/v1/messages`, streaming `/v1/messages` and `/v1/responses`.

## A non-SSE body answering a streaming request

The buffered/hold-back branch was chosen from the **request's** `stream` flag, so an upstream that ignores `stream: true` and returns a plain JSON document entered the SSE hold-back: with no frames in it nothing scanned it, and the seal pass appended a `\n\n` frame terminator to a body that is not SSE before releasing it under the upstream's own content type.

Both routes now branch on what the upstream actually sent, and such a body takes the non-streaming buffered scan+mask path beside it — read under an explicit deadline, because the request-level timeout is deliberately not attached for a streaming request and the per-chunk read timeout lives on the branch this response no longer takes.

`dispatch::upstream_body_is_sse` and the passthrough route's `is_sse` take **opposite** defaults on an unknown content type, and both now say why. Unifying them was tried and reverted: demanding an explicit `text/event-stream` on the typed relays turns any upstream that streams under a wrong or absent label into a hard 502. Not hypothetical — eight of this crate's own `/v1/messages` streaming tests produce that shape by accident (their mock sets `text/event-stream`, then `set_body_string` overwrites the header with `text/plain`) and every one fails under the stricter rule. The bug the predicate exists for is caught by the JSON test alone.

## Error envelopes

**Behaviour change.** Two SSE error frames change shape, each toward its own protocol rather than toward each other:

- **`/v1/messages`** — the HTTP 422 path renders `error.type = "invalid_request_error"` (correct; Anthropic's error-type enum has no `content_filter` member) while the SSE terminal frame emitted `content_filter`. The frame now renders `{"type":"error","error":{"type":"invalid_request_error","message":…}}`, matching the 422 path. No `code` field — the Anthropic envelope has none.
- **`/v1/responses`** — both of the bridge's error frames (guardrail block and upstream failure) now emit the Responses API's own flat event, `{"type":"error","code":…,"message":…,"param":null,"sequence_number":N}`, matching `openai-python`'s `ResponseErrorEvent`. Nesting it under `error` would hand a `responses.stream()` client an event it cannot classify, since that stream is a union discriminated on the top-level `type`. `sequence_number` continues the encoder's own numbering.

The HTTP 422 envelopes on every endpoint are untouched.

## Deliberately unchanged

A frame whose payload parses but whose event type no pass models continues to be released without contributing to the scan text. No raw-text or string-leaf fallback for that case, and no excising of unmodelled frames.

A `/v1/responses` reasoning item's `encrypted_content` is forwarded verbatim and is neither scanned nor rewritten — unfixable at this layer, since it is provider ciphertext, so the masked `text` is a readable copy while the provider still receives the original. Called out in the code so it is not read as closed; the documentation task carries it to customers.

## Tests

A new e2e spec drives all of it against a real binary, etcd and mock upstreams. Every new unit test and e2e case was verified to fail with its own fix reverted; three assertions that turned out to be unfalsifiable were rewritten rather than kept.

Three existing specs update their assertion on the Anthropic SSE error type — the deliberate contract change above, not a weakened assertion. They now parse the frame and assert the whole envelope instead of substring-matching `content_filter`.

Fixes #1103
Fixes #1104
Refs #1105
Refs #1106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Guardrail scanning now covers replayed reasoning, Anthropic thinking blocks, tool results, MCP approval responses, and additional response fields.
  - Streaming responses handle multiline and CRLF-formatted SSE frames more reliably.
  - JSON responses returned when streaming is requested use buffered processing with deadline enforcement.

- **Bug Fixes**
  - Signed Anthropic reasoning blocks are forwarded unchanged while adjacent text remains masked.
  - Streaming guardrail errors now use provider-compatible `invalid_request_error` responses.
  - Unscannable or oversized streaming frames fail closed.
  - Tool-call output remains covered by guardrail scanning while generated reasoning is excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->