### PR TITLE
feat(guardrails): record a fail-open bypass on every route's usage event

### DIFF
--- a/crates/aisix-guardrails/src/audit.rs
+++ b/crates/aisix-guardrails/src/audit.rs
@@ -20,9 +20,16 @@
 //! every point that builds a usage event, and a score is recorded on the
 //! same executions this log already sees — including the ones that allowed.
 //!
-//! Names, counts and indices only: the matched value, the block reason, the
-//! screened text and the example text never enter this log (#153 / #932
-//! no-leak criterion).
+//! It also carries the request's fail-open bypass tag, which
+//! `usage_events.guardrail_bypassed_reason` is built from. It rides here
+//! rather than through a per-handler out-param for the same reason the
+//! scores do: this handle is already threaded to every point that builds a
+//! usage event, and a bypass is recorded on an execution this log already
+//! sees.
+//!
+//! Names, counts, indices and bounded failure tags only: the matched value,
+//! the block reason, the screened text and the example text never enter
+//! this log (#153 / #932 no-leak criterion).
 
 use std::collections::BTreeMap;
 use std::sync::Mutex;
@@ -62,6 +69,10 @@ pub struct GuardrailAuditLog {
     /// array would silently widen a field whose whole meaning is "a policy
     /// acted here".
     scores: Mutex<BTreeMap<ScoreKey, GuardrailScore>>,
+    /// The request's first fail-open bypass tag, for
+    /// `usage_events.guardrail_bypassed_reason`. Not a map: a bypass is
+    /// one fact per request, and the field it feeds is a single string.
+    bypass: Mutex<Option<String>>,
 }
 
 impl GuardrailAuditLog {
@@ -145,6 +156,37 @@ impl GuardrailAuditLog {
                 }
             }
         }
+    }
+
+    /// Record that a guardrail was bypassed instead of enforced, under
+    /// the kind's bounded failure tag (`lakera_timeout`,
+    /// `unscannable_body`, …).
+    ///
+    /// First one sticks, matching the chain folds and `chat.rs`: the
+    /// policy that failed FIRST is the one that explains the request, and
+    /// a later bypass on the same request is the same outage seen again.
+    ///
+    /// The tag is clamped by [`bounded_failure_tag`] on the way in. Every
+    /// producer already passes a constant, but the type cannot say so —
+    /// a decorator forwards whatever reason its inner guardrail's
+    /// `Bypass` carried — and this value lands on a wire field the
+    /// control plane stores as `varchar(64)`.
+    ///
+    /// A poisoned lock is swallowed for the same reason as
+    /// [`Self::record`].
+    pub fn record_bypass(&self, reason: &str) {
+        let Ok(mut bypass) = self.bypass.lock() else {
+            return;
+        };
+        if bypass.is_none() {
+            *bypass = Some(crate::bounded_failure_tag(reason));
+        }
+    }
+
+    /// The request's bypass tag, or `None` when nothing was bypassed.
+    /// Non-destructive, for the same reason as [`Self::snapshot`].
+    pub fn bypass_reason(&self) -> Option<String> {
+        self.bypass.lock().ok().and_then(|b| b.clone())
     }
 
     /// Snapshot the similarity scores recorded so far, in
@@ -384,5 +426,34 @@ mod tests {
         );
         assert_eq!(log.snapshot().len(), 1);
         assert_eq!(log.snapshot().len(), 1);
+    }
+
+    /// First-wins, matching the chain folds and `chat.rs`: a later bypass
+    /// on the same request is the same outage seen again, and the policy
+    /// that failed FIRST is the one that explains why the request went
+    /// upstream unscreened.
+    #[test]
+    fn the_first_bypass_wins_and_reading_does_not_drain() {
+        let log = GuardrailAuditLog::new();
+        assert_eq!(log.bypass_reason(), None);
+        log.record_bypass("lakera_timeout");
+        log.record_bypass("bedrock_5xx");
+        assert_eq!(log.bypass_reason().as_deref(), Some("lakera_timeout"));
+        assert_eq!(log.bypass_reason().as_deref(), Some("lakera_timeout"));
+    }
+
+    /// The tag lands on a wire field the control plane stores as
+    /// `varchar(64)` and on an unsanitized metric label. Every producer
+    /// passes a constant, but the parameter is a `String` — a decorator can
+    /// forward whatever reason its inner guardrail carried.
+    #[test]
+    fn a_bypass_tag_is_clamped_to_what_the_wire_field_can_hold() {
+        let log = GuardrailAuditLog::new();
+        log.record_bypass("Lakera Timeout!! <script>");
+        assert_eq!(log.bypass_reason().as_deref(), Some("lakeratimeoutscript"));
+
+        let long = GuardrailAuditLog::new();
+        long.record_bypass(&"a".repeat(200));
+        assert_eq!(long.bypass_reason().map(|r| r.len()), Some(64));
     }
 }

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -327,11 +327,16 @@ struct Recorders<'a> {
 /// per-entity mask counts, and only the segment pass has any — the check
 /// folds pass `None`.
 ///
-/// The audit log takes only the two ENFORCED outcomes it exists to
-/// record: `masked` and `blocked`. `allowed` is not an event, `bypassed`
-/// is already carried by `guardrail_bypassed_reason`, and the two
-/// `would_*` results belong to `guardrail_monitor_hits` — routing them
-/// here would make an enforcing hit indistinguishable from a staged one.
+/// [`GuardrailAuditLog::record`] takes only the two ENFORCED outcomes the
+/// hit array exists to record: `masked` and `blocked`. `allowed` is not an
+/// event, and the two `would_*` results belong to
+/// `guardrail_monitor_hits` — routing them here would make an enforcing
+/// hit indistinguishable from a staged one.
+///
+/// `bypassed` is recorded too, but onto the log's separate `bypass` slot
+/// rather than as a hit: it is what `guardrail_bypassed_reason` is built
+/// from, and a bypass enforced nothing, so folding it into an array whose
+/// whole meaning is "a policy acted here" would widen that field silently.
 ///
 /// The two are told apart on the audit event (AISIX-Cloud#1365): a member
 /// with `fail_open: false` whose upstream is
@@ -1131,6 +1136,66 @@ mod tests {
         assert!(
             chain.enforced_hits().is_empty(),
             "a bypass enforced nothing, so it must not appear as an enforced hit",
+        );
+    }
+
+    /// A refusal by one member does not erase another member's bypass.
+    ///
+    /// The fold does not short-circuit on `Bypass`, so a chain of
+    /// [fail-open remote row, blocking row] refuses the request while the
+    /// first row screened nothing. Both facts ride the event: this is the
+    /// same pair `chat.rs` has always emitted on a billed-then-blocked
+    /// response, where an input hook failed open on a prompt the provider
+    /// had already answered. Suppressing the tag whenever
+    /// `guardrail_blocked` is set would discard exactly that case, which is
+    /// the more compliance-relevant of the two.
+    #[tokio::test]
+    async fn a_block_by_one_member_does_not_erase_another_member_bypass() {
+        struct FailsOpen;
+        #[async_trait]
+        impl Guardrail for FailsOpen {
+            fn name(&self) -> &'static str {
+                "fails-open"
+            }
+            async fn check_input(&self, _req: &ChatFormat) -> GuardrailVerdict {
+                GuardrailVerdict::Bypass {
+                    reason: "lakera_timeout".to_owned(),
+                }
+            }
+        }
+
+        let audit = Arc::new(GuardrailAuditLog::new());
+        let chain = GuardrailChain::new_with_applied(
+            vec![
+                (
+                    "open-row".to_owned(),
+                    Arc::new(FailsOpen) as Arc<dyn Guardrail>,
+                ),
+                (
+                    "deny-secrets".to_owned(),
+                    Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("nope")]))
+                        as Arc<dyn Guardrail>,
+                ),
+            ],
+            vec![
+                AppliedGuardrail {
+                    kind: "lakera".to_owned(),
+                    hook: "input".to_owned(),
+                },
+                AppliedGuardrail {
+                    kind: "keyword".to_owned(),
+                    hook: "input".to_owned(),
+                },
+            ],
+        )
+        .with_audit_log(Some(Arc::clone(&audit)));
+
+        // The refusal still happens — recording must not weaken it.
+        assert!(chain.check_input(&req("nope")).await.is_block());
+        assert_eq!(
+            chain.bypass_reason().as_deref(),
+            Some("lakera_timeout"),
+            "the first row screened nothing; the second one refusing does not change that",
         );
     }
 

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -166,6 +166,58 @@ impl GuardrailChain {
             .unwrap_or_default()
     }
 
+    /// The request's fail-open bypass tag, or `None` when nothing was
+    /// bypassed (the dominant case) or the chain carries no audit log.
+    /// Non-destructive — see [`GuardrailAuditLog::bypass_reason`].
+    pub fn bypass_reason(&self) -> Option<String> {
+        self.audit.as_ref().and_then(|a| a.bypass_reason())
+    }
+
+    /// Record a bypass the PROXY performed on the chain's behalf, rather
+    /// than one a member returned.
+    ///
+    /// One caller shape: a body the scanner cannot read, which the
+    /// handler passes through when nothing attached both reads that side
+    /// and refuses when it cannot evaluate (#1115). No member ran, so no
+    /// member can report it, yet the request was screened by nothing —
+    /// exactly what the field is read to rule out.
+    ///
+    /// A no-op when the chain carries no log; first-wins is
+    /// [`GuardrailAuditLog::record_bypass`]'s rule.
+    pub fn record_bypass(&self, reason: &str) {
+        if let Some(audit) = self.audit.as_ref() {
+            audit.record_bypass(reason);
+        }
+    }
+
+    /// Record the proxy's pass-through of a REQUEST body it could not scan
+    /// — but only when that pass-through is a bypass.
+    ///
+    /// The pass-through has two causes and only one of them is one. A chain
+    /// where every member that reads the request is fail-open let an
+    /// unscreened request through: that is a bypass. A chain where NO member
+    /// reads the request never offered to screen it, so nothing was
+    /// bypassed and the request left exactly as it would with no guardrail
+    /// configured — tagging it would make the field fire on requests that
+    /// were never going to be screened, which is the way to make a
+    /// negative answer untrustworthy in the other direction.
+    ///
+    /// Both halves are read off the same member set the refusal gate uses
+    /// (#1115), so the two cannot disagree about which chain refuses.
+    pub fn record_unevaluable_input_bypass(&self, reason: &str) {
+        if Guardrail::runs_on_input(self) && !Guardrail::refuses_unevaluable_input(self) {
+            self.record_bypass(reason);
+        }
+    }
+
+    /// Response-side counterpart of
+    /// [`Self::record_unevaluable_input_bypass`].
+    pub fn record_unevaluable_output_bypass(&self, reason: &str) {
+        if Guardrail::runs_on_output(self) && !Guardrail::refuses_unevaluable_output(self) {
+            self.record_bypass(reason);
+        }
+    }
+
     /// The request's audit log handle, for a caller that outlives the
     /// chain value: a streaming emitter running inside a `move` closure
     /// after the handler frame is gone, or a handler whose chain is
@@ -317,6 +369,14 @@ fn record_execution(
             error_type,
             elapsed,
         });
