### PR TITLE
feat: map reasoning effort per direct model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "futures",
  "http 1.4.0",
  "serde",
  "serde_json",

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -12,6 +12,8 @@
 //!
 //! etcd path: `{prefix}/models/{uuid}`. Secondary index on `display_name`.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -315,6 +317,12 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_prompt_caching: Option<AutoPromptCaching>,
 
+    /// Direct-model-only mapping from a client-requested reasoning effort to
+    /// the value sent upstream. The gateway applies one exact lookup after
+    /// resolving the final target; unlisted values pass through unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort_mapping: Option<BTreeMap<String, String>>,
+
     /// Non-schema runtime id. Not part of the JSON payload — filled in by
     /// the snapshot loader from the etcd key path. Kept here so `Resource`
     /// can return a `&str` id.
@@ -361,6 +369,9 @@ impl Model {
     /// never resolved.
     pub fn strip_kind_inapplicable(&mut self) -> Vec<&'static str> {
         let mut stripped = Vec::new();
+        if self.is_embedding() && self.effort_mapping.take().is_some() {
+            stripped.push("effort_mapping");
+        }
         if !(self.is_routing() || self.is_ensemble() || self.is_semantic()) {
             return stripped;
         }
@@ -369,6 +380,9 @@ impl Model {
         }
         if self.cost.take().is_some() {
             stripped.push("cost");
+        }
+        if self.effort_mapping.take().is_some() {
+            stripped.push("effort_mapping");
         }
         if (self.is_routing() || self.is_ensemble()) && self.retries.take().is_some() {
             stripped.push("retries");
@@ -385,6 +399,16 @@ impl Model {
             }
         }
         stripped
+    }
+
+    /// Return the configured upstream effort for one caller-supplied
+    /// value. This is deliberately a single exact lookup: a map such as
+    /// `low -> high, high -> max` rewrites `low` to `high`, never `max`.
+    pub fn mapped_effort<'a>(&'a self, effort: &str) -> Option<&'a str> {
+        self.effort_mapping
+            .as_ref()?
+            .get(effort)
+            .map(String::as_str)
     }
 
     /// This resource's own non-streaming deadline, as one level of the
@@ -471,8 +495,17 @@ fn model_one_of_variant(strict: bool) -> Value {
         // routing: the group slot for timeouts is the top-level pair
         // (api7/aisix#844); retries' group slot is `routing.retries`, so a
         // top-level value is dead — as are the model-specific knobs.
-        extend(&mut arr[0], &["retries", "auto_prompt_caching", "cost"]);
-        // direct (arr[1]): every knob is live.
+        extend(
+            &mut arr[0],
+            &["retries", "auto_prompt_caching", "cost", "effort_mapping"],
+        );
+        // The direct-shaped branch also carries embedding models. They do
+        // not accept generation effort, so forbid the mapping only when the
+        // embedding marker is present; ordinary direct models keep it.
+        arr[1]["not"]["anyOf"]
+            .as_array_mut()
+            .expect("direct not.anyOf array")
+            .push(json!({ "required": ["embedding", "effort_mapping"] }));
         // ensemble: sub-calls resolve member-level knobs only; the
         // parent-level deadline is `ensemble.timeout_ms`.
         extend(
@@ -483,12 +516,16 @@ fn model_one_of_variant(strict: bool) -> Value {
                 "retries",
                 "auto_prompt_caching",
                 "cost",
+                "effort_mapping",
             ],
         );
         // semantic: top-level timeout/stream_timeout/retries ARE the group
         // slots (no routing block to carry them); the model-specific knobs
         // stay direct-only.
-        extend(&mut arr[3], &["auto_prompt_caching", "cost"]);
+        extend(
+            &mut arr[3],
+            &["auto_prompt_caching", "cost", "effort_mapping"],
+        );
     }
     variants
 }
