### PR TITLE
feat(server): bind the proxy listener only after the first configuration is applied

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
  "uuid",
  "yaml-rust2",
 ]

--- a/crates/aisix-core/Cargo.toml
+++ b/crates/aisix-core/Cargo.toml
@@ -37,6 +37,10 @@ http.workspace = true
 # filesource: resources.yaml parsing + deterministic UUIDv5 resource ids
 yaml-rust2.workspace = true
 uuid.workspace = true
+# `tokio::sync::watch` backs ConfigStatus::wait_until_applied — the
+# awaitable first-apply signal the boot path gates the proxy listener on.
+# Runtime-agnostic: no reactor or driver is pulled into this crate.
+tokio.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/aisix-core/src/config_status.rs
+++ b/crates/aisix-core/src/config_status.rs
@@ -52,6 +52,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
+use tokio::sync::watch;
 
 /// Maximum number of source + runtime rejection details retained for status
 /// and heartbeat reporting. Aggregate counts and the runtime identity digest
@@ -267,6 +268,12 @@ pub struct LoadObservation {
 #[derive(Debug, Clone)]
 pub struct ConfigStatus {
     inner: Arc<Mutex<ConfigStatusInner>>,
+    /// Level-triggered mirror of `inner.ever_applied`, so the boot path can
+    /// *await* the first apply instead of polling [`Self::is_ready`].
+    /// A `watch` rather than a `Notify` deliberately: a waiter that arrives
+    /// after the first apply resolves immediately instead of hanging on a
+    /// notification that already fired.
+    ever_applied_tx: Arc<watch::Sender<bool>>,
 }
 
 #[derive(Debug)]
@@ -345,6 +352,7 @@ impl ConfigStatus {
     /// Construct a status handle for a source. Starts in `never_loaded`.
     pub fn new(source_kind: SourceKind) -> Self {
         Self {
+            ever_applied_tx: Arc::new(watch::channel(false).0),
             inner: Arc::new(Mutex::new(ConfigStatusInner {
                 source_kind,
                 connected: false,
@@ -392,6 +400,11 @@ impl ConfigStatus {
         inner.latest_wholly_rejected = obs.wholly_rejected;
 
         if let Some(applied) = obs.applied {
+            if !was_applied {
+                // Open the boot-time proxy-listener gate. Sending under the
+                // inner lock is safe: waiters are woken, not run inline.
+                self.ever_applied_tx.send_replace(true);
+            }
             inner.ever_applied = true;
             inner.config_hash = Some(applied.config_hash);
             inner.applied_revision = applied.revision;
@@ -591,6 +604,20 @@ impl ConfigStatus {
     /// `GET /status/ready`.
     pub fn is_ready(&self) -> bool {
         self.inner.lock().unwrap().ever_applied
+    }
+
+    /// Resolve once a configuration has been applied — the awaitable form of
+    /// [`Self::is_ready`]. Returns immediately when an apply already
+    /// happened, so a caller cannot miss the signal by racing it.
+    ///
+    /// The boot path gates the proxy listener on this: an instance that has
+    /// never applied a configuration must not accept client traffic, because
+    /// a platform that reads "the TCP port accepts" as "this instance is
+    /// ready" would route to a gateway with nothing to serve.
+    pub async fn wait_until_applied(&self) {
+        // `wait_for` inspects the current value before it awaits.
+        // The error arm is unreachable — `self` owns the sender.
+        let _ = self.ever_applied_tx.subscribe().wait_for(|v| *v).await;
     }
 
     /// The hash of the last applied (served) config snapshot, or `None`
@@ -985,6 +1012,65 @@ mod tests {
         let cs = ConfigStatus::new(SourceKind::Etcd);
         assert_eq!(cs.view().state, ConfigState::NeverLoaded);
         assert!(!cs.is_ready());
+    }
+
+    fn clean_load() -> LoadObservation {
+        LoadObservation {
+            source_hash: "h".into(),
+            observed_revision: Some(7),
+            applied: Some(applied("h", &[("models", 1)])),
+            rejected: vec![],
+            partially_compatible: Vec::new(),
+            partially_compatible_rows_by_kind: Default::default(),
+            stale_served_rows_by_kind: Default::default(),
+            is_reload: true,
+            wholly_rejected: false,
+        }
+    }
+
+    // The boot path gates the proxy listener on this: a waiter that never
+    // resolves would hang a gateway that HAS a configuration, and one that
+    // resolves early would bind a listener with nothing to serve.
+    #[tokio::test]
+    async fn wait_until_applied_resolves_on_the_first_apply() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        let waiter = tokio::spawn({
+            let cs = cs.clone();
+            async move { cs.wait_until_applied().await }
+        });
+        // Nothing applied yet, so the waiter must still be pending.
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        cs.record_load(clean_load());
+        waiter.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wait_until_applied_returns_immediately_after_an_earlier_apply() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(clean_load());
+        // Subscribing after the fact must not miss the signal — the reason
+        // this is a watch channel and not a one-shot notification.
+        cs.wait_until_applied().await;
+    }
+
+    #[tokio::test]
+    async fn wait_until_applied_stays_pending_while_every_load_is_rejected() {
+        let cs = ConfigStatus::new(SourceKind::Etcd);
+        cs.record_load(LoadObservation {
+            applied: None,
+            wholly_rejected: true,
+            ..clean_load()
+        });
+        cs.record_fetch_failure();
+        assert!(!cs.is_ready());
+        tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            cs.wait_until_applied(),
+        )
+        .await
+        .expect_err("no configuration was applied, so the gate must stay closed");
     }
 
     #[test]

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -687,7 +687,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // a balancer is still routing here (AISIX-Cloud#1395).
     let (retire_tx, retire_rx) = watch::channel(false);
     let shutdown = ShutdownWatch {
-        retire: retire_rx,
+        retire: retire_rx.clone(),
         cancel: cancel_rx.clone(),
     };
 
@@ -1299,16 +1299,29 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // Only the proxy listener's connections are counted for the drain: it is
     // about client traffic, and folding the platform's probes into the number
     // would report a connection nobody is waiting on.
+    // The gate can defer the real bind indefinitely, so the two failures that
+    // used to surface AT the bind are probed here instead: an address that is
+    // unusable, and certificate material that cannot be loaded. Without this a
+    // typo'd `proxy.tls` path or an occupied port stops being a boot failure
+    // and becomes an exit at an arbitrary later moment — or never, on a
+    // gateway still waiting for its first configuration. Same pattern, and the
+    // same benign re-bind gap, as the metrics listener's probe above.
+    std::net::TcpListener::bind(proxy_addr)
+        .map_err(|e| anyhow::anyhow!("proxy listener bind {proxy_addr} failed: {e}"))?;
+    if let Some(tls) = proxy_tls.as_ref() {
+        downstream_tls_acceptor(tls, "proxy").await?;
+    }
     let proxy_drain = livez_state.clone();
     let gate_status = config_status.clone();
     let mut gate_cancel = cancel_rx.clone();
+    let mut gate_retire = retire_rx.clone();
     // The gate wraps the call rather than living inside `serve_http`, which
     // both listener modes enter: `serve_http_tpc` branches off before the
     // single-listener bind, so a gate placed further in would not cover the
     // thread-per-core `SO_REUSEPORT` path. Left lazy so the shutdown
     // coordinator below is spawned before the wait begins.
     let proxy_serve = async move {
-        if !await_first_config(&gate_status, &mut gate_cancel, proxy_addr).await {
+        if !await_first_config(&gate_status, &mut gate_cancel, &mut gate_retire, proxy_addr).await {
             return Ok(());
         }
         serve_http(
@@ -1924,30 +1937,52 @@ const FIRST_CONFIG_WAIT_LOG_INTERVAL: Duration = Duration::from_secs(10);
 /// indefinitely — the watch supervisor owns the retry loop and its backoff,
 /// and `/status/ready` on the metrics listener answers 503 throughout.
 ///
-/// Returns `false` when shutdown was requested first, in which case the proxy
-/// listener is never bound at all.
+/// Returns `false` once shutdown has started, in which case the proxy listener
+/// is never bound at all. `retire` is what SIGTERM flips; `cancel` only follows
+/// after the drain window, so waiting on `cancel` alone would let a
+/// configuration landing mid-drain open a fresh listener on an instance that is
+/// already terminating.
 async fn await_first_config(
     config_status: &ConfigStatus,
     cancel: &mut watch::Receiver<bool>,
+    retire: &mut watch::Receiver<bool>,
     proxy_addr: std::net::SocketAddr,
 ) -> bool {
     if config_status.is_ready() {
         return true;
     }
+    tracing::info!(
+        addr = %proxy_addr,
+        "waiting for the first configuration before binding the proxy listener",
+    );
     let applied = config_status.wait_until_applied();
     tokio::pin!(applied);
-    // Ticks immediately, so the first line lands as soon as the wait starts.
-    let mut ticker = tokio::time::interval(FIRST_CONFIG_WAIT_LOG_INTERVAL);
+    // First tick one interval in, not immediately: a cold etcd boot reaches
+    // this a few milliseconds before its first `load_all` returns, and a
+    // warning that fires on every healthy boot is one operators learn to
+    // filter out. The INFO line above already records that the wait started.
+    let mut ticker = tokio::time::interval_at(
+        tokio::time::Instant::now() + FIRST_CONFIG_WAIT_LOG_INTERVAL,
+        FIRST_CONFIG_WAIT_LOG_INTERVAL,
+    );
     loop {
-        // `biased` so a configuration arriving in the same wakeup as the
+        // `biased` so a configuration arriving in the same wakeup as a
         // shutdown signal cannot win the race and open a listener the
         // shutdown coordinator is already tearing down.
         tokio::select! {
             biased;
+            _ = retire.wait_for(|draining| *draining) => {
+                tracing::info!(
+                    addr = %proxy_addr,
+                    "shutdown started before the first configuration was applied — \
+                     proxy listener never bound",
+                );
+                return false;
+            }
             _ = cancel.wait_for(|cancelled| *cancelled) => {
                 tracing::info!(
                     addr = %proxy_addr,
-                    "shutdown requested before the first configuration was applied — \
+                    "cancelled before the first configuration was applied — \
                      proxy listener never bound",
                 );
                 return false;
@@ -1962,7 +1997,7 @@ async fn await_first_config(
             _ = ticker.tick() => {
                 tracing::warn!(
                     addr = %proxy_addr,
-                    "proxy listener not bound: waiting for the first configuration to be applied",
+                    "proxy listener still not bound: no configuration has been applied yet",
                 );
             }
         }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -1939,7 +1939,19 @@ async fn await_first_config(
     // Ticks immediately, so the first line lands as soon as the wait starts.
     let mut ticker = tokio::time::interval(FIRST_CONFIG_WAIT_LOG_INTERVAL);
     loop {
+        // `biased` so a configuration arriving in the same wakeup as the
+        // shutdown signal cannot win the race and open a listener the
+        // shutdown coordinator is already tearing down.
         tokio::select! {
+            biased;
+            _ = cancel.wait_for(|cancelled| *cancelled) => {
+                tracing::info!(
+                    addr = %proxy_addr,
+                    "shutdown requested before the first configuration was applied — \
+                     proxy listener never bound",
+                );
+                return false;
+            }
             _ = &mut applied => {
                 tracing::info!(
                     addr = %proxy_addr,
@@ -1952,14 +1964,6 @@ async fn await_first_config(
                     addr = %proxy_addr,
                     "proxy listener not bound: waiting for the first configuration to be applied",
                 );
-            }
-            _ = cancel.wait_for(|cancelled| *cancelled) => {
-                tracing::info!(
-                    addr = %proxy_addr,
-                    "shutdown requested before the first configuration was applied — \
-                     proxy listener never bound",
-                );
-                return false;
             }
         }
     }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -1288,26 +1288,41 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
         }
     };
 
-    // Step 9: bind + serve the proxy (always). Admin is handled above.
+    // Step 9: bind + serve the proxy, once a configuration has been
+    // applied. Admin is handled above.
     let proxy_addr: std::net::SocketAddr = cfg.proxy.addr.parse()?;
     let proxy_tls = cfg.proxy.tls.clone();
     let proxy_workers = cfg
         .proxy
         .thread_per_core_enabled()
         .then(|| cfg.proxy.worker_threads());
-    let proxy_serve = serve_http(
-        proxy_addr,
-        proxy_router,
-        proxy_tls,
-        downstream_idle_timeout,
-        shutdown,
-        "proxy",
-        proxy_workers,
-        // Only the proxy listener's connections are counted: the drain is
-        // about client traffic, and folding the platform's probes into the
-        // number would report a connection nobody is waiting on.
-        Some(livez_state.clone()),
-    );
+    // Only the proxy listener's connections are counted for the drain: it is
+    // about client traffic, and folding the platform's probes into the number
+    // would report a connection nobody is waiting on.
+    let proxy_drain = livez_state.clone();
+    let gate_status = config_status.clone();
+    let mut gate_cancel = cancel_rx.clone();
+    // The gate wraps the call rather than living inside `serve_http`, which
+    // both listener modes enter: `serve_http_tpc` branches off before the
+    // single-listener bind, so a gate placed further in would not cover the
+    // thread-per-core `SO_REUSEPORT` path. Left lazy so the shutdown
+    // coordinator below is spawned before the wait begins.
+    let proxy_serve = async move {
+        if !await_first_config(&gate_status, &mut gate_cancel, proxy_addr).await {
+            return Ok(());
+        }
+        serve_http(
+            proxy_addr,
+            proxy_router,
+            proxy_tls,
+            downstream_idle_timeout,
+            shutdown,
+            "proxy",
+            proxy_workers,
+            Some(proxy_drain),
+        )
+        .await
+    };
 
     // Step 10: shutdown coordinator. Whichever of (signal, proxy, admin)
     // completes first triggers the rest.
@@ -1889,6 +1904,65 @@ async fn sniff_downstream_version(
         Downstream::Http1
     };
     Ok((version, Rewind::new(head[..filled].to_vec(), stream)))
+}
+
+/// How often the boot path repeats the "still waiting for a configuration"
+/// line while the proxy listener is held closed.
+const FIRST_CONFIG_WAIT_LOG_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Hold the boot path until the gateway has applied a configuration, so the
+/// proxy listener never binds on an instance that has nothing to serve. A
+/// platform that reads "the TCP port accepts" as "this instance is ready"
+/// otherwise routes client traffic to a gateway whose first configuration
+/// read is still in flight, and every request is rejected as an unknown API
+/// key.
+///
+/// The paths that already hold a configuration pay nothing: file mode loads
+/// synchronously and boot-fatally before this point, and an etcd boot seeded
+/// from the on-disk snapshot cache has applied that snapshot before the watch
+/// task is spawned. A cold etcd boot is the only one that waits, and it waits
+/// indefinitely — the watch supervisor owns the retry loop and its backoff,
+/// and `/status/ready` on the metrics listener answers 503 throughout.
+///
+/// Returns `false` when shutdown was requested first, in which case the proxy
+/// listener is never bound at all.
+async fn await_first_config(
+    config_status: &ConfigStatus,
+    cancel: &mut watch::Receiver<bool>,
+    proxy_addr: std::net::SocketAddr,
+) -> bool {
+    if config_status.is_ready() {
+        return true;
+    }
+    let applied = config_status.wait_until_applied();
+    tokio::pin!(applied);
+    // Ticks immediately, so the first line lands as soon as the wait starts.
+    let mut ticker = tokio::time::interval(FIRST_CONFIG_WAIT_LOG_INTERVAL);
+    loop {
+        tokio::select! {
+            _ = &mut applied => {
+                tracing::info!(
+                    addr = %proxy_addr,
+                    "first configuration applied — binding the proxy listener",
+                );
+                return true;
+            }
+            _ = ticker.tick() => {
+                tracing::warn!(
+                    addr = %proxy_addr,
+                    "proxy listener not bound: waiting for the first configuration to be applied",
+                );
+            }
+            _ = cancel.wait_for(|cancelled| *cancelled) => {
+                tracing::info!(
+                    addr = %proxy_addr,
+                    "shutdown requested before the first configuration was applied — \
+                     proxy listener never bound",
+                );
+                return false;
+            }
+        }
+    }
 }
 
 /// Serve `router` on `addr`, choosing HTTPS when `tls` is configured and

--- a/tests/e2e/src/cases/startup-config-gate-e2e.test.ts
+++ b/tests/e2e/src/cases/startup-config-gate-e2e.test.ts
@@ -1,0 +1,214 @@
+import { createHash, randomUUID } from "node:crypto";
+import { connect } from "node:net";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startEtcdRelay,
+  startOpenAiUpstream,
+  type EtcdRelay,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// The proxy listener binds only after the gateway has applied a
+// configuration. Before, it bound while the first configuration read was
+// still in flight, so a platform that reads "the TCP port accepts" as
+// "this instance is ready" routed client traffic to a gateway that knew
+// no API keys and answered every request 401 invalid_api_key.
+//
+// Both specs drive the gateway through a TCP relay standing in for etcd,
+// which is what makes the first read's timing controllable: held (the
+// read never completes), refused (the read fails and the supervisor
+// retries), or forwarding.
+
+const MODEL = "startup-gate-model";
+const CALLER_PLAINTEXT = "sk-startup-gate-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+function proxyPort(app: SpawnedApp): number {
+  return Number(new URL(app.proxyUrl).port);
+}
+
+/** True when a TCP connection to `port` on loopback is accepted. */
+function tcpAccepts(port: number, timeoutMs = 1_000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = connect(port, "127.0.0.1");
+    const settle = (accepted: boolean) => {
+      sock.destroy();
+      resolve(accepted);
+    };
+    sock.once("connect", () => settle(true));
+    sock.once("error", () => settle(false));
+    sock.setTimeout(timeoutMs, () => settle(false));
+  });
+}
+
+/** Poll until the port accepts, or the budget runs out. */
+async function waitForTcp(port: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await tcpAccepts(port)) return true;
+    await sleep(100);
+  }
+  return false;
+}
+
+/** The port must stay closed for the whole window, not merely at one instant. */
+async function staysClosed(port: number, windowMs: number): Promise<void> {
+  const deadline = Date.now() + windowMs;
+  while (Date.now() < deadline) {
+    expect(await tcpAccepts(port)).toBe(false);
+    await sleep(100);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("the proxy listener waits for the first configuration", () => {
+  let etcd: EtcdClient | undefined;
+  let etcdReachable = false;
+  let upstream: OpenAiUpstream | undefined;
+  const apps: SpawnedApp[] = [];
+  const relays: EtcdRelay[] = [];
+
+  beforeAll(async () => {
+    etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+    upstream = await startOpenAiUpstream();
+  });
+
+  afterEach(async () => {
+    await Promise.all(apps.splice(0).map((a) => a.exit()));
+    await Promise.all(relays.splice(0).map((r) => r.stop()));
+  });
+
+  /**
+   * Everything a caller needs to get a 200 out of the gateway, written
+   * straight to the real etcd. The relay decides when the gateway is
+   * allowed to read it.
+   */
+  async function seedFixtures(prefix: string): Promise<void> {
+    const seed = new SeedClient(etcd!, prefix);
+    const pk = await seed.createProviderKey({
+      display_name: "startup-gate-pk",
+      secret: "sk-mock",
+      api_base: `${upstream!.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: MODEL,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    await seed.createApiKey({ key_hash: CALLER_KEY_HASH, allowed_models: [MODEL] });
+  }
+
+  async function spawnBehindRelay(
+    relay: EtcdRelay,
+    prefix: string,
+    overrides: Record<string, unknown> = {},
+  ): Promise<SpawnedApp> {
+    const app = await spawnApp({
+      etcdPrefix: prefix,
+      // The subject of both specs is that this listener is NOT up yet.
+      awaitProxyListener: false,
+      extra: {
+        etcd: {
+          endpoints: [relay.endpoint],
+          prefix,
+          dial_timeout_ms: 5000,
+          request_timeout_ms: 5000,
+        },
+      },
+      ...overrides,
+    });
+    apps.push(app);
+    return app;
+  }
+
+  test("refuses TCP while the first read is in flight, then serves that snapshot", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    const prefix = `/aisix-e2e-gate-hold-${randomUUID()}`;
+    const relay = await startEtcdRelay();
+    relays.push(relay);
+    // Accepted but not forwarded: the range read never completes, and
+    // nothing has failed — the configuration is simply slow to arrive.
+    await relay.hold();
+    await seedFixtures(prefix);
+
+    const app = await spawnBehindRelay(relay, prefix);
+    const port = proxyPort(app);
+
+    await staysClosed(port, 2_000);
+    // The readiness surface that IS up while the proxy listener is not.
+    const ready = await fetch(`${app.metricsUrl}/status/ready`);
+    expect(ready.status).toBe(503);
+
+    await relay.release();
+    expect(await waitForTcp(port, 20_000)).toBe(true);
+
+    // Serving the snapshot the gate waited for: the caller key and the
+    // model were seeded before the gateway ever read anything.
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    const res = await proxy.chat({
+      model: MODEL,
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("a first read that fails and recovers binds the listener automatically, exactly once", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    const prefix = `/aisix-e2e-gate-fail-${randomUUID()}`;
+    const relay = await startEtcdRelay();
+    relays.push(relay);
+    // Nothing is listening: every dial is refused, which is what the
+    // watch supervisor retries on with its own backoff.
+    await relay.refuse();
+    await seedFixtures(prefix);
+
+    const app = await spawnBehindRelay(relay, prefix, {
+      // "aisix listening" is emitted once per worker on the
+      // thread-per-core path, so the count below only means "bound once"
+      // with the single-listener mode pinned. The gate itself sits
+      // outside `serve_http` and covers both modes; the sibling spec
+      // exercises whichever mode the suite is running.
+      threadPerCore: false,
+      // The bind line is INFO.
+      logLevel: "info",
+    });
+    const port = proxyPort(app);
+
+    // Several supervisor retries go by without a listener appearing.
+    await staysClosed(port, 3_000);
+    expect(app.output()).toContain("waiting for the first configuration to be applied");
+
+    await relay.release();
+    expect(await waitForTcp(port, 20_000)).toBe(true);
+
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    const res = await proxy.chat({
+      model: MODEL,
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(res.status).toBe(200);
+
+    const bindLines = app
+      .output()
+      .split("\n")
+      .filter((line) => line.includes("aisix listening") && line.includes('label="proxy"'));
+    expect(bindLines).toHaveLength(1);
+  });
+});

--- a/tests/e2e/src/cases/startup-config-gate-e2e.test.ts
+++ b/tests/e2e/src/cases/startup-config-gate-e2e.test.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { connect } from "node:net";
-import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
   ProxyClient,
@@ -8,6 +8,7 @@ import {
   spawnApp,
   startEtcdRelay,
   startOpenAiUpstream,
+  type AppOverrides,
   type EtcdRelay,
   type OpenAiUpstream,
   type SpawnedApp,
@@ -88,6 +89,10 @@ describe("the proxy listener waits for the first configuration", () => {
     await Promise.all(relays.splice(0).map((r) => r.stop()));
   });
 
+  afterAll(async () => {
+    await upstream?.close();
+  });
+
   /**
    * Everything a caller needs to get a 200 out of the gateway, written
    * straight to the real etcd. The relay decides when the gateway is
@@ -112,24 +117,37 @@ describe("the proxy listener waits for the first configuration", () => {
   async function spawnBehindRelay(
     relay: EtcdRelay,
     prefix: string,
-    overrides: Record<string, unknown> = {},
+    overrides: Partial<AppOverrides> = {},
   ): Promise<SpawnedApp> {
     const app = await spawnApp({
+      // Spread first: the three keys below are what make these specs mean
+      // anything, and a caller must not be able to replace the relay
+      // endpoint or re-arm the readiness gate without a type error.
+      ...overrides,
       etcdPrefix: prefix,
       // The subject of both specs is that this listener is NOT up yet.
       awaitProxyListener: false,
-      extra: {
-        etcd: {
-          endpoints: [relay.endpoint],
-          prefix,
-          dial_timeout_ms: 5000,
-          request_timeout_ms: 5000,
-        },
-      },
-      ...overrides,
+      // No dial/request timeouts: those config keys reach nothing in the
+      // etcd client, and writing them here would suggest a timeout is
+      // driving the retries when the supervisor's backoff is.
+      extra: { etcd: { endpoints: [relay.endpoint], prefix } },
     });
     apps.push(app);
     return app;
+  }
+
+  /** Poll the captured output until `needle` shows up. */
+  async function waitForOutput(
+    app: SpawnedApp,
+    needle: string,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (app.output().includes(needle)) return true;
+      await sleep(100);
+    }
+    return false;
   }
 
   test("refuses TCP while the first read is in flight, then serves that snapshot", async (ctx) => {
@@ -154,7 +172,7 @@ describe("the proxy listener waits for the first configuration", () => {
     expect(ready.status).toBe(503);
 
     await relay.release();
-    expect(await waitForTcp(port, 20_000)).toBe(true);
+    expect(await waitForTcp(port, 70_000)).toBe(true);
 
     // Serving the snapshot the gate waited for: the caller key and the
     // model were seeded before the gateway ever read anything.
@@ -193,10 +211,16 @@ describe("the proxy listener waits for the first configuration", () => {
 
     // Several supervisor retries go by without a listener appearing.
     await staysClosed(port, 3_000);
-    expect(app.output()).toContain("waiting for the first configuration to be applied");
+    expect(
+      await waitForOutput(
+        app,
+        "waiting for the first configuration before binding the proxy listener",
+        5_000,
+      ),
+    ).toBe(true);
 
     await relay.release();
-    expect(await waitForTcp(port, 20_000)).toBe(true);
+    expect(await waitForTcp(port, 70_000)).toBe(true);
 
     const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
     const res = await proxy.chat({

--- a/tests/e2e/src/cases/status-config-e2e.test.ts
+++ b/tests/e2e/src/cases/status-config-e2e.test.ts
@@ -442,8 +442,10 @@ async function spawnPointedAtDeadEtcd(): Promise<MinimalApp> {
   const dir = await mkdtemp(join(tmpdir(), "aisix-status-nl-"));
   const cfg = {
     // etcd-client's connect is lazy (no eager dial without auth), so the
-    // gateway boots and binds its listeners even though nothing answers here;
-    // the watch supervisor's first load never succeeds → never_loaded.
+    // gateway boots and binds its metrics listener even though nothing answers
+    // here; the watch supervisor's first load never succeeds → never_loaded.
+    // The proxy listener stays closed for exactly that reason, which is why
+    // this case gates on the metrics listener alone.
     etcd: {
       endpoints: [`http://127.0.0.1:${deadPort}`],
       prefix: "/aisix-never-loaded",

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -265,16 +265,27 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
       "spawnApp: control the admin listener with the `admin` boolean override, not `extra.admin`",
     );
   }
-  if (
-    overrides.awaitProxyListener === false &&
-    !adminEnabled &&
-    !prometheusEnabled
-  ) {
-    throw new Error(
-      "spawnApp: awaitProxyListener:false needs `admin` or `prometheus` on — " +
-        "with all three off nothing is waited on, so spawnApp would return before " +
-        "the binary has started and a later non-zero exit could not surface",
-    );
+  if (overrides.awaitProxyListener === false) {
+    // Readiness now rests entirely on the other two listeners, so both the
+    // ways of turning them off have to be refused. `extra` counts: it
+    // replaces whole top-level blocks, so an `extra.observability` can
+    // disable the metrics listener the readiness probe is waiting on while
+    // `prometheusEnabled` still reads true — spawnApp would then sit out its
+    // full readiness timeout.
+    if (!adminEnabled && !prometheusEnabled) {
+      throw new Error(
+        "spawnApp: awaitProxyListener:false needs `admin` or `prometheus` on — " +
+          "with all three off nothing is waited on, so spawnApp would return before " +
+          "the binary has started and a later non-zero exit could not surface",
+      );
+    }
+    if (overrides.extra && "observability" in overrides.extra) {
+      throw new Error(
+        "spawnApp: awaitProxyListener:false cannot be combined with " +
+          "`extra.observability` — it replaces the generated metrics block, which is " +
+          "what readiness waits on once the proxy listener is not",
+      );
+    }
   }
   const [proxyPort, adminPort, metricsPort] = await pickFreePorts(3);
   const adminKey = overrides.adminKey ?? `admin-${randomUUID()}`;

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -119,6 +119,15 @@ export interface AppOverrides {
    */
   etcdPrefix?: string;
   /**
+   * Skip the proxy `/livez` readiness gate. The proxy listener does not
+   * bind until the gateway has applied its first configuration, so a
+   * spec that deliberately starves the gateway of configuration would
+   * otherwise fail in `spawnApp` instead of in its own assertions.
+   * Readiness then rests on the metrics listener, which binds regardless
+   * of the configuration source. Defaults to true.
+   */
+  awaitProxyListener?: boolean;
+  /**
    * `managed.snapshot_cache_path` — enables the on-disk snapshot cache
    * (#871) without managed mode. Point two sequential apps (same
    * `etcdPrefix`) at one path to exercise cache-restored restarts.
@@ -375,7 +384,11 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   try {
     await Promise.race([
       Promise.all([
-        waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS),
+        // The proxy listener binds only once a configuration has been
+        // applied, so a spec that holds configuration back opts out here.
+        ...((overrides.awaitProxyListener ?? true)
+          ? [waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS)]
+          : []),
         // The admin health endpoint only exists when the admin listener is
         // bound; with `admin: false` there is no admin surface, so gate on
         // the proxy `/livez` and the metrics listener alone. (If both

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -119,12 +119,16 @@ export interface AppOverrides {
    */
   etcdPrefix?: string;
   /**
-   * Skip the proxy `/livez` readiness gate. The proxy listener does not
-   * bind until the gateway has applied its first configuration, so a
-   * spec that deliberately starves the gateway of configuration would
-   * otherwise fail in `spawnApp` instead of in its own assertions.
-   * Readiness then rests on the metrics listener, which binds regardless
-   * of the configuration source. Defaults to true.
+   * Whether readiness waits for the proxy `/livez` to answer. **Defaults
+   * to `true`**; `false` skips that gate.
+   *
+   * The proxy listener does not bind until the gateway has applied its
+   * first configuration, so a spec that deliberately starves the gateway
+   * of configuration would otherwise fail in `spawnApp` instead of in its
+   * own assertions. Readiness then rests on the metrics listener, which
+   * binds regardless of the configuration source — so `prometheus` (or
+   * `admin`) must stay on, and `spawnApp` rejects the combination that
+   * would leave it with nothing to wait for.
    */
   awaitProxyListener?: boolean;
   /**
@@ -259,6 +263,17 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   if (overrides.extra && "admin" in overrides.extra) {
     throw new Error(
       "spawnApp: control the admin listener with the `admin` boolean override, not `extra.admin`",
+    );
+  }
+  if (
+    overrides.awaitProxyListener === false &&
+    !adminEnabled &&
+    !prometheusEnabled
+  ) {
+    throw new Error(
+      "spawnApp: awaitProxyListener:false needs `admin` or `prometheus` on — " +
+        "with all three off nothing is waited on, so spawnApp would return before " +
+        "the binary has started and a later non-zero exit could not surface",
     );
   }
   const [proxyPort, adminPort, metricsPort] = await pickFreePorts(3);

--- a/tests/e2e/src/harness/etcd-relay.ts
+++ b/tests/e2e/src/harness/etcd-relay.ts
@@ -1,0 +1,110 @@
+import { once } from "node:events";
+import { connect, createServer, type Socket } from "node:net";
+
+import { etcdEndpoint } from "./etcd.js";
+import { pickFreePort } from "./ports.js";
+
+/**
+ * A TCP relay the gateway dials instead of etcd, so a spec can decide
+ * exactly when the first configuration read is allowed to complete.
+ *
+ * Three states, and the difference between the first two matters:
+ *
+ * - `hold()` — listening, connections accepted, nothing forwarded. The
+ *   gateway's range read stays in flight indefinitely (etcd-client's
+ *   `Client::connect` is lazy, so the connection is only established
+ *   here). No error is produced; the read is simply slow.
+ * - `refuse()` — not listening. Every dial gets `ECONNREFUSED`, which is
+ *   the reachability failure the watch supervisor retries on.
+ * - `release()` — listening and forwarding, including every connection
+ *   held since `hold()`.
+ *
+ * The target is always `etcdEndpoint()`, so the relay stays on this
+ * fork's own cluster.
+ */
+export interface EtcdRelay {
+  /** Endpoint to put in the gateway's `etcd.endpoints`. */
+  endpoint: string;
+  /** Accept connections but forward nothing. */
+  hold(): Promise<void>;
+  /** Stop listening: dials are refused and held connections are dropped. */
+  refuse(): Promise<void>;
+  /** Forward held and future connections to the real etcd. */
+  release(): Promise<void>;
+  /** Tear the relay down. */
+  stop(): Promise<void>;
+}
+
+export async function startEtcdRelay(): Promise<EtcdRelay> {
+  const target = new URL(etcdEndpoint());
+  if (!target.port) {
+    throw new Error(`etcd endpoint ${target.href} has no port; the relay cannot target it`);
+  }
+  const targetHost = target.hostname;
+  const targetPort = Number(target.port);
+  const port = await pickFreePort();
+
+  let forwarding = false;
+  const held: Socket[] = [];
+  const open = new Set<Socket>();
+
+  const track = (s: Socket) => {
+    open.add(s);
+    s.on("close", () => open.delete(s));
+    // A peer vanishing (gateway teardown, `refuse()`) is expected here and
+    // must not surface as an unhandled 'error' event.
+    s.on("error", () => s.destroy());
+  };
+
+  const forward = (client: Socket) => {
+    const upstream = connect(targetPort, targetHost);
+    track(upstream);
+    upstream.on("error", () => client.destroy());
+    client.on("error", () => upstream.destroy());
+    client.pipe(upstream);
+    upstream.pipe(client);
+  };
+
+  const server = createServer((client) => {
+    track(client);
+    if (forwarding) forward(client);
+    else held.push(client);
+  });
+  server.on("error", () => {});
+
+  const listen = async () => {
+    if (server.listening) return;
+    server.listen(port, "127.0.0.1");
+    await once(server, "listening");
+  };
+
+  const unlisten = async () => {
+    if (!server.listening) return;
+    const closed = once(server, "close");
+    server.close();
+    for (const s of open) s.destroy();
+    open.clear();
+    held.length = 0;
+    await closed;
+  };
+
+  return {
+    endpoint: `http://127.0.0.1:${port}`,
+    async hold() {
+      forwarding = false;
+      await listen();
+    },
+    async refuse() {
+      forwarding = false;
+      await unlisten();
+    },
+    async release() {
+      forwarding = true;
+      await listen();
+      for (const client of held.splice(0)) forward(client);
+    },
+    async stop() {
+      await unlisten();
+    },
+  };
+}

--- a/tests/e2e/src/harness/etcd-relay.ts
+++ b/tests/e2e/src/harness/etcd-relay.ts
@@ -70,12 +70,28 @@ export async function startEtcdRelay(): Promise<EtcdRelay> {
     if (forwarding) forward(client);
     else held.push(client);
   });
+  // Keeps a post-listen accept error from throwing on an EventEmitter with
+  // no 'error' listener. `listen()` adds its own, which still sees the event.
   server.on("error", () => {});
 
   const listen = async () => {
     if (server.listening) return;
+    // Race the two outcomes: awaiting `listening` alone turns a bind
+    // failure into a hang, and the spec would time out with no cause.
+    const up = new Promise<void>((resolve, reject) => {
+      const onListening = () => {
+        server.off("error", onError);
+        resolve();
+      };
+      const onError = (err: Error) => {
+        server.off("listening", onListening);
+        reject(err);
+      };
+      server.once("listening", onListening);
+      server.once("error", onError);
+    });
     server.listen(port, "127.0.0.1");
-    await once(server, "listening");
+    await up;
   };
 
   const unlisten = async () => {

--- a/tests/e2e/src/harness/index.ts
+++ b/tests/e2e/src/harness/index.ts
@@ -2,6 +2,7 @@ export { spawnApp, suiteThreadPerCore, type SpawnedApp, type AppOverrides } from
 export { AdminClient, waitConfigPropagation, awaitWindowHeadroom } from "./admin.js";
 export { ProxyClient } from "./proxy.js";
 export { EtcdClient, etcdEndpoint } from "./etcd.js";
+export { startEtcdRelay, type EtcdRelay } from "./etcd-relay.js";
 export { SeedClient } from "./seed.js";
 export { startOpenAiUpstream, type OpenAiUpstream, type ReceivedRequest } from "./upstream-openai.js";
 export {


### PR DESCRIPTION
## Problem

The proxy listener binds while the gateway's first configuration read is still in flight. A platform that treats "the TCP port accepts" as "this instance is ready" therefore starts routing client traffic to an instance that has no configuration at all: it knows no API keys, so every request comes back `401 invalid_api_key` until the first snapshot lands.

Nothing in the boot path prevented this. The etcd connect is not evidence of anything either — `etcd-client`'s `Client::connect` builds a lazy channel and performs no handshake; its only awaited I/O is an `authenticate` RPC that runs solely when a user/password is configured, which managed mTLS deployments never set. The first real network round-trip is the `load_all` inside the spawned watch task, long after the listener is up.

## The gate

The proxy listener now binds only once **a configuration has ever been applied** — the existing applied-signal behind `ConfigStatus::is_ready()` / `ever_applied`, not "etcd is connected".

`ConfigStatus` gains an awaitable form of that signal. Nothing on it was awaitable before (`is_ready()` reads a `Mutex<Inner>`, `WatchStatus` is poll-only), so the boot path would otherwise have had to busy-poll. It is a `tokio::sync::watch` rather than a `Notify` deliberately: a waiter that subscribes after the first apply resolves immediately instead of hanging on a notification that already fired.

The gate wraps the `serve_http(proxy, …)` **call site**, not the body of `serve_http`. `serve_http_tpc` — the thread-per-core `SO_REUSEPORT` path — branches off inside `serve_http` before the single-listener bind, so a gate placed further in would cover one serving mode and silently miss the other. One gate at the call site covers both. It is left as a lazy future so the shutdown coordinator is spawned before the wait begins.

Unconditional: no config knob, no opt-in flag, no new startup mode. This is simply the startup order now.

## Failure behaviour

A first apply that does not succeed never gives up, never exits, and never binds a degraded listener:

- A read that **fails** puts the watch supervisor back on its existing `ExpBackoff` loop (1s base, doubling, 60s cap). No second retry policy was added.
- A read that **hangs** — a peer that completes the TCP handshake and then never answers — is awaited without a bound, and so never reaches that loop. That is deliberate: `load_all` is a single unpaginated prefix range read with no timeout on the path, and `etcd.dial_timeout_ms` / `etcd.request_timeout_ms` reach nothing in the client. Such an instance waits rather than self-heals; it says so every ten seconds.
- While the gate is closed the boot path logs one line when the wait starts and repeats a warning every ten seconds after that. It says nothing about configuration content.
- `/status/ready` on the metrics listener already answers 503 until the first apply and is the observability surface throughout — the metrics and admin listeners keep binding exactly when they did before.
- When the first apply eventually lands, the listener binds — once, however many failures preceded it.
- Deferring the bind must not defer the failures that *were* the bind, so an unusable proxy address and unloadable `proxy.tls` material are probed eagerly at the call site, the way the metrics listener already probes its own address. They stay boot-fatal.
- Shutdown ends the wait: the gate watches the retire signal SIGTERM raises, not just the cancel that follows the drain window, so a configuration landing mid-drain cannot open a listener on an instance that is already terminating.

## What does not change

- **File mode** (`resources_file`): `load_resources_file_tracked()` already loads synchronously and boot-fatally before the bind, so the gate passes immediately. No added startup latency.
- **etcd mode with a warm on-disk snapshot cache**: `restore_from_cache()` reaches `record_apply()` before the watch task is spawned, so the gate passes immediately. No added startup latency, and `restore_from_cache` semantics are untouched.
- **etcd mode, cold boot with no cache**: the only path that waits, and the path this change exists for.

## Behaviour change for existing etcd-mode deployments

This is user-visible. A cold boot against an unreachable configuration source now **never opens the proxy port**. Previously it opened the port and answered every request with `401 invalid_api_key`. Nothing needs to be edited to get the new behaviour, and there is no way to opt out of it.

An orchestrator whose readiness check is a TCP connect or an HTTP probe on the proxy port will now see the instance as not-ready during that window instead of ready-and-broken, and will hold traffic back accordingly. An instance stuck there stays visible on the metrics listener: `/status/ready` reports 503 and `/status/config` reports `never_loaded`.

`/livez` and `/readyz` are served by the proxy router, so while the gate is closed a probe pointed at them gets a refused connection rather than a response. On Kubernetes that means an instance whose configuration source stays unreachable past the startup-probe budget is restarted by the platform, which is the intended outcome: an instance that has never held a configuration has nothing to serve, and restarting it is the platform's normal expression of that. The first range read costs single-digit seconds even for very large configurations — the 20,000-model case in this repo's own suite completes in about five — so a normal cold boot is nowhere near that budget.

## Tests

New DP standalone E2E, `tests/e2e/src/cases/startup-config-gate-e2e.test.ts`, driving the gateway through a TCP relay that stands in for etcd (`tests/e2e/src/harness/etcd-relay.ts`) so the first read's timing is controllable — held (the read never completes, nothing has failed), refused (the read fails and the supervisor retries), or forwarding:

1. The proxy port refuses TCP while the first read is in flight, `/status/ready` reports 503, and once the relay is released the port accepts and serves a chat completion from the snapshot that was seeded before the gateway read anything.
2. A first read that fails persistently and then recovers binds the listener automatically, exactly once, with no restart.

Both were verified to fail with the gate mutated out, on the final revision of the change. The second pins `thread_per_core: false` because the bind line is emitted once per worker on the thread-per-core path, so the "exactly once" count is only meaningful in the single-listener mode; the gate itself sits outside `serve_http` and covers both, and the first test runs in whichever mode the suite leg is configured for.

Unit coverage on the new signal in `crates/aisix-core/src/config_status.rs`: it resolves on the first apply, resolves immediately for a waiter that arrives afterwards, and stays pending while every load is rejected.

## Upstream baseline

The established Python-based LLM proxy we use as a baseline reaches a similar end state, but by a different route and with different failure behaviour. It loads its configuration inside the ASGI lifespan startup hook, and the ASGI server it runs under only creates its listening socket after that hook returns — so in the default single-worker mode the socket is never bound if the configuration load raises. That is a side effect of the framework's lifespan semantics rather than a purpose-built gate: there is no retry, the process simply exits, and in its multi-worker mode the master process binds the listening socket before any worker's own configuration load has completed.

Two deliberate divergences here. First, a configuration source that is temporarily unreachable is a normal condition for a data plane whose control plane may be restarting, so the gateway retries indefinitely on its existing backoff rather than exiting — an exit would hand the restart loop to the orchestrator and lose the on-disk snapshot cache's warm-boot advantage. Second, the gate is placed outside the listener-mode branch, so the thread-per-core `SO_REUSEPORT` path is covered too; the baseline's multi-worker mode is the case where its equivalent does not hold.

Fixes api7/AISIX-Cloud#1513