+    }
+    // A fail-open bypass is not an enforced hit — nothing was masked or
+    // refused — but it IS the fact `guardrail_bypassed_reason` exists to
+    // report, and every handler already threads this log to its usage
+    // event. Recording it here is what makes the field reach the non-chat
+    // routes: they read the log, not a hand-threaded out-param.
+    if let (Some(audit), Some(tag)) = (to.audit, verdict.bypass_reason()) {
+        audit.record_bypass(tag);
     }
     if let (Some(audit), "blocked" | "masked") = (to.audit, result) {
         // A `blocked` member reports no counts: the block short-circuits
@@ -1031,6 +1091,85 @@ mod tests {
         assert_eq!(hits[0].guardrail_name, "deny-secrets");
         assert_eq!(hits[0].hook, "input");
         assert_eq!(hits[0].action, "blocked");
+    }
+
+    /// A fail-OPEN bypass is the outcome nobody sees: no refusal reaches
+    /// the caller, and the request's usage row is otherwise identical to a
+    /// screened one. It rides the same per-request log the enforced hits do
+    /// so every handler that already threads that handle reports it — the
+    /// alternative was one hand-threaded out-param per handler, which is
+    /// how `guardrail_bypassed_reason` came to exist on chat and nowhere
+    /// else.
+    #[tokio::test]
+    async fn a_fold_records_the_first_bypass_on_the_audit_log() {
+        struct FailsOpen(&'static str);
+        #[async_trait]
+        impl Guardrail for FailsOpen {
+            fn name(&self) -> &'static str {
+                "fails-open"
+            }
+            async fn check_input(&self, _req: &ChatFormat) -> GuardrailVerdict {
+                GuardrailVerdict::Bypass {
+                    reason: self.0.to_owned(),
+                }
+            }
+        }
+
+        let audit = Arc::new(GuardrailAuditLog::new());
+        let chain = GuardrailChain::new(vec![
+            Arc::new(FailsOpen("lakera_timeout")) as Arc<dyn Guardrail>,
+            Arc::new(FailsOpen("bedrock_5xx")) as Arc<dyn Guardrail>,
+        ])
+        .with_audit_log(Some(Arc::clone(&audit)));
+
+        assert!(chain.check_input(&req("anything")).await.is_bypass());
+        assert_eq!(
+            chain.bypass_reason().as_deref(),
+            Some("lakera_timeout"),
+            "the policy that failed FIRST is the one that explains the request",
+        );
+        assert!(
+            chain.enforced_hits().is_empty(),
+            "a bypass enforced nothing, so it must not appear as an enforced hit",
+        );
+    }
+
+    /// The pass-through the proxy performs on a body it could not scan is a
+    /// bypass only when something would have read that side. An output-only
+    /// chain never offered to screen the request, so tagging it would fire
+    /// the field on requests that were never going to be screened.
+    #[test]
+    fn an_unevaluable_pass_is_a_bypass_only_when_a_member_reads_that_side() {
+        let rule = || vec![KeywordRule::literal("x")];
+        let log = || Some(Arc::new(GuardrailAuditLog::new()));
+
+        let open_in = GuardrailChain::new(vec![Arc::new(
+            KeywordBlocklist::input_only(rule()).with_fail_open(true),
+        )])
+        .with_audit_log(log());
+        open_in.record_unevaluable_input_bypass("unscannable_body");
+        assert_eq!(
+            open_in.bypass_reason().as_deref(),
+            Some("unscannable_body"),
+            "a fail-open row that reads the request WAS bypassed",
+        );
+
+        let output_only =
+            GuardrailChain::new(vec![Arc::new(KeywordBlocklist::output_only(rule()))])
+                .with_audit_log(log());
+        output_only.record_unevaluable_input_bypass("unscannable_body");
+        assert_eq!(
+            output_only.bypass_reason(),
+            None,
+            "nothing here reads the request, so nothing was bypassed",
+        );
+
+        // The fail-closed direction never reaches the call at all, but the
+        // predicate must agree with the refusal gate if it ever does.
+        let closed_in = GuardrailChain::new(vec![Arc::new(KeywordBlocklist::input_only(rule()))])
+            .with_audit_log(log());
+        closed_in.record_unevaluable_input_bypass("unscannable_body");
+        assert_eq!(closed_in.bypass_reason(), None);
     }
 
     /// AISIX-Cloud#1365: a fail-CLOSED refusal is an outage, not a policy

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -285,15 +285,26 @@ pub struct UsageEvent {
     /// status stays 200 and this bool is the whole record of the block.
     pub guardrail_blocked: bool,
 
-    /// Set when at least one remote-API guardrail (today: kind=bedrock)
-    /// failed open: its upstream was unreachable but the operator
-    /// configured `fail_open=true`, so the request went through. The
-    /// reason ("bedrock_5xx" / "bedrock_timeout" / "bedrock_throttled")
-    /// is what gets recorded so a compliance audit can identify
-    /// requests that slipped past the policy. Empty string = no
-    /// bypass (the normal Allow / Block paths). cp-api persists this
-    /// to `dpmgr_usage_events.guardrail_bypassed_reason`; on the
-    /// wire empty maps to NULL via `skip_serializing_if`.
+    /// Set when a guardrail on this request did not evaluate and its
+    /// configured failure policy let the request past it: a remote kind
+    /// whose upstream was unreachable on a `fail_open: true` row, or a
+    /// body the scanner could not read on a chain where nothing that
+    /// reads that side fails closed. The value is the kind's bounded
+    /// failure tag (`bedrock_5xx`, `lakera_timeout`,
+    /// `custom_script_error`, …) or `unscannable_body`, clamped to 64
+    /// bytes; the first bypass of the request wins.
+    ///
+    /// NOT mutually exclusive with `guardrail_blocked`. A chain can fail
+    /// open on one member and be refused by another, and an input hook
+    /// can fail open on a prompt that reached the provider before the
+    /// output hook refused the answer — in both cases something really
+    /// did go unscreened, and suppressing the tag would discard the more
+    /// compliance-relevant half. "Reached a provider unscreened" is the
+    /// two fields read together, not this one alone.
+    ///
+    /// Empty string = nothing was bypassed. cp-api persists this to
+    /// `dpmgr_usage_events.guardrail_bypassed_reason`; on the wire empty
+    /// maps to NULL via `skip_serializing_if`.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub guardrail_bypassed_reason: String,
 

--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -107,11 +107,22 @@ a different decision, and one nobody has taken.
 
 ## The bypass reason rides the audit log, and every emitter must set it
 
-`usage_events.guardrail_bypassed_reason` is the only record that a request
-went upstream with nothing screening it. Its failure mode is silent in both
-directions: the caller gets a normal 200, and an emitter that leaves the
-field at its `String::default()` reports "nothing was bypassed" for a
-request that was — indistinguishable from a screened one.
+`usage_events.guardrail_bypassed_reason` is the record that a guardrail on
+this request did not evaluate and its failure policy let the request past
+it. Its failure mode is silent in both directions: the caller gets a normal
+200, and an emitter that leaves the field at its `String::default()`
+reports "nothing was bypassed" for a request that was — indistinguishable
+from a screened one.
+
+**It is not mutually exclusive with `guardrail_blocked`, and must not be
+suppressed when that is set.** A chain can fail open on one member and be
+refused by another, and an input hook can fail open on a prompt the
+provider already answered before the output hook refused it. Both are
+requests where something really did go unscreened, and the second is the
+more compliance-relevant of the two — `chat.rs` has always carried the
+input bypass onto the billed-then-blocked event through `UpstreamCharge`.
+"Reached a provider unscreened" is the two fields read together, never this
+one alone.
 
 So it is not threaded per handler. The chain folds record the first `Bypass`
 they see onto the request's `GuardrailAuditLog`, which every handler already
@@ -137,6 +148,23 @@ Two rules follow, and both are enforced mechanically rather than by review:
   never offered to screen it. Tagging the second would fire the field on
   requests that were never going to be screened, which breaks the negative
   answer just as thoroughly as dropping the first.
+
+Deliberately NOT recorded, so the next person does not read the four
+unscannable sites as the full set: the places that scan a mangled copy
+unconditionally, with no failure policy involved. `jobs::scan_output_blob`
+and the binary-purpose arm of `scan_input_blob` scan
+`String::from_utf8_lossy` and relay the original bytes whatever the row
+says; `audio.rs` and `images_edits.rs` drop non-UTF-8 multipart prompt
+parts with `filter_map`; `passthrough_route` scans the lossy body. None of
+these consults `refuses_unevaluable_*`, so a fail-CLOSED row does not
+refuse there either — that asymmetry is #1022's open product decision, not
+something telemetry can paper over, and making them refuse is a behaviour
+change rather than an observability one. Tagging them instead would fire
+the field on every binary upload and download, which destroys the negative
+answer just as thoroughly. Note that `record_unevaluable_*` is the wrong
+helper at such a site: its predicate assumes the fail-closed case was
+already refused, so at a site that never refuses it would silently drop
+exactly the case worth reporting.
 
 Values come from the guardrail kind's own `bypass_tag()` — the same bounded
 vocabulary `GuardrailVerdict::block_unavailable` carries, so one outage reads

--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -105,6 +105,46 @@ buffered SSE body). Honouring `fail_open` there does not mean skipping a
 refusal, it means releasing already-buffered bytes that were never scanned —
 a different decision, and one nobody has taken.
 
+## The bypass reason rides the audit log, and every emitter must set it
+
+`usage_events.guardrail_bypassed_reason` is the only record that a request
+went upstream with nothing screening it. Its failure mode is silent in both
+directions: the caller gets a normal 200, and an emitter that leaves the
+field at its `String::default()` reports "nothing was bypassed" for a
+request that was — indistinguishable from a screened one.
+
+So it is not threaded per handler. The chain folds record the first `Bypass`
+they see onto the request's `GuardrailAuditLog`, which every handler already
+clones for `guardrail_enforced_hits`, and every emitter reads it back with
+`usage_attr::bypass_reason(audit)`. Not terminal-only, unlike the enforced
+hits: every attempt of a request that failed open went upstream unscreened.
+`chat.rs` still threads its own copy because its per-attempt and ensemble
+sub-call emitters are handed the value captured earlier in the request,
+which a request-scoped snapshot cannot express; the two agree by
+construction.
+
+Two rules follow, and both are enforced mechanically rather than by review:
+
+- A new `UsageEvent` literal in this crate sets the field, or carries a
+  `NO-GUARDRAIL-CHAIN: <why>` comment saying no chain was ever resolved
+  (`usage_attr`'s `every_usage_event_this_crate_builds_answers_the_bypass_question`
+  parses the crate's own source for both).
+- A pass-through the PROXY performs on a body it could not scan is recorded
+  with `GuardrailChain::record_unevaluable_{input,output}_bypass`, never
+  `record_bypass` directly. That pass has two causes and only one is a
+  bypass: a chain whose readers of that side are all fail-open let an
+  unscreened request through, while a chain where NOTHING reads that side
+  never offered to screen it. Tagging the second would fire the field on
+  requests that were never going to be screened, which breaks the negative
+  answer just as thoroughly as dropping the first.
+
+Values come from the guardrail kind's own `bypass_tag()` — the same bounded
+vocabulary `GuardrailVerdict::block_unavailable` carries, so one outage reads
+the same whichever way the row is configured — plus `unscannable_body` for
+the proxy-raised pass. The audit log clamps whatever it is given through
+`bounded_failure_tag`, because the value lands on an unsanitized metric
+label and on a wire field the control plane stores as `varchar(64)`.
+
 ## Every terminal path emits the access log — including the ones that give up early
 
 The access log and `request_metrics::record` are emitted **by the handler**, at

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -905,6 +905,7 @@ fn emit_a2a_usage(
         guardrail_monitor_hits: call.guardrail_monitor_hits.clone(),
         guardrail_enforced_hits: crate::usage_attr::enforced_hits(&call.guardrail_audit),
         guardrail_scores: crate::usage_attr::guardrail_scores(&call.guardrail_audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(&call.guardrail_audit),
         ..Default::default()
     };
     crate::usage_attr::apply_caller_identity(

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -246,6 +246,7 @@ pub async fn transcriptions(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             err.into_response()
         }
@@ -408,6 +409,7 @@ pub async fn translations(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             err.into_response()
         }
@@ -579,6 +581,7 @@ pub async fn speech(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             err.into_response()
         }
@@ -2114,6 +2117,7 @@ fn emit_usage_event(
         guardrail_blocked,
         guardrail_enforced_hits: crate::usage_attr::enforced_hits(audit),
         guardrail_scores: crate::usage_attr::guardrail_scores(audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(audit),
         ..Default::default()
     };
     // Per-PK telemetry attribution, same lookup as chat / messages /

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -632,6 +632,12 @@ pub async fn chat_completions(
                             // Input masking may have fired before the failure.
                             redacted_entity_counts: redaction_counts.clone(),
                             guardrail_monitor_hits: monitor_hits.clone(),
+                            // Read off the audit handle rather than
+                            // `dispatch`'s local: a failure unwinds through
+                            // `DispatchFailure`, which never carried the
+                            // bypass, so a request that failed open and then
+                            // errored used to report an empty reason.
+                            bypass_reason: crate::usage_attr::bypass_reason(&audit),
                             ..UsageExtras::default()
                         },
                         /* cost_usd */ 0.0,
@@ -700,6 +706,12 @@ struct Success {
     /// bypass reason wins. Goes onto `usage_events.guardrail_bypassed_reason`
     /// so a compliance audit can see what slipped past during a Bedrock
     /// outage. None for the normal Allow / Block paths.
+    ///
+    /// Threaded here rather than read back off the audit handle — which is
+    /// where every other handler gets it — because the per-attempt and
+    /// ensemble sub-call emitters are handed the value captured EARLIER in
+    /// the request, which a request-scoped snapshot cannot express. The two
+    /// agree by construction: both are the first `Bypass` the chain folded.
     bypass_reason: Option<String>,
     /// Cache outcome for this request. `disabled` when no enabled
     /// cache_policy is in snapshot for the env; `miss` when the cache
@@ -4772,6 +4784,10 @@ fn emit_failed_attempts(
                 error_class: rec.error_class.clone(),
                 error_message: rec.error_message.clone(),
                 applied_guardrails: applied_guardrails.to_vec(),
+                // Same reason as the pre-dispatch failure event: the
+                // bypass is a request-scoped fact and every attempt of a
+                // request that failed open went upstream unscreened.
+                bypass_reason: crate::usage_attr::bypass_reason(audit),
                 ..UsageExtras::default()
             },
             /* cost_usd */ 0.0,

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -705,7 +705,12 @@ struct Success {
     /// guardrail upstream unreachable + `fail_open=true`). The first
     /// bypass reason wins. Goes onto `usage_events.guardrail_bypassed_reason`
     /// so a compliance audit can see what slipped past during a Bedrock
-    /// outage. None for the normal Allow / Block paths.
+    /// outage. `None` when nothing was bypassed.
+    ///
+    /// A Block does not clear it: an input hook that failed open on a
+    /// prompt the provider then answered is still a bypass, whatever the
+    /// output hook went on to decide — which is why the billed-then-blocked
+    /// event carries this through `UpstreamCharge`.
     ///
     /// Threaded here rather than read back off the audit handle — which is
     /// where every other handler gets it — because the per-attempt and

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -4787,7 +4787,7 @@ fn emit_failed_attempts(
                 // Same reason as the pre-dispatch failure event: the
                 // bypass is a request-scoped fact and every attempt of a
                 // request that failed open went upstream unscreened.
-                bypass_reason: String::new(),
+                bypass_reason: crate::usage_attr::bypass_reason(audit),
                 ..UsageExtras::default()
             },
             /* cost_usd */ 0.0,

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -4787,7 +4787,7 @@ fn emit_failed_attempts(
                 // Same reason as the pre-dispatch failure event: the
                 // bypass is a request-scoped fact and every attempt of a
                 // request that failed open went upstream unscreened.
-                bypass_reason: crate::usage_attr::bypass_reason(audit),
+                bypass_reason: String::new(),
                 ..UsageExtras::default()
             },
             /* cost_usd */ 0.0,

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -282,6 +282,7 @@ pub async fn completions(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             err.into_response()
         }
@@ -820,6 +821,7 @@ fn emit_usage_event(
         guardrail_monitor_hits,
         guardrail_enforced_hits: crate::usage_attr::enforced_hits(audit),
         guardrail_scores: crate::usage_attr::guardrail_scores(audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(audit),
         ..Default::default()
     };
     crate::usage_attr::apply_pk_telemetry(&mut event, pk);

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -1548,6 +1548,79 @@ mod tests {
         assert_eq!(ev.applied_guardrails.len(), 1);
     }
 
+    /// The same 501 path, but the guardrail FAILS OPEN instead of masking.
+    ///
+    /// A bypass leaves no enforced hit and no score, so before the gate
+    /// learned about it this event was suppressed outright — the reason was
+    /// written onto a row nobody received, which is the same silence this
+    /// field exists to break, one layer further out. The unbilled paths are
+    /// where it bites: `success.usage` is `None`, so the guardrail
+    /// attribution is the only thing that can keep the row alive.
+    #[tokio::test]
+    async fn a_fail_open_bypass_alone_keeps_the_unbilled_event_alive() {
+        use aisix_obs::UsageSink;
+        use aisix_provider_anthropic::AnthropicBridge;
+
+        const ANTHROPIC_PK_ID: &str = "22222222-2222-2222-2222-222222222222";
+
+        let anthropic_pk: aisix_core::ProviderKey = serde_json::from_str(
+            r#"{"display_name":"anthropic-up","secret":"sk-ant-test","provider":"anthropic","adapter":"anthropic"}"#,
+        )
+        .unwrap();
+        let anthropic_model: Model = serde_json::from_str(&format!(
+            r#"{{"display_name":"claude-instruct","provider":"anthropic","model_name":"claude-3-haiku-20240307","provider_key_id":"{ANTHROPIC_PK_ID}"}}"#
+        ))
+        .unwrap();
+
+        let snap = AisixSnapshot::new();
+        snap.provider_keys
+            .insert(ResourceEntry::new(ANTHROPIC_PK_ID, anthropic_pk, 1));
+        snap.models
+            .insert(ResourceEntry::new("m-anthropic", anthropic_model, 1));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        // Faults instead of deciding, input hook only.
+        let row: aisix_core::Guardrail = serde_json::from_value(serde_json::json!({
+            "name": "completions-fail-open",
+            "enabled": true,
+            "kind": "custom",
+            "hook_point": "input",
+            "fail_open": true,
+            "script": "export function checkInput() { throw new Error('x'); }",
+            "timeout_ms": 5000,
+        }))
+        .unwrap();
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-open", row, 1));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        let state = crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+
+        let resp = tower::ServiceExt::oneshot(
+            crate::build_router(state),
+            make_req(serde_json::json!({"model": "claude-instruct", "prompt": "hi"})),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("a bypassed request must not have its event suppressed")
+            .expect("usage sink remains open");
+        assert_eq!(
+            ev.guardrail_bypassed_reason, "custom_script_error",
+            "{ev:?}"
+        );
+        // The premise: nothing else on this event could have kept it alive.
+        assert!(ev.guardrail_enforced_hits.is_empty(), "{ev:?}");
+        assert!(ev.guardrail_scores.is_empty(), "{ev:?}");
+        assert!(ev.guardrail_monitor_hits.is_empty(), "{ev:?}");
+        assert_eq!((ev.prompt_tokens, ev.completion_tokens), (0, 0));
+    }
+
     /// A 200 response with NO `usage` block at all (vs `usage: {}`
     /// which is empty-but-present) emits an ESTIMATED usage event
     /// (AISIX-Cloud#1074) — the request must not stay invisible to

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -223,6 +223,7 @@ pub async fn count_tokens(
                 &client,
                 crate::usage_attr::enforced_hits(&screening.audit),
                 crate::usage_attr::guardrail_scores(&screening.audit),
+                crate::usage_attr::bypass_reason(&screening.audit),
             );
             // Anthropic-shape envelope (#336) — count_tokens callers are
             // the Anthropic SDK, not OpenAI-compatible clients.
@@ -294,6 +295,9 @@ async fn screen_input(
                     "cannot scan /v1/messages/count_tokens body for guardrails; \
                      nothing attached both reads the request and fails closed",
                 );
+                // See the same arm in `messages.rs`: unscreened is a
+                // bypass, under the tag the fail-closed direction uses.
+                chain.record_unevaluable_input_bypass(crate::error::TAG_UNSCANNABLE_BODY);
                 return Ok(());
             }
             tracing::warn!(
@@ -825,6 +829,7 @@ fn emit_usage_event(
         guardrail_monitor_hits: screening.monitor_hits.clone(),
         guardrail_enforced_hits: crate::usage_attr::enforced_hits(&screening.audit),
         guardrail_scores: crate::usage_attr::guardrail_scores(&screening.audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(&screening.audit),
         ..Default::default()
     };
     crate::usage_attr::apply_pk_telemetry(&mut event, pk);
@@ -1187,6 +1192,68 @@ mod tests {
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(upstream.received_requests().await.unwrap().len(), 1);
+    }
+
+    /// The forwarding above is a fail-open BYPASS, and an operator has to
+    /// be able to find it: the request reached the provider with nothing
+    /// screening it, and its usage row otherwise reads exactly like a
+    /// screened one. The tag matches what the fail-CLOSED direction puts in
+    /// its refusal envelope, so one unscannable body reads the same
+    /// whichever way the chain is configured.
+    #[tokio::test]
+    async fn a_forwarded_unparseable_body_records_the_bypass_on_its_usage_event() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages/count_tokens"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"input_tokens": 7})),
+            )
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(anthropic_model("ct-open"));
+        snap.apikeys.insert(apikey_entry(&["ct-open"]));
+        let row: aisix_core::models::Guardrail = serde_json::from_str(
+            r#"{"name":"in-open","kind":"keyword","hook_point":"input","fail_open":true,"patterns":[{"kind":"literal","value":"NEVERAPPEARS"}]}"#,
+        )
+        .unwrap();
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-open", row, 1));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized(
+            "anthropic",
+            Arc::new(aisix_provider_anthropic::AnthropicBridge::new()),
+        );
+        let handle = SnapshotHandle::new(snap);
+        let index = aisix_guardrails::LiveGuardrailIndex::new(handle.clone(), None);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let app = crate::build_router(
+            crate::ProxyState::new(handle, hub, &cfg())
+                .without_cache()
+                .with_guardrail_index(index)
+                .with_usage_sink(UsageSink::new(tx)),
+        );
+
+        // No `messages` — the scan parser rejects it, which is what makes
+        // the body unscannable.
+        let res = app
+            .oneshot(make_req(serde_json::json!({ "model": "ct-open" })))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("count_tokens must emit a usage event")
+            .expect("channel open");
+        assert_eq!(
+            event.guardrail_bypassed_reason,
+            crate::error::TAG_UNSCANNABLE_BODY,
+            "{event:?}",
+        );
     }
 
     /// The same body with an INPUT-hook row keeps the fail-closed refusal.

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -253,6 +253,7 @@ pub async fn embeddings(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             err.into_response()
         }
@@ -687,9 +688,6 @@ fn emit_usage_event(
     //   - cost_usd — cp-api computes server-side from pricing catalog
     //   - guardrail_blocked — a blocked input short-circuits before this
     //     emit (success-only path), so it is never set here
-    //   - guardrail_bypassed_reason — embeddings now run input guardrails
-    //     (#719); fail-open bypass telemetry is not yet plumbed for the
-    //     non-chat handlers (follow-up, same as the per-PK fields below)
     //   - cache_status / cache_hit_saved_* — no caching on embeddings
     //   - ttft_ms — embeddings are not streamed
     //   - served_by_model / routing_* — embeddings don't run routing
@@ -719,6 +717,7 @@ fn emit_usage_event(
         guardrail_monitor_hits,
         guardrail_enforced_hits: crate::usage_attr::enforced_hits(audit),
         guardrail_scores: crate::usage_attr::guardrail_scores(audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(audit),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         ..Default::default()

--- a/crates/aisix-proxy/src/guardrail_coverage.rs
+++ b/crates/aisix-proxy/src/guardrail_coverage.rs
@@ -420,7 +420,28 @@ fn census_router() -> axum::Router {
 /// answerable — which is the whole question below.
 pub(crate) fn census_router_with_usage() -> (axum::Router, tokio::sync::mpsc::Receiver<UsageEvent>)
 {
-    let handle = SnapshotHandle::new(census_snapshot());
+    census_router_with(serde_json::json!({
+        "name": GUARDRAIL_ROW,
+        "enabled": true,
+        "kind": "custom",
+        "hook_point": "input",
+        "fail_open": false,
+        "script": BLOCK_EVERYTHING,
+        "timeout_ms": 5000,
+    }))
+}
+
+/// [`census_router_with_usage`] with the census guardrail row replaced, so
+/// a test can drive the same router-derived surface set against a
+/// different disposition (block, fail open) without restating the wiring.
+fn census_router_with(
+    row: serde_json::Value,
+) -> (axum::Router, tokio::sync::mpsc::Receiver<UsageEvent>) {
+    let snap = census_snapshot();
+    snap.guardrails.remove("g-census");
+    let guardrail: aisix_core::Guardrail = serde_json::from_value(row).expect("valid guardrail");
+    crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-census", guardrail, 2));
+    let handle = SnapshotHandle::new(snap);
     let index = aisix_guardrails::LiveGuardrailIndex::new(handle.clone(), None);
     let (tx, rx) = tokio::sync::mpsc::channel(32);
     let state = crate::ProxyState::new(handle, census_hub(), &cfg())
@@ -832,4 +853,92 @@ async fn fixtures_do_not_self_refuse_without_a_guardrail() {
             "{surface} reported a guardrail refusal with no guardrail configured: {body}",
         );
     }
+}
+
+/// A script that faults instead of deciding. Paired with `fail_open: true`
+/// it produces the OTHER outcome an operator has to be able to see: the
+/// request went upstream with nothing screening it.
+const FAULT_EVERYTHING: &str = r#"
+export function checkInput() {
+  throw new Error("census");
+}
+"#;
+
+/// The tag `kind: custom` reports for a script that threw. Asserted as a
+/// literal rather than derived: the value is the operator's filter, and a
+/// test that accepted any non-empty string would pass on a typo.
+const FAULT_TAG: &str = "custom_script_error";
+
+/// A fail-open bypass has to be REPORTED on the same router-derived set a
+/// refusal is, and for a stronger reason: a refusal is visible to the
+/// caller, so an unreported one is at least noticed. A bypass is visible to
+/// nobody. `guardrail_bypassed_reason` was written on `/v1/chat/completions`
+/// alone, so on every other surface an outage passed traffic unscreened and
+/// the usage record said the same thing it says for a screened request.
+///
+/// Driven with `fail_open: true` and a script that faults, which is the
+/// provider-outage shape without a provider: the chain runs, decides
+/// nothing, and lets the request through.
+#[tokio::test]
+async fn a_bypassed_surface_reports_the_bypass() {
+    let mut wrong = Vec::new();
+
+    for (surface, posture) in POSTURE {
+        if !matches!(posture, Posture::Enforced) {
+            continue;
+        }
+        let Some(request) = fixture(surface) else {
+            // `enforced_surfaces_refuse_a_blocking_guardrail` owns the
+            // missing-fixture complaint.
+            continue;
+        };
+        let (router, mut rx) = census_router_with(serde_json::json!({
+            "name": GUARDRAIL_ROW,
+            "enabled": true,
+            "kind": "custom",
+            "hook_point": "input",
+            "fail_open": true,
+            "script": FAULT_EVERYTHING,
+            "timeout_ms": 5000,
+        }));
+        let response = router.oneshot(request).await.expect("router must answer");
+        let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+            .await
+            .expect("body must read");
+        let body = String::from_utf8_lossy(&bytes).into_owned();
+        // A fail-open row must not refuse — if it did, the surface never
+        // reached the bypass this test is about and the assertion below
+        // would be measuring the wrong thing.
+        if refused_by_guardrail(&body) {
+            wrong.push(format!("{surface}: fail_open row still refused: {body}"));
+            continue;
+        }
+
+        let mut events = Vec::new();
+        while let Ok(Some(event)) =
+            tokio::time::timeout(std::time::Duration::from_millis(300), rx.recv()).await
+        {
+            events.push(event);
+        }
+        if events.is_empty() {
+            wrong.push(format!("{surface}: bypassed but emitted no usage event"));
+            continue;
+        }
+        for event in &events {
+            if event.guardrail_bypassed_reason != FAULT_TAG {
+                wrong.push(format!(
+                    "{surface}: usage event carries guardrail_bypassed_reason {:?}, want {FAULT_TAG:?}",
+                    event.guardrail_bypassed_reason,
+                ));
+            }
+        }
+    }
+
+    assert!(
+        wrong.is_empty(),
+        "a guardrail that failed OPEN must say so on every enforced surface's usage event \
+         (usage_events.guardrail_bypassed_reason) — otherwise an unscreened request is \
+         indistinguishable from a screened one:\n  {}",
+        wrong.join("\n  "),
+    );
 }

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -234,6 +234,7 @@ pub async fn image_generations(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             err.into_response()
         }
@@ -580,6 +581,7 @@ pub(crate) fn emit_usage_event(
         guardrail_monitor_hits,
         guardrail_enforced_hits: crate::usage_attr::enforced_hits(audit),
         guardrail_scores: crate::usage_attr::guardrail_scores(audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(audit),
         ..Default::default()
     };
     crate::usage_attr::apply_pk_telemetry(&mut event, pk);

--- a/crates/aisix-proxy/src/images_edits.rs
+++ b/crates/aisix-proxy/src/images_edits.rs
@@ -229,6 +229,7 @@ pub async fn image_edits(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             err.into_response()
         }

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -497,6 +497,9 @@ async fn scan_input_blob(
     // audit logs (AISIX-Cloud#1330 / #1024).
     enforced_hits: &mut Vec<aisix_core::GuardrailEnforcedHit>,
     scores: &mut Vec<aisix_core::GuardrailScore>,
+    // The request's fail-open bypass tag, accumulated the same way and
+    // for the same reason. First one sticks, matching the chain folds.
+    bypass: &mut String,
 ) -> Result<(), ProxyError> {
     let ctx = aisix_guardrails::RequestContext {
         passthrough_route_id: "",
@@ -549,8 +552,19 @@ async fn scan_input_blob(
                 Some(crate::error::TAG_UNSCANNABLE_BODY),
             ));
         }
-        // Binary-purpose upload, or a text one nothing on the request side
-        // would have read: best-effort lossy scan, forwarded verbatim.
+        // A text-purpose upload nothing on the request side would have
+        // read: best-effort lossy scan, forwarded verbatim. The scan runs
+        // on a copy with every invalid sequence replaced, so whatever the
+        // original bytes spelled was never screened — that is a bypass,
+        // and it is recorded under the same tag the fail-CLOSED direction
+        // refuses with.
+        (Err(_), Undecodable::Refuse) => {
+            chain.record_unevaluable_input_bypass(crate::error::TAG_UNSCANNABLE_BODY);
+            String::from_utf8_lossy(blob)
+        }
+        // Binary-purpose upload: the lossy scan is the contract, not a
+        // fallback — a PDF was never going to decode and refusing it was
+        // never on the table, so nothing was bypassed.
         (Err(_), _) => String::from_utf8_lossy(blob),
     };
     let chat = aisix_gateway::ChatFormat::new(
@@ -563,6 +577,11 @@ async fn scan_input_blob(
     // that leaves through `Err`, and the caller's `?` would drop it.
     enforced_hits.extend(chain.enforced_hits());
     scores.extend(chain.scores());
+    if bypass.is_empty() {
+        if let Some(reason) = chain.bypass_reason() {
+            *bypass = reason;
+        }
+    }
     if let aisix_guardrails::GuardrailVerdict::Block {
         reason,
         guardrail_name,
@@ -598,6 +617,7 @@ async fn scan_input_blob(
 /// the input side tell a JSONL payload from a lawful PDF. Failing closed
 /// here would refuse lawful downloads, so the direction needs a product
 /// decision rather than a mirrored `match`. Tracked in #1022.
+#[allow(clippy::too_many_arguments)]
 async fn scan_output_blob(
     state: &ProxyState,
     auth: &AuthenticatedKey,
@@ -609,6 +629,9 @@ async fn scan_output_blob(
     // audit logs (AISIX-Cloud#1330 / #1024).
     enforced_hits: &mut Vec<aisix_core::GuardrailEnforcedHit>,
     scores: &mut Vec<aisix_core::GuardrailScore>,
+    // The request's fail-open bypass tag, accumulated the same way and
+    // for the same reason. First one sticks, matching the chain folds.
+    bypass: &mut String,
 ) -> Result<(), ProxyError> {
     let ctx = aisix_guardrails::RequestContext {
         passthrough_route_id: "",
@@ -633,6 +656,11 @@ async fn scan_output_blob(
     // See `scan_input_blob`.
     enforced_hits.extend(chain.enforced_hits());
     scores.extend(chain.scores());
+    if bypass.is_empty() {
+        if let Some(reason) = chain.bypass_reason() {
+            *bypass = reason;
+        }
+    }
     if let aisix_guardrails::GuardrailVerdict::Block {
         reason,
         guardrail_name,
@@ -712,6 +740,7 @@ fn emit_job_usage_event(
     // (AISIX-Cloud#1330).
     guardrail_enforced_hits: Vec<aisix_core::GuardrailEnforcedHit>,
     guardrail_scores: Vec<aisix_core::GuardrailScore>,
+    guardrail_bypassed_reason: String,
 ) {
     let mut event = UsageEvent {
         request_id: request_id.to_string(),
@@ -730,6 +759,7 @@ fn emit_job_usage_event(
         guardrail_monitor_hits,
         guardrail_enforced_hits,
         guardrail_scores,
+        guardrail_bypassed_reason,
         ..Default::default()
     };
     let pk = crate::usage_attr::ResolvedPk::resolve(snap, &target.pk_entry.id);
@@ -815,6 +845,7 @@ fn finish(
     monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
     enforced_hits: Vec<aisix_core::GuardrailEnforcedHit>,
     scores: Vec<aisix_core::GuardrailScore>,
+    bypass: String,
 ) -> Response {
     let elapsed = started.elapsed();
     // `path` carries the real job/file id — bounded route template only.
@@ -857,6 +888,7 @@ fn finish(
                 monitor_hits,
                 enforced_hits,
                 scores,
+                bypass,
             );
             if let Ok(hv) = HeaderValue::from_str(&request_id) {
                 resp.headers_mut().insert("x-aisix-request-id", hv);
@@ -901,6 +933,7 @@ fn finish(
                 client,
                 enforced_hits,
                 scores,
+                bypass,
             );
             err.into_response()
         }
@@ -981,6 +1014,7 @@ pub(crate) async fn create_file(
     let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     let mut enforced_hits: Vec<aisix_core::GuardrailEnforcedHit> = Vec::new();
     let mut scores: Vec<aisix_core::GuardrailScore> = Vec::new();
+    let mut bypass = String::new();
     // Loaded below, after the upload is drained — see the note in
     // `audio::multipart_dispatch` (#941 audit M2).
     let mut snapshot = None;
@@ -1076,6 +1110,7 @@ pub(crate) async fn create_file(
             &mut monitor_hits,
             &mut enforced_hits,
             &mut scores,
+            &mut bypass,
         )
         .await?;
         let _reservation = crate::quota::enforce(
@@ -1108,6 +1143,7 @@ pub(crate) async fn create_file(
             &mut monitor_hits,
             &mut enforced_hits,
             &mut scores,
+            &mut bypass,
         )
         .await?;
         let model = target.display_name().to_string();
@@ -1134,6 +1170,7 @@ pub(crate) async fn create_file(
         monitor_hits,
         enforced_hits,
         scores,
+        bypass,
     )
 }
 
@@ -1290,6 +1327,7 @@ pub(crate) async fn create_batch(
     let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     let mut enforced_hits: Vec<aisix_core::GuardrailEnforcedHit> = Vec::new();
     let mut scores: Vec<aisix_core::GuardrailScore> = Vec::new();
+    let mut bypass = String::new();
 
     // One snapshot for the whole request (#941) — see `embeddings`.
     let snapshot = state.snapshot.load();
@@ -1345,6 +1383,7 @@ pub(crate) async fn create_batch(
             &mut monitor_hits,
             &mut enforced_hits,
             &mut scores,
+            &mut bypass,
         )
         .await?;
         let _reservation = crate::quota::enforce(
@@ -1377,6 +1416,7 @@ pub(crate) async fn create_batch(
             &mut monitor_hits,
             &mut enforced_hits,
             &mut scores,
+            &mut bypass,
         )
         .await?;
         let model = target.display_name().to_string();
@@ -1401,6 +1441,7 @@ pub(crate) async fn create_batch(
         monitor_hits,
         enforced_hits,
         scores,
+        bypass,
     )
 }
 
@@ -1418,6 +1459,7 @@ pub(crate) async fn get_batch(
     let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     let mut enforced_hits: Vec<aisix_core::GuardrailEnforcedHit> = Vec::new();
     let mut scores: Vec<aisix_core::GuardrailScore> = Vec::new();
+    let mut bypass = String::new();
 
     // One snapshot for the whole request (#941) — see `embeddings`.
     let snapshot = state.snapshot.load();
@@ -1456,6 +1498,7 @@ pub(crate) async fn get_batch(
             &mut monitor_hits,
             &mut enforced_hits,
             &mut scores,
+            &mut bypass,
         )
         .await?;
 
@@ -1489,6 +1532,7 @@ pub(crate) async fn get_batch(
         monitor_hits,
         enforced_hits,
         scores,
+        bypass,
     )
 }
 
@@ -1585,6 +1629,7 @@ pub(crate) async fn create_ft_job(
     let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     let mut enforced_hits: Vec<aisix_core::GuardrailEnforcedHit> = Vec::new();
     let mut scores: Vec<aisix_core::GuardrailScore> = Vec::new();
+    let mut bypass = String::new();
 
     // One snapshot for the whole request (#941) — see `embeddings`.
     let snapshot = state.snapshot.load();
@@ -1637,6 +1682,7 @@ pub(crate) async fn create_ft_job(
             &mut monitor_hits,
             &mut enforced_hits,
             &mut scores,
+            &mut bypass,
         )
         .await?;
         let _reservation = crate::quota::enforce(
@@ -1669,6 +1715,7 @@ pub(crate) async fn create_ft_job(
             &mut monitor_hits,
             &mut enforced_hits,
             &mut scores,
+            &mut bypass,
         )
         .await?;
         let model = target.display_name().to_string();
@@ -1693,6 +1740,7 @@ pub(crate) async fn create_ft_job(
         monitor_hits,
         enforced_hits,
         scores,
+        bypass,
     )
 }
 
@@ -1819,6 +1867,7 @@ async fn forward_simple(
     let mut monitor_hits: Vec<aisix_core::GuardrailMonitorHit> = Vec::new();
     let mut enforced_hits: Vec<aisix_core::GuardrailEnforcedHit> = Vec::new();
     let mut scores: Vec<aisix_core::GuardrailScore> = Vec::new();
+    let mut bypass = String::new();
 
     // One snapshot for the whole request (#941) — see `embeddings`.
     let snapshot = state.snapshot.load();
@@ -1847,6 +1896,7 @@ async fn forward_simple(
                 &mut monitor_hits,
                 &mut enforced_hits,
                 &mut scores,
+                &mut bypass,
             )
             .await?;
         }
@@ -1878,6 +1928,7 @@ async fn forward_simple(
             &mut monitor_hits,
             &mut enforced_hits,
             &mut scores,
+            &mut bypass,
         )
         .await?;
 
@@ -1912,6 +1963,7 @@ async fn forward_simple(
         monitor_hits,
         enforced_hits,
         scores,
+        bypass,
     )
 }
 
@@ -2113,6 +2165,11 @@ async fn attribute_batch_usage(
     for (idx, (provider_model, agg)) in per_model.iter().enumerate() {
         let request_id = batch_attribution_request_id(raw_batch_id, idx, multi);
         let mut event = UsageEvent {
+            // NO-GUARDRAIL-CHAIN: a retroactive billing row for work the
+            // provider did inside a batch. There is no request here, so no
+            // chain was ever resolved and nothing could have been bypassed;
+            // the upload that created the batch was screened at its own
+            // time, and carries its own event.
             request_id,
             occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             model_id: model_id.to_string(),
@@ -3098,6 +3155,53 @@ mod tests {
                 .any(|w| w == NON_UTF8_UPLOAD),
             "the original bytes must still forward byte-for-byte"
         );
+    }
+
+    /// The forwarding above is a fail-open BYPASS: the upload reached the
+    /// provider having been screened only as a copy with every invalid
+    /// sequence replaced, so a term written in a non-UTF-8 encoding was
+    /// never in the scanned text. Its usage row must say so, under the same
+    /// tag the fail-CLOSED direction refuses with.
+    ///
+    /// A binary-purpose upload is the control: the lossy scan is the
+    /// contract there, refusing it was never on the table, and nothing was
+    /// bypassed.
+    #[tokio::test]
+    async fn a_forwarded_non_utf8_upload_records_the_bypass_only_when_it_is_one() {
+        for (purpose, want) in [
+            (Some("batch"), crate::error::TAG_UNSCANNABLE_BODY),
+            (Some("assistants"), ""),
+        ] {
+            let upstream = MockServer::start().await;
+            files_upstream_mock().expect(1).mount(&upstream).await;
+
+            let snap = AisixSnapshot::new();
+            snap.provider_keys.insert(openai_pk(PK_A, &upstream.uri()));
+            snap.models.insert(model("m-a", "jobs-a", PK_A));
+            snap.apikeys.insert(apikey_entry(&["*"]));
+            seed_fail_open_input_guardrail(&snap);
+            assert_scanned_but_fail_open(&snap);
+            let (app, mut rx) = build_app_with_sink(snap);
+
+            let resp = app
+                .oneshot(upload_request_with_purpose(
+                    "XBOUNDARYX",
+                    purpose,
+                    NON_UTF8_UPLOAD,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "purpose {purpose:?}");
+
+            let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+                .await
+                .expect("/v1/files must emit a usage event")
+                .expect("channel open");
+            assert_eq!(
+                event.guardrail_bypassed_reason, want,
+                "purpose {purpose:?}: {event:?}",
+            );
+        }
     }
 
     /// A mixed chain folds to the strictest: one fail-CLOSED input row is

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -4016,6 +4016,115 @@ data: [DONE]\n\n"
         ResourceEntry::new("model-id-1", model, 1)
     }
 
+    /// A request that failed OPEN and then died before any attempt still
+    /// has to report the bypass.
+    ///
+    /// This is `chat.rs`'s `routing.attempts.is_empty()` terminal arm, and
+    /// it is not reachable from the router-derived census in
+    /// `guardrail_coverage`: that fixture's upstream refuses the
+    /// connection, so an attempt is always recorded and the failed-attempt
+    /// emitter runs instead. The arm is live in production — a quota
+    /// refusal, a budget refusal, or a pre-dispatch resolution failure all
+    /// land here — and the guardrail chain has already run and already
+    /// failed open by then.
+    ///
+    /// Driven with `rpm: 1`: the first request goes upstream unscreened,
+    /// the second is refused before dispatch. Both events must name the
+    /// bypass; the refusal is not what stopped the FIRST one from leaving.
+    #[tokio::test]
+    async fn a_pre_dispatch_failure_after_a_fail_open_still_reports_the_bypass() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "cmpl-1",
+                "object": "chat.completion",
+                "model": "gpt-4o",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            })))
+            .mount(&upstream)
+            .await;
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("openai", Arc::new(openai_test_bridge()));
+        let snap = new_snap(&upstream.uri());
+        snap.models.insert(model_entry_with_rate_limit(
+            "rl-open",
+            serde_json::json!({"rpm": 1}),
+        ));
+        snap.apikeys.insert(apikey_entry("sk-caller", &["rl-open"]));
+        // Faults instead of deciding. Input hook only: `custom` reads its
+        // output policy from `output_fail_open`, which fails CLOSED by
+        // default, and a refused response would not be a bypass.
+        let row: aisix_core::Guardrail = serde_json::from_value(serde_json::json!({
+            "name": "rl-fail-open",
+            "enabled": true,
+            "kind": "custom",
+            "hook_point": "input",
+            "fail_open": true,
+            "script": "export function checkInput() { throw new Error('x'); }",
+            "timeout_ms": 5000,
+        }))
+        .unwrap();
+        seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-rl-open", row, 1));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let state = build_state(snap, hub).with_usage_sink(UsageSink::new(tx));
+
+        let make_req = || {
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("authorization", "Bearer sk-caller")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"model":"rl-open","messages":[{"role":"user","content":"go"}]}"#,
+                ))
+                .unwrap()
+        };
+
+        let first = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(
+            first.status(),
+            StatusCode::OK,
+            "premise: a fail-open row must not refuse",
+        );
+        let second = run(build_router(state.clone()), make_req()).await;
+        assert_eq!(
+            second.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "premise: the second request must die BEFORE any attempt",
+        );
+
+        let mut events = Vec::new();
+        while let Ok(Some(event)) =
+            tokio::time::timeout(std::time::Duration::from_millis(300), rx.recv()).await
+        {
+            events.push(event);
+        }
+        assert_eq!(events.len(), 2, "{events:?}");
+        for event in &events {
+            assert_eq!(
+                event.guardrail_bypassed_reason, "custom_script_error",
+                "{event:?}",
+            );
+        }
+        // The one that pins the arm: the refused request recorded no
+        // attempt, so its event came from the pre-dispatch emitter.
+        let refused = events
+            .iter()
+            .find(|e| e.status_code == 429)
+            .expect("the refusal must emit its own event");
+        assert_eq!(refused.attempt_kind, "initial", "{refused:?}");
+    }
+
     #[tokio::test]
     async fn passthrough_enforces_model_rate_limit_from_body_model_field() {
         let upstream = MockServer::start().await;

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -978,7 +978,10 @@ async fn apply_output_guardrails(
     let value: serde_json::Value = match serde_json::from_slice(response_bytes) {
         Ok(value) => value,
         Err(_) if !aisix_guardrails::Guardrail::refuses_unevaluable_output(chain) => {
-            return ToolResultOutcome::Allow(None)
+            // Released unscanned — a bypass, under the tag the fail-closed
+            // arm below refuses with. See the same pair in `messages.rs`.
+            chain.record_unevaluable_output_bypass(crate::error::TAG_UNSCANNABLE_BODY);
+            return ToolResultOutcome::Allow(None);
         }
         Err(_) => {
             return ToolResultOutcome::Block {
@@ -1211,6 +1214,9 @@ fn emit_tool_call_usage(
             .map(|c| c.enforced_hits())
             .unwrap_or_default(),
         guardrail_scores: guardrail_chain.map(|c| c.scores()).unwrap_or_default(),
+        guardrail_bypassed_reason: guardrail_chain
+            .and_then(|c| c.bypass_reason())
+            .unwrap_or_default(),
         ..Default::default()
     };
     crate::usage_attr::apply_caller_identity(
@@ -2773,6 +2779,46 @@ mod tests {
                 .await
                 .is_some(),
             "an output-hook row must still fail closed"
+        );
+    }
+
+    /// Releasing an unparseable tool result under a fail-open OUTPUT row is
+    /// a bypass — the client got tool output nothing screened — and it is
+    /// recorded under the same tag the fail-closed direction refuses with.
+    ///
+    /// The input-only chain is the control: nothing in it was ever going to
+    /// read the result, so releasing it bypassed nothing and the field must
+    /// stay empty. Tagging that case would make the field fire on results
+    /// that were never going to be screened.
+    #[tokio::test]
+    async fn releasing_an_unparseable_tool_result_records_a_bypass_only_when_a_row_read_it() {
+        let sse_body = b"event: message\ndata: {\"jsonrpc\":\"2.0\",\"result\":{}}\n\n";
+
+        const OUTPUT_OPEN_GUARD: &str = r#"{"name":"mcp-output-open","kind":"keyword","hook_point":"output","fail_open":true,"patterns":[{"kind":"literal","value":"forbidden-token"}]}"#;
+        let output_open = env_chain_with(OUTPUT_OPEN_GUARD);
+        assert!(
+            output_guardrail_block(&output_open, sse_body, "echo", &mut Vec::new())
+                .await
+                .is_none(),
+            "premise: a fail-open output row must release the result"
+        );
+        assert_eq!(
+            output_open.bypass_reason().as_deref(),
+            Some(crate::error::TAG_UNSCANNABLE_BODY),
+        );
+
+        const INPUT_ONLY_GUARD: &str = r#"{"name":"mcp-input-only","kind":"keyword","hook_point":"input","patterns":[{"kind":"literal","value":"forbidden-token"}]}"#;
+        let input_only = env_chain_with(INPUT_ONLY_GUARD);
+        assert!(
+            output_guardrail_block(&input_only, sse_body, "echo", &mut Vec::new())
+                .await
+                .is_none(),
+            "premise: an input-only row must release the result"
+        );
+        assert_eq!(
+            input_only.bypass_reason(),
+            None,
+            "nothing in this chain reads the result, so nothing was bypassed",
         );
     }
 

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -659,6 +659,12 @@ async fn dispatch(
                     "cannot scan /v1/messages body for guardrails; nothing \
                      attached both reads the request and fails closed",
                 );
+                // The request goes upstream unscreened, so it is a bypass
+                // even though no member ran to report one — recorded under
+                // the tag the fail-CLOSED direction refuses with, so one
+                // unscannable body reads the same whichever way the chain
+                // is configured.
+                resolved_chain.record_unevaluable_input_bypass(crate::error::TAG_UNSCANNABLE_BODY);
                 break 'input_screen;
             }
             Err(err) => {
@@ -3097,6 +3103,7 @@ fn emit_anthropic_usage_event(
         // otherwise repeat the same hit once per retry.
         guardrail_enforced_hits: crate::usage_attr::terminal_enforced_hits(terminal, audit),
         guardrail_scores: crate::usage_attr::terminal_guardrail_scores(terminal, audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(audit),
         // Same rule, same reason.
         guardrail_blocked: terminal && guardrail_blocked,
         ..Default::default()
@@ -6617,6 +6624,68 @@ event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n"
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(upstream.received_requests().await.unwrap().len(), 1);
+    }
+
+    /// The forwarding above is a fail-open BYPASS, and it has to be
+    /// findable: the prompt reached the provider with nothing screening
+    /// it, and the usage row otherwise reads exactly like a screened one.
+    /// The tag matches what the fail-CLOSED direction puts in its refusal
+    /// envelope.
+    #[tokio::test]
+    async fn a_forwarded_unparseable_body_records_the_bypass_on_its_usage_event() {
+        use aisix_obs::UsageSink;
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1}
+            })))
+            .mount(&upstream)
+            .await;
+
+        let snap = new_snap_anthropic(&upstream.uri());
+        snap.models.insert(anthropic_model("my-claude"));
+        snap.apikeys.insert(apikey_entry(&["*"]));
+        let row: aisix_core::models::Guardrail = serde_json::from_str(
+            r#"{"name":"in-open","enabled":true,"kind":"keyword","hook_point":"input","fail_open":true,"patterns":[{"kind":"literal","value":"NEVERAPPEARS"}]}"#,
+        )
+        .unwrap();
+        crate::seed_env_scoped_guardrail(&snap, ResourceEntry::new("g-open", row, 1));
+
+        let hub = Arc::new(Hub::new());
+        hub.register_specialized("anthropic", Arc::new(AnthropicBridge::new()));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        let state = crate::ProxyState::new(SnapshotHandle::new(snap), hub, &cfg())
+            .without_cache()
+            .with_usage_sink(UsageSink::new(tx));
+
+        // No `messages` — the scan parser rejects it, which is what makes
+        // the body unscannable.
+        let resp = crate::build_router(state)
+            .oneshot(make_req(serde_json::json!({
+                "model": "my-claude",
+                "max_tokens": 100,
+            })))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("/v1/messages must emit a usage event")
+            .expect("channel open");
+        assert_eq!(
+            event.guardrail_bypassed_reason,
+            crate::error::TAG_UNSCANNABLE_BODY,
+            "{event:?}",
+        );
     }
 
     /// The same unparseable body with an INPUT-hook row attached keeps the

--- a/crates/aisix-proxy/src/passthrough_route.rs
+++ b/crates/aisix-proxy/src/passthrough_route.rs
@@ -357,6 +357,7 @@ pub async fn entry(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             // The route matched before the pipeline failed, so a rejected
             // request still attributes to it — an operator triaging 401s
@@ -2284,6 +2285,7 @@ impl RouteTelemetry {
             guardrail_monitor_hits: std::mem::take(&mut self.monitor_hits),
             guardrail_enforced_hits: crate::usage_attr::enforced_hits(&self.audit),
             guardrail_scores: crate::usage_attr::guardrail_scores(&self.audit),
+            guardrail_bypassed_reason: crate::usage_attr::bypass_reason(&self.audit),
             ..Default::default()
         };
         crate::usage_attr::apply_pk_telemetry(&mut event, &pk);

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -289,9 +289,10 @@ pub(crate) async fn realtime(
                 &client,
                 // Refused before the handshake, so no chain was ever
                 // resolved and no guardrail can have enforced anything —
-                // nor scored anything.
+                // nor scored anything, nor been bypassed.
                 Vec::new(),
                 Vec::new(),
+                String::new(),
             );
             err.into_response()
         }
@@ -767,6 +768,7 @@ async fn run_session(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             return;
         }
@@ -1011,6 +1013,7 @@ async fn run_session(
         guardrail_monitor_hits: monitor_hits,
         guardrail_enforced_hits: crate::usage_attr::enforced_hits(&audit),
         guardrail_scores: crate::usage_attr::guardrail_scores(&audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(&audit),
         ..Default::default()
     };
     crate::usage_attr::apply_pk_telemetry(&mut event, &pk);

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -239,6 +239,7 @@ pub async fn rerank(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             err.into_response()
         }
@@ -747,6 +748,7 @@ fn emit_usage_event(
         guardrail_monitor_hits,
         guardrail_enforced_hits: crate::usage_attr::enforced_hits(audit),
         guardrail_scores: crate::usage_attr::guardrail_scores(audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(audit),
         ..Default::default()
     };
     // Per-PK attribution tags (provider_kind / provider_featured /

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -3376,6 +3376,7 @@ fn emit_usage_event(
         // See `emit_zero_token_event`: request-scoped, so terminal only.
         guardrail_enforced_hits: crate::usage_attr::terminal_enforced_hits(terminal, audit),
         guardrail_scores: crate::usage_attr::terminal_guardrail_scores(terminal, audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(audit),
         ..Default::default()
     };
     crate::usage_attr::apply_caller_identity(
@@ -3538,6 +3539,7 @@ fn emit_zero_token_event(
         // Only the terminal event carries them.
         guardrail_enforced_hits: crate::usage_attr::terminal_enforced_hits(terminal, audit),
         guardrail_scores: crate::usage_attr::terminal_guardrail_scores(terminal, audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(audit),
         // Same rule, same reason as the hits above.
         guardrail_blocked: terminal && guardrail_blocked,
         ..Default::default()

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -1071,6 +1071,18 @@ mod tests {
             let src = std::fs::read_to_string(&path).expect("source must read");
             let name = path.file_name().unwrap().to_string_lossy().into_owned();
             for (idx, _) in src.match_indices("UsageEvent {") {
+                // This file writes the token it searches for, in a string
+                // literal and in a doc comment, and both would be counted
+                // as emitters — a check that inflates its own coverage.
+                // Judged from the line prefix rather than the whole file:
+                // none of these matches sits inside a multi-line construct,
+                // and a whole-file string scanner would have to model raw
+                // strings to be worth more.
+                let line_start = src[..idx].rfind('\n').map_or(0, |n| n + 1);
+                let prefix = &src[line_start..idx];
+                if prefix.contains("//") || prefix.matches('"').count() % 2 == 1 {
+                    continue;
+                }
                 // `-> UsageEvent {` (optionally path-qualified) is a
                 // return type followed by a function body, not a literal.
                 let before = src[..idx]

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -1060,27 +1060,37 @@ mod tests {
         let mut blocks = 0usize;
         let mut missing = Vec::new();
 
-        let mut files: Vec<_> = std::fs::read_dir(&src_dir)
-            .expect("the crate's own src/ must be readable")
-            .filter_map(|e| e.ok().map(|e| e.path()))
-            .filter(|p| p.extension().is_some_and(|e| e == "rs"))
-            .collect();
+        // Recursive: `src/` is flat today, and a refactor that moved a
+        // handler into a subdirectory would otherwise take its emitter out
+        // of scope while this still reported green.
+        fn rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            let entries = std::fs::read_dir(dir).expect("the crate's own src/ must be readable");
+            for path in entries.filter_map(|e| e.ok().map(|e| e.path())) {
+                if path.is_dir() {
+                    rs_files(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+        let mut files = Vec::new();
+        rs_files(&src_dir, &mut files);
         files.sort();
 
         for path in files {
             let src = std::fs::read_to_string(&path).expect("source must read");
-            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            let name = path
+                .strip_prefix(&src_dir)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .into_owned();
+            let code = code_mask(&src);
             for (idx, _) in src.match_indices("UsageEvent {") {
-                // This file writes the token it searches for, in a string
-                // literal and in a doc comment, and both would be counted
-                // as emitters — a check that inflates its own coverage.
-                // Judged from the line prefix rather than the whole file:
-                // none of these matches sits inside a multi-line construct,
-                // and a whole-file string scanner would have to model raw
-                // strings to be worth more.
-                let line_start = src[..idx].rfind('\n').map_or(0, |n| n + 1);
-                let prefix = &src[line_start..idx];
-                if prefix.contains("//") || prefix.matches('"').count() % 2 == 1 {
+                // Skip anything that is not Rust code: this file writes the
+                // token it searches for in a string literal and in a
+                // comment, and both would otherwise be counted as emitters
+                // — a check inflating its own coverage.
+                if !code[idx] {
                     continue;
                 }
                 // `-> UsageEvent {` (optionally path-qualified) is a
@@ -1093,11 +1103,11 @@ mod tests {
                     continue;
                 }
                 let open = idx + "UsageEvent ".len();
-                let Some(block) = braced_block(&src[open..]) else {
+                let Some(block) = braced_block(&src, &code, open) else {
                     panic!("{name}: unbalanced UsageEvent literal at byte {idx}");
                 };
                 blocks += 1;
-                if !block.contains("guardrail_bypassed_reason") && !block.contains(EXEMPT) {
+                if !sets_bypass_reason(block) && !block.contains(EXEMPT) {
                     let line = src[..idx].lines().count();
                     missing.push(format!("{name}:{line}"));
                 }
@@ -1106,8 +1116,12 @@ mod tests {
 
         // The parse must actually find the emitters, not silently yield an
         // empty set that makes the assertion below vacuous.
+        // The crate's real count. A floor rather than an equality so
+        // adding an emitter does not fail here (the `missing` check
+        // already governs a new one) — but losing four to a parse that
+        // quietly stopped matching is the drift this exists to catch.
         assert!(
-            blocks >= 15,
+            blocks >= 18,
             "the UsageEvent literal scan found only {blocks} — it has stopped tracking the \
              emitter family",
         );
@@ -1120,36 +1134,200 @@ mod tests {
         );
     }
 
-    /// The `{ … }` starting at `src`, string-literal aware so a brace
-    /// inside a quoted value cannot end the block early.
-    fn braced_block(src: &str) -> Option<&str> {
-        let bytes = src.as_bytes();
-        assert_eq!(bytes[0], b'{');
-        let mut depth = 0usize;
-        let mut in_str = false;
-        let mut escaped = false;
-        for (i, b) in bytes.iter().enumerate() {
-            if in_str {
-                match b {
-                    _ if escaped => escaped = false,
-                    b'\\' => escaped = true,
-                    b'"' => in_str = false,
-                    _ => {}
+    /// A byte mask over `src` marking the bytes that are Rust CODE —
+    /// false inside string literals (raw ones included), char literals,
+    /// line comments and nestable block comments.
+    ///
+    /// A real lexer pass rather than a per-line heuristic. The heuristic
+    /// this replaces judged a match by whether its line prefix held a `//`
+    /// or an odd number of quotes, which gets two things wrong that occur
+    /// in ordinary code: a literal after a completed string on the same
+    /// line (`let u = "https://x"; ... UsageEvent {`) reads as commented
+    /// out, and an escaped quote miscounts the parity.
+    fn code_mask(src: &str) -> Vec<bool> {
+        #[derive(Clone, Copy)]
+        enum St {
+            Code,
+            Str,
+            Raw(usize),
+            Char,
+            Line,
+            Block(usize),
+        }
+        let b = src.as_bytes();
+        let mut mask = vec![false; b.len()];
+        let mut st = St::Code;
+        let mut i = 0;
+        while i < b.len() {
+            match st {
+                St::Code => {
+                    mask[i] = true;
+                    match b[i] {
+                        b'/' if b.get(i + 1) == Some(&b'/') => {
+                            st = St::Line;
+                            mask[i] = false;
+                        }
+                        b'/' if b.get(i + 1) == Some(&b'*') => {
+                            st = St::Block(1);
+                            mask[i] = false;
+                            i += 2;
+                            continue;
+                        }
+                        b'"' => st = St::Str,
+                        // A char literal is `'x'` or `'\\n'`; anything
+                        // else starting with a quote is a LIFETIME
+                        // (`&'a str`), and treating one as a literal
+                        // swallows every byte up to the next apostrophe.
+                        b'\'' if b.get(i + 1) == Some(&b'\\') || b.get(i + 2) == Some(&b'\'') => {
+                            st = St::Char
+                        }
+                        b'r' => {
+                            // `r"…"` / `r#"…"#`, but not an identifier
+                            // ending in `r`, and not a lifetime.
+                            let prev_ident =
+                                i > 0 && (b[i - 1].is_ascii_alphanumeric() || b[i - 1] == b'_');
+                            let mut j = i + 1;
+                            while b.get(j) == Some(&b'#') {
+                                j += 1;
+                            }
+                            if !prev_ident && b.get(j) == Some(&b'"') {
+                                st = St::Raw(j - i - 1);
+                                i = j + 1;
+                                continue;
+                            }
+                        }
+                        _ => {}
+                    }
                 }
+                St::Str => {
+                    if b[i] == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    if b[i] == b'"' {
+                        st = St::Code;
+                    }
+                }
+                St::Raw(hashes) => {
+                    if b[i] == b'"' && b[i + 1..].iter().take(hashes).all(|c| *c == b'#') {
+                        st = St::Code;
+                        i += hashes + 1;
+                        continue;
+                    }
+                }
+                St::Char => {
+                    if b[i] == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    if b[i] == b'\'' {
+                        st = St::Code;
+                    }
+                }
+                St::Line => {
+                    if b[i] == b'\n' {
+                        st = St::Code;
+                    }
+                }
+                St::Block(depth) => {
+                    if b[i] == b'/' && b.get(i + 1) == Some(&b'*') {
+                        st = St::Block(depth + 1);
+                        i += 2;
+                        continue;
+                    }
+                    if b[i] == b'*' && b.get(i + 1) == Some(&b'/') {
+                        st = if depth == 1 {
+                            St::Code
+                        } else {
+                            St::Block(depth - 1)
+                        };
+                        i += 2;
+                        continue;
+                    }
+                }
+            }
+            i += 1;
+        }
+        mask
+    }
+
+    /// Whether an emitter block ASSIGNS the field, rather than merely
+    /// mentioning it.
+    ///
+    /// `block.contains("guardrail_bypassed_reason")` would be satisfied by
+    /// a comment, and by `guardrail_bypassed_reason: String::new()` — which
+    /// is exactly the shape of a reverted fix, so the check would have been
+    /// unfalsifiable in the one dimension it is here to guard.
+    fn sets_bypass_reason(block: &str) -> bool {
+        let Some(at) = block.find("guardrail_bypassed_reason") else {
+            return false;
+        };
+        let rest = &block[at + "guardrail_bypassed_reason".len()..];
+        // Field-init shorthand (`guardrail_bypassed_reason,`) takes its
+        // value from a binding, which cannot be an inline empty literal.
+        let Some(rest) = rest.strip_prefix(':') else {
+            return rest.starts_with(',');
+        };
+        // Values run to the end of their line, except the one that wraps
+        // onto continuation lines — whose first line is a receiver, which
+        // is non-empty and passes for the right reason.
+        let value = rest
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .trim_end_matches(',')
+            .trim();
+        !matches!(
+            value,
+            "" | "\"\"" | "String::new()" | "String::default()" | "Default::default()"
+        )
+    }
+
+    /// The `{ … }` at `open`, skipping braces the mask says are not code.
+    fn braced_block<'a>(src: &'a str, code: &[bool], open: usize) -> Option<&'a str> {
+        let b = src.as_bytes();
+        assert_eq!(b[open], b'{');
+        let mut depth = 0usize;
+        for i in open..b.len() {
+            if !code[i] {
                 continue;
             }
-            match b {
-                b'"' => in_str = true,
+            match b[i] {
                 b'{' => depth += 1,
                 b'}' => {
                     depth -= 1;
                     if depth == 0 {
-                        return Some(&src[..=i]);
+                        return Some(&src[open..=i]);
                     }
                 }
                 _ => {}
             }
         }
         None
+    }
+
+    /// The mask is load-bearing for the guard above, so it is pinned
+    /// directly: every one of these would be a false positive or a false
+    /// negative under the line-prefix heuristic it replaces.
+    #[test]
+    fn the_code_mask_excludes_strings_comments_and_raw_strings() {
+        let at = |src: &str, needle: &str| {
+            let m = code_mask(src);
+            m[src.find(needle).expect("needle must appear")]
+        };
+        assert!(at("let x = 1; UsageEvent {}", "UsageEvent"));
+        assert!(!at("let s = \"UsageEvent {\";", "UsageEvent"));
+        assert!(!at("// UsageEvent {", "UsageEvent"));
+        assert!(!at("/* a /* b */ UsageEvent */", "UsageEvent"));
+        assert!(!at("let s = r#\"UsageEvent {\"#;", "UsageEvent"));
+        // The two the heuristic got wrong: a completed string earlier on
+        // the line, and an escaped quote inside one.
+        assert!(at("let u = \"https://x\"; UsageEvent {}", "UsageEvent"));
+        assert!(at("let e = \"a\\\"b\"; UsageEvent {}", "UsageEvent"));
+        // A char literal must not open a string, and an identifier ending
+        // in `r` must not open a raw string.
+        assert!(at("let c = '\"'; UsageEvent {}", "UsageEvent"));
+        assert!(at("let var = 1; UsageEvent {}", "UsageEvent"));
     }
 }

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -95,14 +95,23 @@ pub(crate) fn guardrail_scores(audit: &GuardrailAudit) -> Vec<aisix_core::Guardr
 /// and unparseable-usage paths historically suppress zero-value noise rows.
 /// A mask/block, monitor hit, or similarity score is an operator-visible
 /// security fact, so those paths must emit a zero-token event instead.
+///
+/// A BYPASS is one too, and it needs saying separately because it leaves no
+/// enforced hit and no score — a bypass is precisely the outcome where no
+/// policy acted. Without this arm a fail-open request whose upstream
+/// reported no parseable usage has its whole event suppressed, so the
+/// reason is written onto an event nobody ever receives: the same silence
+/// this field exists to break, one layer further out.
 pub(crate) fn has_guardrail_attribution(
     audit: &GuardrailAudit,
     monitor_hits: &[aisix_core::GuardrailMonitorHit],
 ) -> bool {
     !monitor_hits.is_empty()
-        || audit
-            .as_ref()
-            .is_some_and(|log| !log.snapshot().is_empty() || !log.score_snapshot().is_empty())
+        || audit.as_ref().is_some_and(|log| {
+            !log.snapshot().is_empty()
+                || !log.score_snapshot().is_empty()
+                || log.bypass_reason().is_some()
+        })
 }
 
 /// [`guardrail_scores`] for the retrying families — see
@@ -787,6 +796,27 @@ mod tests {
             top_example_index: 0,
             embedding_model: "embedder".into(),
         });
+        assert!(has_guardrail_attribution(&audit, &[]));
+    }
+
+    /// A bypass leaves no enforced hit and no score — it is the outcome
+    /// where no policy acted — so it has to be named here explicitly.
+    /// Without it, the unbilled paths that consult this gate
+    /// (`/v1/completions`, `/v1/embeddings`, `/v1/images/*`, `/v1/rerank`)
+    /// suppress the whole event, and the reason lands on a row nobody
+    /// receives.
+    #[test]
+    fn a_bypass_alone_requires_a_zero_token_event() {
+        let log = Arc::new(aisix_guardrails::GuardrailAuditLog::new());
+        let audit = Some(Arc::clone(&log));
+        assert!(!has_guardrail_attribution(&audit, &[]));
+
+        log.record_bypass("lakera_timeout");
+        assert!(
+            log.snapshot().is_empty() && log.score_snapshot().is_empty(),
+            "premise: a bypass is not an enforced hit and not a score, so the \
+             other two arms of this gate cannot be what carries it",
+        );
         assert!(has_guardrail_attribution(&audit, &[]));
     }
 

--- a/crates/aisix-proxy/src/usage_attr.rs
+++ b/crates/aisix-proxy/src/usage_attr.rs
@@ -55,6 +55,27 @@ pub(crate) fn enforced_hits(audit: &GuardrailAudit) -> Vec<aisix_core::Guardrail
     audit.as_ref().map(|a| a.snapshot()).unwrap_or_default()
 }
 
+/// Snapshot `audit` into a `UsageEvent`'s `guardrail_bypassed_reason`:
+/// the bounded tag of the first guardrail this request failed OPEN on,
+/// empty when none did.
+///
+/// Not terminal-only, unlike [`enforced_hits`]. A bypass says the request
+/// went upstream unscreened, which is true of every attempt the request
+/// made, and `chat.rs` has stamped it on its per-attempt events since the
+/// field existed — a retry that dropped it would read as a screened
+/// attempt.
+///
+/// `chat.rs` keeps threading its own copy instead of calling this: it
+/// hands the value to per-attempt and ensemble sub-call emitters at
+/// points where the value is deliberately the one captured EARLIER in the
+/// request, which a request-scoped snapshot cannot express.
+pub(crate) fn bypass_reason(audit: &GuardrailAudit) -> String {
+    audit
+        .as_ref()
+        .and_then(|a| a.bypass_reason())
+        .unwrap_or_default()
+}
+
 /// Snapshot `audit` into a terminal `UsageEvent`'s `guardrail_scores`
 /// (AISIX-Cloud#1467). Same handle, same terminal-only rule and same
 /// non-destructive read as [`enforced_hits`] — a scoring guardrail runs
@@ -537,6 +558,11 @@ pub(crate) fn emit_error_usage_event(
     // operator is certain to look at — as the only execution with no
     // number attached.
     scores: Vec<aisix_core::GuardrailScore>,
+    // The request's fail-open bypass tag, drained the same way. A request
+    // that went upstream unscreened and THEN failed is still a request
+    // that went upstream unscreened, so dropping the tag here would make
+    // the field answerable only for the requests that succeeded.
+    bypass: String,
 ) {
     let event = build_error_usage_event(
         inbound_protocol,
@@ -549,6 +575,7 @@ pub(crate) fn emit_error_usage_event(
         client,
         enforced,
         scores,
+        bypass,
     );
     // The failed request's own attribution, off the same cell
     // `request_metrics::LastTarget` reads — so the usage-event counters and
@@ -583,6 +610,8 @@ pub(crate) fn build_error_usage_event(
     client: &ClientContext,
     enforced: Vec<aisix_core::GuardrailEnforcedHit>,
     scores: Vec<aisix_core::GuardrailScore>,
+    // See [`emit_error_usage_event`].
+    bypass: String,
 ) -> UsageEvent {
     let mut event = UsageEvent {
         request_id: request_id.to_string(),
@@ -597,6 +626,7 @@ pub(crate) fn build_error_usage_event(
         guardrail_blocked,
         guardrail_enforced_hits: enforced,
         guardrail_scores: scores,
+        guardrail_bypassed_reason: bypass,
         ..Default::default()
     };
     apply_caller_identity(
@@ -1002,5 +1032,112 @@ mod tests {
 
         let snap = snap_with_pk("\u{1}\u{2}", "");
         assert_eq!(ResolvedPk::resolve(&snap, PK_ID).labels().name, "unknown");
+    }
+
+    /// Every `UsageEvent` this crate builds must set
+    /// `guardrail_bypassed_reason`, and an emitter that genuinely has no
+    /// chain behind it must say so where it is written.
+    ///
+    /// The field defaults to empty, so an emitter that forgets it reports
+    /// "nothing was bypassed" for a request that went upstream unscreened —
+    /// and no behavioural test can see the omission, because an unset field
+    /// and a screened request produce the same row. That is exactly how the
+    /// field spent its whole life written on `/v1/chat/completions` and
+    /// nowhere else.
+    ///
+    /// A parse of the source rather than a list of emitters, for the reason
+    /// `guardrail_coverage` parses the router instead of listing routes: a
+    /// hand-written list nobody updates agrees with itself forever, and the
+    /// emitter family here has sixteen members that keep gaining a
+    /// seventeenth.
+    #[test]
+    fn every_usage_event_this_crate_builds_answers_the_bypass_question() {
+        /// Written inside an emitter that has no guardrail chain behind it
+        /// at all, followed by why.
+        const EXEMPT: &str = "NO-GUARDRAIL-CHAIN:";
+
+        let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut blocks = 0usize;
+        let mut missing = Vec::new();
+
+        let mut files: Vec<_> = std::fs::read_dir(&src_dir)
+            .expect("the crate's own src/ must be readable")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|e| e == "rs"))
+            .collect();
+        files.sort();
+
+        for path in files {
+            let src = std::fs::read_to_string(&path).expect("source must read");
+            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            for (idx, _) in src.match_indices("UsageEvent {") {
+                // `-> UsageEvent {` (optionally path-qualified) is a
+                // return type followed by a function body, not a literal.
+                let before = src[..idx]
+                    .trim_end()
+                    .trim_end_matches(|c: char| c.is_alphanumeric() || c == '_' || c == ':')
+                    .trim_end();
+                if before.ends_with("->") {
+                    continue;
+                }
+                let open = idx + "UsageEvent ".len();
+                let Some(block) = braced_block(&src[open..]) else {
+                    panic!("{name}: unbalanced UsageEvent literal at byte {idx}");
+                };
+                blocks += 1;
+                if !block.contains("guardrail_bypassed_reason") && !block.contains(EXEMPT) {
+                    let line = src[..idx].lines().count();
+                    missing.push(format!("{name}:{line}"));
+                }
+            }
+        }
+
+        // The parse must actually find the emitters, not silently yield an
+        // empty set that makes the assertion below vacuous.
+        assert!(
+            blocks >= 15,
+            "the UsageEvent literal scan found only {blocks} — it has stopped tracking the \
+             emitter family",
+        );
+        assert!(
+            missing.is_empty(),
+            "these UsageEvent emitters neither set guardrail_bypassed_reason nor carry a \
+             `{EXEMPT} <why>` comment saying they have no guardrail chain: {missing:?}\n\
+             An unset field reports a screened request, so an emitter that skips it makes the \
+             field unusable as a negative answer.",
+        );
+    }
+
+    /// The `{ … }` starting at `src`, string-literal aware so a brace
+    /// inside a quoted value cannot end the block early.
+    fn braced_block(src: &str) -> Option<&str> {
+        let bytes = src.as_bytes();
+        assert_eq!(bytes[0], b'{');
+        let mut depth = 0usize;
+        let mut in_str = false;
+        let mut escaped = false;
+        for (i, b) in bytes.iter().enumerate() {
+            if in_str {
+                match b {
+                    _ if escaped => escaped = false,
+                    b'\\' => escaped = true,
+                    b'"' => in_str = false,
+                    _ => {}
+                }
+                continue;
+            }
+            match b {
+                b'"' => in_str = true,
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(&src[..=i]);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
     }
 }

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -1614,6 +1614,7 @@ pub async fn create_video(
                 &client,
                 crate::usage_attr::enforced_hits(&audit),
                 crate::usage_attr::guardrail_scores(&audit),
+                crate::usage_attr::bypass_reason(&audit),
             );
             err.into_response()
         }
@@ -2055,6 +2056,7 @@ fn emit_submit_usage_event(
         guardrail_monitor_hits,
         guardrail_enforced_hits: crate::usage_attr::enforced_hits(audit),
         guardrail_scores: crate::usage_attr::guardrail_scores(audit),
+        guardrail_bypassed_reason: crate::usage_attr::bypass_reason(audit),
         client_source_ip: client.source_ip.clone(),
         client_user_agent: client.user_agent.clone(),
         ..Default::default()

--- a/tests/e2e/src/cases/guardrail-bypass-reason-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-bypass-reason-e2e.test.ts
@@ -1,0 +1,270 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startMockSls,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  waitForSlsLog,
+  type MockSls,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: `UsageEvent.guardrail_bypassed_reason` across the handler family
+// (api7/aisix, follow-up to #1115), against a real DP + etcd + a real SOC
+// export target.
+//
+// A fail-open bypass is the one guardrail outcome nobody sees. The caller
+// gets a normal 200, the response looks screened, and the usage row is
+// byte-identical to a request the chain actually decided. The field exists
+// so an operator can tell those apart — and until this change it was
+// written on `/v1/chat/completions` and nowhere else, so on every other
+// route an outage passed traffic unscreened and left no trace.
+//
+// Two causes reach the field and both are driven here:
+//   - the guardrail could not evaluate (a `kind: custom` script that
+//     throws is the provider-outage shape without a provider), which
+//     reports the kind's own bounded tag;
+//   - the body could not be scanned at all, which reports the same tag the
+//     fail-CLOSED direction puts in its refusal envelope.
+//
+// One `fail_open: true` row governs the whole family, which is the point:
+// the reason has to reach every handler's terminal event, not just the one
+// whose test was written first.
+
+const KEY = "sk-bypass-reason-e2e";
+const sha256 = (s: string) => createHash("sha256").update(s).digest("hex");
+
+const CREDENTIAL_REF = "mock";
+const SLS_PROJECT = "aisix-e2e-obs";
+const LOGSTORE = "bypass-reason";
+
+const ROW = "bypass-reason-open";
+/** `ScriptFailure::Threw`'s bounded tag — the operator's filter value. */
+const SCRIPT_TAG = "custom_script_error";
+/** The tag the proxy raises for a body it could not scan at all. */
+const UNSCANNABLE_TAG = "unscannable_body";
+
+/**
+ * Faults instead of deciding. Paired with `fail_open: true` this is the
+ * outage shape: the chain runs, decides nothing, and the request goes
+ * upstream with nothing screening it.
+ *
+ * Input hook only, deliberately. `kind: custom` reads its OUTPUT policy
+ * from `output_fail_open`, which defaults to fail-CLOSED, so a row that
+ * also faulted on the response would refuse every one of these requests
+ * and the cases below would be measuring a refusal instead of a bypass.
+ */
+const FAULTING_SCRIPT = `
+export function checkInput() {
+  throw new Error("bypass-reason-e2e");
+}
+`;
+
+describe("guardrail bypass reason across the handler family", () => {
+  let app: SpawnedApp | undefined;
+  let sls: MockSls | undefined;
+  const upstreams: OpenAiUpstream[] = [];
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    const chatUp = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-bypass-1",
+        object: "chat.completion",
+        model: "gpt-4o-2024-08-06",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "ok" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 4, total_tokens: 9 },
+      },
+    });
+    const messagesUp = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "msg_bypass_2",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        model: "claude-3-5-haiku-20241022",
+        stop_reason: "end_turn",
+        usage: { input_tokens: 6, output_tokens: 4 },
+      },
+    });
+    const embeddingsUp = await startOpenAiUpstream({
+      nonStreamBody: {
+        object: "list",
+        data: [{ object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] }],
+        model: "text-embedding-3-small",
+        usage: { prompt_tokens: 3, total_tokens: 3 },
+      },
+    });
+    upstreams.push(chatUp, messagesUp, embeddingsUp);
+
+    sls = await startMockSls();
+    app = await spawnApp({
+      extraEnv: {
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_ID`]: "mock-akid",
+        [`SLS_CRED_${CREDENTIAL_REF.toUpperCase()}_AK_SECRET`]: "mock-secret",
+      },
+    });
+
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    await seed.createObservabilityExporter({
+      name: "sls-bypass-reason",
+      enabled: true,
+      kind: "aliyun_sls",
+      endpoint: sls.url,
+      project: SLS_PROJECT,
+      logstore: LOGSTORE,
+      credential_ref: CREDENTIAL_REF,
+    });
+    await seed.createGuardrail({
+      name: ROW,
+      enabled: true,
+      hook_point: "input",
+      fail_open: true,
+      kind: "custom",
+      script: FAULTING_SCRIPT,
+      timeout_ms: 5000,
+    });
+
+    const mk = async (
+      display: string,
+      provider: string,
+      modelName: string,
+      up: OpenAiUpstream,
+      extra: Record<string, unknown> = {},
+    ): Promise<void> => {
+      const pk = await seed.createProviderKey({
+        display_name: `${display}-pk`,
+        secret: "sk-mock-upstream",
+        api_base: up.baseUrl,
+        provider,
+        adapter: provider,
+      });
+      await seed.createModel({
+        display_name: display,
+        provider,
+        model_name: modelName,
+        provider_key_id: pk.id,
+        ...extra,
+      });
+    };
+    await mk("bypass-chat", "openai", "gpt-4o", chatUp);
+    await mk("bypass-messages", "anthropic", "claude-3-5-haiku-20241022", messagesUp);
+    // Its own model so the unscannable case can be gated on `requested_model`
+    // — a field independent of the one under test — without racing the
+    // `/v1/messages` case above for the same name.
+    await mk("bypass-unscannable", "anthropic", "claude-3-5-haiku-20241022", messagesUp);
+    await mk("bypass-embeddings", "openai", "text-embedding-3-small", embeddingsUp, {
+      kind: "embedding",
+    });
+
+    // Caller key LAST: a key that authenticates implies every row above is
+    // already in the snapshot.
+    await seed.createApiKey({ key_hash: sha256(KEY), allowed_models: ["*"] });
+    const proxy = new ProxyClient(app.proxyUrl, KEY);
+    await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);
+  }, 90_000);
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+    await sls?.close();
+  });
+
+  const post = (path: string, body: unknown, anthropic = false): Promise<Response> =>
+    fetch(`${app!.proxyUrl}${path}`, {
+      method: "POST",
+      headers: anthropic
+        ? {
+            "content-type": "application/json",
+            "x-api-key": KEY,
+            "anthropic-version": "2023-06-01",
+          }
+        : { "content-type": "application/json", authorization: `Bearer ${KEY}` },
+      body: JSON.stringify(body),
+    });
+
+  /**
+   * Gated on the requested MODEL, which rides every event the route emits
+   * and is therefore independent of the field under test — waiting on the
+   * reason itself would turn a lost value into a poll timeout instead of an
+   * assertion (tests/e2e/AGENTS.md).
+   */
+  const expectBypassReason = async (model: string, want: string): Promise<void> => {
+    const log = await waitForSlsLog(
+      sls!,
+      LOGSTORE,
+      (entry) => entry.get("requested_model") === model,
+      `${model} usage event`,
+    );
+    expect(
+      log.get("guardrail_bypassed_reason") ?? "",
+      `${model}: the request went upstream with nothing screening it and its usage row does not say so`,
+    ).toBe(want);
+  };
+
+  test("/v1/chat/completions reports the kind's failure tag", async (ctx) => {
+    if (!etcdReachable || !app || !sls) return ctx.skip();
+
+    const res = await post("/v1/chat/completions", {
+      model: "bypass-chat",
+      messages: [{ role: "user", content: "go" }],
+    });
+    // Premise: a fail-open row must NOT refuse. Without this, an empty
+    // reason and a refused request would be the same observation.
+    expect(res.status).toBe(200);
+
+    await expectBypassReason("bypass-chat", SCRIPT_TAG);
+  });
+
+  test("/v1/messages reports it too (Claude-Code path)", async (ctx) => {
+    if (!etcdReachable || !app || !sls) return ctx.skip();
+
+    const res = await post(
+      "/v1/messages",
+      { model: "bypass-messages", max_tokens: 64, messages: [{ role: "user", content: "go" }] },
+      true,
+    );
+    expect(res.status).toBe(200);
+
+    await expectBypassReason("bypass-messages", SCRIPT_TAG);
+  });
+
+  test("/v1/embeddings reports it on its own terminal event", async (ctx) => {
+    if (!etcdReachable || !app || !sls) return ctx.skip();
+
+    const res = await post("/v1/embeddings", { model: "bypass-embeddings", input: "go" });
+    expect(res.status).toBe(200);
+
+    await expectBypassReason("bypass-embeddings", SCRIPT_TAG);
+  });
+
+  test("a body the scanner cannot read reports the unscannable tag", async (ctx) => {
+    if (!etcdReachable || !app || !sls) return ctx.skip();
+
+    // No `messages`: the Anthropic scan parser rejects it, so the chain is
+    // never offered the body at all. Nothing in scope refuses an
+    // unevaluable request, so it is forwarded — as a bypass, which is what
+    // the tag has to say. A different tag from the case above on purpose:
+    // "the guardrail broke" and "we could not give it the body" are
+    // different outages with different fixes.
+    const res = await post("/v1/messages", { model: "bypass-unscannable", max_tokens: 64 }, true);
+    expect(res.status).toBe(200);
+
+    await expectBypassReason("bypass-unscannable", UNSCANNABLE_TAG);
+  });
+});


### PR DESCRIPTION
## Problem

`usage_events.guardrail_bypassed_reason` is the record that a guardrail on a request did not evaluate and its failure policy let the request past it. It was written in exactly one place in the data plane — `crates/aisix-proxy/src/chat.rs` — so on every other route a bypass happened silently: the caller got a normal 200, and the usage row was byte-identical to a request the chain actually decided. `embeddings.rs` carried the gap as an acknowledged TODO ("fail-open bypass telemetry is not yet plumbed for the non-chat handlers"); this is that follow-up, and the TODO is removed.

The failure mode is silent in both directions, which is why it survived: an unset field reads as "nothing was bypassed", so no behavioural test could see the omission and no operator could tell a screened request from an unscreened one.

## The carrier

The chain folds already see every `Bypass` verdict, and every handler already clones the request's `GuardrailAuditLog` for `guardrail_enforced_hits`. So the reason rides that log rather than a per-handler out-param: `record_execution` records the first bypass, and each emitter reads it back with `usage_attr::bypass_reason(audit)`. That is one line per emitter, which is what makes covering the whole family tractable rather than the thing that gets deferred again.

Not terminal-only, unlike the enforced hits — every attempt of a request that failed open went upstream unscreened, which is how `chat.rs` has always stamped it. `chat.rs` keeps threading its own copy, because its per-attempt and ensemble sub-call emitters are handed the value captured *earlier* in the request, which a request-scoped snapshot cannot express; the two agree by construction (both are the first `Bypass` the chain folded).

## Both causes

**Provider-failure fail-open** — a guardrail that could not evaluate on a `fail_open: true` row — reports the kind's own bounded tag, the existing vocabulary (`lakera_timeout`, `bedrock_5xx`, `azure_cs_5xx`, `custom_script_error`, …). No new values are minted for this cause.

**The unscannable-body pass** #1115 introduced reports `unscannable_body` — the same tag the fail-CLOSED direction already puts in its refusal envelope, so one unscannable body reads the same whichever way the chain is configured.

That pass is recorded only when it actually *is* a bypass. It has two causes and only one of them is one: a chain whose readers of that side are all fail-open let an unscreened request through, while a chain where **nothing** reads that side never offered to screen it. Tagging the second would fire the field on requests that were never going to be screened, which breaks the negative answer as thoroughly as dropping the first. The predicate (`record_unevaluable_{input,output}_bypass`) is folded off the same member set the refusal gate uses, so the two cannot disagree about which chain refuses.

## Contract point: bypass and blocked are not mutually exclusive

`guardrail_bypassed_reason` is **not** suppressed when `guardrail_blocked` is set. A chain can fail open on one member and be refused by another, and an input hook can fail open on a prompt the provider already answered before the output hook refused the answer. `chat.rs` has always carried the input bypass onto the billed-then-blocked event through `UpstreamCharge`, so suppressing would be both a behaviour change and a loss of the more compliance-relevant of the two cases. **"Reached a provider unscreened" is the two fields read together, never this one alone.** Pinned by a chain test; the `UsageEvent` field doc and `AGENTS.md` now say it.

## Also fixed in chat

Two chat paths recorded the reason on the success path only:

- `DispatchFailure` never carried it, so `emit_failed_attempts` and the pre-dispatch terminal event both built their `UsageExtras` with the field defaulted — a request that failed open and then hit a dead upstream reported an empty reason. Both now read it off the audit handle.
- `has_guardrail_attribution` decides whether the unbilled paths emit an event *at all* when the upstream reported no parseable usage. A bypass leaves no enforced hit and no score, so a fail-open request on `/v1/completions`, `/v1/embeddings`, `/v1/images/*` or `/v1/rerank` had its whole event suppressed — the reason written onto a row nobody received. The gate now passes on a recorded bypass.

## Where a bypass is now recorded

`/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/messages`, `/v1/messages/count_tokens`, `/v1/embeddings`, `/v1/rerank`, `/v1/audio/{transcriptions,translations,speech}`, `/v1/images/{generations,edits}`, `/v1/videos`, `/v1/realtime`, `/mcp`, `/a2a/:agent`, the jobs surface (`/v1/files`, `/v1/batches`, `/v1/fine_tuning/jobs`), and the passthrough routes. Both the success and the error event carry it.

The one `UsageEvent` this crate builds that deliberately does not is the batch-completion attribution row: a retroactive billing record for work the provider did inside a batch, with no request and no chain behind it. It says so in place, under the marker the source guard reads.

## Deliberately not covered

So the four unscannable sites are not read as the full set. These scan a lossy copy **unconditionally**, with no failure policy involved: `jobs::scan_output_blob`, the binary-purpose arm of `scan_input_blob`, the non-UTF-8 multipart prompt parts dropped by `filter_map` in `audio.rs` and `images_edits.rs`, and `passthrough_route`'s lossy body scan. None consults `refuses_unevaluable_*`, so a fail-CLOSED row does not refuse there either — that asymmetry is #1022's open product decision, and making them refuse would be a behaviour change rather than an observability one. Tagging them instead would fire the field on every binary upload and download, destroying the negative answer just as thoroughly. `AGENTS.md` records this, including why `record_unevaluable_*` is the wrong helper at a site that never refuses.

## Behaviour

Observability only. What is refused, released or masked is byte-for-byte what `a889c8a0` does. No control-plane change: the field is free-form (`String` here, `varchar(64)` there, `*string` in the bindings, one CSV column on export), and the audit log clamps whatever it is handed through `bounded_failure_tag`, so the 64-byte limit is now structural rather than a convention.

## Tests

- **The router-derived census** (`guardrail_coverage`) gains a leg that drives every `Posture::Enforced` surface against a fail-open guardrail and requires the reason on every usage event it emits. The set comes out of `build_router`, so a new route cannot be added without it. This leg found chat's failed-attempt gap, and later caught a stray revert of it.
- **A source guard** parses this crate for `UsageEvent` literals and requires each to set the field or carry a `NO-GUARDRAIL-CHAIN: <why>` comment. The census only reaches the *error* emitters (its upstreams point nowhere by design), so the success emitters needed a check that cannot be fooled by an unreached path. It runs a real code mask (strings, raw strings, char literals, line and nestable block comments) rather than a line heuristic, requires an assignment rather than a mention, and recurses.
- **Per-cause unit tests on all four sites that raise the unscannable pass** — `/v1/messages`, `/v1/messages/count_tokens`, `/mcp` tool results, `/v1/files` — each with its control: an output-only chain and a binary-purpose upload record nothing.
- **The two suppression paths**: a `/v1/completions` 501 that survives only because of the bypass, and an `rpm: 1` refusal that exercises chat's pre-dispatch arm (unreachable from the census, whose fixture always records an attempt).
- **A DP e2e** (`guardrail-bypass-reason-e2e`) drives a real binary + etcd + a real SLS export target for both causes across `/v1/chat/completions`, `/v1/messages` and `/v1/embeddings`.
- **Chain and audit-log units** for first-wins, the tag clamp, the reads-that-side predicate, the block/bypass co-occurrence, and the code mask itself.

Every one of these was mutation-checked: each fails with its fix removed.

Refs #1115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)