### PR TITLE
fix(etcd): accept configuration snapshots up to 16 MiB

### DIFF
--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -24,6 +24,7 @@ use aisix_core::{
     A2aAgent, ApiKey, CachePolicy, Guardrail, McpServer, Model, ObservabilityExporter,
     PassthroughRoute, ProviderKey,
 };
+use aisix_etcd::ETCD_MAX_DECODING_MESSAGE_SIZE;
 use etcd_client::{Client, GetOptions};
 use serde::de::DeserializeOwned;
 use tokio::sync::Mutex;
@@ -88,10 +89,10 @@ impl EtcdConfigStore {
         &self,
         key: &str,
     ) -> Result<Option<(T, i64)>, StoreError> {
-        let resp = self
-            .client
-            .lock()
-            .await
+        let client = self.client.lock().await;
+        let resp = client
+            .kv_client()
+            .max_decoding_message_size(ETCD_MAX_DECODING_MESSAGE_SIZE)
             .get(key.as_bytes().to_vec(), None)
             .await
             .map_err(|e| StoreError::Backend(e.to_string()))?;
@@ -109,10 +110,10 @@ impl EtcdConfigStore {
         kind: &str,
     ) -> Result<Vec<(String, T, i64)>, StoreError> {
         let prefix = self.range_prefix(kind);
-        let resp = self
-            .client
-            .lock()
-            .await
+        let client = self.client.lock().await;
+        let resp = client
+            .kv_client()
+            .max_decoding_message_size(ETCD_MAX_DECODING_MESSAGE_SIZE)
             .get(
                 prefix.as_bytes().to_vec(),
                 Some(GetOptions::new().with_prefix()),

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -33,6 +33,7 @@ use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AdminConfig, AisixSnapshot};
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
+use etcd_client::DeleteOptions;
 use serde_json::{json, Value};
 use tower::ServiceExt;
 
@@ -176,6 +177,53 @@ async fn models_round_trip_through_real_etcd() {
         }),
     )
     .await;
+}
+
+#[tokio::test]
+async fn model_list_accepts_snapshot_larger_than_tonic_default() {
+    let Some(url) = etcd_url() else {
+        eprintln!("skipping: ADMIN_TEST_ETCD_URL not set");
+        return;
+    };
+
+    let prefix = unique_prefix();
+    let mut client = etcd_client_for(&url).await;
+    let store = EtcdConfigStore::new(client.clone(), &prefix);
+    let display_name = "x".repeat(128 * 1024);
+    let mut snapshot_size = 0;
+    let entry_count = 34;
+    for i in 0..entry_count {
+        let payload = json!({
+            "display_name": display_name,
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111"
+        });
+        snapshot_size += serde_json::to_vec(&payload).expect("serialize").len();
+        seed(
+            &mut client,
+            &prefix,
+            "models",
+            &format!("m-large-{i}"),
+            &payload,
+        )
+        .await;
+    }
+    assert!(
+        snapshot_size > 4 * 1024 * 1024,
+        "fixture must exceed tonic's default receive limit",
+    );
+
+    let models = store
+        .list_models()
+        .await
+        .expect("list large model snapshot");
+    assert_eq!(models.len(), entry_count);
+
+    client
+        .delete(prefix, Some(DeleteOptions::new().with_prefix()))
+        .await
+        .expect("cleanup large model snapshot");
 }
 
 #[tokio::test]

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -43,6 +43,8 @@ use crate::provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 /// Fixed-interval retry: 5s × 5 attempts (spec §2).
 pub const CONNECT_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 pub const CONNECT_MAX_ATTEMPTS: u32 = 5;
+/// Maximum gRPC response size accepted from etcd.
+pub const ETCD_MAX_DECODING_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 
 /// Retry policy used on the initial connect. Exposed for tests so they
 /// can shrink the interval; production uses [`ConnectPolicy::default`].