@@ -766,6 +803,25 @@ mod tests {
         .unwrap();
         assert!(none.allowed_cidrs.is_none());
         assert!(none.ip_allowed("203.0.113.7"));
+    }
+
+    #[test]
+    fn effort_mapping_is_a_single_exact_lookup() {
+        let model: Model = serde_json::from_value(serde_json::json!({
+            "display_name": "glm",
+            "provider": "openai",
+            "model_name": "glm-5.3",
+            "provider_key_id": "pk-1",
+            "effort_mapping": {
+                "medium": "high",
+                "high": "max"
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(model.mapped_effort("medium"), Some("high"));
+        assert_eq!(model.mapped_effort("high"), Some("max"));
+        assert_eq!(model.mapped_effort("low"), None);
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -490,11 +490,13 @@ pub fn validate_model(value: &Value) -> Result<(), SchemaError> {
     if validate(&SCHEMAS.model, &probe).is_err() {
         return Err(err);
     }
-    // strip_kind_inapplicable only reports on these three kinds.
+    // strip_kind_inapplicable reports only on these non-direct shapes.
     let kind = if model.is_routing() {
         "model group"
     } else if model.is_ensemble() {
         "ensemble"
+    } else if model.is_embedding() {
+        "embedding model"
     } else {
         "semantic router"
     };
@@ -4935,6 +4937,19 @@ mod tests {
         let msg = validate_model(&semantic).unwrap_err().message;
         assert!(msg.contains("`auto_prompt_caching`"), "{msg}");
         assert!(msg.contains("semantic router"), "{msg}");
+
+        let embedding = json!({
+            "display_name": "embed",
+            "provider": "openai",
+            "model_name": "text-embedding-3-small",
+            "provider_key_id": "pk",
+            "embedding": {"dimensions": 1536},
+            "effort_mapping": {"medium": "high"}
+        });
+        let msg = validate_model(&embedding).unwrap_err().message;
+        assert!(msg.contains("`effort_mapping`"), "{msg}");
+        assert!(msg.contains("embedding model"), "{msg}");
+        assert!(!msg.contains("semantic router"), "{msg}");
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -2725,6 +2725,52 @@ mod tests {
     }
 
     #[test]
+    fn effort_mapping_is_direct_only_on_strict_writes() {
+        let direct = json!({
+            "display_name": "glm",
+            "provider": "openai",
+            "model_name": "glm-5.3",
+            "provider_key_id": "pk-1",
+            "effort_mapping": {"medium": "high"}
+        });
+        validate_model(&direct).unwrap();
+
+        for virtual_model in [
+            json!({
+                "display_name": "group",
+                "routing": {"targets": [{"model": "glm"}]},
+                "effort_mapping": {"medium": "high"}
+            }),
+            json!({
+                "display_name": "ensemble",
+                "ensemble": {"panel": [{"model": "glm"}], "judge": {"model": "glm"}},
+                "effort_mapping": {"medium": "high"}
+            }),
+            json!({
+                "display_name": "semantic",
+                "semantic": {
+                    "embedding_model": "embed",
+                    "routes": [{"name": "default", "target": "glm", "examples": ["hello"]}],
+                    "default": "glm",
+                    "match": {"threshold": 0.5}
+                },
+                "effort_mapping": {"medium": "high"}
+            }),
+            json!({
+                "display_name": "embed",
+                "provider": "openai",
+                "model_name": "text-embedding-3-small",
+                "provider_key_id": "pk-1",
+                "embedding": {"dimensions": 1536},
+                "effort_mapping": {"medium": "high"}
+            }),
+        ] {
+            assert!(validate_model(&virtual_model).is_err());
+            validate_model_lenient(&virtual_model).unwrap();
+        }
+    }
+
+    #[test]
     fn routing_fallback_on_statuses_range_is_enforced() {
         // AISIX-Cloud#1012: entries outside 400-599 are rejected by the
         // same committed-schema validation the admin API and etcd watch

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -482,7 +482,7 @@ pub fn build_request<'a>(
 /// specifically, not the presence of an `output_config`: the object also
 /// carries `format` and `task_budget`, and treating it as an effort
 /// declaration would drop the tier of any request that sent one of those.
-fn translate_reasoning_effort_to_anthropic(
+pub fn translate_reasoning_effort_to_anthropic(
     extras: &mut serde_json::Map<String, serde_json::Value>,
 ) {
     let Some(effort) = extras.remove("reasoning_effort") else {

--- a/crates/aisix-provider-bedrock/Cargo.toml
+++ b/crates/aisix-provider-bedrock/Cargo.toml
@@ -40,6 +40,7 @@ aws-smithy-runtime-api.workspace = true
 aws-smithy-types.workspace = true
 
 [dev-dependencies]
+futures.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 wiremock.workspace = true
 http.workspace = true

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -1902,6 +1902,27 @@ fn map_tool_choice(choice: &serde_json::Value) -> Option<ToolChoice> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::StreamExt;
+
+    async fn consume_invalid_mock_stream(result: Result<ChatChunkStream, BridgeError>) {
+        match result {
+            Err(BridgeError::Transport(message)) => {
+                assert!(
+                    !message.is_empty(),
+                    "transport error must explain the failure"
+                );
+            }
+            Err(other) => panic!("unexpected mock stream error: {other:?}"),
+            Ok(mut stream) => {
+                while let Some(chunk) = stream.next().await {
+                    assert!(
+                        chunk.is_err(),
+                        "a non-eventstream mock must not yield a valid chat chunk"
+                    );
+                }
+            }
+        }
+    }
 
     // ─── Mid-stream event errors (AISIX-Cloud#1222) ──────────────────
 
@@ -2632,7 +2653,7 @@ mod tests {
             .insert("reasoning_effort".to_string(), serde_json::json!("high"));
 
         bridge.chat(&req, &ctx).await.unwrap();
-        let _ = bridge.chat_stream(&req, &ctx).await;
+        consume_invalid_mock_stream(bridge.chat_stream(&req, &ctx).await).await;
 
         let invoke_body = invoke.captured_body.lock().unwrap().clone().unwrap();
         assert_eq!(
@@ -3197,7 +3218,7 @@ mod tests {
         // valid eventstream) OR returns Err directly from the SDK.
         // Both prove the dispatch reached wiremock — wiremock's
         // `.expect(1)` enforces this on drop.
-        let _ = bridge.chat_stream(&req, &ctx).await;
+        consume_invalid_mock_stream(bridge.chat_stream(&req, &ctx).await).await;
     }
 
     #[tokio::test]
@@ -3222,7 +3243,7 @@ mod tests {
             sample_pk_with_secret(valid_secret_json()),
         );
         let req = ChatFormat::new("my-llama", vec![ChatMessage::user("hi")]);
-        let _ = bridge.chat_stream(&req, &ctx).await;
+        consume_invalid_mock_stream(bridge.chat_stream(&req, &ctx).await).await;
     }
 
     /// Audit HIGH-1+HIGH-2 (PR #389): Converse 4xx must preserve
@@ -4636,7 +4657,7 @@ mod tests {
                 "param_constraints": { "temperature_max": 1.0 }
             })),
         );
-        let _ = bridge.chat_stream(&req, &ctx).await;
+        consume_invalid_mock_stream(bridge.chat_stream(&req, &ctx).await).await;
 
         let body = responder.captured_body.lock().unwrap().clone().unwrap();
         let cfg = body

--- a/crates/aisix-provider-bedrock/src/bridge.rs
+++ b/crates/aisix-provider-bedrock/src/bridge.rs
@@ -44,7 +44,8 @@ use serde::Deserialize;
 use std::time::{Duration, Instant};
 
 use aisix_provider_anthropic::wire::{
-    build_request, response_into_chat_response, split_system, AnthropicResponse,
+    build_request, response_into_chat_response, split_system,
+    translate_reasoning_effort_to_anthropic, AnthropicResponse,
 };
 
 // Per-`ProviderKey` request override pipeline (#302 §5 / #340). The JSON-body
@@ -978,6 +979,9 @@ impl BedrockBridge {
         if let Some(cfg) = build_inference_config(req, pk_param_constraints(ctx)) {
             call = call.inference_config(cfg);
         }
+        if let Some(fields) = build_converse_additional_model_request_fields(req, upstream_id) {
+            call = call.additional_model_request_fields(fields);
+        }
         // #560: forward OpenAI `tools` / `tool_choice` into Converse's
         // `toolConfig`. Without this every Converse publisher silently
         // drops tool calling and improvises the call as prose
@@ -1047,6 +1051,9 @@ impl BedrockBridge {
         // the #463 param_constraints temperature clamp.
         if let Some(cfg) = build_inference_config(req, pk_param_constraints(ctx)) {
             call = call.inference_config(cfg);
+        }
+        if let Some(fields) = build_converse_additional_model_request_fields(req, upstream_id) {
+            call = call.additional_model_request_fields(fields);
         }
         // #560: forward tools on the stream path too (all publishers,
         // incl. Anthropic, stream through Converse).
@@ -1760,6 +1767,35 @@ fn build_inference_config(
         b = b.top_p(p);
     }
     Some(b.build())
+}
+
+/// Carry Anthropic-specific reasoning controls through Bedrock Converse.
+/// Anthropic non-streaming requests use the native `/invoke` envelope, where
+/// `build_request` already translates `reasoning_effort`; streaming has to use
+/// Converse and therefore places the same provider fields under
+/// `additionalModelRequestFields`. Other Bedrock publishers must not receive
+/// Anthropic parameters they may reject.
+fn build_converse_additional_model_request_fields(
+    req: &ChatFormat,
+    upstream_id: &str,
+) -> Option<aws_smithy_types::Document> {
+    if BedrockPublisher::from_model_id(upstream_id) != Some(BedrockPublisher::Anthropic) {
+        return None;
+    }
+
+    let mut extras = req.extra.clone();
+    translate_reasoning_effort_to_anthropic(&mut extras);
+    let mut fields = serde_json::Map::new();
+    for name in ["thinking", "output_config", "anthropic_beta"] {
+        if let Some(value) = extras.remove(name) {
+            fields.insert(name.to_string(), value);
+        }
+    }
+    if fields.is_empty() {
+        None
+    } else {
+        Some(json_to_document(&serde_json::Value::Object(fields)))
+    }
 }
 
 /// Build a Converse [`ToolConfiguration`] from the OpenAI `tools` /
@@ -2564,6 +2600,59 @@ mod tests {
         assert_eq!(
             messages[0].get("role").and_then(|v| v.as_str()),
             Some("user")
+        );
+    }
+
+    #[tokio::test]
+    async fn anthropic_effort_reaches_both_invoke_and_converse_stream_wires() {
+        let server = MockServer::start().await;
+        let invoke = CapturingResponder::default();
+        let stream = CapturingResponder::default();
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/model/.+/invoke$"))
+            .respond_with(invoke.clone())
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/model/.+/converse-stream$"))
+            .respond_with(stream.clone())
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let bridge = BedrockBridge::new().with_endpoint_override(server.uri());
+        let ctx = BridgeContext::new(
+            "req-effort",
+            sample_model_with("anthropic.claude-opus-4-5-20251101-v1:0"),
+            sample_pk_with_secret(valid_secret_json()),
+        );
+        let mut req = ChatFormat::new("my-claude", vec![ChatMessage::user("hi")]);
+        req.extra
+            .insert("reasoning_effort".to_string(), serde_json::json!("high"));
+
+        bridge.chat(&req, &ctx).await.unwrap();
+        let _ = bridge.chat_stream(&req, &ctx).await;
+
+        let invoke_body = invoke.captured_body.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            invoke_body
+                .pointer("/output_config/effort")
+                .and_then(|v| v.as_str()),
+            Some("high"),
+            "legacy non-streaming wire lost reasoning effort; body={invoke_body}"
+        );
+        let stream_body = stream.captured_body.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            stream_body
+                .pointer("/additionalModelRequestFields/output_config/effort")
+                .and_then(|v| v.as_str()),
+            Some("high"),
+            "ConverseStream wire must carry the same Anthropic effort; body={stream_body}"
+        );
+        assert!(
+            stream_body.pointer("/reasoning_effort").is_none(),
+            "OpenAI-shaped reasoning_effort must not leak onto the Bedrock wire; body={stream_body}"
         );
     }
 

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1626,6 +1626,7 @@ async fn dispatch(
 
         'targets: for (target_idx, attempt) in attempt_models.iter().enumerate() {
             let model = &attempt.model;
+            let upstream_req = crate::effort_mapping::chat_request(req, model);
             let Ok(provider) = crate::dispatch::require_provider(model) else {
                 last_reserve_reject = None;
                 last_err = Some(BridgeError::Config("model has no provider".into()));
@@ -1769,7 +1770,7 @@ async fn dispatch(
                 // heartbeats cover the wait for the first token. The
                 // read-timeout wrapper is a no-op when the budget is None.
                 let attempt_stream: Result<aisix_gateway::ChatChunkStream, BridgeError> =
-                    match bridge.chat_stream(req, &ctx).await {
+                    match bridge.chat_stream(upstream_req.as_ref(), &ctx).await {
                         Err(e) => Err(e),
                         Ok(up) => {
                             let up = crate::stream_timeout::with_read_timeout(up, stream_budget);
@@ -2756,6 +2757,7 @@ async fn dispatch(
 
     'targets: for (target_idx, attempt) in attempt_models.iter().enumerate() {
         let model = &attempt.model;
+        let upstream_req = crate::effort_mapping::chat_request(req, model);
         let Some(provider) = model.provider.as_deref() else {
             last_reserve_reject = None;
             last_err = Some(BridgeError::Config("model has no provider".into()));
@@ -2898,7 +2900,7 @@ async fn dispatch(
             // once `bridge.chat` returns; the guard drops at the end of this
             // attempt's scope on both the success-break and failure paths.
             let _in_flight = state.runtime_status.begin_in_flight(&attempt.id);
-            let result = bridge.chat(req, &ctx).await;
+            let result = bridge.chat(upstream_req.as_ref(), &ctx).await;
             let attempt_latency_ms =
                 attempt_started.elapsed().as_millis().min(u32::MAX as u128) as u32;
             match result {
@@ -3583,6 +3585,7 @@ async fn dispatch_ensemble(
             ));
         };
         let judge_model = &judge_entry.value;
+        let judge_req = crate::effort_mapping::chat_request(&judge_req, judge_model);
         let judge_pk = match crate::dispatch::resolve_provider_key(snapshot, judge_model) {
             Ok(pk) => pk,
             Err(e) => {
@@ -3659,7 +3662,10 @@ async fn dispatch_ensemble(
         // what `upstream_ttft_ms` should be measured against — `started`
         // additionally covers the whole panel that ran before it.
         let judge_started = Instant::now();
-        let judge_stream = match judge_bridge.chat_stream(&judge_req, &judge_ctx).await {
+        let judge_stream = match judge_bridge
+            .chat_stream(judge_req.as_ref(), &judge_ctx)
+            .await
+        {
             Ok(s) => s,
             // Judge connect failed AFTER the panel round-tripped: bill the
             // panel (same invariant as the non-streaming judge-failure path),
@@ -3783,7 +3789,7 @@ async fn dispatch_ensemble(
         // their usage separately).
         let judge_estimator = crate::token_estimate::Estimator::new(
             judge_model.upstream_model().unwrap_or("unknown"),
-            crate::token_estimate::PromptInput::Chat(Box::new(judge_req)),
+            crate::token_estimate::PromptInput::Chat(Box::new(judge_req.into_owned())),
         );
         let sse_stream = build_sse_stream(
             judge_stream,

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -601,7 +601,7 @@ async fn count_tokens_to_target(
     client: &ClientContext,
 ) -> Result<CountTokensSuccess, ProxyError> {
     let attempt_started = Instant::now();
-    let mut body = body.clone();
+    let mut body = crate::effort_mapping::anthropic_request(body, model).into_owned();
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
     let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?;
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();

--- a/crates/aisix-proxy/src/effort_mapping.rs
+++ b/crates/aisix-proxy/src/effort_mapping.rs
@@ -1,0 +1,125 @@
+use std::borrow::Cow;
+
+use aisix_core::Model;
+use aisix_gateway::ChatFormat;
+use serde_json::Value;
+
+/// Apply the final direct target's mapping to an OpenAI Chat Completions
+/// request. The caller-owned request stays untouched so retries against a
+/// different target always start from the original effort.
+pub(crate) fn chat_request<'a>(request: &'a ChatFormat, model: &Model) -> Cow<'a, ChatFormat> {
+    let Some(requested) = request
+        .extra
+        .get("reasoning_effort")
+        .and_then(Value::as_str)
+    else {
+        return Cow::Borrowed(request);
+    };
+    let Some(mapped) = model.mapped_effort(requested) else {
+        return Cow::Borrowed(request);
+    };
+    if mapped == requested {
+        return Cow::Borrowed(request);
+    }
+
+    let mut outbound = request.clone();
+    outbound
+        .extra
+        .insert("reasoning_effort".to_string(), mapped.into());
+    Cow::Owned(outbound)
+}
+
+/// Apply the final direct target's mapping to an Anthropic Messages request.
+pub(crate) fn anthropic_request<'a>(body: &'a Value, model: &Model) -> Cow<'a, Value> {
+    json_request(body, model, "/output_config/effort")
+}
+
+/// Apply the final direct target's mapping to an OpenAI Responses request.
+pub(crate) fn responses_request<'a>(body: &'a Value, model: &Model) -> Cow<'a, Value> {
+    json_request(body, model, "/reasoning/effort")
+}
+
+fn json_request<'a>(body: &'a Value, model: &Model, pointer: &str) -> Cow<'a, Value> {
+    let Some(requested) = body.pointer(pointer).and_then(Value::as_str) else {
+        return Cow::Borrowed(body);
+    };
+    let Some(mapped) = model.mapped_effort(requested) else {
+        return Cow::Borrowed(body);
+    };
+    if mapped == requested {
+        return Cow::Borrowed(body);
+    }
+
+    let mut outbound = body.clone();
+    *outbound
+        .pointer_mut(pointer)
+        .expect("effort pointer resolved before cloning") = Value::String(mapped.to_string());
+    Cow::Owned(outbound)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use aisix_gateway::{ChatFormat, ChatMessage};
+    use serde_json::json;
+
+    use super::*;
+
+    fn model() -> Model {
+        serde_json::from_value(json!({
+            "display_name": "glm",
+            "provider": "openai",
+            "model_name": "glm-5.3",
+            "provider_key_id": "pk-1",
+            "effort_mapping": {
+                "medium": "high",
+                "high": "max"
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn maps_each_supported_request_shape_once() {
+        let model = model();
+
+        let mut chat = ChatFormat::new("glm", vec![ChatMessage::user("hi")]);
+        chat.extra
+            .insert("reasoning_effort".to_string(), "medium".into());
+        let mapped = chat_request(&chat, &model);
+        assert_eq!(mapped.extra["reasoning_effort"], "high");
+        assert_eq!(chat.extra["reasoning_effort"], "medium");
+
+        let messages = json!({
+            "output_config": {"effort": "medium", "format": {"type": "json_schema"}}
+        });
+        let mapped = anthropic_request(&messages, &model);
+        assert_eq!(mapped["output_config"]["effort"], "high");
+        assert_eq!(mapped["output_config"]["format"]["type"], "json_schema");
+
+        let responses = json!({"reasoning": {"effort": "medium", "summary": "auto"}});
+        let mapped = responses_request(&responses, &model);
+        assert_eq!(mapped["reasoning"]["effort"], "high");
+        assert_eq!(mapped["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn does_not_chain_or_clone_for_an_unmapped_value() {
+        let model = model();
+        let body = json!({"reasoning": {"effort": "low"}});
+        assert!(matches!(responses_request(&body, &model), Cow::Borrowed(_)));
+
+        let body = json!({"reasoning": {"effort": "medium"}});
+        let mapped = responses_request(&body, &model);
+        assert_eq!(mapped["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn leaves_missing_and_non_string_effort_untouched() {
+        let model = model();
+        for body in [json!({}), json!({"output_config": {"effort": 3}})] {
+            assert!(matches!(anthropic_request(&body, &model), Cow::Borrowed(_)));
+        }
+    }
+}

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -416,6 +416,10 @@ fn judge_request(req: &ChatFormat, judge: &Judge, candidates: &[ChatResponse]) -
         .replace("{labeled_candidates}", &label_candidates(candidates));
 
     let mut out = ChatFormat::new(judge.model.clone(), vec![ChatMessage::user(prompt)]);
+    if let Some(effort) = req.extra.get("reasoning_effort") {
+        out.extra
+            .insert("reasoning_effort".to_string(), effort.clone());
+    }
     out.temperature = Some(JUDGE_TEMPERATURE);
     out.stream = Some(false);
     out
@@ -586,9 +590,10 @@ mod tests {
         let cfg =
             config(r#"{"panel":[{"model":"gpt"},{"model":"claude"}],"judge":{"model":"judge"}}"#);
 
-        let out = run_ensemble(&user_request("what is 2+2?"), &cfg, &caller)
-            .await
-            .unwrap();
+        let mut req = user_request("what is 2+2?");
+        req.extra
+            .insert("reasoning_effort".to_string(), "medium".into());
+        let out = run_ensemble(&req, &cfg, &caller).await.unwrap();
 
         assert_eq!(out.response.message.content_str(), "synthesized answer");
         assert_eq!(out.panel.len(), 2);
@@ -604,6 +609,10 @@ mod tests {
         assert!(judge_prompt.contains("answer from gpt"));
         assert!(judge_prompt.contains("answer from claude"));
         assert!(judge_prompt.contains("what is 2+2?"));
+        assert_eq!(
+            caller.calls_to("judge")[0].extra["reasoning_effort"],
+            "medium"
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/ensemble.rs
+++ b/crates/aisix-proxy/src/ensemble.rs
@@ -192,8 +192,9 @@ impl ModelCaller for ProxyModelCaller<'_> {
         // `ctx`'s deadline is per attempt while the ensemble's own
         // `config.timeout()` — applied by the caller — remains the ceiling on
         // the whole attempt sequence.
+        let upstream_req = crate::effort_mapping::chat_request(req, model);
         let response = crate::routing::retrying_dispatch(self.state, model, "ensemble", || {
-            bridge.chat(req, &ctx)
+            bridge.chat(upstream_req.as_ref(), &ctx)
         })
         .await?;
         let effective = crate::chat::effective_subcall_usage(

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -38,6 +38,7 @@ pub(crate) mod cooldown;
 mod count_tokens;
 mod dispatch;
 mod ebml;
+mod effort_mapping;
 mod embeddings;
 mod ensemble;
 mod error;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1084,6 +1084,8 @@ async fn dispatch_to_target(
     input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<DispatchOutcome, ProxyError> {
     let model = &target.model;
+    let body = crate::effort_mapping::anthropic_request(body, model);
+    let body = body.as_ref();
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
 
     if !crate::dispatch::speaks_anthropic(snapshot, model) {

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1116,7 +1116,7 @@ async fn responses_to_target(
             .map(|e| &e.value),
     );
     let captured_prompt = content_cap.map(|_| serde_json::to_string(body).unwrap_or_default());
-    let mut body = body.clone();
+    let mut body = crate::effort_mapping::responses_request(body, model).into_owned();
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
     // Resolved PK id for per-PK telemetry attribution on the emitted
     // UsageEvent (AISIX-Cloud#867).
@@ -2128,7 +2128,9 @@ async fn responses_cross_provider_to_target(
     // Faithful Responses → ChatFormat transform; `chat.model` stays the
     // operator-facing name so the bridge re-resolves the upstream id via
     // `ctx.model.upstream_model()` exactly like chat.rs.
-    let chat = crate::responses_bridge::responses_request_to_chat(requested_model, body);
+    let outbound_body = crate::effort_mapping::responses_request(body, model);
+    let chat =
+        crate::responses_bridge::responses_request_to_chat(requested_model, outbound_body.as_ref());
 
     let is_stream = chat.is_streaming();
     let mut ctx = crate::dispatch::bridge_ctx(

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -12,12 +12,11 @@
 //!
 //! Only the Responses fields that map cleanly onto chat completions are
 //! carried (`instructions`, `input`, `tools`, `tool_choice`,
-//! `temperature`, `top_p`, `max_output_tokens`, `stream`). OpenAI-only
-//! knobs (`reasoning`, `store`, `previous_response_id`, `text`, …) are
-//! dropped rather than forwarded — the downstream provider bridges flatten
-//! unknown `extra` fields onto the upstream wire, where an OpenAI-only key
-//! would 400 (e.g. Anthropic). Reasoning/thinking has no canonical bridge
-//! mapping today, so it is intentionally not translated.
+//! `temperature`, `top_p`, `max_output_tokens`, `stream`, and
+//! `reasoning.effort`). Other OpenAI-only knobs (`store`,
+//! `previous_response_id`, `text`, …) are dropped rather than forwarded —
+//! the downstream provider bridges flatten unknown `extra` fields onto the
+//! upstream wire, where an OpenAI-only key would 400 (e.g. Anthropic).
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -86,6 +85,10 @@ pub fn responses_request_to_chat(model: &str, body: &Value) -> ChatFormat {
         .and_then(responses_tool_choice_to_chat)
     {
         chat.extra.insert("tool_choice".to_string(), tc);
+    }
+    if let Some(effort) = body.pointer("/reasoning/effort").and_then(Value::as_str) {
+        chat.extra
+            .insert("reasoning_effort".to_string(), effort.into());
     }
     chat
 }
@@ -1515,8 +1518,9 @@ mod tests {
             "stream": true,
             "tools": [{"type": "function", "name": "get_weather", "description": "d", "parameters": {"type": "object"}}],
             "tool_choice": {"type": "function", "name": "get_weather"},
-            // OpenAI-only knobs must NOT leak into chat.extra (they'd 400 Anthropic).
-            "reasoning": {"effort": "high"},
+            // Only the portable effort value is translated; the Responses
+            // carrier object itself must not leak to another protocol.
+            "reasoning": {"effort": "high", "summary": "auto"},
             "store": false,
         });
         let chat = responses_request_to_chat("m", &body);
@@ -1530,6 +1534,7 @@ mod tests {
             chat.extra.get("tool_choice").unwrap()["function"]["name"],
             "get_weather"
         );
+        assert_eq!(chat.extra.get("reasoning_effort"), Some(&json!("high")));
         assert!(!chat.extra.contains_key("reasoning"));
         assert!(!chat.extra.contains_key("store"));
     }

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -801,6 +801,11 @@
             "required": [
               "cost"
             ]
+          },
+          {
+            "required": [
+              "effort_mapping"
+            ]
           }
         ]
       },
@@ -824,6 +829,12 @@
           {
             "required": [
               "semantic"
+            ]
+          },
+          {
+            "required": [
+              "embedding",
+              "effort_mapping"
             ]
           }
         ]
@@ -901,6 +912,11 @@
             "required": [
               "cost"
             ]
+          },
+          {
+            "required": [
+              "effort_mapping"
+            ]
           }
         ]
       },
@@ -960,6 +976,11 @@
             "required": [
               "cost"
             ]
+          },
+          {
+            "required": [
+              "effort_mapping"
+            ]
           }
         ]
       },
@@ -1013,6 +1034,13 @@
       "description": "Operator-facing unique label. Surfaces on `/v1/models`, `req.model` on chat completions, `ApiKey.allowed_models`, and the dashboard model list. `Resource::name()` returns this.",
       "minLength": 1,
       "type": "string"
+    },
+    "effort_mapping": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Direct-model-only mapping from a client-requested reasoning effort to the value sent upstream. The gateway applies one exact lookup after resolving the final target; unlisted values pass through unchanged.",
+      "type": "object"
     },
     "embedding": {
       "allOf": [

--- a/tests/e2e/src/cases/effort-mapping-e2e.test.ts
+++ b/tests/e2e/src/cases/effort-mapping-e2e.test.ts
@@ -39,10 +39,65 @@ const anthropicResponse = {
   usage: { input_tokens: 2, output_tokens: 1 },
 };
 
+const openaiStreamEvents = [
+  JSON.stringify({
+    id: "chatcmpl-effort-stream",
+    object: "chat.completion.chunk",
+    model: "upstream-model",
+    choices: [
+      {
+        index: 0,
+        delta: { role: "assistant", content: "ok" },
+        finish_reason: null,
+      },
+    ],
+  }),
+  JSON.stringify({
+    id: "chatcmpl-effort-stream",
+    object: "chat.completion.chunk",
+    model: "upstream-model",
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+  }),
+  "[DONE]",
+];
+
+const anthropicStreamEvents = [
+  JSON.stringify({
+    type: "message_start",
+    message: {
+      id: "msg_effort_stream",
+      role: "assistant",
+      content: [],
+      model: "upstream-model",
+      stop_reason: null,
+      usage: { input_tokens: 2, output_tokens: 1 },
+    },
+  }),
+  JSON.stringify({
+    type: "content_block_start",
+    index: 0,
+    content_block: { type: "text", text: "" },
+  }),
+  JSON.stringify({
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "text_delta", text: "ok" },
+  }),
+  JSON.stringify({ type: "content_block_stop", index: 0 }),
+  JSON.stringify({
+    type: "message_delta",
+    delta: { stop_reason: "end_turn" },
+    usage: { output_tokens: 1 },
+  }),
+  JSON.stringify({ type: "message_stop" }),
+];
+
 describe("direct-model effort mapping", () => {
   let app: SpawnedApp | undefined;
   let openai: OpenAiUpstream | undefined;
   let anthropic: OpenAiUpstream | undefined;
+  let openaiStream: OpenAiUpstream | undefined;
+  let anthropicStream: OpenAiUpstream | undefined;
   let etcdReachable = false;
 
   beforeAll(async () => {
@@ -59,6 +114,12 @@ describe("direct-model effort mapping", () => {
         { nonStreamBody: { input_tokens: 3 } },
       ],
     });
+    openaiStream = await startOpenAiUpstream({
+      streamEvents: openaiStreamEvents,
+    });
+    anthropicStream = await startOpenAiUpstream({
+      streamEvents: anthropicStreamEvents,
+    });
     app = await spawnApp();
     const seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -74,6 +135,18 @@ describe("direct-model effort mapping", () => {
       secret: "sk-anthropic-mock",
       api_base: anthropic.baseUrl,
     });
+    const openaiStreamKey = await seed.createProviderKey({
+      display_name: "effort-map-openai-stream-key",
+      secret: "sk-openai-stream-mock",
+      api_base: `${openaiStream.baseUrl}/v1`,
+    });
+    const anthropicStreamKey = await seed.createProviderKey({
+      display_name: "effort-map-anthropic-stream-key",
+      provider: "anthropic",
+      adapter: "anthropic",
+      secret: "sk-anthropic-stream-mock",
+      api_base: anthropicStream.baseUrl,
+    });
 
     const mapping = { medium: "high", high: "max" };
     await seed.createModel({
@@ -81,6 +154,20 @@ describe("direct-model effort mapping", () => {
       provider: "openai",
       model_name: "glm-openai-wire",
       provider_key_id: openaiKey.id,
+      effort_mapping: mapping,
+    });
+    await seed.createModel({
+      display_name: "effort-map-openai-stream",
+      provider: "openai",
+      model_name: "glm-openai-stream-wire",
+      provider_key_id: openaiStreamKey.id,
+      effort_mapping: mapping,
+    });
+    await seed.createModel({
+      display_name: "effort-map-anthropic-stream",
+      provider: "anthropic",
+      model_name: "glm-anthropic-stream-wire",
+      provider_key_id: anthropicStreamKey.id,
       effort_mapping: mapping,
     });
     await seed.createModel({
@@ -105,6 +192,8 @@ describe("direct-model effort mapping", () => {
       allowed_models: [
         "effort-map-openai",
         "effort-map-anthropic",
+        "effort-map-openai-stream",
+        "effort-map-anthropic-stream",
         "effort-map-group",
       ],
     });
@@ -118,13 +207,15 @@ describe("direct-model effort mapping", () => {
     await app?.exit();
     await openai?.close();
     await anthropic?.close();
+    await openaiStream?.close();
+    await anthropicStream?.close();
   });
 
   async function post(
     path: string,
     body: Record<string, unknown>,
     auth: "openai" | "anthropic" = "openai",
-  ) {
+  ): Promise<{ body: string; contentType: string | null }> {
     const response = await fetch(`${app!.proxyUrl}${path}`, {
       method: "POST",
       headers: {
@@ -135,7 +226,12 @@ describe("direct-model effort mapping", () => {
       },
       body: JSON.stringify(body),
     });
-    expect(response.ok, await response.text()).toBe(true);
+    const responseBody = await response.text();
+    expect(response.ok, responseBody).toBe(true);
+    return {
+      body: responseBody,
+      contentType: response.headers.get("content-type"),
+    };
   }
 
   function receivedSince(
@@ -274,5 +370,40 @@ describe("direct-model effort mapping", () => {
       receivedSince(openai, baseline, "/v1/chat/completions")
         .reasoning_effort,
     ).toBe("low");
+  });
+
+  test("maps native and translated streaming requests", async (ctx) => {
+    if (!etcdReachable || !app || !openaiStream || !anthropicStream) {
+      ctx.skip();
+      return;
+    }
+
+    let baseline = openaiStream.receivedRequests.length;
+    const openaiResponse = await post("/v1/chat/completions", {
+      model: "effort-map-openai-stream",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "high",
+      stream: true,
+    });
+    expect(openaiResponse.contentType).toContain("text/event-stream");
+    expect(openaiResponse.body).toContain("data:");
+    expect(
+      receivedSince(openaiStream, baseline, "/v1/chat/completions")
+        .reasoning_effort,
+    ).toBe("max");
+
+    baseline = anthropicStream.receivedRequests.length;
+    const translatedResponse = await post("/v1/chat/completions", {
+      model: "effort-map-anthropic-stream",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "medium",
+      stream: true,
+    });
+    expect(translatedResponse.contentType).toContain("text/event-stream");
+    expect(translatedResponse.body).toContain("data:");
+    expect(
+      receivedSince(anthropicStream, baseline, "/v1/messages")
+        .output_config,
+    ).toEqual({ effort: "high" });
   });
 });

--- a/tests/e2e/src/cases/effort-mapping-e2e.test.ts
+++ b/tests/e2e/src/cases/effort-mapping-e2e.test.ts
@@ -1,0 +1,278 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+const API_KEY = "sk-effort-mapping";
+const KEY_HASH = createHash("sha256").update(API_KEY).digest("hex");
+
+const chatResponse = {
+  id: "chatcmpl-effort-map",
+  object: "chat.completion",
+  created: 1,
+  model: "upstream-model",
+  choices: [
+    {
+      index: 0,
+      message: { role: "assistant", content: "ok" },
+      finish_reason: "stop",
+    },
+  ],
+  usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+};
+
+const anthropicResponse = {
+  id: "msg_effort_map",
+  type: "message",
+  role: "assistant",
+  content: [{ type: "text", text: "ok" }],
+  model: "upstream-model",
+  stop_reason: "end_turn",
+  usage: { input_tokens: 2, output_tokens: 1 },
+};
+
+describe("direct-model effort mapping", () => {
+  let app: SpawnedApp | undefined;
+  let openai: OpenAiUpstream | undefined;
+  let anthropic: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    openai = await startOpenAiUpstream({ nonStreamBody: chatResponse });
+    anthropic = await startOpenAiUpstream({
+      scriptedResponses: [
+        { nonStreamBody: anthropicResponse },
+        { nonStreamBody: anthropicResponse },
+        { nonStreamBody: anthropicResponse },
+        { nonStreamBody: { input_tokens: 3 } },
+      ],
+    });
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const openaiKey = await seed.createProviderKey({
+      display_name: "effort-map-openai-key",
+      secret: "sk-openai-mock",
+      api_base: `${openai.baseUrl}/v1`,
+    });
+    const anthropicKey = await seed.createProviderKey({
+      display_name: "effort-map-anthropic-key",
+      provider: "anthropic",
+      adapter: "anthropic",
+      secret: "sk-anthropic-mock",
+      api_base: anthropic.baseUrl,
+    });
+
+    const mapping = { medium: "high", high: "max" };
+    await seed.createModel({
+      display_name: "effort-map-openai",
+      provider: "openai",
+      model_name: "glm-openai-wire",
+      provider_key_id: openaiKey.id,
+      effort_mapping: mapping,
+    });
+    await seed.createModel({
+      display_name: "effort-map-anthropic",
+      provider: "anthropic",
+      model_name: "glm-anthropic-wire",
+      provider_key_id: anthropicKey.id,
+      effort_mapping: mapping,
+    });
+    await seed.createModel({
+      display_name: "effort-map-group",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "effort-map-openai" }],
+      },
+    });
+
+    // The caller key is seeded last, so successful authentication implies
+    // every model and provider key above has reached the snapshot.
+    await seed.createApiKey({
+      key_hash: KEY_HASH,
+      allowed_models: [
+        "effort-map-openai",
+        "effort-map-anthropic",
+        "effort-map-group",
+      ],
+    });
+    const proxy = new ProxyClient(app.proxyUrl, API_KEY);
+    await waitConfigPropagation(
+      async () => (await proxy.listModels()).status === 200,
+    );
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await openai?.close();
+    await anthropic?.close();
+  });
+
+  async function post(
+    path: string,
+    body: Record<string, unknown>,
+    auth: "openai" | "anthropic" = "openai",
+  ) {
+    const response = await fetch(`${app!.proxyUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(auth === "openai"
+          ? { authorization: `Bearer ${API_KEY}` }
+          : { "x-api-key": API_KEY }),
+      },
+      body: JSON.stringify(body),
+    });
+    expect(response.ok, await response.text()).toBe(true);
+  }
+
+  function receivedSince(
+    upstream: OpenAiUpstream,
+    baseline: number,
+    path: string,
+  ): Record<string, unknown> {
+    const request = upstream.receivedRequests
+      .slice(baseline)
+      .find((candidate) => candidate.path === path);
+    expect(request).toBeDefined();
+    return JSON.parse(request!.body) as Record<string, unknown>;
+  }
+
+  test("maps every supported request shape on native and translated paths", async (ctx) => {
+    if (!etcdReachable || !app || !openai || !anthropic) {
+      ctx.skip();
+      return;
+    }
+
+    let baseline = openai.receivedRequests.length;
+    await post("/v1/chat/completions", {
+      model: "effort-map-openai",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "medium",
+    });
+    expect(
+      receivedSince(openai, baseline, "/v1/chat/completions")
+        .reasoning_effort,
+    ).toBe("high");
+
+    baseline = openai.receivedRequests.length;
+    await post(
+      "/v1/messages",
+      {
+        model: "effort-map-openai",
+        max_tokens: 64,
+        messages: [{ role: "user", content: "hello" }],
+        output_config: { effort: "medium" },
+      },
+      "anthropic",
+    );
+    expect(
+      receivedSince(openai, baseline, "/v1/chat/completions")
+        .reasoning_effort,
+    ).toBe("high");
+
+    baseline = openai.receivedRequests.length;
+    await post("/v1/responses", {
+      model: "effort-map-openai",
+      input: "hello",
+      reasoning: { effort: "medium", summary: "auto" },
+    });
+    expect(
+      receivedSince(openai, baseline, "/v1/responses").reasoning,
+    ).toEqual({ effort: "high", summary: "auto" });
+
+    baseline = anthropic.receivedRequests.length;
+    await post(
+      "/v1/messages",
+      {
+        model: "effort-map-anthropic",
+        max_tokens: 64,
+        messages: [{ role: "user", content: "hello" }],
+        output_config: { effort: "medium" },
+      },
+      "anthropic",
+    );
+    expect(
+      receivedSince(anthropic, baseline, "/v1/messages").output_config,
+    ).toEqual({ effort: "high" });
+
+    baseline = anthropic.receivedRequests.length;
+    await post("/v1/chat/completions", {
+      model: "effort-map-anthropic",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "medium",
+    });
+    expect(
+      receivedSince(anthropic, baseline, "/v1/messages").output_config,
+    ).toEqual({ effort: "high" });
+
+    baseline = anthropic.receivedRequests.length;
+    await post("/v1/responses", {
+      model: "effort-map-anthropic",
+      input: "hello",
+      reasoning: { effort: "medium" },
+    });
+    expect(
+      receivedSince(anthropic, baseline, "/v1/messages").output_config,
+    ).toEqual({ effort: "high" });
+
+    baseline = anthropic.receivedRequests.length;
+    await post(
+      "/v1/messages/count_tokens",
+      {
+        model: "effort-map-anthropic",
+        messages: [{ role: "user", content: "hello" }],
+        output_config: { effort: "medium" },
+      },
+      "anthropic",
+    );
+    expect(
+      receivedSince(
+        anthropic,
+        baseline,
+        "/v1/messages/count_tokens",
+      ).output_config,
+    ).toEqual({ effort: "high" });
+  });
+
+  test("uses the dispatched target map once and passes unlisted values through", async (ctx) => {
+    if (!etcdReachable || !app || !openai) {
+      ctx.skip();
+      return;
+    }
+
+    let baseline = openai.receivedRequests.length;
+    await post("/v1/chat/completions", {
+      model: "effort-map-group",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "medium",
+    });
+    expect(
+      receivedSince(openai, baseline, "/v1/chat/completions")
+        .reasoning_effort,
+    ).toBe("high");
+
+    baseline = openai.receivedRequests.length;
+    await post("/v1/chat/completions", {
+      model: "effort-map-openai",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "low",
+    });
+    expect(
+      receivedSince(openai, baseline, "/v1/chat/completions")
+        .reasoning_effort,
+    ).toBe("low");
+  });
+});

--- a/tests/e2e/src/cases/effort-mapping-e2e.test.ts
+++ b/tests/e2e/src/cases/effort-mapping-e2e.test.ts
@@ -98,6 +98,7 @@ describe("direct-model effort mapping", () => {
   let anthropic: OpenAiUpstream | undefined;
   let openaiStream: OpenAiUpstream | undefined;
   let anthropicStream: OpenAiUpstream | undefined;
+  let ensembleStream: OpenAiUpstream | undefined;
   let etcdReachable = false;
 
   beforeAll(async () => {
@@ -119,6 +120,12 @@ describe("direct-model effort mapping", () => {
     });
     anthropicStream = await startOpenAiUpstream({
       streamEvents: anthropicStreamEvents,
+    });
+    ensembleStream = await startOpenAiUpstream({
+      scriptedResponses: [
+        { nonStreamBody: chatResponse },
+        { streamEvents: openaiStreamEvents },
+      ],
     });
     app = await spawnApp();
     const seed = new SeedClient(etcd, app.etcdPrefix);
@@ -146,6 +153,11 @@ describe("direct-model effort mapping", () => {
       adapter: "anthropic",
       secret: "sk-anthropic-stream-mock",
       api_base: anthropicStream.baseUrl,
+    });
+    const ensembleStreamKey = await seed.createProviderKey({
+      display_name: "effort-map-ensemble-stream-key",
+      secret: "sk-ensemble-stream-mock",
+      api_base: `${ensembleStream.baseUrl}/v1`,
     });
 
     const mapping = { medium: "high", high: "max" };
@@ -178,6 +190,50 @@ describe("direct-model effort mapping", () => {
       effort_mapping: mapping,
     });
     await seed.createModel({
+      display_name: "effort-map-ensemble-panel",
+      provider: "openai",
+      model_name: "glm-ensemble-panel-wire",
+      provider_key_id: openaiKey.id,
+      effort_mapping: mapping,
+    });
+    await seed.createModel({
+      display_name: "effort-map-ensemble-judge",
+      provider: "openai",
+      model_name: "glm-ensemble-judge-wire",
+      provider_key_id: openaiKey.id,
+      effort_mapping: { medium: "max" },
+    });
+    await seed.createModel({
+      display_name: "effort-map-ensemble",
+      ensemble: {
+        panel: [{ model: "effort-map-ensemble-panel" }],
+        judge: { model: "effort-map-ensemble-judge" },
+        min_responses: 1,
+      },
+    });
+    await seed.createModel({
+      display_name: "effort-map-ensemble-stream-panel",
+      provider: "openai",
+      model_name: "glm-ensemble-stream-panel-wire",
+      provider_key_id: ensembleStreamKey.id,
+      effort_mapping: mapping,
+    });
+    await seed.createModel({
+      display_name: "effort-map-ensemble-stream-judge",
+      provider: "openai",
+      model_name: "glm-ensemble-stream-judge-wire",
+      provider_key_id: ensembleStreamKey.id,
+      effort_mapping: { medium: "max" },
+    });
+    await seed.createModel({
+      display_name: "effort-map-ensemble-stream",
+      ensemble: {
+        panel: [{ model: "effort-map-ensemble-stream-panel" }],
+        judge: { model: "effort-map-ensemble-stream-judge" },
+        min_responses: 1,
+      },
+    });
+    await seed.createModel({
       display_name: "effort-map-group",
       routing: {
         strategy: "failover",
@@ -194,6 +250,8 @@ describe("direct-model effort mapping", () => {
         "effort-map-anthropic",
         "effort-map-openai-stream",
         "effort-map-anthropic-stream",
+        "effort-map-ensemble",
+        "effort-map-ensemble-stream",
         "effort-map-group",
       ],
     });
@@ -209,6 +267,7 @@ describe("direct-model effort mapping", () => {
     await anthropic?.close();
     await openaiStream?.close();
     await anthropicStream?.close();
+    await ensembleStream?.close();
   });
 
   async function post(
@@ -244,6 +303,16 @@ describe("direct-model effort mapping", () => {
       .find((candidate) => candidate.path === path);
     expect(request).toBeDefined();
     return JSON.parse(request!.body) as Record<string, unknown>;
+  }
+
+  function chatRequestsSince(
+    upstream: OpenAiUpstream,
+    baseline: number,
+  ): Record<string, unknown>[] {
+    return upstream.receivedRequests
+      .slice(baseline)
+      .filter((request) => request.path === "/v1/chat/completions")
+      .map((request) => JSON.parse(request.body) as Record<string, unknown>);
   }
 
   test("maps every supported request shape on native and translated paths", async (ctx) => {
@@ -370,10 +439,34 @@ describe("direct-model effort mapping", () => {
       receivedSince(openai, baseline, "/v1/chat/completions")
         .reasoning_effort,
     ).toBe("low");
+
+    baseline = openai.receivedRequests.length;
+    await post("/v1/chat/completions", {
+      model: "effort-map-ensemble",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "medium",
+    });
+    const ensembleRequests = chatRequestsSince(openai, baseline);
+    expect(
+      ensembleRequests.find(
+        (request) => request.model === "glm-ensemble-panel-wire",
+      )?.reasoning_effort,
+    ).toBe("high");
+    expect(
+      ensembleRequests.find(
+        (request) => request.model === "glm-ensemble-judge-wire",
+      )?.reasoning_effort,
+    ).toBe("max");
   });
 
   test("maps native and translated streaming requests", async (ctx) => {
-    if (!etcdReachable || !app || !openaiStream || !anthropicStream) {
+    if (
+      !etcdReachable ||
+      !app ||
+      !openaiStream ||
+      !anthropicStream ||
+      !ensembleStream
+    ) {
       ctx.skip();
       return;
     }
@@ -405,5 +498,26 @@ describe("direct-model effort mapping", () => {
       receivedSince(anthropicStream, baseline, "/v1/messages")
         .output_config,
     ).toEqual({ effort: "high" });
+
+    baseline = ensembleStream.receivedRequests.length;
+    const ensembleResponse = await post("/v1/chat/completions", {
+      model: "effort-map-ensemble-stream",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "medium",
+      stream: true,
+    });
+    expect(ensembleResponse.contentType).toContain("text/event-stream");
+    expect(ensembleResponse.body).toContain("data:");
+    const ensembleRequests = chatRequestsSince(ensembleStream, baseline);
+    expect(
+      ensembleRequests.find(
+        (request) => request.model === "glm-ensemble-stream-panel-wire",
+      )?.reasoning_effort,
+    ).toBe("high");
+    expect(
+      ensembleRequests.find(
+        (request) => request.model === "glm-ensemble-stream-judge-wire",
+      )?.reasoning_effort,
+    ).toBe("max");
   });
 });


### PR DESCRIPTION
Direct models can now translate a caller-supplied reasoning effort before sending the request upstream. This lets one logical model normalize protocol effort values to the values its provider deployment accepts.

The mapping is an exact, single lookup on the final dispatched direct target. Unlisted and missing values pass through unchanged. It covers Chat Completions, Responses, Anthropic Messages, Anthropic count_tokens, streaming and non-streaming calls, and the existing cross-provider translations. Routing, semantic, and ensemble parents do not accept the field; their selected direct targets own the behavior.

Anthropic requests sent through Bedrock preserve the mapped value on both legacy InvokeModel and ConverseStream wires. The resource schema rejects the field on non-direct and embedding models while lenient loading strips misplaced values.

Standalone E2E coverage exercises native and translated OpenAI/Anthropic paths, target-level routing behavior, non-chaining, and pass-through semantics.

Control plane: api7/AISIX-Cloud#1504.
Documentation: api7/docs#2302 and api7/docs.apiseven.com#579.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable reasoning-effort mappings for eligible direct models.
  - Applied mapped values across Chat, Messages, Responses, token-counting, ensemble, and streaming requests.
  - Improved reasoning-control translation across OpenAI, Anthropic, and Bedrock requests.
  - Preserved reasoning controls when converting Responses requests to chat format.

- **Validation**
  - Model validation now identifies unsupported mappings and embedding-model restrictions.

- **Testing**
  - Added coverage for direct, streaming, cross-provider, ensemble, and Bedrock reasoning-effort scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes api7/AISIX-Cloud#1503