### PR TITLE
fix(etcd): lift the 4 MiB gRPC decode ceiling on configuration reads

### DIFF
--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -24,7 +24,8 @@ use aisix_core::{
     A2aAgent, ApiKey, CachePolicy, Guardrail, McpServer, Model, ObservabilityExporter,
     PassthroughRoute, ProviderKey,
 };
-use etcd_client::{Client, GetOptions};
+use aisix_etcd::kv_client;
+use etcd_client::{Client, GetOptions, KvClient};
 use serde::de::DeserializeOwned;
 use tokio::sync::Mutex;
 
@@ -43,7 +44,10 @@ pub const A2A_AGENTS_SUBKEY: &str = "a2a_agents";
 pub const PASSTHROUGH_ROUTES_SUBKEY: &str = "passthrough_routes";
 
 pub struct EtcdConfigStore {
-    client: Mutex<Client>,
+    /// A KV client carrying the gateway's raised gRPC decode limit, not the
+    /// `Client` handed in: `Client::get` reads through a sub-client that
+    /// keeps tonic's 4 MiB default, which a full configuration set outgrows.
+    client: Mutex<KvClient>,
     prefix: String,
 }
 
@@ -59,7 +63,7 @@ impl EtcdConfigStore {
     pub fn new(client: Client, prefix: impl Into<String>) -> Self {
         let prefix = prefix.into().trim_end_matches('/').to_string();
         Self {
-            client: Mutex::new(client),
+            client: Mutex::new(kv_client(&client)),
             prefix,
         }
     }

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -33,6 +33,7 @@ use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AdminConfig, AisixSnapshot};
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
+use etcd_client::{DeleteOptions, Txn, TxnOp};
 use serde_json::{json, Value};
 use tower::ServiceExt;
 
@@ -176,6 +177,71 @@ async fn models_round_trip_through_real_etcd() {
         }),
     )
     .await;
+}
+
+/// The admin read surface ranges a whole kind subtree in one gRPC
+/// message, so it meets the transport's default 4 MiB decode ceiling the
+/// same way the gateway's bootstrap range does — by resource count, not by
+/// any one document being large. A store that read through that default
+/// would fail this list with `OutOfRange`.
+#[tokio::test]
+async fn model_list_reads_a_range_larger_than_the_default_decode_limit() {
+    let Some(url) = etcd_url() else {
+        eprintln!("skipping: ADMIN_TEST_ETCD_URL not set");
+        return;
+    };
+
+    let prefix = unique_prefix();
+    let mut client = etcd_client_for(&url).await;
+    let store = EtcdConfigStore::new(client.clone(), &prefix);
+
+    // etcd caps a transaction at 128 operations, so the fixture is written
+    // in batches of that rather than one round trip per key.
+    const COUNT: usize = 26_000;
+    const BATCH: usize = 128;
+    let mut seeded_bytes = 0usize;
+    let mut ops: Vec<TxnOp> = Vec::with_capacity(BATCH);
+    for i in 0..COUNT {
+        let key = format!("{prefix}/models/m-large-{i:05}");
+        let value = serde_json::to_vec(&json!({
+            "display_name": format!("large-{i:05}"),
+            "provider": "openai",
+            "model_name": "gpt-4o",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111"
+        }))
+        .expect("serialize");
+        seeded_bytes += key.len() + value.len();
+        ops.push(TxnOp::put(key.into_bytes(), value, None));
+        if ops.len() == BATCH {
+            client
+                .txn(Txn::new().and_then(std::mem::take(&mut ops)))
+                .await
+                .expect("seed batch");
+        }
+    }
+    if !ops.is_empty() {
+        client
+            .txn(Txn::new().and_then(ops))
+            .await
+            .expect("seed batch");
+    }
+
+    // Key and value bytes only: protobuf framing adds to this, so it is a
+    // lower bound on the response the store has to decode. Guards the
+    // fixture — a shrunken one would pass against the very ceiling this
+    // test exists to cross.
+    assert!(
+        seeded_bytes > 4 * 1024 * 1024,
+        "fixture must exceed the default decode limit, got {seeded_bytes} bytes",
+    );
+
+    let models = store.list_models().await.expect("list models");
+    assert_eq!(models.len(), COUNT);
+
+    client
+        .delete(prefix, Some(DeleteOptions::new().with_prefix()))
+        .await
+        .expect("cleanup");
 }
 
 #[tokio::test]

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -235,13 +235,17 @@ async fn model_list_reads_a_range_larger_than_the_default_decode_limit() {
         "fixture must exceed the default decode limit, got {seeded_bytes} bytes",
     );
 
