### PR TITLE
docs: an absent optional config block means the feature is off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,12 @@ Anchor on a release that has **already shipped**, never on a guess at the next v
 
 `crates/aisix-core/tests/compat_debt.rs` is the gate. It runs in the required `rust unit + coverage` job on every PR, and fails once a stable tag with a higher `MAJOR.MINOR` than the anchor exists; release candidates never count as shipped, and a patch on the anchor's own line does not come due. When it fires, either remove the code and its marker and close the tracking issue, or re-anchor deliberately to the newest release and say why in the issue. Full rules, including how a `release/X.Y` maintenance line is scoped, live in that file's module docs.
 
+## An Absent Config Block Means Off
+
+**Never give an absent optional block a default that switches on user-visible behaviour.** The operator who omitted it did not ask for the feature, the console has no field showing it is on, and nothing in the request path reveals it — so the first sign is the behaviour itself. Defaults for the knobs INSIDE a block the operator did enable are a different thing and stay.
+
+When you add such a block, its schema description must say what omitting it means; that sentence is what the published reference shows. (Precedent: `cooldown` — AISIX-Cloud#1499.)
+
 ## A Retired Startup-Config Key Is Tombstoned, Never Deleted
 
 **`Config` and its blocks are `deny_unknown_fields`, so deleting a startup-config field stops every gateway whose `config.yaml` still carries it from booting** — including everyone who copied it out of `config.example.yaml` and never turned it on. Removing the key is a far larger break than the dead setting ever was.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,9 +197,11 @@ Anchor on a release that has **already shipped**, never on a guess at the next v
 
 ## An Absent Config Block Means Off
 
-**An optional block's absence must mean the feature is off — including the block's own `enabled` flag, when the operator wrote the block and omitted the flag.** Neither the console nor the request path reveals a default that switches user-visible behavior on, so the first sign of one is the behavior. The block's other knobs keep their defaults, and a security control still defaults fail-closed: restricting is not enabling.
+**An optional block on a projected resource must resolve, when absent, to the feature being off — and so must the block's own `enabled` flag when the operator wrote the block and omitted the flag.** A default that switches behavior on instead is not visible from either end: the console renders the block from the stored document and shows a block nobody wrote as disabled, so the first sign is the behavior.
 
-State what omitting the block means in the field's own description and in `cp-admin.yaml`. (Precedent: `cooldown` — AISIX-Cloud#1499.)
+Three things this does not govern. The other knobs inside a block whose `enabled` was set. A resource ROW's own `enabled`, which every collection defaults to `true` — creating the row is the opt-in. And a fail-closed default, which restricts rather than enables. The startup `Config` is a separate contract: an absent `observability:` block still binds the metrics listener, deliberately.
+
+Say what omitting the block means in `cp-admin.yaml` — the spec the published API reference renders, and the one artifact both planes read. (Precedent: `cooldown` — AISIX-Cloud#1499.)
 
 ## A Retired Startup-Config Key Is Tombstoned, Never Deleted
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,9 +197,9 @@ Anchor on a release that has **already shipped**, never on a guess at the next v
 
 ## An Absent Config Block Means Off
 
-**Never give an absent optional block a default that switches on user-visible behaviour.** The operator who omitted it did not ask for the feature, the console has no field showing it is on, and nothing in the request path reveals it — so the first sign is the behaviour itself. Defaults for the knobs INSIDE a block the operator did enable are a different thing and stay.
+**An optional block's absence must mean the feature is off — including the block's own `enabled` flag, when the operator wrote the block and omitted the flag.** Neither the console nor the request path reveals a default that switches user-visible behavior on, so the first sign of one is the behavior. The block's other knobs keep their defaults, and a security control still defaults fail-closed: restricting is not enabling.
 
-When you add such a block, its schema description must say what omitting it means; that sentence is what the published reference shows. (Precedent: `cooldown` — AISIX-Cloud#1499.)
+State what omitting the block means in the field's own description and in `cp-admin.yaml`. (Precedent: `cooldown` — AISIX-Cloud#1499.)
 
 ## A Retired Startup-Config Key Is Tombstoned, Never Deleted
 


### PR DESCRIPTION
Adds one rule to the repository's instruction file: an optional block on a projected resource must resolve, when absent, to the feature being off — and so must the block's own `enabled` flag when the operator wrote the block and omitted it. The sentence saying what omitting the block means belongs in `cp-admin.yaml`, which is what the published API reference renders.

Three shapes that ship here deliberately are excluded, so the rule is true of the repository as it stands: the other knobs inside a block whose `enabled` was set; a resource row's own `enabled`, which defaults to `true` in all ten collections that have one because creating the row is the opt-in; and a fail-closed default, which restricts rather than enables. The startup `Config` is named as a separate contract — an absent `observability:` block still binds the metrics listener.

It lands in the root pair (`AGENTS.md` is a symlink to `CLAUDE.md`, so both names carry it): the description half's target lives in another repository, which no nested file could cover. The cooldown default corrected in #1122 (api7/AISIX-Cloud#1499) is the precedent it cites; no code or test changes.