@@ -136,8 +138,10 @@ impl EtcdConfigProvider {
 #[async_trait]
 impl ConfigProvider for EtcdConfigProvider {
     async fn load_all(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
-        let mut client = self.client.lock().await;
+        let client = self.client.lock().await;
         let resp = client
+            .kv_client()
+            .max_decoding_message_size(ETCD_MAX_DECODING_MESSAGE_SIZE)
             .get(
                 self.prefix.as_bytes(),
                 Some(GetOptions::new().with_prefix()),
@@ -167,11 +171,13 @@ impl ConfigProvider for EtcdConfigProvider {
         Box<dyn Stream<Item = Result<WatchEvent, ProviderError>> + Send + Unpin>,
         ProviderError,
     > {
-        let mut client = self.client.lock().await;
+        let client = self.client.lock().await;
         let opts = WatchOptions::new()
             .with_prefix()
             .with_start_revision(start_revision);
         let (watcher, stream) = client
+            .watch_client()
+            .max_decoding_message_size(ETCD_MAX_DECODING_MESSAGE_SIZE)
             .watch(self.prefix.as_bytes(), Some(opts))
             .await
             .map_err(|e| ProviderError::Watch(format_error_chain(&e)))?;

--- a/crates/aisix-etcd/src/lib.rs
+++ b/crates/aisix-etcd/src/lib.rs
@@ -30,7 +30,7 @@ pub mod supervisor;
 pub use backoff::{ExpBackoff, BASE_MS, MAX_MS};
 pub use etcd_provider::{
     ConnectPolicy, EtcdConfigProvider, EtcdWatchStream, CONNECT_MAX_ATTEMPTS,
-    CONNECT_RETRY_INTERVAL,
+    CONNECT_RETRY_INTERVAL, ETCD_MAX_DECODING_MESSAGE_SIZE,
 };
 pub use key::{parse as parse_key, KeyError, ResourceKey};
 pub use loader::{build_snapshot, BuildStats};

--- a/crates/aisix-etcd/tests/watch_integration.rs
+++ b/crates/aisix-etcd/tests/watch_integration.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use aisix_etcd::provider::ConfigProvider;
 use aisix_etcd::EtcdConfigProvider;
-use etcd_client::Client;
+use etcd_client::{Client, DeleteOptions};
 use futures::StreamExt;
 use tokio::time::timeout;
 
@@ -30,6 +30,49 @@ fn unique_prefix() -> String {
         .unwrap_or_default();
     let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     format!("/aisix-etcd-it/{nanos:x}-{}-{seq}", std::process::id())
+}
+
+/// A full environment snapshot can legitimately exceed tonic's 4 MiB
+/// default receive limit even though every individual etcd value is small.
+/// A fresh gateway must still be able to bootstrap that snapshot.
+#[tokio::test]
+async fn load_all_accepts_snapshot_larger_than_tonic_default() {
+    let url = match etcd_url() {
+        Some(u) => u,
+        None => {
+            eprintln!("ETCD_TEST_URL not set — skipping");
+            return;
+        }
+    };
+
+    let prefix = unique_prefix();
+    let mut writer = Client::connect([url.as_str()], None)
+        .await
+        .expect("writer connect");
+    let value = vec![b'x'; 128 * 1024];
+    let entry_count = 34;
+    for i in 0..entry_count {
+        writer
+            .put(format!("{prefix}/large/{i}"), value.clone(), None)
+            .await
+            .expect("put large snapshot entry");
+    }
+
+    let provider = EtcdConfigProvider::connect(&[url.clone()], prefix.clone(), None)
+        .await
+        .expect("provider connect");
+    let (entries, _) = provider.load_all().await.expect("load large snapshot");
+
+    assert_eq!(entries.len(), entry_count);
+    assert!(
+        entries.iter().map(|entry| entry.value.len()).sum::<usize>() > 4 * 1024 * 1024,
+        "fixture must exceed tonic's default receive limit",
+    );
+
+    writer
+        .delete(prefix, Some(DeleteOptions::new().with_prefix()))
+        .await
+        .expect("cleanup large snapshot entries");
 }
 
 /// The core regression test for issue #237: after `watch()` returns,


### PR DESCRIPTION
A full etcd range response can exceed tonic's 4 MiB default even when each configuration entry is small. In that case, the data plane cannot apply its initial snapshot and remains unready.

This raises the bounded etcd gRPC decoding limit to 16 MiB for bootstrap reads, watch responses, and Admin API reads.

Tests cover responses larger than 4 MiB through real etcd on both the configuration provider and Admin store paths.