-    let models = store.list_models().await.expect("list models");
-    assert_eq!(models.len(), COUNT);
-
+    // Clean up before asserting: a store that decodes at the default limit
+    // fails this list, and panicking first would leave the whole fixture
+    // behind in an etcd other tests share.
+    let listed = store.list_models().await;
     client
         .delete(prefix, Some(DeleteOptions::new().with_prefix()))
         .await
         .expect("cleanup");
+
+    let models = listed.expect("list models");
+    assert_eq!(models.len(), COUNT);
 }
 
 #[tokio::test]

--- a/crates/aisix-etcd/src/client.rs
+++ b/crates/aisix-etcd/src/client.rs
@@ -1,0 +1,34 @@
+//! etcd sub-clients configured with this gateway's gRPC decode limit.
+//!
+//! `Client::get` / `Client::watch` delegate to sub-clients the `Client`
+//! keeps private, and `Client::kv_client()` / `watch_client()` hand back
+//! clones — so the decode limit can only be raised on the sub-client that
+//! actually issues the call. Every etcd read in this repository is built
+//! here so no call site can drift back onto tonic's default.
+
+use etcd_client::{Client, KvClient, WatchClient};
+
+/// Maximum size, in bytes, of a gRPC message decoded from etcd.
+///
+/// The gateway reads its whole configuration set in a single range
+/// response and keeps it resident in memory, so tonic's 4 MiB default is
+/// really a cap on how much configuration a deployment may hold — and
+/// crossing it is unrecoverable on its own: the supervisor backs off and
+/// re-issues the identical oversized range forever. Any finite ceiling
+/// would only move that failure to a larger config set, so the limit is
+/// lifted to the largest length a gRPC frame can express.
+pub const MAX_DECODING_MESSAGE_SIZE: usize = i32::MAX as usize;
+
+/// KV client for reads under [`MAX_DECODING_MESSAGE_SIZE`].
+pub fn kv_client(client: &Client) -> KvClient {
+    client
+        .kv_client()
+        .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE)
+}
+
+/// Watch client for streams under [`MAX_DECODING_MESSAGE_SIZE`].
+pub fn watch_client(client: &Client) -> WatchClient {
+    client
+        .watch_client()
+        .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE)
+}

--- a/crates/aisix-etcd/src/client.rs
+++ b/crates/aisix-etcd/src/client.rs
@@ -3,8 +3,9 @@
 //! `Client::get` / `Client::watch` delegate to sub-clients the `Client`
 //! keeps private, and `Client::kv_client()` / `watch_client()` hand back
 //! clones — so the decode limit can only be raised on the sub-client that
-//! actually issues the call. Every etcd read in this repository is built
-//! here so no call site can drift back onto tonic's default.
+//! actually issues the call. Every etcd read the gateway itself makes is
+//! built here so no call site can drift back onto tonic's default; test
+//! fixtures that talk to etcd directly are their own business.
 
 use etcd_client::{Client, KvClient, WatchClient};
 

