### PR TITLE
fix(cooldown): make cooldown opt-in, and put a dropped routing candidate on the record

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -2344,7 +2344,7 @@ fn add_schema_defaults(doc: &mut Value) {
         ),
         (
             "/components/schemas/CooldownConfig/properties/enabled",
-            serde_json::json!(true),
+            serde_json::json!(false),
         ),
         (
             "/components/schemas/CooldownConfig/properties/honor_retry_after",
@@ -2978,6 +2978,13 @@ mod tests {
             schemas["CooldownConfig"]["properties"]["trigger_statuses"]["default"],
             serde_json::json!([401, 408, 429, 500, 502, 503, 504]),
             "runtime default cooldown trigger statuses should be visible in OpenAPI"
+        );
+        // Cooldown is opt-in (AISIX-Cloud#1499): the reference must not
+        // advertise a feature the gateway does not switch on by itself.
+        assert_eq!(
+            schemas["CooldownConfig"]["properties"]["enabled"]["default"],
+            serde_json::json!(false),
+            "cooldown must be documented as off unless the operator enables it"
         );
         assert_eq!(
             schemas["Routing"]["properties"]["when_all_unavailable"]["default"],

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -112,10 +112,10 @@ pub struct BackgroundModelCheck {
     pub stale_after_seconds: u64,
 }
 
-/// Request-path cooldown settings for a direct model after retryable upstream failures.
+/// Request-path cooldown settings for a direct model after retryable upstream failures. Cooldown is opt-in: it runs only when `enabled` is `true`.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq, Default)]
 pub struct CooldownConfig {
-    /// Whether cooldown is active for this model. Set to `false` to keep the model in rotation regardless of upstream failures.
+    /// Whether cooldown is active for this model. Cooldown is off unless this is set to `true`, so a model that omits it stays in rotation regardless of upstream failures.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     /// Cooldown TTL in seconds when the upstream did not supply a `Retry-After` header or `honor_retry_after` is `false`.
@@ -148,8 +148,13 @@ const DEFAULT_COOLDOWN_SECONDS: u64 = 30;
 const DEFAULT_COOLDOWN_MAX_SECONDS: u64 = 600;
 
 impl CooldownConfig {
-    pub fn enabled_or_default(&self) -> bool {
-        self.enabled.unwrap_or(true)
+    /// Cooldown is opt-in, so an absent `enabled` reads as `false` — the
+    /// same answer a model with no `cooldown` block at all gets. Taking a
+    /// direct model out of rotation is a user-visible availability
+    /// decision, and the gateway does not make it for an operator who
+    /// never asked (AISIX-Cloud#1499).
+    pub fn is_enabled(&self) -> bool {
+        self.enabled == Some(true)
     }
 
     pub fn default_seconds_or_default(&self) -> u64 {
@@ -302,7 +307,7 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub background_model_check: Option<BackgroundModelCheck>,
 
-    /// Direct-model-only request-path cooldown configuration. Omit this field to use the built-in cooldown behavior.
+    /// Direct-model-only request-path cooldown configuration. Cooldown is opt-in: omit this field, or leave `enabled` unset, and the model is never taken out of rotation by request-path failures.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cooldown: Option<CooldownConfig>,
 
@@ -812,7 +817,10 @@ mod tests {
     #[test]
     fn cooldown_config_defaults_via_helpers() {
         let cfg = CooldownConfig::default();
-        assert!(cfg.enabled_or_default());
+        // Cooldown itself is opt-in; the knobs inside it keep their
+        // defaults, because those are parameters of a feature the
+        // operator turned on.
+        assert!(!cfg.is_enabled());
         assert_eq!(cfg.default_seconds_or_default(), 30);
         assert_eq!(cfg.max_seconds_or_default(), 600);
         assert!(cfg.honor_retry_after_or_default());
@@ -839,15 +847,22 @@ mod tests {
         let cfg: CooldownConfig = serde_json::from_str(r#"{"default_seconds": 90}"#).unwrap();
         assert_eq!(cfg.default_seconds_or_default(), 90);
         // Other fields fall back to defaults.
-        assert!(cfg.enabled_or_default());
         assert_eq!(cfg.max_seconds_or_default(), 600);
         assert!(cfg.honor_retry_after_or_default());
+        // …but tuning a knob is not enabling the feature: a block that
+        // never says `enabled: true` leaves cooldown off.
+        assert!(!cfg.is_enabled());
     }
 
     #[test]
-    fn cooldown_config_disable_via_enabled_false() {
-        let cfg: CooldownConfig = serde_json::from_str(r#"{"enabled": false}"#).unwrap();
-        assert!(!cfg.enabled_or_default());
+    fn cooldown_runs_only_when_the_operator_enables_it() {
+        // AISIX-Cloud#1499. Three ways to say "not asked for", one answer.
+        let absent: CooldownConfig = serde_json::from_str("{}").unwrap();
+        assert!(!absent.is_enabled());
+        let off: CooldownConfig = serde_json::from_str(r#"{"enabled": false}"#).unwrap();
+        assert!(!off.is_enabled());
+        let on: CooldownConfig = serde_json::from_str(r#"{"enabled": true}"#).unwrap();
+        assert!(on.is_enabled());
     }
 
     #[test]
@@ -873,9 +888,31 @@ mod tests {
         )
         .unwrap();
         let cooldown = m.cooldown.unwrap();
-        assert!(cooldown.enabled_or_default());
+        assert!(cooldown.is_enabled());
         assert_eq!(cooldown.default_seconds_or_default(), 45);
         assert_eq!(cooldown.effective_trigger_statuses().as_ref(), &[429, 503]);
+    }
+
+    #[test]
+    fn partial_cooldown_block_still_loads_the_row() {
+        // AISIX-Cloud#1499 turned an absent `enabled` from ON into OFF.
+        // That is a semantic change only: a stored row carrying a
+        // cooldown block written before the change must still
+        // deserialize, because a model row the loader cannot parse is
+        // skipped whole.
+        let m: Model = serde_json::from_str(
+            r#"{
+              "display_name": "my-gpt4",
+              "provider": "openai",
+              "model_name": "gpt-4o",
+              "provider_key_id": "11111111-1111-1111-1111-111111111111",
+              "cooldown": {"default_seconds": 60}
+            }"#,
+        )
+        .expect("a cooldown block without `enabled` must still load");
+        let cooldown = m.cooldown.expect("cooldown block preserved");
+        assert_eq!(cooldown.default_seconds_or_default(), 60);
+        assert!(!cooldown.is_enabled());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1854,12 +1854,12 @@ async fn dispatch(
                             },
                         );
                         let retryable = is_retryable(&err, retry_on_429, fallback_statuses);
-                        tracing::warn!(
-                            target_model = %model.display_name,
-                            target_attempt = attempt_idx + 1,
-                            error = %err,
+                        crate::routing::log_attempt_failure(
+                            &model.display_name,
+                            attempt_idx + 1,
+                            &err,
                             retryable,
-                            "streaming routing target attempt failed",
+                            fallback_statuses,
                         );
                         if retryable {
                             state.health.record_failure(&model.display_name);
@@ -2953,12 +2953,12 @@ async fn dispatch(
                         },
                     );
                     let retryable = is_retryable(&err, retry_on_429, fallback_statuses);
-                    tracing::warn!(
-                        target_model = %model.display_name,
-                        target_attempt = attempt_idx + 1,
-                        error = %err,
+                    crate::routing::log_attempt_failure(
+                        &model.display_name,
+                        attempt_idx + 1,
+                        &err,
                         retryable,
-                        "routing target attempt failed",
+                        fallback_statuses,
                     );
                     if retryable {
                         state.health.record_failure(&model.display_name);

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -5938,9 +5938,51 @@ mod cooldown_tests {
         )
     }
 
+    /// The minimum an operator has to write to turn cooldown on. Every
+    /// default-knob test below runs against it, because an absent
+    /// `enabled` is now "off" and would make them all vacuously pass.
+    fn enabled() -> CooldownConfig {
+        CooldownConfig {
+            enabled: Some(true),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn no_cooldown_config_never_cools_down() {
+        // AISIX-Cloud#1499: a model whose operator never configured
+        // cooldown stays in rotation, whatever the upstream returns.
+        // Every status in the old built-in trigger list, plus the
+        // transport categories that used to fire on the same default.
+        for status in [401, 408, 429, 500, 502, 503, 504] {
+            assert!(
+                decide_cooldown(&upstream(status), None).is_none(),
+                "status={status} cooled down a model with no cooldown config"
+            );
+        }
+        assert!(decide_cooldown(&BridgeError::Transport("conn refused".into()), None).is_none());
+        assert!(decide_cooldown(&BridgeError::StreamAborted, None).is_none());
+        assert!(decide_cooldown(
+            &BridgeError::Timeout {
+                cause: String::new(),
+                elapsed_ms: 30_000
+            },
+            None
+        )
+        .is_none());
+        // A present block that never says `enabled: true` is the same
+        // "not asked for" — this is the shape the console writes when
+        // the operator only touched another knob.
+        let tuned = CooldownConfig {
+            default_seconds: Some(90),
+            ..Default::default()
+        };
+        assert!(decide_cooldown(&upstream(429), Some(&tuned)).is_none());
+    }
+
     #[test]
     fn default_config_cooldowns_429() {
-        let (ttl, reason) = decide_cooldown(&upstream(429), None).unwrap();
+        let (ttl, reason) = decide_cooldown(&upstream(429), Some(&enabled())).unwrap();
         assert_eq!(ttl, StdDuration::from_secs(30));
         assert_eq!(reason, "upstream_rate_limited");
     }
@@ -5951,21 +5993,21 @@ mod cooldown_tests {
         // (auth failure) should still take the target out of rotation,
         // because the same key will keep failing on subsequent
         // requests. The retry-vs-cooldown split is the whole point.
-        let (ttl, reason) = decide_cooldown(&upstream(401), None).unwrap();
+        let (ttl, reason) = decide_cooldown(&upstream(401), Some(&enabled())).unwrap();
         assert_eq!(ttl, StdDuration::from_secs(30));
         assert_eq!(reason, "upstream_auth_failure");
     }
 
     #[test]
     fn default_config_cooldowns_408() {
-        let (_, reason) = decide_cooldown(&upstream(408), None).unwrap();
+        let (_, reason) = decide_cooldown(&upstream(408), Some(&enabled())).unwrap();
         assert_eq!(reason, "upstream_request_timeout");
     }
 
     #[test]
     fn default_config_cooldowns_5xx() {
         for status in [500, 502, 503, 504] {
-            let (_, reason) = decide_cooldown(&upstream(status), None).unwrap();
+            let (_, reason) = decide_cooldown(&upstream(status), Some(&enabled())).unwrap();
             assert_eq!(reason, "upstream_server_error", "status={status}");
         }
     }
@@ -5974,9 +6016,9 @@ mod cooldown_tests {
     fn default_config_skips_400_and_other_4xx() {
         // Caller bugs (400, 403, 422) are not cooldown signals — the
         // model didn't fail, the request did.
-        assert!(decide_cooldown(&upstream(400), None).is_none());
-        assert!(decide_cooldown(&upstream(403), None).is_none());
-        assert!(decide_cooldown(&upstream(422), None).is_none());
+        assert!(decide_cooldown(&upstream(400), Some(&enabled())).is_none());
+        assert!(decide_cooldown(&upstream(403), Some(&enabled())).is_none());
+        assert!(decide_cooldown(&upstream(422), Some(&enabled())).is_none());
     }
 
     #[test]
@@ -5986,12 +6028,20 @@ mod cooldown_tests {
                 cause: String::new(),
                 elapsed_ms: 30_000
             },
-            None
+            Some(&enabled())
         )
         .is_some());
-        assert!(decide_cooldown(&BridgeError::Transport("conn refused".into()), None).is_some());
-        assert!(decide_cooldown(&BridgeError::StreamAborted, None).is_some());
-        assert!(decide_cooldown(&BridgeError::UpstreamDecode("bad json".into()), None).is_some());
+        assert!(decide_cooldown(
+            &BridgeError::Transport("conn refused".into()),
+            Some(&enabled())
+        )
+        .is_some());
+        assert!(decide_cooldown(&BridgeError::StreamAborted, Some(&enabled())).is_some());
+        assert!(decide_cooldown(
+            &BridgeError::UpstreamDecode("bad json".into()),
+            Some(&enabled())
+        )
+        .is_some());
     }
 
     #[test]
@@ -6010,7 +6060,7 @@ mod cooldown_tests {
         // already handles burst). 500s still cool down.
         let cfg = CooldownConfig {
             trigger_statuses: Some(vec![500, 502, 503]),
-            ..Default::default()
+            ..enabled()
         };
         assert!(decide_cooldown(&upstream(429), Some(&cfg)).is_none());
         assert!(decide_cooldown(&upstream(503), Some(&cfg)).is_some());
@@ -6018,7 +6068,8 @@ mod cooldown_tests {
 
     #[test]
     fn honor_retry_after_uses_upstream_hint() {
-        let (ttl, _) = decide_cooldown(&upstream_with_retry_after(429, 75), None).unwrap();
+        let (ttl, _) =
+            decide_cooldown(&upstream_with_retry_after(429, 75), Some(&enabled())).unwrap();
         assert_eq!(ttl, StdDuration::from_secs(75));
     }
 
@@ -6028,7 +6079,7 @@ mod cooldown_tests {
         // configured max so we don't lose the target for hours.
         let cfg = CooldownConfig {
             max_seconds: Some(60),
-            ..Default::default()
+            ..enabled()
         };
         let (ttl, _) =
             decide_cooldown(&upstream_with_retry_after(429, 100_000), Some(&cfg)).unwrap();
@@ -6040,7 +6091,7 @@ mod cooldown_tests {
         let cfg = CooldownConfig {
             honor_retry_after: Some(false),
             default_seconds: Some(45),
-            ..Default::default()
+            ..enabled()
         };
         let (ttl, _) = decide_cooldown(&upstream_with_retry_after(429, 5), Some(&cfg)).unwrap();
         assert_eq!(ttl, StdDuration::from_secs(45));
@@ -6050,7 +6101,7 @@ mod cooldown_tests {
     fn trigger_on_timeout_false_disables_timeout_cooldown() {
         let cfg = CooldownConfig {
             trigger_on_timeout: Some(false),
-            ..Default::default()
+            ..enabled()
         };
         assert!(decide_cooldown(
             &BridgeError::Timeout {
@@ -6065,7 +6116,9 @@ mod cooldown_tests {
     #[test]
     fn config_error_never_cools_down() {
         // Misconfig = WE are wrong; cooling down doesn't help.
-        assert!(decide_cooldown(&BridgeError::Config("bad key".into()), None).is_none());
+        assert!(
+            decide_cooldown(&BridgeError::Config("bad key".into()), Some(&enabled())).is_none()
+        );
     }
 }
 

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -1744,7 +1744,15 @@ mod tests {
             .await;
 
         let snap = new_snap(&upstream.uri());
-        snap.models.insert(model_entry("instruct"));
+        // Cooldown is opt-in (AISIX-Cloud#1499). The subject here is that
+        // this handler routes its failures through the cooldown
+        // chokepoint at all, so the model has to ask for cooldown.
+        let mut entry = model_entry("instruct");
+        entry.value.cooldown = Some(aisix_core::CooldownConfig {
+            enabled: Some(true),
+            ..Default::default()
+        });
+        snap.models.insert(entry);
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-proxy/src/cooldown.rs
+++ b/crates/aisix-proxy/src/cooldown.rs
@@ -47,13 +47,21 @@ use crate::health::ModelRuntimeStatusTracker;
 /// `default_seconds: 0` is treated as "do not cool down on this
 /// category" — matches the operator's likely intent of "disable
 /// cooldown TTL" (M-2 audit on PR #268).
+///
+/// Cooldown itself is opt-in. A model with no `cooldown` block never
+/// reaches the decision at all: it used to be handed a
+/// `CooldownConfig::default()` whose `enabled` then read as `true`,
+/// which is how every direct model nobody configured ended up cooling
+/// down for 30s on a built-in status list while the console showed the
+/// feature as disabled (AISIX-Cloud#1499). The knobs INSIDE an enabled
+/// block keep their defaults — those are parameters of a feature the
+/// operator opted into.
 pub fn decide_cooldown(
     err: &BridgeError,
     cfg: Option<&CooldownConfig>,
 ) -> Option<(Duration, &'static str)> {
-    let default_cfg = CooldownConfig::default();
-    let cfg = cfg.unwrap_or(&default_cfg);
-    if !cfg.enabled_or_default() {
+    let cfg = cfg?;
+    if !cfg.is_enabled() {
         return None;
     }
 
@@ -170,6 +178,16 @@ mod tests {
         BridgeError::upstream_status(status, "boom")
     }
 
+    /// The minimum an operator writes to turn cooldown on. Cooldown is
+    /// opt-in, so passing `None` here would make every knob assertion
+    /// below pass for the wrong reason.
+    fn enabled() -> CooldownConfig {
+        CooldownConfig {
+            enabled: Some(true),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn in_band_errors_cool_down_by_embedded_status_or_transport_gate() {
         let in_band = |status: Option<u16>| BridgeError::UpstreamInBand {
@@ -180,16 +198,17 @@ mod tests {
         };
         // Embedded status follows the trigger-status list: 503 is in
         // the default list, 400 is not.
-        let (ttl, reason) = decide_cooldown(&in_band(Some(503)), None).expect("cooldown");
+        let (ttl, reason) =
+            decide_cooldown(&in_band(Some(503)), Some(&enabled())).expect("cooldown");
         assert_eq!(reason, "upstream_server_error");
         assert!(ttl > Duration::ZERO);
-        assert!(decide_cooldown(&in_band(Some(400)), None).is_none());
+        assert!(decide_cooldown(&in_band(Some(400)), Some(&enabled())).is_none());
         // Status-less in-band errors follow the transport gate.
-        let (_, reason) = decide_cooldown(&in_band(None), None).expect("cooldown");
+        let (_, reason) = decide_cooldown(&in_band(None), Some(&enabled())).expect("cooldown");
         assert_eq!(reason, "upstream_in_band_error");
         let cfg = CooldownConfig {
             trigger_on_transport: Some(false),
-            ..Default::default()
+            ..enabled()
         };
         assert!(decide_cooldown(&in_band(None), Some(&cfg)).is_none());
     }
@@ -201,7 +220,7 @@ mod tests {
         // cap, which surprised operators who expected disable.
         let cfg = CooldownConfig {
             default_seconds: Some(0),
-            ..Default::default()
+            ..enabled()
         };
         assert!(decide_cooldown(&upstream(429), Some(&cfg)).is_none());
         assert!(decide_cooldown(&upstream(503), Some(&cfg)).is_none());
@@ -232,7 +251,8 @@ mod tests {
         // responses.rs / audio.rs / rerank.rs all route through here.
         let tracker = ModelRuntimeStatusTracker::new();
         let err = BridgeError::Transport("connection refused".into());
-        let returned = note_failure(&tracker, "m-1", None, err);
+        let cfg = enabled();
+        let returned = note_failure(&tracker, "m-1", Some(&cfg), err);
         // Error returned unchanged.
         assert!(matches!(returned, BridgeError::Transport(_)));
         // Tracker now reports cooldown for this target.
@@ -250,7 +270,8 @@ mod tests {
     fn note_failure_marks_cooldown_for_decode_errors() {
         let tracker = ModelRuntimeStatusTracker::new();
         let err = BridgeError::UpstreamDecode("bad json".into());
-        let _ = note_failure(&tracker, "m-1", None, err);
+        let cfg = enabled();
+        let _ = note_failure(&tracker, "m-1", Some(&cfg), err);
         assert_eq!(
             tracker.status("m-1").status,
             crate::health::RuntimeStatus::Cooldown
@@ -273,10 +294,25 @@ mod tests {
     }
 
     #[test]
+    fn note_failure_no_op_when_no_cooldown_config() {
+        // AISIX-Cloud#1499: `None` — the shape every model gets when the
+        // operator never enabled cooldown — takes nothing out of
+        // rotation. This is the same guard as the test above, on the
+        // input the control plane actually projects.
+        let tracker = ModelRuntimeStatusTracker::new();
+        let err = BridgeError::upstream_status(503, "boom");
+        let _ = note_failure(&tracker, "m-1", None, err);
+        assert_eq!(
+            tracker.status("m-1").status,
+            crate::health::RuntimeStatus::Healthy
+        );
+    }
+
+    #[test]
     fn honor_retry_after_clamps_to_max_seconds() {
         let cfg = CooldownConfig {
             max_seconds: Some(60),
-            ..Default::default()
+            ..enabled()
         };
         let err = BridgeError::upstream_status_with_retry_after(
             429,

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -543,6 +543,13 @@ async fn dispatch(
                         &e,
                         ProxyError::Bridge(be) if crate::routing::is_retryable(be, retry_on_429, fallback_statuses)
                     );
+                    crate::routing::log_attempt_failure(
+                        &target.model.display_name,
+                        attempt_idx + 1,
+                        &e,
+                        retryable,
+                        fallback_statuses,
+                    );
                     // See `RetryBudget::covers`: a default budget skips
                     // same-target retries for timeouts; fail-over is
                     // unaffected (the outer loop still moves on).

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -1939,7 +1939,15 @@ mod tests {
             .await;
 
         let snap = new_snap(&upstream.uri());
-        snap.models.insert(model_entry("embed-model"));
+        // Cooldown is opt-in (AISIX-Cloud#1499). The subject here is that
+        // this handler routes its failures through the cooldown
+        // chokepoint at all, so the model has to ask for cooldown.
+        let mut entry = model_entry("embed-model");
+        entry.value.cooldown = Some(aisix_core::CooldownConfig {
+            enabled: Some(true),
+            ..Default::default()
+        });
+        snap.models.insert(entry);
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -301,11 +301,6 @@ struct RuntimeEntry {
     /// target, so [`ModelRuntimeStatusTracker::sync_deployment_state`] can
     /// skip a write when nothing changed. `None` = never published.
     emitted_state: Option<DeploymentState>,
-    /// Reason and instant of the last `routing candidate excluded` line
-    /// written for this target, throttling that line to one per
-    /// [`EXCLUSION_LOG_INTERVAL`]. See
-    /// [`ModelRuntimeStatusTracker::should_log_exclusion`].
-    last_exclusion_log: Option<(&'static str, Instant)>,
 }
 
 impl RuntimeEntry {
@@ -540,6 +535,15 @@ pub struct ModelRuntimeStatusTracker {
     /// every method runs its historical write path. See
     /// [`BookkeepingFlags`].
     flags: Option<Arc<BookkeepingFlags>>,
+    /// When the last `routing candidate excluded` line was written, per
+    /// (routing group, target, reason). See
+    /// [`ModelRuntimeStatusTracker::should_log_exclusion`] for why the
+    /// group is part of the key and not just the target.
+    ///
+    /// Bounded by the configured groups times their members times the two
+    /// reasons; entries for a group or target the operator has since
+    /// deleted are never revisited and cost one key each.
+    exclusion_log: DashMap<(String, String, &'static str), Instant>,
 }
 
 /// RAII guard that decrements a target's in-flight counter when dropped.
@@ -652,6 +656,7 @@ impl ModelRuntimeStatusTracker {
             metrics: Some(metrics),
             snapshot: Some(snapshot),
             flags: Some(flags),
+            exclusion_log: DashMap::new(),
         }
     }
 
@@ -660,24 +665,34 @@ impl ModelRuntimeStatusTracker {
     }
 
     /// Rate gate for the `routing candidate excluded` line: true at most
-    /// once per [`EXCLUSION_LOG_INTERVAL`] for a given (target, reason).
+    /// once per [`EXCLUSION_LOG_INTERVAL`] for a given (routing group,
+    /// target, reason).
+    ///
+    /// The **group** is in the key because the line names one, and the
+    /// operator reads it per group. One direct model is routinely a
+    /// target of several groups; keyed on the target alone, a busy group
+    /// would win the window almost every time it opened and a quiet group
+    /// sharing that target would print nothing at all — leaving exactly
+    /// the "one attempt, no explanation" trace this line exists to
+    /// remove. It also decides `candidates`, which differs per group.
     ///
     /// A change of reason logs immediately rather than waiting out the
     /// previous window, so a target that goes from cooling to
     /// background-unhealthy is not hidden behind the cooling line. Only
     /// excluded candidates reach here, so the steady state of a healthy
     /// group takes no write lock at all.
-    pub(crate) fn should_log_exclusion(&self, model_id: &str, reason: &'static str) -> bool {
+    pub(crate) fn should_log_exclusion(
+        &self,
+        virtual_name: &str,
+        model_id: &str,
+        reason: &'static str,
+    ) -> bool {
         let now = Instant::now();
-        let mut entry = self.entries.entry(model_id.to_string()).or_default();
-        match entry.last_exclusion_log {
-            Some((last, at))
-                if last == reason && now.duration_since(at) < EXCLUSION_LOG_INTERVAL =>
-            {
-                false
-            }
+        let key = (virtual_name.to_string(), model_id.to_string(), reason);
+        match self.exclusion_log.get(&key) {
+            Some(at) if now.duration_since(*at) < EXCLUSION_LOG_INTERVAL => false,
             _ => {
-                entry.last_exclusion_log = Some((reason, now));
+                self.exclusion_log.insert(key, now);
                 true
             }
         }
@@ -1090,6 +1105,7 @@ mod tests {
             metrics: None,
             snapshot: None,
             flags: Some(flags),
+            ..Default::default()
         };
         (handle, t)
     }
@@ -1536,12 +1552,17 @@ mod tests {
         // the same (target, reason) twice inside the window, and never
         // let the window hide a target whose reason has changed.
         let t = ModelRuntimeStatusTracker::new();
-        assert!(t.should_log_exclusion("m-1", "cooling"));
-        assert!(!t.should_log_exclusion("m-1", "cooling"));
-        assert!(t.should_log_exclusion("m-1", "unhealthy"));
-        assert!(!t.should_log_exclusion("m-1", "unhealthy"));
+        assert!(t.should_log_exclusion("g-1", "m-1", "cooling"));
+        assert!(!t.should_log_exclusion("g-1", "m-1", "cooling"));
+        assert!(t.should_log_exclusion("g-1", "m-1", "unhealthy"));
+        assert!(!t.should_log_exclusion("g-1", "m-1", "unhealthy"));
         // Throttling is per target, not global.
-        assert!(t.should_log_exclusion("m-2", "cooling"));
+        assert!(t.should_log_exclusion("g-1", "m-2", "cooling"));
+        // …and per routing group: a second group that shares `m-1` still
+        // gets its own line, because it has its own `candidates` count and
+        // its own operator reading it.
+        assert!(t.should_log_exclusion("g-2", "m-1", "cooling"));
+        assert!(!t.should_log_exclusion("g-2", "m-1", "cooling"));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -17,7 +17,7 @@ use dashmap::DashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, RoutingStrategy};
@@ -301,6 +301,11 @@ struct RuntimeEntry {
     /// target, so [`ModelRuntimeStatusTracker::sync_deployment_state`] can
     /// skip a write when nothing changed. `None` = never published.
     emitted_state: Option<DeploymentState>,
+    /// Reason and instant of the last `routing candidate excluded` line
+    /// written for this target, throttling that line to one per
+    /// [`EXCLUSION_LOG_INTERVAL`]. See
+    /// [`ModelRuntimeStatusTracker::should_log_exclusion`].
+    last_exclusion_log: Option<(&'static str, Instant)>,
 }
 
 impl RuntimeEntry {
@@ -507,6 +512,14 @@ pub struct HealthTracker {
 /// jitter, roughly matching LiteLLM's last-10-samples moving average.
 const LATENCY_EWMA_ALPHA: f64 = 0.3;
 
+/// Minimum gap between two `routing candidate excluded` lines for the same
+/// (target, reason). The exclusion happens on the per-request routing path,
+/// so an unthrottled line would be one log per request for as long as a
+/// target stays out of rotation — on a busy gateway that is a flood, and a
+/// flood is what gets a diagnostic turned off before the incident that
+/// needs it.
+const EXCLUSION_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
 #[derive(Default, Debug)]
 pub struct ModelRuntimeStatusTracker {
     entries: DashMap<String, RuntimeEntry>,
@@ -644,6 +657,30 @@ impl ModelRuntimeStatusTracker {
 
     fn bookkeeping_active(&self) -> bool {
         self.flags.as_ref().is_none_or(|f| f.any_active())
+    }
+
+    /// Rate gate for the `routing candidate excluded` line: true at most
+    /// once per [`EXCLUSION_LOG_INTERVAL`] for a given (target, reason).
+    ///
+    /// A change of reason logs immediately rather than waiting out the
+    /// previous window, so a target that goes from cooling to
+    /// background-unhealthy is not hidden behind the cooling line. Only
+    /// excluded candidates reach here, so the steady state of a healthy
+    /// group takes no write lock at all.
+    pub(crate) fn should_log_exclusion(&self, model_id: &str, reason: &'static str) -> bool {
+        let now = Instant::now();
+        let mut entry = self.entries.entry(model_id.to_string()).or_default();
+        match entry.last_exclusion_log {
+            Some((last, at))
+                if last == reason && now.duration_since(at) < EXCLUSION_LOG_INTERVAL =>
+            {
+                false
+            }
+            _ => {
+                entry.last_exclusion_log = Some((reason, now));
+                true
+            }
+        }
     }
 
     pub fn mark_cooldown(&self, model_id: &str, ttl: Duration, reason: impl Into<String>) {
@@ -1490,6 +1527,21 @@ mod tests {
         assert_eq!(s.status, RuntimeStatus::Healthy);
         assert_eq!(s.last_check_status, Some(429));
         assert_eq!(s.status_reason.as_deref(), Some("ignored_transient_error"));
+    }
+
+    #[test]
+    fn exclusion_log_gate_throttles_a_repeat_and_lets_a_new_reason_through() {
+        // The gate is what keeps the `routing candidate excluded` WARN
+        // off the per-request hot path. Its two obligations: never write
+        // the same (target, reason) twice inside the window, and never
+        // let the window hide a target whose reason has changed.
+        let t = ModelRuntimeStatusTracker::new();
+        assert!(t.should_log_exclusion("m-1", "cooling"));
+        assert!(!t.should_log_exclusion("m-1", "cooling"));
+        assert!(t.should_log_exclusion("m-1", "unhealthy"));
+        assert!(!t.should_log_exclusion("m-1", "unhealthy"));
+        // Throttling is per target, not global.
+        assert!(t.should_log_exclusion("m-2", "cooling"));
     }
 
     #[test]

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -1399,7 +1399,15 @@ mod tests {
             .await;
 
         let snap = new_snap(&upstream.uri());
-        snap.models.insert(model_entry("img"));
+        // Cooldown is opt-in (AISIX-Cloud#1499). The subject here is that
+        // this handler routes its failures through the cooldown
+        // chokepoint at all, so the model has to ask for cooldown.
+        let mut entry = model_entry("img");
+        entry.value.cooldown = Some(aisix_core::CooldownConfig {
+            enabled: Some(true),
+            ..Default::default()
+        });
+        snap.models.insert(entry);
         snap.apikeys.insert(apikey_entry(&["*"]));
 
         let hub = Arc::new(Hub::new());

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -7236,8 +7236,15 @@ data: [DONE]\n\n";
             .insert(pk_entry_with_id("pk-flaky", &flaky_upstream.uri()));
         snap.provider_keys
             .insert(pk_entry_with_id("pk-stable", &stable_upstream.uri()));
-        snap.models
-            .insert(model_entry_with_id("m-flaky", "primary", "pk-flaky"));
+        // Cooldown is opt-in (AISIX-Cloud#1499): the primary has to ask
+        // to be taken out of rotation. The subject is that a retryable
+        // failure on request 1 keeps it out on request 2.
+        let mut flaky = model_entry_with_id("m-flaky", "primary", "pk-flaky");
+        flaky.value.cooldown = Some(aisix_core::CooldownConfig {
+            enabled: Some(true),
+            ..Default::default()
+        });
+        snap.models.insert(flaky);
         snap.models
             .insert(model_entry_with_id("m-stable", "secondary", "pk-stable"));
         snap.models.insert(routing_entry(

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -980,6 +980,13 @@ async fn dispatch(
                         &e,
                         ProxyError::Bridge(be) if crate::routing::is_retryable(be, retry_on_429, fallback_statuses)
                     );
+                    crate::routing::log_attempt_failure(
+                        &target.model.display_name,
+                        attempt_idx + 1,
+                        &e,
+                        retryable,
+                        fallback_statuses,
+                    );
                     let (error_class, error_message) = attempt_error_from_proxy(&e);
                     routing.record(
                         state,

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -895,6 +895,13 @@ async fn dispatch(
                         &e,
                         ProxyError::Bridge(be) if crate::routing::is_retryable(be, retry_on_429, fallback_statuses)
                     );
+                    crate::routing::log_attempt_failure(
+                        &target.model.display_name,
+                        attempt_idx + 1,
+                        &e,
+                        retryable,
+                        fallback_statuses,
+                    );
                     let (error_class, error_message) = attempt_error_from_proxy(&e);
                     routing.record(
                         state,

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -64,38 +64,6 @@ const FALLBACK_ALL_UNHEALTHY_RETRY_AFTER: Duration = Duration::from_secs(30);
 /// conditions (overload, queue full, quota): a status in the list is
 /// retryable regardless of the default classification. Empty by default,
 /// which preserves the historical behavior exactly.
-/// One WARN per failed routing-target attempt, naming the target, the
-/// error, whether the loop will move on, and the `fallback_on_statuses`
-/// list that answer was computed against.
-///
-/// Kept in one place because the endpoint family had already drifted:
-/// `/v1/chat/completions` wrote this line on both its branches while
-/// `/v1/messages`, `/v1/responses` and `/v1/messages/count_tokens`
-/// emitted nothing at all on a failed attempt, at any level.
-///
-/// The status list is on the line because the retry/failover decision is
-/// not reconstructable without it. A group configured to fail over on an
-/// upstream 400, whose projected snapshot never carried the list, refuses
-/// to fail over and leaves exactly the trace a group with one reachable
-/// candidate leaves — one attempt, error class `upstream_status`
-/// (AISIX-Cloud#1499).
-pub(crate) fn log_attempt_failure(
-    target_model: &str,
-    attempt_number: usize,
-    err: &dyn std::fmt::Display,
-    retryable: bool,
-    fallback_on_statuses: &[u16],
-) {
-    tracing::warn!(
-        target_model = %target_model,
-        target_attempt = attempt_number,
-        error = %err,
-        retryable,
-        ?fallback_on_statuses,
-        "routing target attempt failed",
-    );
-}
-
 pub fn is_retryable(err: &BridgeError, retry_on_429: bool, fallback_on_statuses: &[u16]) -> bool {
     match err {
         BridgeError::UpstreamStatus { status, .. } => {
@@ -148,6 +116,38 @@ pub fn is_retryable(err: &BridgeError, retry_on_429: bool, fallback_on_statuses:
         | BridgeError::Config(_)
         | BridgeError::StreamAborted => true,
     }
+}
+
+/// One WARN per failed routing-target attempt, naming the target, the
+/// error, whether the loop will move on, and the `fallback_on_statuses`
+/// list that answer was computed against.
+///
+/// Kept in one place because the endpoint family had already drifted:
+/// `/v1/chat/completions` wrote this line on both its branches while
+/// `/v1/messages`, `/v1/responses` and `/v1/messages/count_tokens`
+/// emitted nothing at all on a failed attempt, at any level.
+///
+/// The status list is on the line because the retry/failover decision is
+/// not reconstructable without it. A group configured to fail over on an
+/// upstream 400, whose projected snapshot never carried the list, refuses
+/// to fail over and leaves exactly the trace a group with one reachable
+/// candidate leaves — one attempt, error class `upstream_status`
+/// (AISIX-Cloud#1499).
+pub(crate) fn log_attempt_failure(
+    target_model: &str,
+    attempt_number: usize,
+    err: &dyn std::fmt::Display,
+    retryable: bool,
+    fallback_on_statuses: &[u16],
+) {
+    tracing::warn!(
+        target_model = %target_model,
+        target_attempt = attempt_number,
+        error = %err,
+        retryable,
+        ?fallback_on_statuses,
+        "routing target attempt failed",
+    );
 }
 
 /// Base delay before the first same-target retry. Each subsequent retry
@@ -1289,7 +1289,7 @@ fn log_candidate_exclusions(
     excluded: &[ExcludedCandidate],
 ) {
     for ex in excluded {
-        if !runtime_status.should_log_exclusion(&ex.id, ex.reason) {
+        if !runtime_status.should_log_exclusion(virtual_name, &ex.id, ex.reason) {
             continue;
         }
         tracing::warn!(
@@ -2629,6 +2629,34 @@ mod tests {
                 assert_eq!(excluded[0].id, "a");
                 assert_eq!(excluded[0].model, "a");
                 assert_eq!(excluded[0].reason, EXCLUDED_COOLING);
+            }
+            _ => panic!("expected Selected"),
+        }
+    }
+
+    #[test]
+    fn healthy_survivor_reports_both_cooling_and_unhealthy_drops() {
+        // The three-or-more-target group, which is the common production
+        // shape: one healthy survivor, one cooling, one background-dead.
+        // Without this case the `extend` that appends the unhealthy
+        // drops could be deleted outright and every other filter test
+        // would still pass — the group would quietly lose a target with
+        // nothing naming it, which is the whole failure this record
+        // exists to remove.
+        let t = crate::ModelRuntimeStatusTracker::new();
+        t.mark_cooldown("b", Duration::from_secs(30), "x");
+        t.mark_unhealthy("c", Some(503), "background_check_failed");
+        let attempts = vec![am("a"), am("b"), am("c")];
+        match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
+            FilterOutcome::Selected { attempts, excluded } => {
+                assert_eq!(attempts.len(), 1);
+                assert_eq!(attempts[0].id, "a");
+                let mut got: Vec<(&str, &str)> = excluded
+                    .iter()
+                    .map(|e| (e.model.as_str(), e.reason))
+                    .collect();
+                got.sort_unstable();
+                assert_eq!(got, [("b", EXCLUDED_COOLING), ("c", EXCLUDED_UNHEALTHY)]);
             }
             _ => panic!("expected Selected"),
         }

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -64,6 +64,38 @@ const FALLBACK_ALL_UNHEALTHY_RETRY_AFTER: Duration = Duration::from_secs(30);
 /// conditions (overload, queue full, quota): a status in the list is
 /// retryable regardless of the default classification. Empty by default,
 /// which preserves the historical behavior exactly.
+/// One WARN per failed routing-target attempt, naming the target, the
+/// error, whether the loop will move on, and the `fallback_on_statuses`
+/// list that answer was computed against.
+///
+/// Kept in one place because the endpoint family had already drifted:
+/// `/v1/chat/completions` wrote this line on both its branches while
+/// `/v1/messages`, `/v1/responses` and `/v1/messages/count_tokens`
+/// emitted nothing at all on a failed attempt, at any level.
+///
+/// The status list is on the line because the retry/failover decision is
+/// not reconstructable without it. A group configured to fail over on an
+/// upstream 400, whose projected snapshot never carried the list, refuses
+/// to fail over and leaves exactly the trace a group with one reachable
+/// candidate leaves — one attempt, error class `upstream_status`
+/// (AISIX-Cloud#1499).
+pub(crate) fn log_attempt_failure(
+    target_model: &str,
+    attempt_number: usize,
+    err: &dyn std::fmt::Display,
+    retryable: bool,
+    fallback_on_statuses: &[u16],
+) {
+    tracing::warn!(
+        target_model = %target_model,
+        target_attempt = attempt_number,
+        error = %err,
+        retryable,
+        ?fallback_on_statuses,
+        "routing target attempt failed",
+    );
+}
+
 pub fn is_retryable(err: &BridgeError, retry_on_429: bool, fallback_on_statuses: &[u16]) -> bool {
     match err {
         BridgeError::UpstreamStatus { status, .. } => {
@@ -941,20 +973,62 @@ pub(crate) struct AttemptModel {
     pub weight: u32,
 }
 
+/// A candidate the health/cooldown filter dropped, kept so the caller can
+/// say WHICH target went and WHY.
+///
+/// Without it the exclusion is invisible: the request records one attempt
+/// against the surviving target and nothing anywhere names the one that was
+/// never tried, so "the group failed over to nobody" and "the group only
+/// ever had one candidate" produce the identical trace
+/// (AISIX-Cloud#1499).
+pub(crate) struct ExcludedCandidate {
+    /// Snapshot id of the dropped target — the key health/cooldown state
+    /// is tracked under.
+    pub id: String,
+    /// The target's configured `display_name`, i.e. the name the operator
+    /// wrote in `routing.targets`.
+    pub model: String,
+    pub reason: &'static str,
+}
+
+/// `reason` on an [`ExcludedCandidate`] dropped for an unexpired
+/// request-path cooldown.
+pub(crate) const EXCLUDED_COOLING: &str = "cooling";
+/// `reason` on an [`ExcludedCandidate`] dropped because its background
+/// health check has it marked down.
+pub(crate) const EXCLUDED_UNHEALTHY: &str = "unhealthy";
+
 /// Outcome of routing-candidate filtering. Lifts the "all candidates
 /// excluded" case out into a typed result so the dispatch loop can
 /// short-circuit to a 503 + Retry-After instead of sending traffic to
 /// a target we just confirmed is bad.
 pub(crate) enum FilterOutcome {
-    /// At least one candidate survived the filter. The returned vector
-    /// is the filtered attempt list, in the original strategy order
-    /// minus the excluded entries.
-    Selected(Vec<AttemptModel>),
+    /// At least one candidate survived the filter. `attempts` is the
+    /// filtered list, in the original strategy order minus the excluded
+    /// entries; `excluded` names what was dropped to get there.
+    Selected {
+        attempts: Vec<AttemptModel>,
+        excluded: Vec<ExcludedCandidate>,
+    },
     /// Every candidate is currently background-unhealthy and the
     /// routing model is configured with `when_all_unavailable: fail`. The
     /// caller should surface a 503 with the supplied Retry-After hint
     /// (in seconds), if any.
-    AllUnhealthy { retry_after_secs: Option<u64> },
+    AllUnhealthy {
+        retry_after_secs: Option<u64>,
+        excluded: Vec<ExcludedCandidate>,
+    },
+}
+
+fn excluded(attempts: &[AttemptModel], reason: &'static str) -> Vec<ExcludedCandidate> {
+    attempts
+        .iter()
+        .map(|a| ExcludedCandidate {
+            id: a.id.clone(),
+            model: a.model.display_name.clone(),
+            reason,
+        })
+        .collect()
 }
 
 pub(crate) fn filter_attempt_models(
@@ -964,7 +1038,7 @@ pub(crate) fn filter_attempt_models(
 ) -> FilterOutcome {
     let mut healthy = Vec::new();
     let mut cooldown_only = Vec::new();
-    let mut unhealthy_count = 0usize;
+    let mut unhealthy = Vec::new();
 
     for attempt in attempts.iter().cloned() {
         let stale_after = attempt
@@ -974,7 +1048,7 @@ pub(crate) fn filter_attempt_models(
             .map(|cfg| Duration::from_secs(cfg.stale_after_seconds));
         let snapshot = runtime_status.status_with_stale(&attempt.id, stale_after);
         match snapshot.status {
-            crate::RuntimeStatus::Unhealthy => unhealthy_count += 1,
+            crate::RuntimeStatus::Unhealthy => unhealthy.push(attempt),
             crate::RuntimeStatus::Cooldown => cooldown_only.push(attempt),
             crate::RuntimeStatus::Healthy | crate::RuntimeStatus::NotApplicable => {
                 healthy.push(attempt)
@@ -983,7 +1057,12 @@ pub(crate) fn filter_attempt_models(
     }
 
     if !healthy.is_empty() {
-        return FilterOutcome::Selected(healthy);
+        let mut dropped = excluded(&cooldown_only, EXCLUDED_COOLING);
+        dropped.extend(excluded(&unhealthy, EXCLUDED_UNHEALTHY));
+        return FilterOutcome::Selected {
+            attempts: healthy,
+            excluded: dropped,
+        };
     }
     // No healthy candidates — prefer cooldown over unhealthy when
     // some non-unhealthy candidates exist. Sending to a target whose
@@ -997,8 +1076,11 @@ pub(crate) fn filter_attempt_models(
     // race window — a candidate flipping to unhealthy between the two
     // reads could yield an empty `Selected`, which streaming callers
     // turn into a panic by indexing `attempt_models[0]`.
-    if unhealthy_count < attempts.len() && !cooldown_only.is_empty() {
-        return FilterOutcome::Selected(cooldown_only);
+    if !cooldown_only.is_empty() {
+        return FilterOutcome::Selected {
+            excluded: excluded(&unhealthy, EXCLUDED_UNHEALTHY),
+            attempts: cooldown_only,
+        };
     }
     // All candidates are excluded. Policy decides.
     //
@@ -1012,8 +1094,14 @@ pub(crate) fn filter_attempt_models(
     match policy {
         WhenAllUnavailablePolicy::Fail => FilterOutcome::AllUnhealthy {
             retry_after_secs: Some(FALLBACK_ALL_UNHEALTHY_RETRY_AFTER.as_secs()),
+            excluded: excluded(&unhealthy, EXCLUDED_UNHEALTHY),
         },
-        WhenAllUnavailablePolicy::TryAnyway => FilterOutcome::Selected(attempts),
+        // `try_anyway` dispatches the unfiltered list, so nothing was
+        // dropped and there is no exclusion to report.
+        WhenAllUnavailablePolicy::TryAnyway => FilterOutcome::Selected {
+            attempts,
+            excluded: Vec::new(),
+        },
     }
 }
 
@@ -1164,8 +1252,15 @@ pub(crate) fn resolve_attempt_models(
         resolved,
         routing.when_all_unavailable_or_default(),
     ) {
-        FilterOutcome::Selected(list) => Ok(list),
-        FilterOutcome::AllUnhealthy { retry_after_secs } => {
+        FilterOutcome::Selected { attempts, excluded } => {
+            log_candidate_exclusions(runtime_status, virtual_name, attempts.len(), &excluded);
+            Ok(attempts)
+        }
+        FilterOutcome::AllUnhealthy {
+            retry_after_secs,
+            excluded,
+        } => {
+            log_candidate_exclusions(runtime_status, virtual_name, 0, &excluded);
             tracing::warn!(
                 virtual_model = %virtual_name,
                 retry_after_secs,
@@ -1173,6 +1268,37 @@ pub(crate) fn resolve_attempt_models(
             );
             Err(ProxyError::AllCandidatesUnavailable { retry_after_secs })
         }
+    }
+}
+
+/// Name every target the health/cooldown filter dropped, and how many
+/// candidates the dispatch loop is left with.
+///
+/// At WARN, because a group running on fewer targets than the operator
+/// configured is a degraded state they want to see without having raised
+/// verbosity first — an incident is diagnosed from the log level the
+/// gateway was already running at, and `info` is the default. Throttled per
+/// (target, reason) by
+/// [`crate::ModelRuntimeStatusTracker::should_log_exclusion`] so a cooling
+/// target in a busy group produces one line a minute rather than one per
+/// request.
+fn log_candidate_exclusions(
+    runtime_status: &crate::ModelRuntimeStatusTracker,
+    virtual_name: &str,
+    candidates: usize,
+    excluded: &[ExcludedCandidate],
+) {
+    for ex in excluded {
+        if !runtime_status.should_log_exclusion(&ex.id, ex.reason) {
+            continue;
+        }
+        tracing::warn!(
+            virtual_model = %virtual_name,
+            target_model = %ex.model,
+            reason = ex.reason,
+            candidates,
+            "routing candidate excluded before dispatch",
+        );
     }
 }
 
@@ -2477,8 +2603,9 @@ mod tests {
         let t = crate::ModelRuntimeStatusTracker::new();
         let attempts = vec![am("a"), am("b")];
         match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
-            FilterOutcome::Selected(list) => {
-                assert_eq!(list.len(), 2);
+            FilterOutcome::Selected { attempts, excluded } => {
+                assert_eq!(attempts.len(), 2);
+                assert!(excluded.is_empty());
             }
             other => panic!(
                 "expected Selected, got {:?}",
@@ -2493,9 +2620,15 @@ mod tests {
         t.mark_cooldown("a", Duration::from_secs(30), "retryable_failure");
         let attempts = vec![am("a"), am("b")];
         match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
-            FilterOutcome::Selected(list) => {
-                assert_eq!(list.len(), 1);
-                assert_eq!(list[0].id, "b");
+            FilterOutcome::Selected { attempts, excluded } => {
+                assert_eq!(attempts.len(), 1);
+                assert_eq!(attempts[0].id, "b");
+                // The dropped target is named, with why — the record the
+                // dispatch loop turns into the WARN line.
+                assert_eq!(excluded.len(), 1);
+                assert_eq!(excluded[0].id, "a");
+                assert_eq!(excluded[0].model, "a");
+                assert_eq!(excluded[0].reason, EXCLUDED_COOLING);
             }
             _ => panic!("expected Selected"),
         }
@@ -2512,8 +2645,15 @@ mod tests {
         t.mark_unhealthy("b", Some(503), "background_check_failed");
         let attempts = vec![am("a"), am("b")];
         match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
-            FilterOutcome::AllUnhealthy { retry_after_secs } => {
+            FilterOutcome::AllUnhealthy {
+                retry_after_secs,
+                excluded,
+            } => {
                 assert_eq!(retry_after_secs, Some(30));
+                let mut names: Vec<&str> = excluded.iter().map(|e| e.model.as_str()).collect();
+                names.sort_unstable();
+                assert_eq!(names, ["a", "b"]);
+                assert!(excluded.iter().all(|e| e.reason == EXCLUDED_UNHEALTHY));
             }
             _ => panic!("expected AllUnhealthy"),
         }
@@ -2530,9 +2670,16 @@ mod tests {
         t.mark_cooldown("c", Duration::from_secs(30), "x");
         let attempts = vec![am("a"), am("b"), am("c")];
         match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
-            FilterOutcome::Selected(list) => {
-                assert_eq!(list.len(), 1);
-                assert_eq!(list[0].id, "c");
+            FilterOutcome::Selected { attempts, excluded } => {
+                assert_eq!(attempts.len(), 1);
+                assert_eq!(attempts[0].id, "c");
+                // `c` was dispatched, so only the two unhealthy targets
+                // count as excluded — a candidate that gets used is not
+                // reported as dropped.
+                let mut names: Vec<&str> = excluded.iter().map(|e| e.model.as_str()).collect();
+                names.sort_unstable();
+                assert_eq!(names, ["a", "b"]);
+                assert!(excluded.iter().all(|e| e.reason == EXCLUDED_UNHEALTHY));
             }
             _ => panic!("expected Selected with cooldown candidate"),
         }
@@ -2546,8 +2693,11 @@ mod tests {
         t.mark_unhealthy("b", Some(503), "background_check_failed");
         let attempts = vec![am("a"), am("b")];
         match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::TryAnyway) {
-            FilterOutcome::Selected(list) => {
-                assert_eq!(list.len(), 2);
+            FilterOutcome::Selected { attempts, excluded } => {
+                assert_eq!(attempts.len(), 2);
+                // Nothing was dropped: `try_anyway` dispatches the whole
+                // list, so reporting an exclusion here would be a lie.
+                assert!(excluded.is_empty());
             }
             _ => panic!("expected Selected under TryAnyway policy"),
         }
@@ -2563,8 +2713,9 @@ mod tests {
         t.mark_cooldown("b", Duration::from_secs(30), "x");
         let attempts = vec![am("a"), am("b")];
         match filter_attempt_models(&t, attempts, WhenAllUnavailablePolicy::Fail) {
-            FilterOutcome::Selected(list) => {
-                assert_eq!(list.len(), 2);
+            FilterOutcome::Selected { attempts, excluded } => {
+                assert_eq!(attempts.len(), 2);
+                assert!(excluded.is_empty());
             }
             _ => panic!("expected Selected for cooldown-only"),
         }

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -103,7 +103,7 @@
     },
     "CooldownConfig": {
       "additionalProperties": false,
-      "description": "Request-path cooldown settings for a direct model after retryable upstream failures.",
+      "description": "Request-path cooldown settings for a direct model after retryable upstream failures. Cooldown is opt-in: it runs only when `enabled` is `true`.",
       "properties": {
         "default_seconds": {
           "description": "Cooldown TTL in seconds when the upstream did not supply a `Retry-After` header or `honor_retry_after` is `false`.",
@@ -112,7 +112,7 @@
           "type": "integer"
         },
         "enabled": {
-          "description": "Whether cooldown is active for this model. Set to `false` to keep the model in rotation regardless of upstream failures.",
+          "description": "Whether cooldown is active for this model. Cooldown is off unless this is set to `true`, so a model that omits it stays in rotation regardless of upstream failures.",
           "type": "boolean"
         },
         "honor_retry_after": {
@@ -999,7 +999,7 @@
           "$ref": "#/definitions/CooldownConfig"
         }
       ],
-      "description": "Direct-model-only request-path cooldown configuration. Omit this field to use the built-in cooldown behavior."
+      "description": "Direct-model-only request-path cooldown configuration. Cooldown is opt-in: omit this field, or leave `enabled` unset, and the model is never taken out of rotation by request-path failures."
     },
     "cost": {
       "allOf": [

--- a/tests/e2e/src/cases/consistent-hash-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/consistent-hash-routing-e2e.test.ts
@@ -350,7 +350,7 @@ describe("consistent-hash routing + priority tiers e2e", () => {
       },
     });
     await createMember("ch-recover-a1", a1, {
-      cooldown: { default_seconds: 1 },
+      cooldown: { enabled: true, default_seconds: 1 },
     });
     await createMember("ch-recover-b1", b1);
     await waitMembersVisible(["ch-recover-a1", "ch-recover-b1"]);

--- a/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
+++ b/tests/e2e/src/cases/cooldown-contract-e2e.test.ts
@@ -97,6 +97,9 @@ describe("cooldown contract (H1) — 401 cools down despite being non-retryable"
         provider: "openai",
         model_name: "gpt-4o-mini",
         provider_key_id: failPk.id,
+        // Cooldown is opt-in — this suite's subject is what an
+        // operator who enabled it gets.
+        cooldown: { enabled: true },
       })
     ).id;
     await seed.createModel({
@@ -250,6 +253,9 @@ describe("cooldown contract (M1) — 429 cools down even when retry_on_429=false
         provider: "openai",
         model_name: "gpt-4o-mini",
         provider_key_id: rateLimitedPk.id,
+        // Cooldown is opt-in — this suite's subject is what an
+        // operator who enabled it gets.
+        cooldown: { enabled: true },
       })
     ).id;
     await seed.createModel({
@@ -405,6 +411,9 @@ describe("cooldown contract (H2) — Retry-After header from upstream drives TTL
         provider: "openai",
         model_name: "gpt-4o-mini",
         provider_key_id: upstreamPk.id,
+        // Cooldown is opt-in — this suite's subject is what an
+        // operator who enabled it gets.
+        cooldown: { enabled: true },
       })
     ).id;
     await seed.createModel({
@@ -807,6 +816,9 @@ describe("cooldown observability — a cooldown transition emits aisix_deploymen
         provider: "openai",
         model_name: "gpt-4o-mini",
         provider_key_id: failPk.id,
+        // Cooldown is opt-in — this suite's subject is what an
+        // operator who enabled it gets.
+        cooldown: { enabled: true },
       })
     ).id;
     await seed.createModel({
@@ -1004,7 +1016,7 @@ describe("cooldown observability — the state gauge follows a target back into 
         provider_key_id: flakyPk.id,
         // A 1s TTL keeps the test honest: it must observe the cooldown
         // lapsing on its own, which is what the router does in production.
-        cooldown: { default_seconds: 1 },
+        cooldown: { enabled: true, default_seconds: 1 },
       })
     ).id;
     await seed.createModel({

--- a/tests/e2e/src/cases/cooldown-opt-in-e2e.test.ts
+++ b/tests/e2e/src/cases/cooldown-opt-in-e2e.test.ts
@@ -1,0 +1,433 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  AdminClient,
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+/**
+ * Two contracts that live next to each other (AISIX-Cloud#1499).
+ *
+ * 1. **Cooldown is opt-in.** A direct model whose operator never wrote a
+ *    `cooldown` block is never taken out of rotation, however the
+ *    upstream fails. It used to be the opposite: an absent block became
+ *    a default one that read as enabled, so every such model cooled for
+ *    30s on a built-in status list — 401/408/429/500/502/503/504 — while
+ *    the console showed cooldown as disabled.
+ * 2. **An exclusion is on the record.** When cooldown IS enabled and the
+ *    filter drops the cooling target before the dispatch loop starts,
+ *    the gateway says so, naming the target and the reason, at a level a
+ *    production deployment is already running at. Without it the request
+ *    that never tried the target and the group that only ever had one
+ *    candidate leave the same trace.
+ */
+
+const CALLER_PLAINTEXT = "sk-cooldown-opt-in-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+function okBody(content: string) {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe("cooldown is opt-in — an unconfigured model stays in rotation", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  let failing: OpenAiUpstream | undefined;
+  let stable: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    // 503 is in the trigger list the gateway used to apply on its own.
+    failing = await startOpenAiUpstream({
+      status: 503,
+      errorBody: { error: { message: "upstream down", type: "server_error" } },
+    });
+    stable = await startOpenAiUpstream({ nonStreamBody: okBody("stable-served") });
+
+    app = await spawnApp({ admin: false });
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const failPk = await seed.createProviderKey({
+      display_name: "optin-fail-pk",
+      secret: "sk-mock",
+      api_base: `${failing.baseUrl}/v1`,
+    });
+    const stablePk = await seed.createProviderKey({
+      display_name: "optin-stable-pk",
+      secret: "sk-mock",
+      api_base: `${stable.baseUrl}/v1`,
+    });
+
+    // No `cooldown` block anywhere — exactly what the control plane
+    // projects for an operator who left cooldown switched off.
+    await seed.createModel({
+      display_name: "optin-primary",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: failPk.id,
+    });
+    await seed.createModel({
+      display_name: "optin-stable",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: stablePk.id,
+    });
+    await seed.createModel({
+      display_name: "optin-router",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "optin-primary" }, { model: "optin-stable" }],
+        max_fallbacks: 1,
+      },
+    });
+    // Seeded last: the key authenticating is the gate that implies every
+    // resource above is in the snapshot.
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["optin-router"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await failing?.close();
+    await stable?.close();
+  });
+
+  test("a 503 on a model with no cooldown config leaves it in the candidate list", async (ctx) => {
+    if (!etcdReachable || !app || !admin || !failing || !stable) {
+      ctx.skip();
+      return;
+    }
+    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => (await probe.listModels()).status === 200);
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    const first = await client.chat.completions.create({
+      model: "optin-router",
+      messages: [{ role: "user", content: "first" }],
+    });
+    expect(first.choices[0]?.message.content).toBe("stable-served");
+    const failedOnce = failing.receivedRequests.length;
+    expect(failedOnce).toBeGreaterThan(0);
+
+    const second = await client.chat.completions.create({
+      model: "optin-router",
+      messages: [{ role: "user", content: "second" }],
+    });
+    expect(second.choices[0]?.message.content).toBe("stable-served");
+
+    // The regression: with the old built-in default the 503 cooled the
+    // primary for 30s and the second request never reached it, so this
+    // delta was 0.
+    expect(failing.receivedRequests.length - failedOnce).toBeGreaterThan(0);
+
+    const row = (await admin.listModelStatuses()).find(
+      (r) => r.display_name === "optin-primary",
+    );
+    expect(row?.status).toBe("healthy");
+  });
+});
+
+describe("an enabled cooldown records the exclusion it causes", () => {
+  let app: SpawnedApp | undefined;
+  let admin: AdminClient | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  let failing: OpenAiUpstream | undefined;
+  let stable: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    failing = await startOpenAiUpstream({
+      status: 503,
+      errorBody: { error: { message: "upstream down", type: "server_error" } },
+    });
+    stable = await startOpenAiUpstream({ nonStreamBody: okBody("survivor-served") });
+
+    // Spawned at the harness default level. The lines asserted below
+    // have to be visible without an operator having raised verbosity in
+    // advance — nobody turns on debug before the incident.
+    app = await spawnApp({ admin: false });
+    admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const failPk = await seed.createProviderKey({
+      display_name: "excl-fail-pk",
+      secret: "sk-mock",
+      api_base: `${failing.baseUrl}/v1`,
+    });
+    const stablePk = await seed.createProviderKey({
+      display_name: "excl-stable-pk",
+      secret: "sk-mock",
+      api_base: `${stable.baseUrl}/v1`,
+    });
+
+    await seed.createModel({
+      display_name: "excl-primary",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: failPk.id,
+      cooldown: { enabled: true, default_seconds: 120 },
+    });
+    await seed.createModel({
+      display_name: "excl-stable",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: stablePk.id,
+    });
+    await seed.createModel({
+      display_name: "excl-router",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "excl-primary" }, { model: "excl-stable" }],
+        max_fallbacks: 1,
+        fallback_on_statuses: [418],
+      },
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["excl-router"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await failing?.close();
+    await stable?.close();
+  });
+
+  test("the dropped target and its reason reach the log, with the surviving candidate count", async (ctx) => {
+    if (!etcdReachable || !app || !admin || !failing || !stable) {
+      ctx.skip();
+      return;
+    }
+    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => (await probe.listModels()).status === 200);
+
+    const client = new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+
+    // Request 1 trips the cooldown; request 2 is the one whose candidate
+    // list is short by a target.
+    await client.chat.completions.create({
+      model: "excl-router",
+      messages: [{ role: "user", content: "trip the cooldown" }],
+    });
+    await waitConfigPropagation(async () => {
+      const rows = await admin!.listModelStatuses();
+      return rows.some(
+        (r) => r.display_name === "excl-primary" && r.status === "cooldown",
+      );
+    });
+    const beforeSecond = failing.receivedRequests.length;
+
+    const second = await client.chat.completions.create({
+      model: "excl-router",
+      messages: [{ role: "user", content: "served by the survivor" }],
+    });
+    expect(second.choices[0]?.message.content).toBe("survivor-served");
+    expect(failing.receivedRequests.length - beforeSecond).toBe(0);
+
+    const out = app.output();
+    const excluded = out
+      .split("\n")
+      .filter((l) => l.includes("routing candidate excluded before dispatch"));
+    expect(
+      excluded.length,
+      `no exclusion line in gateway output:\n${out}`,
+    ).toBeGreaterThan(0);
+    const line = excluded[0]!;
+    expect(line).toContain("excl-primary");
+    expect(line).toContain("excl-router");
+    expect(line).toMatch(/reason="?cooling"?/);
+    // The list the dispatch loop was actually left with.
+    expect(line).toContain("candidates=1");
+
+    // The other half of the same question: request 1 above produced a
+    // real upstream failure on `excl-primary`, and the line that records
+    // it names the fallback status list the retry/failover decision was
+    // judged against — so an operator can tell "the status was not in
+    // the list" from "the list never reached the gateway". Before this
+    // change only /v1/chat/completions wrote such a line at all.
+    const failures = out
+      .split("\n")
+      .filter((l) => l.includes("routing target attempt failed"));
+    expect(
+      failures.length,
+      `no attempt-failure line in gateway output:\n${out}`,
+    ).toBeGreaterThan(0);
+    expect(failures[0]!).toContain("excl-primary");
+    expect(failures[0]!).toContain("fallback_on_statuses=[418]");
+  });
+});
+
+/**
+ * Family lockstep. The failed-attempt WARN existed only on
+ * `/v1/chat/completions`; `/v1/messages`, `/v1/messages/count_tokens` and
+ * `/v1/responses` walked routing targets and recorded nothing at any
+ * level, so the same incident on an Anthropic-SDK or Codex client left no
+ * trace at all. All four now share one emitter.
+ */
+describe("every routing endpoint records a failed target attempt", () => {
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  let failing: OpenAiUpstream | undefined;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    // Path-agnostic mock: every endpoint the four handlers call gets the
+    // same 503.
+    failing = await startOpenAiUpstream({
+      status: 503,
+      errorBody: { error: { message: "upstream down", type: "server_error" } },
+    });
+
+    app = await spawnApp({ admin: false });
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const openaiPk = await seed.createProviderKey({
+      display_name: "fam-openai-pk",
+      secret: "sk-mock",
+      api_base: `${failing.baseUrl}/v1`,
+    });
+    const anthropicPk = await seed.createProviderKey({
+      display_name: "fam-anthropic-pk",
+      provider: "anthropic",
+      adapter: "anthropic",
+      secret: "sk-ant-mock",
+      // The Anthropic bridge appends /v1/messages itself.
+      api_base: failing.baseUrl,
+    });
+
+    await seed.createModel({
+      display_name: "fam-openai-target",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: openaiPk.id,
+    });
+    await seed.createModel({
+      display_name: "fam-anthropic-target",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: anthropicPk.id,
+    });
+    await seed.createModel({
+      display_name: "fam-openai-router",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "fam-openai-target" }],
+        max_fallbacks: 0,
+      },
+    });
+    await seed.createModel({
+      display_name: "fam-anthropic-router",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "fam-anthropic-target" }],
+        max_fallbacks: 0,
+      },
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["fam-openai-router", "fam-anthropic-router"],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await failing?.close();
+  });
+
+  test("/v1/messages, /v1/messages/count_tokens and /v1/responses each name the target that failed", async (ctx) => {
+    if (!etcdReachable || !app || !failing) {
+      ctx.skip();
+      return;
+    }
+    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => (await probe.listModels()).status === 200);
+
+    const post = async (path: string, body: unknown) =>
+      fetch(`${app!.proxyUrl}${path}`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${CALLER_PLAINTEXT}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+    await post("/v1/messages", {
+      model: "fam-anthropic-router",
+      max_tokens: 64,
+      messages: [{ role: "user", content: "hello" }],
+    });
+    await post("/v1/messages/count_tokens", {
+      model: "fam-anthropic-router",
+      messages: [{ role: "user", content: "hello" }],
+    });
+    await post("/v1/responses", {
+      model: "fam-openai-router",
+      input: "hello",
+    });
+
+    const failures = app
+      .output()
+      .split("\n")
+      .filter((l) => l.includes("routing target attempt failed"));
+    // Each of the three requests failed on its group's only target, so
+    // each owes at least one line naming it.
+    expect(
+      failures.filter((l) => l.includes("fam-anthropic-target")).length,
+      `no attempt-failure line for the Anthropic-shape endpoints:\n${app.output()}`,
+    ).toBeGreaterThan(0);
+    expect(
+      failures.filter((l) => l.includes("fam-openai-target")).length,
+      `no attempt-failure line for /v1/responses:\n${app.output()}`,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/src/cases/cooldown-opt-in-e2e.test.ts
+++ b/tests/e2e/src/cases/cooldown-opt-in-e2e.test.ts
@@ -182,10 +182,13 @@ describe("an enabled cooldown records the exclusion it causes", () => {
     });
     stable = await startOpenAiUpstream({ nonStreamBody: okBody("survivor-served") });
 
-    // Spawned at the harness default level. The lines asserted below
-    // have to be visible without an operator having raised verbosity in
-    // advance — nobody turns on debug before the incident.
-    app = await spawnApp({ admin: false });
+    // Pinned to the gateway's own production default
+    // (`observability.log_level: info`) rather than the harness default
+    // of `warn`, because the claim under test is that these lines are
+    // visible without an operator having raised verbosity in advance —
+    // nobody turns on debug before the incident. Passing it explicitly
+    // also keeps an ambient `RUST_LOG` from deciding the outcome.
+    app = await spawnApp({ admin: false, logLevel: "info" });
     admin = new AdminClient(app.adminUrl, app.adminKey, app.metricsUrl);
     seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -327,7 +330,7 @@ describe("every routing endpoint records a failed target attempt", () => {
       errorBody: { error: { message: "upstream down", type: "server_error" } },
     });
 
-    app = await spawnApp({ admin: false });
+    app = await spawnApp({ admin: false, logLevel: "info" });
     seed = new SeedClient(etcd, app.etcdPrefix);
 
     const openaiPk = await seed.createProviderKey({
@@ -356,6 +359,16 @@ describe("every routing endpoint records a failed target attempt", () => {
       model_name: "claude-3-5-haiku-20241022",
       provider_key_id: anthropicPk.id,
     });
+    // count_tokens gets a target of its own. Sharing one with
+    // /v1/messages would let either endpoint's line satisfy the
+    // assertion for both, and the endpoint whose emitter is not pinned
+    // alone is the one free to drift out again.
+    await seed.createModel({
+      display_name: "fam-count-tokens-target",
+      provider: "anthropic",
+      model_name: "claude-3-5-haiku-20241022",
+      provider_key_id: anthropicPk.id,
+    });
     await seed.createModel({
       display_name: "fam-openai-router",
       routing: {
@@ -372,9 +385,21 @@ describe("every routing endpoint records a failed target attempt", () => {
         max_fallbacks: 0,
       },
     });
+    await seed.createModel({
+      display_name: "fam-count-tokens-router",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "fam-count-tokens-target" }],
+        max_fallbacks: 0,
+      },
+    });
     await seed.createApiKey({
       key_hash: CALLER_KEY_HASH,
-      allowed_models: ["fam-openai-router", "fam-anthropic-router"],
+      allowed_models: [
+        "fam-openai-router",
+        "fam-anthropic-router",
+        "fam-count-tokens-router",
+      ],
     });
   });
 
@@ -407,7 +432,7 @@ describe("every routing endpoint records a failed target attempt", () => {
       messages: [{ role: "user", content: "hello" }],
     });
     await post("/v1/messages/count_tokens", {
-      model: "fam-anthropic-router",
+      model: "fam-count-tokens-router",
       messages: [{ role: "user", content: "hello" }],
     });
     await post("/v1/responses", {
@@ -419,15 +444,18 @@ describe("every routing endpoint records a failed target attempt", () => {
       .output()
       .split("\n")
       .filter((l) => l.includes("routing target attempt failed"));
-    // Each of the three requests failed on its group's only target, so
-    // each owes at least one line naming it.
-    expect(
-      failures.filter((l) => l.includes("fam-anthropic-target")).length,
-      `no attempt-failure line for the Anthropic-shape endpoints:\n${app.output()}`,
-    ).toBeGreaterThan(0);
-    expect(
-      failures.filter((l) => l.includes("fam-openai-target")).length,
-      `no attempt-failure line for /v1/responses:\n${app.output()}`,
-    ).toBeGreaterThan(0);
+    // Each of the three requests failed on its group's only target, and
+    // each target is addressed by exactly one endpoint — so every one of
+    // the three emitters is pinned on its own.
+    for (const [endpoint, target] of [
+      ["/v1/messages", "fam-anthropic-target"],
+      ["/v1/messages/count_tokens", "fam-count-tokens-target"],
+      ["/v1/responses", "fam-openai-target"],
+    ] as const) {
+      expect(
+        failures.filter((l) => l.includes(target)).length,
+        `no attempt-failure line for ${endpoint}:\n${app.output()}`,
+      ).toBeGreaterThan(0);
+    }
   });
 });

--- a/tests/e2e/src/cases/retry-on-429-vs-background-ignore-e2e.test.ts
+++ b/tests/e2e/src/cases/retry-on-429-vs-background-ignore-e2e.test.ts
@@ -86,6 +86,8 @@ describe("retry_on_429 vs background ignore e2e", () => {
       provider: "openai",
       model_name: "gpt-4o-mini",
       provider_key_id: primaryPk.id,
+      // Cooldown is opt-in; the assertion below is on the cooldown row.
+      cooldown: { enabled: true },
       background_model_check: {
         enabled: true,
         interval_seconds: 5,

--- a/tests/e2e/src/cases/runtime-mixed-filtering-e2e.test.ts
+++ b/tests/e2e/src/cases/runtime-mixed-filtering-e2e.test.ts
@@ -119,6 +119,9 @@ describe("runtime mixed filtering e2e", () => {
       provider: "openai",
       model_name: "gpt-4o-mini",
       provider_key_id: cooldownPk.id,
+      // Cooldown is opt-in; this target's whole role is to BE the
+      // cooling one.
+      cooldown: { enabled: true },
     });
     await seed.createModel({
       display_name: "mixed-healthy",

--- a/tests/e2e/src/cases/runtime-status-e2e.test.ts
+++ b/tests/e2e/src/cases/runtime-status-e2e.test.ts
@@ -96,6 +96,9 @@ describe("runtime status e2e", () => {
       provider: "openai",
       model_name: "gpt-4o-mini",
       provider_key_id: flakyPk.id,
+      // Cooldown is opt-in; this suite's subject is the cooldown row on
+      // /status/models.
+      cooldown: { enabled: true },
     });
     flakyModelID = flakyModel.id;
     const stableModel = await seed.createModel({

--- a/tests/e2e/src/cases/semantic-member-gates-e2e.test.ts
+++ b/tests/e2e/src/cases/semantic-member-gates-e2e.test.ts
@@ -224,7 +224,7 @@ describe("semantic router member gates e2e", () => {
     });
     await directModel("smg-open", await chatUpstream("served-open"));
     await directModel("smg-flaky", await chatUpstream("unused", { status: 500 }), {
-      cooldown: { default_seconds: 120 },
+      cooldown: { enabled: true, default_seconds: 120 },
     });
     await directModel("smg-t4-code", await chatUpstream("served-t4-code"));
     await directModel("smg-t4-default", await chatUpstream("served-t4-default"));

--- a/tests/e2e/src/cases/status-models-e2e.test.ts
+++ b/tests/e2e/src/cases/status-models-e2e.test.ts
@@ -107,6 +107,8 @@ describe("status/models: etcd mode — equivalence with the admin endpoint", () 
         provider: "openai",
         model_name: "gpt-4o-mini",
         provider_key_id: failPk.id,
+        // Cooldown is opt-in; this test's subject is the cooldown row.
+        cooldown: { enabled: true },
       })
     ).id;
     stableModelID = (


### PR DESCRIPTION
## Cooldown is opt-in

An absent `cooldown` block on a direct model used to mean cooldown **on**. `decide_cooldown` built a `CooldownConfig::default()` for a model that carried no block, and `enabled_or_default()` read the absent `enabled` flag as `true`.

The control plane's console omits the whole `cooldown` block whenever the operator does not enable it, and fills in no default — so the etcd document has no `cooldown` key at all. The net effect: **every direct model whose operator never asked for cooldown ran with cooldown**, taking the model out of rotation for 30s on an upstream 401, 408, 429, 500, 502, 503 or 504, and on timeout, transport, decode and stream-abort errors, while the console displayed the feature as disabled.

After this change, cooldown runs only when the operator explicitly enables it:

| stored configuration | before | after |
| --- | --- | --- |
| no `cooldown` block | on, 30s TTL, built-in trigger list | **off** |
| `cooldown` present, `enabled` unset | on, 30s TTL, built-in trigger list | **off** |
| `cooldown: {enabled: false}` | off | off |
| `cooldown: {enabled: true}` | on | on |

`decide_cooldown` returns early on a missing config rather than manufacturing a default one and asking it whether it is enabled — the shape that made the old behaviour invisible.

**Who is affected.** Any private-deployment or SaaS user who never configured cooldown on a direct model. Their models were being taken out of rotation after upstream failures and are no longer. Anyone who wants the previous behaviour enables cooldown explicitly on the model (`cooldown: {enabled: true}`); the defaults inside an enabled block are unchanged, so an enabled block with no other keys reproduces exactly what an unconfigured model used to get.

**What is deliberately unchanged.** The knobs *inside* an enabled cooldown — `default_seconds` (30), `max_seconds` (600), `honor_retry_after`, `trigger_statuses` (the same seven codes), `trigger_on_timeout`, `trigger_on_transport` — keep their values and their fallbacks. Those are parameters of a feature the operator opted into, which is a different thing from the feature switching itself on.

**Row loadability.** No field became required at the deserialization level and no parsing was tightened. Every stored model row still loads, including one carrying a partial cooldown block written before this change; only the meaning of the absent flag moved. `partial_cooldown_block_still_loads_the_row` pins that.

`enabled_or_default()` is renamed `is_enabled()` so a caller cannot pick up the old semantics under the old name.

### Documentation surfaces in this repo

The published resource schema and the Admin API reference stated the old contract in prose and are corrected with it: `schemas/resources/model.schema.json` no longer says "Omit this field to use the built-in cooldown behavior", and the `enabled` property's documented default flips from `true` to `false`. A test pins that default so the reference cannot drift back to advertising a feature the gateway does not switch on by itself.

## A dropped routing candidate is now on the record

A model group with targets A and B, where A returned an upstream status the group *was* configured to fail over on and no failover happened, left exactly one trace: a single attempt with error class `upstream_status`. Two different mechanisms produce that identical record — B was dropped from the candidate list before the dispatch loop started, or the configured `fallback_on_statuses` list never reached this gateway's snapshot — and nothing distinguished them after the fact. Neither mechanism wrote anything at any level, so raising verbosity in advance would not have helped.

Three additions, all at `WARN`, so they are present at the level a deployment is already running at (the default is `info`):

**1. The exclusion itself.** `filter_attempt_models` now returns the candidates it dropped, and `resolve_attempt_models` names each one:

```
WARN routing candidate excluded before dispatch
     virtual_model=my-group target_model=target-b reason="cooling" candidates=1
```

`candidates` is the size of the list the dispatch loop was actually left with. Only genuinely dropped candidates are reported: a cooling target that gets dispatched anyway because nothing healthier exists is not an exclusion, and `when_all_unavailable: try_anyway` reports none because it dispatches the whole list. The existing "all routing candidates are unavailable" warning now has the per-target detail beside it.

**2. Throttling.** The line sits on the per-request routing path, so unthrottled it would be one log per request for as long as a target stays out of rotation — a flood on a busy gateway, and a flood is what gets a diagnostic switched off before the incident that needs it. It is gated to one line per minute per (target, reason). A change of reason logs immediately rather than waiting out the previous window, so a target moving from cooling to background-unhealthy is not hidden behind the cooling line.

**3. Endpoint-family parity on the failed-attempt line.** The per-attempt failure WARN existed only on `/v1/chat/completions`. `/v1/messages`, `/v1/messages/count_tokens` and `/v1/responses` walk routing targets the same way and recorded nothing at all, so the same incident on an Anthropic-SDK or Codex client left no trace whatsoever. All four now go through one shared emitter, which additionally carries the group's effective `fallback_on_statuses` next to the `retryable` verdict:

```
WARN routing target attempt failed target_model=target-a target_attempt=1
     error=upstream returned HTTP 400: … retryable=false fallback_on_statuses=[400]
```

That field is what separates "the status was not in the list" from "the list never reached the gateway" — the second mechanism in the incident above.

### Log-message change

The two chat.rs messages `routing target attempt failed` and `streaming routing target attempt failed` are now one message. The streaming and non-streaming branches were never distinguished by anything a consumer reads, and one message keeps the four endpoints greppable together. An operator matching on the streaming variant's exact text should match on `routing target attempt failed` instead.

### Not added, and why

No new metric. `aisix_deployment_state` already reports a cooling or background-unhealthy target as Down, and `aisix_deployment_cooled_down_total` already counts cooldown entries, so the aggregate rate signal exists; what was missing was the per-request record naming the target, which is what the log line supplies.

### Deliberately deferred

Two adjacent blind spots of the same shape were found while reviewing this change and are **not** fixed here, because each needs a design call rather than a parallel edit:

- **Semantic routing.** `semantic::select_eligible` is the single-winner analogue of the group filter, and when its primary target is displaced for cooling or background-unhealthy it logs at `debug` and does not say which of the two. It cannot reuse this change's line verbatim: there, health is a *soft preference* — with no candidate available it dispatches the primary anyway — so "excluded before dispatch" and a `candidates` count do not describe what happened.
- **The two pre-filters ahead of the health filter.** `eligible_targets` (routing tags) and `targets_allowed_for_ip` (per-target `allowed_cidrs`) also drop candidates, and each surfaces only when it excludes *every* target; a partial exclusion is silent at any level. Neither is a mechanism in the incident that motivated this change.

## Testing

New spec `tests/e2e/src/cases/cooldown-opt-in-e2e.test.ts`, real binary + etcd + mock upstreams:

- a direct model with **no** cooldown configuration whose upstream returns 503 (a status in the old built-in trigger list) is still attempted on the next request, and `/status/models` reports it `healthy`;
- an enabled cooldown's exclusion appears in the gateway's output at the harness default log level, naming the target, `reason="cooling"`, the group, and the surviving candidate count;
- `/v1/messages`, `/v1/messages/count_tokens` and `/v1/responses` each write a failed-attempt line naming their target, with the group's `fallback_on_statuses`.

Each of the three was verified by mutation — restoring the old cooldown default, suppressing the exclusion line, and removing the sibling emitters (together, and then `/v1/responses` alone) — and each went red.

Unit coverage: `is_enabled` across the three "not asked for" shapes, the partial-block load, `decide_cooldown` returning `None` for an unconfigured model on every status in the old trigger list, the exclusion records `filter_attempt_models` returns on each of its branches, and the throttle gate's two obligations. The existing cooldown unit tests passed `None` and asserted a cooldown fired; they now run against an explicitly enabled config, so they still measure the knob defaults rather than passing vacuously.

Existing e2e specs whose subject is cooldown firing now enable it explicitly on the model that has to cool: `cooldown-contract`, `runtime-status`, `status-models`, `runtime-mixed-filtering`, `retry-on-429-vs-background-ignore`, `consistent-hash-routing` and `semantic-member-gates`.

Part of api7/AISIX-Cloud#1499.

Fixes api7/AISIX-Cloud#1499
