### PR TITLE
docs(proxy): correct a stale unscannable-body claim in the proxy AGENTS.md

### DIFF
--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -154,17 +154,22 @@ unscannable sites as the full set: the places that scan a mangled copy
 unconditionally, with no failure policy involved. `jobs::scan_output_blob`
 and the binary-purpose arm of `scan_input_blob` scan
 `String::from_utf8_lossy` and relay the original bytes whatever the row
-says; `audio.rs` and `images_edits.rs` drop non-UTF-8 multipart prompt
-parts with `filter_map`; `passthrough_route` scans the lossy body. None of
-these consults `refuses_unevaluable_*`, so a fail-CLOSED row does not
-refuse there either — that asymmetry is #1022's open product decision, not
-something telemetry can paper over, and making them refuse is a behaviour
-change rather than an observability one. Tagging them instead would fire
-the field on every binary upload and download, which destroys the negative
-answer just as thoroughly. Note that `record_unevaluable_*` is the wrong
-helper at such a site: its predicate assumes the fail-closed case was
-already refused, so at a site that never refuses it would silently drop
-exactly the case worth reporting.
+says; `passthrough_route` scans the lossy body. None of these consults
+`refuses_unevaluable_*`, so a fail-CLOSED row does not refuse there either
+— that asymmetry is settled rather than pending (the section below rules on
+the download side), and making them refuse would be a behaviour change, not
+an observability one. Tagging them instead would fire the field on every
+binary upload and download, which destroys the negative answer just as
+thoroughly. Note that `record_unevaluable_*` is the wrong helper at such a
+site: its predicate assumes the fail-closed case was already refused, so at
+a site that never refuses it would silently drop exactly the case worth
+reporting.
+
+`audio.rs` and `images_edits.rs` are NOT in that set: since #1016 both call
+`dispatch::require_utf8_prompt_fields` after model resolution and before the
+chain runs, so an undecodable `prompt` part is answered 400 and the
+`filter_map` in their scan builders can no longer be reached by one. Do not
+describe those surfaces as silently dropping non-UTF-8 prompt parts.
 
 Values come from the guardrail kind's own `bypass_tag()` — the same bounded
 vocabulary `GuardrailVerdict::block_unavailable` carries, so one outage reads
@@ -172,6 +177,20 @@ the same whichever way the row is configured — plus `unscannable_body` for
 the proxy-raised pass. The audit log clamps whatever it is given through
 `bounded_failure_tag`, because the value lands on an unsanitized metric
 label and on a wire field the control plane stores as `varchar(64)`.