--- a/crates/aisix-etcd/src/client.rs
+++ b/crates/aisix-etcd/src/client.rs
@@ -15,8 +15,8 @@ use etcd_client::{Client, KvClient, WatchClient};
 /// really a cap on how much configuration a deployment may hold — and
 /// crossing it is unrecoverable on its own: the supervisor backs off and
 /// re-issues the identical oversized range forever. Any finite ceiling
-/// would only move that failure to a larger config set, so the limit is
-/// lifted to the largest length a gRPC frame can express.
+/// would only move that failure to a larger config set, so the limit goes
+/// to `i32::MAX`, the conventional ceiling for a gRPC message size.
 ///
 /// The trade-off that buys: an oversized length prefix is no longer
 /// rejected before the buffer for it is reserved. The peer is the etcd

--- a/crates/aisix-etcd/src/client.rs
+++ b/crates/aisix-etcd/src/client.rs
@@ -17,6 +17,12 @@ use etcd_client::{Client, KvClient, WatchClient};
 /// re-issues the identical oversized range forever. Any finite ceiling
 /// would only move that failure to a larger config set, so the limit is
 /// lifted to the largest length a gRPC frame can express.
+///
+/// The trade-off that buys: an oversized length prefix is no longer
+/// rejected before the buffer for it is reserved. The peer is the etcd
+/// the operator configured, whose entire contents this process already
+/// trusts and holds resident, so the ceiling was never what stood between
+/// it and this gateway's memory.
 pub const MAX_DECODING_MESSAGE_SIZE: usize = i32::MAX as usize;
 
 /// KV client for reads under [`MAX_DECODING_MESSAGE_SIZE`].

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -9,7 +9,8 @@
 
 use async_trait::async_trait;
 use etcd_client::{
-    Client, ConnectOptions, Error as EtcdError, EventType, GetOptions, WatchOptions,
+    Client, ConnectOptions, Error as EtcdError, EventType, GetOptions, KvClient, WatchClient,
+    WatchOptions,
 };
 use futures::{Stream, StreamExt};
 use std::collections::VecDeque;
@@ -38,6 +39,7 @@ fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
     out
 }
 
+use crate::client::{kv_client, watch_client};
 use crate::provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 
 /// Fixed-interval retry: 5s × 5 attempts (spec §2).
@@ -62,10 +64,14 @@ impl Default for ConnectPolicy {
 }
 
 pub struct EtcdConfigProvider {
-    /// The etcd client itself is `Clone`-cheap (internally Arc'd), but we
-    /// still serialise access for watches through a Mutex because the
-    /// underlying channel is not Sync at construction time.
-    client: Mutex<Client>,
+    /// The sub-clients are `Clone`-cheap (internally Arc'd), but we still
+    /// serialise access through a Mutex because their RPC methods take
+    /// `&mut self`. They are held rather than derived from a `Client` per
+    /// call so the raised decode limit cannot be lost by a later call site
+    /// reaching for `Client::get` / `Client::watch`, which keep tonic's
+    /// 4 MiB default.
+    kv: Mutex<KvClient>,
+    watch: Mutex<WatchClient>,
     prefix: String,
 }
 
@@ -102,7 +108,8 @@ impl EtcdConfigProvider {
                 Ok(client) => {
                     tracing::info!(attempt, prefix = %prefix, "etcd connected");
                     return Ok(Self {
-                        client: Mutex::new(client),
+                        kv: Mutex::new(kv_client(&client)),
+                        watch: Mutex::new(watch_client(&client)),
                         prefix,
                     });
                 }
@@ -136,8 +143,8 @@ impl EtcdConfigProvider {
 #[async_trait]
 impl ConfigProvider for EtcdConfigProvider {
     async fn load_all(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
-        let mut client = self.client.lock().await;
-        let resp = client
+        let mut kv = self.kv.lock().await;
+        let resp = kv
             .get(
                 self.prefix.as_bytes(),
                 Some(GetOptions::new().with_prefix()),
@@ -167,11 +174,11 @@ impl ConfigProvider for EtcdConfigProvider {
         Box<dyn Stream<Item = Result<WatchEvent, ProviderError>> + Send + Unpin>,
         ProviderError,
     > {
-        let mut client = self.client.lock().await;
+        let mut watch = self.watch.lock().await;
         let opts = WatchOptions::new()
             .with_prefix()
             .with_start_revision(start_revision);
-        let (watcher, stream) = client
+        let (watcher, stream) = watch
             .watch(self.prefix.as_bytes(), Some(opts))
             .await
             .map_err(|e| ProviderError::Watch(format_error_chain(&e)))?;

--- a/crates/aisix-etcd/src/lib.rs
+++ b/crates/aisix-etcd/src/lib.rs
@@ -20,6 +20,7 @@
 #![deny(rust_2018_idioms)]
 
 pub mod backoff;
+pub mod client;
 pub mod etcd_provider;
 pub mod key;
 pub mod loader;
@@ -28,6 +29,7 @@ pub mod snapshot_cache;
 pub mod supervisor;
 
 pub use backoff::{ExpBackoff, BASE_MS, MAX_MS};
+pub use client::{kv_client, watch_client, MAX_DECODING_MESSAGE_SIZE};
 pub use etcd_provider::{
     ConnectPolicy, EtcdConfigProvider, EtcdWatchStream, CONNECT_MAX_ATTEMPTS,
     CONNECT_RETRY_INTERVAL,

--- a/tests/e2e/src/cases/etcd-large-config-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-large-config-e2e.test.ts
@@ -6,7 +6,6 @@ import {
   SeedClient,
   spawnApp,
   startOpenAiUpstream,
-  waitConfigPropagation,
   type OpenAiUpstream,
   type SpawnedApp,
 } from "../harness/index.js";
@@ -38,6 +37,12 @@ interface StatusConfig {
   state: string;
   applied?: { resource_counts: Record<string, number> };
   last_failure: { last_error_kind: string; last_error: string } | null;
+}
+
+async function getStatusConfig(app: SpawnedApp): Promise<StatusConfig> {
+  const res = await fetch(`${app.metricsUrl}/status/config`);
+  expect(res.status).toBe(200);
+  return (await res.json()) as StatusConfig;
 }
 
 describe("etcd bootstrap: a configuration set larger than one gRPC message", () => {
@@ -110,20 +115,22 @@ describe("etcd bootstrap: a configuration set larger than one gRPC message", () 
     // very ceiling it exists to cross.
     expect(seededBytes).toBeGreaterThan(4 * 1024 * 1024);
 
-    // Wait for the config cycle to SETTLE, either way. Waiting only for
-    // success would turn a regression into a timeout; a gateway that
-    // cannot decode the range reports its failure within a second and
-    // then loops on it, so the assertions below run on a real verdict.
-    let status: StatusConfig | undefined;
-    await waitConfigPropagation(async () => {
-      const res = await fetch(`${app!.metricsUrl}/status/config`);
-      expect(res.status).toBe(200);
-      status = (await res.json()) as StatusConfig;
-      return status.state === "synced" || status.last_failure !== null;
-    });
+    // Poll rather than gate: a gateway that cannot decode the range never
+    // reaches a terminal state — it loops on the same failed read — so the
+    // deadline has to expire, and the assertion that follows names the
+    // reason (`never_loaded`, plus the fetch error) instead of leaving a
+    // timeout to explain itself. `last_failure` is no shortcut out of the
+    // wait: it is sticky for the life of the process, so one transient
+    // etcd blip would end the wait against a snapshot still loading.
+    let status = await getStatusConfig(app);
+    const deadline = Date.now() + 60_000;
+    while (status.state !== "synced" && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 100));
+      status = await getStatusConfig(app);
+    }
 
-    expect(status?.state, JSON.stringify(status?.last_failure)).toBe("synced");
-    expect(status?.applied?.resource_counts.models).toBe(BULK_MODEL_COUNT + 1);
+    expect(status.state, JSON.stringify(status.last_failure)).toBe("synced");
+    expect(status.applied?.resource_counts.models).toBe(BULK_MODEL_COUNT + 1);
   }, 120_000);
 
   test("a model from that set serves traffic", async (ctx) => {

--- a/tests/e2e/src/cases/etcd-large-config-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-large-config-e2e.test.ts
@@ -39,9 +39,17 @@ interface StatusConfig {
   last_failure: { last_error_kind: string; last_error: string } | null;
 }
 
-async function getStatusConfig(app: SpawnedApp): Promise<StatusConfig> {
+/**
+ * `GET /status/config`, or undefined while the listener answers anything
+ * else — the caller is polling, so a transient non-200 is "not yet", not a
+ * verdict. The body is consumed either way.
+ */
+async function getStatusConfig(app: SpawnedApp): Promise<StatusConfig | undefined> {
   const res = await fetch(`${app.metricsUrl}/status/config`);
-  expect(res.status).toBe(200);
+  if (res.status !== 200) {
+    await res.text();
+    return undefined;
+  }
   return (await res.json()) as StatusConfig;
 }
 
@@ -124,13 +132,13 @@ describe("etcd bootstrap: a configuration set larger than one gRPC message", () 
     // etcd blip would end the wait against a snapshot still loading.
     let status = await getStatusConfig(app);
     const deadline = Date.now() + 60_000;
-    while (status.state !== "synced" && Date.now() < deadline) {
+    while (status?.state !== "synced" && Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 100));
       status = await getStatusConfig(app);
     }
 
-    expect(status.state, JSON.stringify(status.last_failure)).toBe("synced");
-    expect(status.applied?.resource_counts.models).toBe(BULK_MODEL_COUNT + 1);
+    expect(status?.state, JSON.stringify(status?.last_failure)).toBe("synced");
+    expect(status?.applied?.resource_counts.models).toBe(BULK_MODEL_COUNT + 1);
   }, 120_000);
 
   test("a model from that set serves traffic", async (ctx) => {

--- a/tests/e2e/src/cases/etcd-large-config-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-large-config-e2e.test.ts
@@ -1,0 +1,142 @@
+import { createHash, randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// A gateway whose configuration set does not fit in one gRPC message must
+// still boot on it. The data plane reads its whole prefix in a single
+// range response at startup, so the transport's decode ceiling is crossed
+// by how MANY resources an environment has, not by any one of them being
+// large — and crossing it does not heal: the supervisor backs off and
+// re-issues the identical oversized range forever, while the snapshot
+// cache keeps serving whatever config last fit.
+//
+// The fixture is therefore many small models, the shape a deployment
+// actually grows into, and everything is seeded BEFORE the gateway starts
+// so the oversized read is the bootstrap range.
+
+const CALLER_PLAINTEXT = "sk-large-config-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+const SERVING_MODEL = "large-config-model";
+
+/**
+ * Bulk models seeded beside the serving one. Sized so the raw key+value
+ * bytes alone exceed 4 MiB; `seededBytes` below asserts that rather than
+ * trusting the arithmetic here.
+ */
+const BULK_MODEL_COUNT = 20_000;
+
+interface StatusConfig {
+  state: string;
+  applied?: { resource_counts: Record<string, number> };
+  last_failure: { last_error_kind: string; last_error: string } | null;
+}
+
+describe("etcd bootstrap: a configuration set larger than one gRPC message", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcd: EtcdClient | undefined;
+  let etcdReachable = false;
+  let seededBytes = 0;
+
+  beforeAll(async () => {
+    etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+
+    // A prefix of our own, seeded before the gateway exists, and handed
+    // to it on spawn so its first range read is the oversized one.
+    const prefix = `/aisix-e2e-${randomUUID()}`;
+    const seed = new SeedClient(etcd, prefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "large-config-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: SERVING_MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+
+    const bulk: Array<[string, string]> = [];
+    for (let i = 0; i < BULK_MODEL_COUNT; i++) {
+      const key = `${prefix}/models/${randomUUID()}`;
+      const value = JSON.stringify({
+        display_name: `bulk-model-${i}`,
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pk.id,
+      });
+      seededBytes += Buffer.byteLength(key) + Buffer.byteLength(value);
+      bulk.push([key, value]);
+    }
+    await etcd.putMany(bulk);
+
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [SERVING_MODEL],
+    });
+
+    app = await spawnApp({ etcdPrefix: prefix });
+  }, 300_000);
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  }, 60_000);
+
+  test("the whole set loads, none of it dropped", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    // Key and value bytes only: protobuf framing adds to this, so it is a
+    // lower bound on the range response the gateway has to decode. Guards
+    // the fixture — a shrunken one would leave the test green against the
+    // very ceiling it exists to cross.
+    expect(seededBytes).toBeGreaterThan(4 * 1024 * 1024);
+
+    // Wait for the config cycle to SETTLE, either way. Waiting only for
+    // success would turn a regression into a timeout; a gateway that
+    // cannot decode the range reports its failure within a second and
+    // then loops on it, so the assertions below run on a real verdict.
+    let status: StatusConfig | undefined;
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.metricsUrl}/status/config`);
+      expect(res.status).toBe(200);
+      status = (await res.json()) as StatusConfig;
+      return status.state === "synced" || status.last_failure !== null;
+    });
+
+    expect(status?.state, JSON.stringify(status?.last_failure)).toBe("synced");
+    expect(status?.applied?.resource_counts.models).toBe(BULK_MODEL_COUNT + 1);
+  }, 120_000);
+
+  test("a model from that set serves traffic", async (ctx) => {
+    if (!etcdReachable || !app) {
+      ctx.skip();
+      return;
+    }
+
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    const chat = await proxy.chat({
+      model: SERVING_MODEL,
+      messages: [{ role: "user", content: "does the oversized config serve?" }],
+    });
+    expect(chat.status, JSON.stringify(chat.body)).toBe(200);
+  }, 60_000);
+});

--- a/tests/e2e/src/harness/etcd.ts
+++ b/tests/e2e/src/harness/etcd.ts
@@ -172,6 +172,38 @@ export class EtcdClient {
     }
   }
 
+  /**
+   * Put many key/values in as few round trips as etcd allows (etcd v3
+   * `/v3/kv/txn`, whose `success` branch applies every op atomically).
+   *
+   * etcd caps a transaction at 128 operations (`--max-txn-ops`) and a
+   * whole request at 1.5 MiB (`--max-request-bytes`), so entries are sent
+   * in chunks of 128 and callers with large values may need smaller ones.
+   * For a fixture of tens of thousands of keys, one `put` per key is tens
+   * of thousands of round trips.
+   */
+  async putMany(entries: Array<[key: string, value: string]>): Promise<void> {
+    const CHUNK = 128;
+    for (let i = 0; i < entries.length; i += CHUNK) {
+      const ops = entries.slice(i, i + CHUNK).map(([key, value]) => ({
+        requestPut: {
+          key: Buffer.from(key, "utf8").toString("base64"),
+          value: Buffer.from(value, "utf8").toString("base64"),
+        },
+      }));
+      const res = await harnessRequest(`${this.endpoint}/v3/kv/txn`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ success: ops }),
+      });
+      if (res.statusCode >= 300) {
+        const body = await res.body.text();
+        throw new Error(`etcd txn failed (${res.statusCode}): ${body}`);
+      }
+      await res.body.dump();
+    }
+  }
+
   /** Read one key's value (etcd v3 `/v3/kv/range`); undefined when absent. */
   async get(key: string): Promise<string | undefined> {
     const res = await harnessRequest(`${this.endpoint}/v3/kv/range`, {


### PR DESCRIPTION
## Symptom

A gateway whose configuration set has grown past 4 MiB never loads it:

```
WARN aisix_etcd::supervisor: etcd watch failed; backing off before reconnect
error=etcd range request failed: grpc request error: status: OutOfRange,
message: "Error, decoded message length too large: found 4211298 bytes, the limit is: 4194304 bytes"
```

The data plane reads its entire prefix in a single etcd range response at
startup, and tonic caps a decoded gRPC message at 4 MiB. The ceiling is
therefore crossed by how *many* resources an environment has, not by any one
of them being large.

It does not heal: the supervisor backs off and re-issues the identical
oversized range on every reconnect. What that looks like depends on when the
instance started.

- One that was **already running** keeps serving the in-memory snapshot it
  loaded before the set outgrew the limit. Its configuration silently stops
  changing, with nothing failing.
- One that **restarts** — a rolling update, a scale-out, a rescheduled pod —
  never applies a configuration at all, and `/readyz` answers 503 until the
  first apply, so it never joins its Service. The published chart mounts the
  gateway's state directory as an `emptyDir`, per-pod and ephemeral, so there
  is no cached snapshot for a new pod to fall back on.

## What changed

The limit is raised on the sub-clients that actually issue the calls. It has
to be: `Client::get` / `Client::watch` delegate to sub-clients the `Client`
keeps private, `Client::kv_client()` hands back a clone, and the client
library exposes no `ConnectOptions` equivalent — so a connection-level option
was not available, and configuring a clone would not affect `client.get(...)`.

`aisix-etcd` now owns one constant and two constructors (`kv_client`,
`watch_client`), and both etcd readers hold sub-clients built from them: the
config provider (bootstrap range + watch stream, which the CLI export path
shares) and the admin read surface. Nothing else in the repository constructs
an etcd read path, and holding the configured sub-clients rather than a
`Client` keeps a future call site from silently dropping back to the default.

The limit is `i32::MAX` rather than a larger finite number. The configuration
set has to be fully resident in memory whatever its size, so the transport
ceiling buys nothing here — any value we picked would only move this same
incident to a slightly larger deployment. What that gives up is stated at the
constant: an oversized length prefix is no longer rejected before its buffer
is reserved, and the peer is the etcd the operator configured, whose entire
contents this process already trusts and holds resident.

No new configuration key: the startup config block rejects unknown fields, so
adding one would make a downgraded binary fail to parse its own config, and
the knob has no operable meaning for an operator.

## Behavior change

A configuration set larger than 4 MiB now loads. Existing deployments below
that size behave exactly as before — nothing else about the etcd path,
including timeouts and retry policy, is touched.

## Tests

`tests/e2e/src/cases/etcd-large-config-e2e.test.ts` seeds 20,000 models
before the gateway starts, so the oversized read is the bootstrap range, and
asserts the gateway reports every one of them applied and serves a chat
completion through one of them. The fixture guards itself: it asserts the
seeded key+value bytes exceed 4 MiB, which is a lower bound on the message
the gateway has to decode. Verified red on the unfixed binary — `state:
never_loaded` with a `fetch` failure, and the caller's key 401s because it
never reached the snapshot — and green with the fix.

`crates/aisix-admin/tests/etcd_integration.rs` covers the second reader the
same way at the Rust level: a `models` subtree larger than 4 MiB listed
through `EtcdConfigStore`, which fails with `OutOfRange` if the store reads
through a default-limit client.

The watch stream shares the same helper but has no test of its own: a single
`WatchResponse` over 4 MiB cannot be produced deterministically, because the
batch boundary is the server's choice and one transaction is itself capped
well below 4 MiB by etcd's `--max-request-bytes`.

`EtcdClient.putMany` is new in the e2e harness — etcd allows 128 operations
per transaction, so a fixture of this size needs batching rather than one
round trip per key.