+
+## The `/v1/files` download blob is scanned lossily and never refused, by decision
+
+`jobs::scan_output_blob` decodes the downloaded blob with
+`String::from_utf8_lossy`, relays the provider's bytes verbatim, and does not
+consult `refuses_unevaluable_output` — so no row, fail-closed or not, makes it
+refuse. That is deliberate, not an oversight: a download carries arbitrary
+provider-side bytes the caller did not choose the content of, so refusing an
+undecodable body would reject legitimate downloads. The upload side does refuse
+(#1113/#1114/#1115) because those are the caller's own bytes and its text
+purposes are contractually UTF-8.
+
+Do not mirror the input-side `match` here, and do not report the asymmetry as a
+finding or file an issue for it.
 
 ## Every terminal path emits the access log — including the ones that give up early
 

--- a/crates/aisix-proxy/AGENTS.md
+++ b/crates/aisix-proxy/AGENTS.md
@@ -154,22 +154,25 @@ unscannable sites as the full set: the places that scan a mangled copy
 unconditionally, with no failure policy involved. `jobs::scan_output_blob`
 and the binary-purpose arm of `scan_input_blob` scan
 `String::from_utf8_lossy` and relay the original bytes whatever the row
-says; `passthrough_route` scans the lossy body. None of these consults
-`refuses_unevaluable_*`, so a fail-CLOSED row does not refuse there either
-— that asymmetry is settled rather than pending (the section below rules on
-the download side), and making them refuse would be a behaviour change, not
-an observability one. Tagging them instead would fire the field on every
-binary upload and download, which destroys the negative answer just as
-thoroughly. Note that `record_unevaluable_*` is the wrong helper at such a
-site: its predicate assumes the fail-closed case was already refused, so at
-a site that never refuses it would silently drop exactly the case worth
+says; `passthrough_route` scans the lossy body; `audio.rs`'s
+`transcription_output_text` falls back to the lossy body for the plain-text
+transcript formats (`text` / `srt` / `vtt`). None of these consults
+`refuses_unevaluable_*`, so a fail-CLOSED row does not refuse there either —
+not something telemetry can paper over, and making them refuse is a behaviour
+change rather than an observability one. Tagging them instead would fire the
+field on every binary upload and download, which destroys the negative answer
+just as thoroughly. Note that `record_unevaluable_*` is the wrong helper at
+such a site: its predicate assumes the fail-closed case was already refused,
+so at a site that never refuses it would silently drop exactly the case worth
 reporting.
 
-`audio.rs` and `images_edits.rs` are NOT in that set: since #1016 both call
+What is no longer in that set is the multipart `prompt` on `audio.rs` and
+`images_edits.rs`: since #1016 both call
 `dispatch::require_utf8_prompt_fields` after model resolution and before the
 chain runs, so an undecodable `prompt` part is answered 400 and the
 `filter_map` in their scan builders can no longer be reached by one. Do not
-describe those surfaces as silently dropping non-UTF-8 prompt parts.
+describe those surfaces as silently dropping non-UTF-8 prompt parts — audio's
+transcript OUTPUT scan, listed above, is a separate site and still lossy.
 
 Values come from the guardrail kind's own `bypass_tag()` — the same bounded
 vocabulary `GuardrailVerdict::block_unavailable` carries, so one outage reads
@@ -177,20 +180,6 @@ the same whichever way the row is configured — plus `unscannable_body` for
 the proxy-raised pass. The audit log clamps whatever it is given through
 `bounded_failure_tag`, because the value lands on an unsanitized metric
 label and on a wire field the control plane stores as `varchar(64)`.
-
-## The `/v1/files` download blob is scanned lossily and never refused, by decision
-
-`jobs::scan_output_blob` decodes the downloaded blob with
-`String::from_utf8_lossy`, relays the provider's bytes verbatim, and does not
-consult `refuses_unevaluable_output` — so no row, fail-closed or not, makes it
-refuse. That is deliberate, not an oversight: a download carries arbitrary
-provider-side bytes the caller did not choose the content of, so refusing an
-undecodable body would reject legitimate downloads. The upload side does refuse
-(#1113/#1114/#1115) because those are the caller's own bytes and its text
-purposes are contractually UTF-8.
-
-Do not mirror the input-side `match` here, and do not report the asymmetry as a
-finding or file an issue for it.
 
 ## Every terminal path emits the access log — including the ones that give up early
 

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -615,9 +615,8 @@ async fn scan_input_blob(
 /// caller never chose (whatever the provider holds under a file id), and it
 /// has no `purpose` to classify it by — the upload's `purpose` is what lets
 /// the input side tell a JSONL payload from a lawful PDF. Failing closed
-/// here would refuse lawful downloads, so this side stays lossy and
-/// unrefused by decision (#1022, closed): do not mirror the input-side
-/// `match` here, and do not re-file the asymmetry as a finding.
+/// here would refuse lawful downloads, so the direction needs a product
+/// decision rather than a mirrored `match`. Tracked in #1022.
 #[allow(clippy::too_many_arguments)]
 async fn scan_output_blob(
     state: &ProxyState,

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -615,8 +615,9 @@ async fn scan_input_blob(
 /// caller never chose (whatever the provider holds under a file id), and it
 /// has no `purpose` to classify it by — the upload's `purpose` is what lets
 /// the input side tell a JSONL payload from a lawful PDF. Failing closed
-/// here would refuse lawful downloads, so the direction needs a product
-/// decision rather than a mirrored `match`. Tracked in #1022.
+/// here would refuse lawful downloads, so this side stays lossy and
+/// unrefused by decision (#1022, closed): do not mirror the input-side
+/// `match` here, and do not re-file the asymmetry as a finding.
 #[allow(clippy::too_many_arguments)]
 async fn scan_output_blob(
     state: &ProxyState,


### PR DESCRIPTION
Documentation-of-code only, one file: `crates/aisix-proxy/AGENTS.md`. No behaviour change, no code change, no test change.

### The stale claim

The "bypass reason rides the audit log" section listed `audio.rs` and `images_edits.rs` among the sites that pass an unscannable body through unrecorded, on the grounds that they "drop non-UTF-8 multipart prompt parts with `filter_map`". That has not been reachable since #1016. Both surfaces call `dispatch::require_utf8_prompt_fields` after model resolution and before the guardrail chain is resolved (`audio.rs:897`, `images_edits.rs:313`), and the guard's field scope is exactly the `filter_map`'s — both are keyed on the part named `prompt` — so an undecodable `prompt` is answered 400 and the `filter_map` can no longer be handed one.

This file is what agents read instead of the code, so a wrong sentence in it propagates rather than sitting still; a documentation change in another repository nearly published this one verbatim.

### What the correction had to be narrower about

Only the multipart `prompt` path left that set. `audio.rs` did not: `transcription_output_text` still falls back to `String::from_utf8_lossy(body)` for the `text` / `srt` / `vtt` response formats, consults neither `refuses_unevaluable_output` nor `record_unevaluable_output_bypass`, and the original bytes are relayed to the caller — the same shape as the `passthrough_route` entry already in the list. So the output-side site is now listed explicitly, and the correction says in as many words that it is a separate site, so the next reader auditing unscannable bodies does not skip `audio.rs` on the strength of the `prompt` fix.

The section also described the lossy-scan-but-forward asymmetry as "#1022's open product decision". #1022 is closed, so that clause is dropped; the mechanical statement it was attached to — none of these sites consults `refuses_unevaluable_*`, and making them refuse would be a behaviour change rather than an observability one — is unchanged and still holds.

### Checked and left alone

Verified against current code in the same pass and unchanged because they still hold: the `jobs::scan_output_blob` / binary-purpose `scan_input_blob` / `passthrough_route` lossy-scan claims, the four `record_unevaluable_*` sites (`count_tokens.rs`, `mcp.rs`, `jobs.rs`, `messages.rs`), the `NO-GUARDRAIL-CHAIN:` marker and the test that parses for it, `usage_attr::bypass_reason`, `bypass_tag()` / `bounded_failure_tag`, `chat.rs`'s `UpstreamCharge.bypass_reason`, and the `varchar(64)` width the control plane gives `usage_events.guardrail_bypassed_reason`.

### Tests

None — the branch contains no code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified audio and image-edit request handling, including rejection of unsupported multipart prompts with HTTP 400 responses before scanning.
  - Documented scanning of lossy transcript output for guardrail bypass detection.
  - Removed the separate documentation section covering `/v1/files` downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->