### PR TITLE
fix(etcd): make dial_timeout_ms and request_timeout_ms take effect

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,8 +7,21 @@ etcd:
   prefix: "/aisix"
   # user: "aisix"
   # password_env: "AISIX_ETCD_PASSWORD"
-  dial_timeout_ms: 5000
-  request_timeout_ms: 5000
+  # Optional bounds on etcd I/O. Both are unset by default, and unset
+  # means unbounded.
+  #
+  # `dial_timeout_ms` bounds establishing the connection.
+  # `request_timeout_ms` bounds a single unary call — the configuration
+  # range read at boot and on every reconnect, and the admin API's reads.
+  # It deliberately does not apply to the watch stream, which is
+  # long-lived and would be torn down by any such bound.
+  #
+  # Leave `request_timeout_ms` unset unless you specifically want a slow
+  # etcd to fail fast: the range read grows with the size of your
+  # configuration, and a bound it cannot finish inside makes the gateway
+  # retry the same read forever without ever serving traffic.
+  # dial_timeout_ms: 5000
+  # request_timeout_ms: 5000
   # Optional TLS / mTLS bundle. Required when connecting to an
   # AISIX Cloud Data Plane Manager (endpoint is https:// and the control plane issues
   # a client cert via IssueAIDataplaneCertificate). Uncomment and

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,7 +10,8 @@ etcd:
   # Optional bounds on etcd I/O. Both are unset by default, and unset
   # means unbounded.
   #
-  # `dial_timeout_ms` bounds establishing the connection.
+  # `dial_timeout_ms` bounds the TCP connect — not the TLS handshake
+  # after it, and not the authentication exchange when `user` is set.
   # `request_timeout_ms` bounds a single unary call — the configuration
   # range read at boot and on every reconnect, and the admin API's reads.
   # It deliberately does not apply to the watch stream, which is

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -38,7 +38,8 @@ etcd:
     - "https://placeholder-overridden-at-register:2379"
   prefix: "/aisix"
   # Both timeouts are unset by default, and unset means unbounded.
-  # `dial_timeout_ms` bounds the connect; `request_timeout_ms` bounds a
+  # `dial_timeout_ms` bounds the TCP connect only, not the TLS handshake
+  # layered above it; `request_timeout_ms` bounds a
   # single unary call (the configuration range read, the admin reads) but
   # never the watch stream. A `request_timeout_ms` the range read cannot
   # finish inside makes the gateway retry it forever without ever serving

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -37,8 +37,14 @@ etcd:
   endpoints:
     - "https://placeholder-overridden-at-register:2379"
   prefix: "/aisix"
-  dial_timeout_ms: 5000
-  request_timeout_ms: 5000
+  # Both timeouts are unset by default, and unset means unbounded.
+  # `dial_timeout_ms` bounds the connect; `request_timeout_ms` bounds a
+  # single unary call (the configuration range read, the admin reads) but
+  # never the watch stream. A `request_timeout_ms` the range read cannot
+  # finish inside makes the gateway retry it forever without ever serving
+  # traffic, so leave it unset unless a slow etcd must fail fast.
+  # dial_timeout_ms: 5000
+  # request_timeout_ms: 5000
 
 proxy:
   addr: "0.0.0.0:3000"

--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -115,11 +115,12 @@ impl EtcdConfigStore {
         &self,
         key: &str,
     ) -> Result<Option<(T, i64)>, StoreError> {
-        let mut client = self.client.lock().await;
-        let resp = self
-            .bound(client.get(key.as_bytes().to_vec(), None))
-            .await?
-            .map_err(|e| StoreError::Backend(e.to_string()))?;
+        let resp = {
+            let mut client = self.client.lock().await;
+            self.bound(client.get(key.as_bytes().to_vec(), None))
+                .await?
+        }
+        .map_err(|e| StoreError::Backend(e.to_string()))?;
         let kv = match resp.kvs().first() {
             Some(kv) => kv,
             None => return Ok(None),
@@ -134,14 +135,17 @@ impl EtcdConfigStore {
         kind: &str,
     ) -> Result<Vec<(String, T, i64)>, StoreError> {
         let prefix = self.range_prefix(kind);
-        let mut client = self.client.lock().await;
-        let resp = self
-            .bound(client.get(
+        // Scoped so the guard covers the call and not the decode loop
+        // below, which is where it sat before the bound was introduced.
+        let resp = {
+            let mut client = self.client.lock().await;
+            self.bound(client.get(
                 prefix.as_bytes().to_vec(),
                 Some(GetOptions::new().with_prefix()),
             ))
             .await?
-            .map_err(|e| StoreError::Backend(e.to_string()))?;
+        }
+        .map_err(|e| StoreError::Backend(e.to_string()))?;
 
         let mut out = Vec::with_capacity(resp.kvs().len());
         for kv in resp.kvs() {

--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -27,6 +27,7 @@ use aisix_core::{
 use aisix_etcd::kv_client;
 use etcd_client::{Client, GetOptions, KvClient};
 use serde::de::DeserializeOwned;
+use std::time::Duration;
 use tokio::sync::Mutex;
 
 use crate::store::{ConfigStore, StoreError};
@@ -49,6 +50,10 @@ pub struct EtcdConfigStore {
     /// keeps tonic's 4 MiB default, which a full configuration set outgrows.
     client: Mutex<KvClient>,
     prefix: String,
+    /// `etcd.request_timeout_ms`, applied per call. `None` — the default
+    /// — leaves the reads unbounded, which is what they were before the
+    /// key was wired to anything.
+    request_timeout: Option<Duration>,
 }
 
 impl std::fmt::Debug for EtcdConfigStore {
@@ -60,11 +65,16 @@ impl std::fmt::Debug for EtcdConfigStore {
 }
 
 impl EtcdConfigStore {
-    pub fn new(client: Client, prefix: impl Into<String>) -> Self {
+    pub fn new(
+        client: Client,
+        prefix: impl Into<String>,
+        request_timeout: Option<Duration>,
+    ) -> Self {
         let prefix = prefix.into().trim_end_matches('/').to_string();
         Self {
             client: Mutex::new(kv_client(&client)),
             prefix,
+            request_timeout,
         }
     }
 
@@ -88,16 +98,27 @@ impl EtcdConfigStore {
         full_key.strip_prefix(&needle)
     }
 
+    /// Apply `request_timeout`, when set, to one in-flight read.
+    async fn bound<T>(&self, fut: impl std::future::Future<Output = T>) -> Result<T, StoreError> {
+        match self.request_timeout {
+            None => Ok(fut.await),
+            Some(d) => tokio::time::timeout(d, fut).await.map_err(|_| {
+                StoreError::Backend(format!(
+                    "etcd read exceeded etcd.request_timeout_ms ({} ms)",
+                    d.as_millis()
+                ))
+            }),
+        }
+    }
+
     async fn get_one<T: DeserializeOwned>(
         &self,
         key: &str,
     ) -> Result<Option<(T, i64)>, StoreError> {
+        let mut client = self.client.lock().await;
         let resp = self
-            .client
-            .lock()
-            .await
-            .get(key.as_bytes().to_vec(), None)
-            .await
+            .bound(client.get(key.as_bytes().to_vec(), None))
+            .await?
             .map_err(|e| StoreError::Backend(e.to_string()))?;
         let kv = match resp.kvs().first() {
             Some(kv) => kv,
@@ -113,15 +134,13 @@ impl EtcdConfigStore {
         kind: &str,
     ) -> Result<Vec<(String, T, i64)>, StoreError> {
         let prefix = self.range_prefix(kind);
+        let mut client = self.client.lock().await;
         let resp = self
-            .client
-            .lock()
-            .await
-            .get(
+            .bound(client.get(
                 prefix.as_bytes().to_vec(),
                 Some(GetOptions::new().with_prefix()),
-            )
-            .await
+            ))
+            .await?
             .map_err(|e| StoreError::Backend(e.to_string()))?;
 
         let mut out = Vec::with_capacity(resp.kvs().len());
@@ -339,7 +358,7 @@ mod tests {
             .unwrap()
             .block_on(client_fut)
             .expect("lazy connect never fails synchronously");
-        EtcdConfigStore::new(client, "/aisix")
+        EtcdConfigStore::new(client, "/aisix", None)
     }
 
     #[test]
@@ -379,7 +398,7 @@ mod tests {
                 None,
             ))
             .expect("lazy connect never fails synchronously");
-        let store = EtcdConfigStore::new(client, "/aisix/");
+        let store = EtcdConfigStore::new(client, "/aisix/", None);
         assert_eq!(store.prefix(), "/aisix");
         assert_eq!(store.key_for("models", "a"), "/aisix/models/a");
     }
@@ -409,7 +428,7 @@ mod tests {
         let mut client = etcd_client::Client::connect([endpoint], None)
             .await
             .expect("etcd client");
-        let store = EtcdConfigStore::new(client.clone(), "/aisix-it");
+        let store = EtcdConfigStore::new(client.clone(), "/aisix-it", None);
 
         // Resources reach etcd by direct writes (the declarative path);
         // the store is the read side. Seed a model the way an operator

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -63,7 +63,7 @@ async fn etcd_client_for(url: &str) -> etcd_client::Client {
 }
 
 async fn build_state(client: etcd_client::Client, prefix: &str) -> AdminState {
-    let store: Arc<dyn ConfigStore> = Arc::new(EtcdConfigStore::new(client, prefix));
+    let store: Arc<dyn ConfigStore> = Arc::new(EtcdConfigStore::new(client, prefix, None));
     let handle = SnapshotHandle::new(AisixSnapshot::new());
     let cfg = AdminConfig {
         enabled: true,
@@ -193,7 +193,7 @@ async fn model_list_reads_a_range_larger_than_the_default_decode_limit() {
 
     let prefix = unique_prefix();
     let mut client = etcd_client_for(&url).await;
-    let store = EtcdConfigStore::new(client.clone(), &prefix);
+    let store = EtcdConfigStore::new(client.clone(), &prefix, None);
 
     // etcd caps a transaction at 128 operations, so the fixture is written
     // in batches of that rather than one round trip per key.

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -124,10 +124,27 @@ pub struct EtcdConfig {
     /// read at connect time — never stored in the config struct.
     #[serde(default)]
     pub password_env: Option<String>,
-    #[serde(default = "EtcdConfig::default_dial_timeout")]
-    pub dial_timeout_ms: u64,
-    #[serde(default = "EtcdConfig::default_request_timeout")]
-    pub request_timeout_ms: u64,
+    /// Bound on establishing the gRPC connection to etcd, in
+    /// milliseconds. Unset — the default — leaves the dial unbounded and
+    /// the OS TCP stack is the only limit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dial_timeout_ms: Option<u64>,
+    /// Bound on a single unary etcd call, in milliseconds. Unset — the
+    /// default — leaves those calls unbounded.
+    ///
+    /// When set it covers the configuration range read (`load_all`) and
+    /// the admin surface's reads. It deliberately does NOT cover the
+    /// watch: that stream is long-lived by construction, so a bound on it
+    /// would expire on every interval quiet enough to produce no event
+    /// and leave the gateway reconnecting instead of watching.
+    ///
+    /// The default is unset rather than a finite value because the range
+    /// read scales with the size of the configuration set: a bound short
+    /// enough to be useful on a small deployment aborts the read on a
+    /// large one, and the supervisor then re-issues the identical read
+    /// forever without the instance ever serving traffic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_timeout_ms: Option<u64>,
     /// Optional TLS / mTLS bundle used to authenticate to the etcd
     /// endpoint. Required when talking to an aisix.cloud DP Manager
     /// (see prd-09 §9.3.3 — the CP issues a 10-year client cert via
@@ -345,8 +362,8 @@ impl Default for EtcdConfig {
             env_id: String::new(),
             user: None,
             password_env: None,
-            dial_timeout_ms: Self::default_dial_timeout(),
-            request_timeout_ms: Self::default_request_timeout(),
+            dial_timeout_ms: None,
+            request_timeout_ms: None,
             tls: None,
         }
     }
@@ -356,19 +373,20 @@ impl EtcdConfig {
     fn default_prefix() -> String {
         "/aisix".into()
     }
-    const fn default_dial_timeout() -> u64 {
-        5_000
-    }
-    const fn default_request_timeout() -> u64 {
-        5_000
-    }
-
-    pub const fn dial_timeout(&self) -> Duration {
-        Duration::from_millis(self.dial_timeout_ms)
+    /// `None` when unset: the dial is unbounded.
+    pub const fn dial_timeout(&self) -> Option<Duration> {
+        match self.dial_timeout_ms {
+            Some(ms) => Some(Duration::from_millis(ms)),
+            None => None,
+        }
     }
 
-    pub const fn request_timeout(&self) -> Duration {
-        Duration::from_millis(self.request_timeout_ms)
+    /// `None` when unset: unary calls are unbounded.
+    pub const fn request_timeout(&self) -> Option<Duration> {
+        match self.request_timeout_ms {
+            Some(ms) => Some(Duration::from_millis(ms)),
+            None => None,
+        }
     }
 
     /// The full env-scoped key prefix the DP watches and parses.
@@ -1755,6 +1773,55 @@ admin:
         assert!(!cfg.proxy.real_ip.recursive);
         assert_eq!(cfg.proxy.real_ip.header, "x-forwarded-for");
         assert!(cfg.proxy.real_ip.parse_trusted().unwrap().is_empty());
+    }
+
+    #[test]
+    fn etcd_timeouts_default_to_unset_meaning_unbounded() {
+        // Both keys are optional and default to unbounded. A finite
+        // default would bound the configuration range read, whose cost
+        // scales with the size of the configuration set — the one call
+        // whose expiry leaves the instance with nothing to serve.
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+  prefix: "/aisix"
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.etcd.dial_timeout_ms, None);
+        assert_eq!(cfg.etcd.request_timeout_ms, None);
+        assert_eq!(cfg.etcd.dial_timeout(), None);
+        assert_eq!(cfg.etcd.request_timeout(), None);
+    }
+
+    #[test]
+    fn etcd_timeouts_when_set_are_read_as_milliseconds() {
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+  prefix: "/aisix"
+  dial_timeout_ms: 2500
+  request_timeout_ms: 7000
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.etcd.dial_timeout(), Some(Duration::from_millis(2500)));
+        assert_eq!(
+            cfg.etcd.request_timeout(),
+            Some(Duration::from_millis(7000))
+        );
     }
 
     #[test]

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -124,16 +124,26 @@ pub struct EtcdConfig {
     /// read at connect time — never stored in the config struct.
     #[serde(default)]
     pub password_env: Option<String>,
-    /// Bound on establishing the gRPC connection to etcd, in
-    /// milliseconds. Unset — the default — leaves the dial unbounded and
-    /// the OS TCP stack is the only limit.
+    /// Bound on the TCP connect to etcd, in milliseconds. Unset — the
+    /// default — leaves it to the OS TCP stack.
+    ///
+    /// It reaches hyper's connector via `Endpoint::connect_timeout`, so
+    /// it covers the TCP handshake and nothing after it. Two later steps
+    /// of "connecting" are outside it and remain unbounded: the TLS
+    /// handshake, which is layered above the connector, and the
+    /// `Authenticate` call etcd-client issues inside `Client::connect`
+    /// when `user` / `password_env` are set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dial_timeout_ms: Option<u64>,
     /// Bound on a single unary etcd call, in milliseconds. Unset — the
     /// default — leaves those calls unbounded.
     ///
     /// When set it covers the configuration range read (`load_all`) and
-    /// the admin surface's reads. It deliberately does NOT cover the
+    /// the admin surface's reads. It does not reach the two calls that
+    /// sit outside that set and are still unbounded — the `Authenticate`
+    /// inside `Client::connect`, and the watch-create handshake — so an
+    /// etcd that answers a range read but stalls on either of those can
+    /// still hang the gateway. It deliberately does NOT cover the
     /// watch: that stream is long-lived by construction, so a bound on it
     /// would expire on every interval quiet enough to produce no event
     /// and leave the gateway reconnecting instead of watching.

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -165,9 +165,12 @@ impl EtcdConfigProvider {
 
 /// Apply `timeout`, when set, to one in-flight etcd call.
 ///
-/// Expiry is reported as [`ProviderError::Range`] so it lands on the
-/// supervisor's existing reconnect-with-backoff path: the aborted read is
-/// retried rather than ending the watch task.
+/// Expiry is reported as [`ProviderError::Range`] to match the variant
+/// the same call's transport failures already use, so the supervisor's
+/// warn line attributes it to the range read. It is attribution, not
+/// control flow: `Supervisor::run` routes every `ProviderError` out of
+/// `load_all` to the same reconnect-with-backoff path, so the aborted
+/// read is retried whichever variant carries it.
 async fn bound<T>(
     timeout: Option<Duration>,
     what: &str,
@@ -352,11 +355,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn expiry_maps_to_range_so_the_supervisor_backs_off_and_retries() {
-        // The variant matters as much as the expiry: `Range` is what
-        // `Supervisor::run` treats as a retryable source outage. Any other
-        // variant either ends the watch task or (for `Compacted`) skips
-        // the backoff entirely.
+    async fn expiry_reports_the_call_and_the_key_that_bounded_it() {
+        // An expiry has to reach the operator as a diagnosable failure,
+        // not as a bare cancellation: the message names both the call it
+        // aborted and the config key that set the bound, so a boot loop
+        // is traceable to `etcd.request_timeout_ms` without a code read.
+        // `Range` is chosen to match the variant this call's transport
+        // failures already use — the supervisor sends every
+        // `ProviderError` from `load_all` down the same backoff path, so
+        // the variant is what the warn line says, not what it does.
         let err = bound(
             Some(Duration::from_millis(1)),
             "range read",

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -73,6 +73,19 @@ pub struct EtcdConfigProvider {
     kv: Mutex<KvClient>,
     watch: Mutex<WatchClient>,
     prefix: String,
+    /// Bound applied to each unary call this provider makes — currently
+    /// the range read in [`Self::load_all`]. `None` leaves it unbounded.
+    ///
+    /// Applied per call with [`tokio::time::timeout`] rather than through
+    /// `ConnectOptions::with_timeout`, for two reasons. That option is
+    /// channel-wide, so it would also bound opening the watch. And it
+    /// bounds only the response *future*: tonic's `GrpcTimeout` races the
+    /// deadline against the arrival of response headers and then lets the
+    /// body stream run untimed, so an etcd that answers a range request
+    /// and stalls part-way through a large body would still hang here
+    /// forever — the very case a bound on the configuration read is for.
+    /// Wrapping the call bounds it whole, body included.
+    request_timeout: Option<Duration>,
 }
 
 impl std::fmt::Debug for EtcdConfigProvider {
@@ -89,8 +102,16 @@ impl EtcdConfigProvider {
         endpoints: &[String],
         prefix: impl Into<String>,
         options: Option<ConnectOptions>,
+        request_timeout: Option<Duration>,
     ) -> Result<Self, ProviderError> {
-        Self::connect_with_policy(endpoints, prefix, options, ConnectPolicy::default()).await
+        Self::connect_with_policy(
+            endpoints,
+            prefix,
+            options,
+            request_timeout,
+            ConnectPolicy::default(),
+        )
+        .await
     }
 
     /// Connect with a caller-chosen retry policy. Returns the last-seen
@@ -99,6 +120,7 @@ impl EtcdConfigProvider {
         endpoints: &[String],
         prefix: impl Into<String>,
         options: Option<ConnectOptions>,
+        request_timeout: Option<Duration>,
         policy: ConnectPolicy,
     ) -> Result<Self, ProviderError> {
         let prefix = prefix.into();
@@ -111,6 +133,7 @@ impl EtcdConfigProvider {
                         kv: Mutex::new(kv_client(&client)),
                         watch: Mutex::new(watch_client(&client)),
                         prefix,
+                        request_timeout,
                     });
                 }
                 Err(err) => {
@@ -140,16 +163,37 @@ impl EtcdConfigProvider {
     }
 }
 
+/// Apply `timeout`, when set, to one in-flight etcd call.
+///
+/// Expiry is reported as [`ProviderError::Range`] so it lands on the
+/// supervisor's existing reconnect-with-backoff path: the aborted read is
+/// retried rather than ending the watch task.
+async fn bound<T>(
+    timeout: Option<Duration>,
+    what: &str,
+    fut: impl std::future::Future<Output = T>,
+) -> Result<T, ProviderError> {
+    match timeout {
+        None => Ok(fut.await),
+        Some(d) => tokio::time::timeout(d, fut).await.map_err(|_| {
+            ProviderError::Range(format!(
+                "{what} exceeded etcd.request_timeout_ms ({} ms)",
+                d.as_millis()
+            ))
+        }),
+    }
+}
+
 #[async_trait]
 impl ConfigProvider for EtcdConfigProvider {
     async fn load_all(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
         let mut kv = self.kv.lock().await;
-        let resp = kv
-            .get(
-                self.prefix.as_bytes(),
-                Some(GetOptions::new().with_prefix()),
-            )
-            .await
+        let read = kv.get(
+            self.prefix.as_bytes(),
+            Some(GetOptions::new().with_prefix()),
+        );
+        let resp = bound(self.request_timeout, "range read", read)
+            .await?
             .map_err(|e| ProviderError::Range(format_error_chain(&e)))?;
 
         let revision = resp.header().map(|h| h.revision()).unwrap_or(0);
@@ -295,10 +339,38 @@ mod tests {
             attempts: 1,
         };
         let endpoints: Vec<String> = vec![];
-        let err = EtcdConfigProvider::connect_with_policy(&endpoints, "/aisix", None, policy)
+        let err = EtcdConfigProvider::connect_with_policy(&endpoints, "/aisix", None, None, policy)
             .await
             .unwrap_err();
         assert!(matches!(err, ProviderError::Connect(_)));
+    }
+
+    #[tokio::test]
+    async fn bound_passes_through_when_no_timeout_is_set() {
+        let out = bound(None, "range read", async { 7u8 }).await.unwrap();
+        assert_eq!(out, 7);
+    }
+
+    #[tokio::test]
+    async fn expiry_maps_to_range_so_the_supervisor_backs_off_and_retries() {
+        // The variant matters as much as the expiry: `Range` is what
+        // `Supervisor::run` treats as a retryable source outage. Any other
+        // variant either ends the watch task or (for `Compacted`) skips
+        // the backoff entirely.
+        let err = bound(
+            Some(Duration::from_millis(1)),
+            "range read",
+            std::future::pending::<()>(),
+        )
+        .await
+        .unwrap_err();
+        let ProviderError::Range(msg) = err else {
+            panic!("expiry must surface as ProviderError::Range, got {err:?}");
+        };
+        assert!(
+            msg.contains("range read") && msg.contains("etcd.request_timeout_ms"),
+            "the message must name the call and the key that bounded it: {msg}"
+        );
     }
 
     #[test]

--- a/crates/aisix-etcd/tests/watch_integration.rs
+++ b/crates/aisix-etcd/tests/watch_integration.rs
@@ -48,7 +48,7 @@ async fn watch_stream_delivers_events_after_put() {
 
     let prefix = unique_prefix();
     let endpoints = vec![url.clone()];
-    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None)
+    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None, None)
         .await
         .expect("connect");
 
@@ -109,7 +109,7 @@ async fn supervisor_applied_revision_catches_up_to_writer_revision() {
 
     let prefix = unique_prefix();
     let endpoints = vec![url.clone()];
-    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None)
+    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None, None)
         .await
         .expect("connect");
     let supervisor = std::sync::Arc::new(aisix_etcd::Supervisor::new(
@@ -178,7 +178,7 @@ async fn watch_stream_delivers_all_events_from_batched_response() {
 
     let prefix = unique_prefix();
     let endpoints = vec![url.clone()];
-    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None)
+    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None, None)
         .await
         .expect("connect");
 

--- a/crates/aisix-server/src/export/mod.rs
+++ b/crates/aisix-server/src/export/mod.rs
@@ -58,6 +58,10 @@ pub async fn run(args: ExportArgs) -> anyhow::Result<()> {
         &args.endpoints,
         &args.prefix,
         None,
+        // The export CLI takes endpoints on the command line, not a
+        // config file, so there is no `etcd.request_timeout_ms` to honour
+        // — and an operator can interrupt it. The read stays unbounded.
+        None,
         CLI_CONNECT_POLICY,
     )
     .await

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -743,6 +743,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                     &cfg.etcd.endpoints,
                     etcd_prefix.clone(),
                     connect_options.clone(),
+                    cfg.etcd.request_timeout(),
                 )
                 .await
                 .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?,
@@ -763,6 +764,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                         .await
                         .map_err(|e| anyhow::anyhow!("etcd admin client connect failed: {e}"))?,
                     etcd_prefix.clone(),
+                    cfg.etcd.request_timeout(),
                 ))
             };
             // Snapshot cache: persist to disk so the DP can serve traffic
@@ -1184,7 +1186,11 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // view of the file-loaded snapshot. The admin resource surface is
     // read-only — writes were removed with the Admin API write path.
     let admin_store: Option<Arc<dyn ConfigStore>> = match (admin_client, &file_source_path) {
-        (Some((client, prefix)), _) => Some(Arc::new(EtcdConfigStore::new(client, prefix))),
+        (Some((client, prefix, request_timeout)), _) => Some(Arc::new(EtcdConfigStore::new(
+            client,
+            prefix,
+            request_timeout,
+        ))),
         (None, Some(_)) if !cfg.managed.is_managed() => {
             Some(Arc::new(FileManagedStore::new(snapshot_handle.clone())))
         }
@@ -1408,6 +1414,14 @@ fn build_etcd_connect_options_with_extra_ca(
 ) -> anyhow::Result<Option<ConnectOptions>> {
     let mut needs_options = false;
     let mut options = ConnectOptions::new();
+
+    // `with_connect_timeout` bounds establishing the channel only; it is
+    // not a deadline on the calls made over it (that is
+    // `etcd.request_timeout_ms`, applied per call).
+    if let Some(dial) = etcd.dial_timeout() {
+        options = options.with_connect_timeout(dial);
+        needs_options = true;
+    }
 
     if let (Some(user), Some(env_key)) = (etcd.user.as_ref(), etcd.password_env.as_ref()) {
         let pw = std::env::var(env_key).map_err(|_| {
@@ -2946,8 +2960,8 @@ models:
             env_id: String::new(),
             user: None,
             password_env: None,
-            dial_timeout_ms: 5000,
-            request_timeout_ms: 5000,
+            dial_timeout_ms: None,
+            request_timeout_ms: None,
             tls: None,
         };
         let opts = build_etcd_connect_options(&etcd).unwrap();
@@ -2965,8 +2979,8 @@ models:
             env_id: String::new(),
             user: None,
             password_env: None,
-            dial_timeout_ms: 5000,
-            request_timeout_ms: 5000,
+            dial_timeout_ms: None,
+            request_timeout_ms: None,
             tls: Some(aisix_core::EtcdTlsConfig {
                 ca_cert_file: "/definitely/does/not/exist/ca.crt".into(),
                 client_cert_file: "/tmp/c.crt".into(),

--- a/tests/e2e/src/cases/cache-env-namespace-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-env-namespace-e2e.test.ts
@@ -71,8 +71,6 @@ function envEtcd(prefix: string, envId: string) {
     endpoints: [ETCD_ENDPOINT],
     prefix,
     env_id: envId,
-    dial_timeout_ms: 5000,
-    request_timeout_ms: 5000,
   };
 }
 

--- a/tests/e2e/src/cases/etcd-request-timeout-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-request-timeout-e2e.test.ts
@@ -1,0 +1,233 @@
+import { createHash, randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  etcdEndpoint,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startEtcdRelay,
+  startOpenAiUpstream,
+  type EtcdRelay,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// `etcd.request_timeout_ms` bounds one unary etcd call. Until it was
+// wired, both etcd timeout keys were accepted by the config parser and
+// read by nothing: a configuration range read that never answered stayed
+// in flight forever, and the instance served nothing while producing no
+// error that explained why.
+//
+// The three specs pin the three halves of the contract — the bound aborts
+// such a read and hands the supervisor a retryable failure; unset leaves
+// the read unbounded, with no implicit default, which is what keeps a
+// large configuration set bootable; and the watch stream is exempt, so a
+// set bound does not tear down a quiet watch.
+//
+// The first two drive the gateway through a TCP relay standing in for
+// etcd, which is what makes a read that never completes reproducible:
+// `hold()` accepts the connection and forwards nothing.
+
+const MODEL = "etcd-timeout-model";
+const SECOND_MODEL = "etcd-timeout-model-after-idle";
+const CALLER_PLAINTEXT = "sk-etcd-timeout-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+/** The supervisor's retry log line, emitted at WARN on every failed cycle. */
+const BACKOFF_LINE = "etcd watch failed; backing off before reconnect";
+/** The abort's own wording, so a failure of a different kind can't pass. */
+const TIMEOUT_LINE = "exceeded etcd.request_timeout_ms";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Poll the captured output until `needle` appears at least `count` times. */
+async function waitForOutput(
+  app: SpawnedApp,
+  needle: string,
+  timeoutMs: number,
+  count = 1,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const seen = app.output().split(needle).length - 1;
+    if (seen >= count || Date.now() >= deadline) return seen;
+    await sleep(100);
+  }
+}
+
+/**
+ * Poll `model` until the gateway answers 200 for it, or the budget runs
+ * out. A refused connection counts as "not yet": the proxy listener binds
+ * only once a configuration has been applied, which in these specs is
+ * after the read the relay was holding finally lands.
+ */
+async function waitForChat(app: SpawnedApp, model: string, timeoutMs: number): Promise<number> {
+  const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+  const deadline = Date.now() + timeoutMs;
+  let status = 0;
+  for (;;) {
+    try {
+      status = (await proxy.chat({ model, messages: [{ role: "user", content: "hi" }] })).status;
+    } catch {
+      status = 0;
+    }
+    if (status === 200 || Date.now() >= deadline) return status;
+    await sleep(500);
+  }
+}
+
+describe("etcd.request_timeout_ms", () => {
+  let etcd: EtcdClient | undefined;
+  let etcdReachable = false;
+  let upstream: OpenAiUpstream | undefined;
+  const apps: SpawnedApp[] = [];
+  const relays: EtcdRelay[] = [];
+
+  beforeAll(async () => {
+    etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+    upstream = await startOpenAiUpstream();
+  });
+
+  afterEach(async () => {
+    await Promise.all(apps.splice(0).map((a) => a.exit()));
+    await Promise.all(relays.splice(0).map((r) => r.stop()));
+  });
+
+  afterAll(async () => {
+    await upstream?.close();
+  });
+
+  /** A model reachable through a mock upstream, written to the real etcd. */
+  async function seedModel(prefix: string, displayName: string): Promise<void> {
+    const seed = new SeedClient(etcd!, prefix);
+    const pk = await seed.createProviderKey({
+      display_name: `etcd-timeout-pk-${displayName}`,
+      secret: "sk-mock",
+      api_base: `${upstream!.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+  }
+
+  /** Everything a caller needs for a 200. One API key, both models allowed. */
+  async function seedFixtures(prefix: string): Promise<void> {
+    await seedModel(prefix, MODEL);
+    await new SeedClient(etcd!, prefix).createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [MODEL, SECOND_MODEL],
+    });
+  }
+
+  async function spawnAgainst(
+    endpoint: string,
+    prefix: string,
+    etcdExtra: Record<string, unknown>,
+    opts: { awaitProxyListener?: boolean } = {},
+  ): Promise<SpawnedApp> {
+    const app = await spawnApp({
+      etcdPrefix: prefix,
+      awaitProxyListener: opts.awaitProxyListener ?? true,
+      // The supervisor's backoff line is WARN, which this level keeps.
+      logLevel: "warn",
+      extra: { etcd: { endpoints: [endpoint], prefix, ...etcdExtra } },
+    });
+    apps.push(app);
+    return app;
+  }
+
+  test("aborts a black-holed read and retries it on the supervisor's backoff", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    const prefix = `/aisix-e2e-etcd-rt-bounded-${randomUUID()}`;
+    const relay = await startEtcdRelay();
+    relays.push(relay);
+    // Connection accepted, nothing forwarded: the range read is issued and
+    // never answered. Unbounded, it stays in flight forever.
+    await relay.hold();
+    await seedFixtures(prefix);
+
+    const app = await spawnAgainst(
+      relay.endpoint,
+      prefix,
+      { request_timeout_ms: 1000 },
+      { awaitProxyListener: false },
+    );
+
+    // Two occurrences, not one: a single abort would also be produced by a
+    // read that failed and then gave up. The retry loop is the subject.
+    expect(await waitForOutput(app, BACKOFF_LINE, 30_000, 2)).toBeGreaterThanOrEqual(2);
+    // …and the abort was the timeout, not some other transport failure.
+    expect(app.output()).toContain(TIMEOUT_LINE);
+
+    // The loop being live is what lets the gateway recover on its own once
+    // the read can complete: no restart, no operator action.
+    await relay.release();
+    expect(await waitForChat(app, MODEL, 60_000)).toBe(200);
+  }, 150_000);
+
+  test("leaves the read unbounded when unset", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    const prefix = `/aisix-e2e-etcd-rt-unset-${randomUUID()}`;
+    const relay = await startEtcdRelay();
+    relays.push(relay);
+    await relay.hold();
+    await seedFixtures(prefix);
+
+    // No `request_timeout_ms` — the shipped default, and what the example
+    // config files now leave commented out.
+    const app = await spawnAgainst(relay.endpoint, prefix, {}, { awaitProxyListener: false });
+
+    // Well past the 5000 ms this key was previously documented as
+    // defaulting to. Any implicit default reintroduced here would abort
+    // the read inside this window and log the backoff line; unbounded
+    // logs neither. A deployment whose range read simply takes a while —
+    // the reason the default is unset — depends on exactly this.
+    await sleep(12_000);
+    expect(app.output()).not.toContain(BACKOFF_LINE);
+    expect(app.output()).not.toContain(TIMEOUT_LINE);
+
+    // Still a live read rather than a wedged one: releasing it serves that
+    // very snapshot.
+    await relay.release();
+    expect(await waitForChat(app, MODEL, 60_000)).toBe(200);
+  }, 150_000);
+
+  test("does not bound the watch: a quiet interval past the timeout keeps it live", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    // Straight at the real etcd — the subject is the watch surviving, not
+    // a controllable read. The regression this guards is a bound reaching
+    // the watch stream itself: the supervisor then treats every quiet
+    // interval as a failed cycle, logs the backoff line and reconnects,
+    // and a configuration that changes rarely never stops churning.
+    const prefix = `/aisix-e2e-etcd-rt-watch-${randomUUID()}`;
+    await seedFixtures(prefix);
+    const app = await spawnAgainst(etcdEndpoint(), prefix, { request_timeout_ms: 1000 });
+
+    expect(await waitForChat(app, MODEL, 30_000)).toBe(200);
+
+    // Nothing written under the prefix for many multiples of the bound.
+    await sleep(6_000);
+    expect(app.output()).not.toContain(BACKOFF_LINE);
+
+    // The watch opened before that idle window must still deliver this.
+    await seedModel(prefix, SECOND_MODEL);
+    expect(await waitForChat(app, SECOND_MODEL, 30_000)).toBe(200);
+  }, 150_000);
+});

--- a/tests/e2e/src/cases/etcd-request-timeout-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-request-timeout-e2e.test.ts
@@ -63,18 +63,36 @@ async function waitForOutput(
  * out. A refused connection counts as "not yet": the proxy listener binds
  * only once a configuration has been applied, which in these specs is
  * after the read the relay was holding finally lands.
+ *
+ * Two ways to run out of budget, and they need different reports. If the
+ * gateway answered at all, the last status is returned and the caller's
+ * `toBe(200)` names it. If every attempt was refused, there is no status
+ * to report — returning `0` would fail as "expected 0 to be 200" and lose
+ * the transport cause — so the last error is raised instead.
  */
 async function waitForChat(app: SpawnedApp, model: string, timeoutMs: number): Promise<number> {
   const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
   const deadline = Date.now() + timeoutMs;
   let status = 0;
+  let lastError: unknown;
   for (;;) {
     try {
       status = (await proxy.chat({ model, messages: [{ role: "user", content: "hi" }] })).status;
-    } catch {
+      lastError = undefined;
+    } catch (err) {
       status = 0;
+      lastError = err;
     }
-    if (status === 200 || Date.now() >= deadline) return status;
+    if (status === 200) return status;
+    if (Date.now() >= deadline) {
+      if (lastError !== undefined) {
+        throw new Error(
+          `no response for model ${model} within ${timeoutMs} ms — the proxy listener never bound`,
+          { cause: lastError },
+        );
+      }
+      return status;
+    }
     await sleep(500);
   }
 }

--- a/tests/e2e/src/cases/etcd-request-timeout-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-request-timeout-e2e.test.ts
@@ -240,9 +240,17 @@ describe("etcd.request_timeout_ms", () => {
 
     expect(await waitForChat(app, MODEL, 30_000)).toBe(200);
 
+    // Assert on the log written during the idle window, not on the whole
+    // log. The boot range read is bounded by this same 1000 ms, and on a
+    // loaded runner a cold TCP + HTTP/2 handshake plus the read can
+    // exceed it once — the supervisor then retries and succeeds, and the
+    // spec still reaches this point. Reading the cumulative output would
+    // report that as the watch being torn down, which it is not.
+    const beforeIdle = app.output().length;
+
     // Nothing written under the prefix for many multiples of the bound.
     await sleep(6_000);
-    expect(app.output()).not.toContain(BACKOFF_LINE);
+    expect(app.output().slice(beforeIdle)).not.toContain(BACKOFF_LINE);
 
     // The watch opened before that idle window must still deliver this.
     await seedModel(prefix, SECOND_MODEL);

--- a/tests/e2e/src/cases/listener-tls-e2e.test.ts
+++ b/tests/e2e/src/cases/listener-tls-e2e.test.ts
@@ -70,8 +70,6 @@ describe("listener TLS (#473)", () => {
       etcd: {
         endpoints: [etcdEndpoint()],
         prefix: `/aisix-e2e-tls-${randomUUID()}`,
-        dial_timeout_ms: 5000,
-        request_timeout_ms: 5000,
       },
       proxy: {
         addr: `127.0.0.1:${proxyPort}`,

--- a/tests/e2e/src/cases/ratelimit-cluster-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-cluster-e2e.test.ts
@@ -62,8 +62,6 @@ function sharedEtcd(prefix: string) {
   return {
     endpoints: [ETCD_ENDPOINT],
     prefix,
-    dial_timeout_ms: 5000,
-    request_timeout_ms: 5000,
   };
 }
 

--- a/tests/e2e/src/cases/startup-config-gate-e2e.test.ts
+++ b/tests/e2e/src/cases/startup-config-gate-e2e.test.ts
@@ -127,9 +127,11 @@ describe("the proxy listener waits for the first configuration", () => {
       etcdPrefix: prefix,
       // The subject of both specs is that this listener is NOT up yet.
       awaitProxyListener: false,
-      // No dial/request timeouts: those config keys reach nothing in the
-      // etcd client, and writing them here would suggest a timeout is
-      // driving the retries when the supervisor's backoff is.
+      // No dial/request timeouts. `etcd.request_timeout_ms` would abort
+      // the held read, and writing one here would suggest a timeout is
+      // driving the retries when the supervisor's backoff is. Unset —
+      // the shipped default — leaves the read unbounded, which is what
+      // makes "held" mean "still in flight" for these two specs.
       extra: { etcd: { endpoints: [relay.endpoint], prefix } },
     });
     apps.push(app);

--- a/tests/e2e/src/cases/status-config-e2e.test.ts
+++ b/tests/e2e/src/cases/status-config-e2e.test.ts
@@ -449,8 +449,6 @@ async function spawnPointedAtDeadEtcd(): Promise<MinimalApp> {
     etcd: {
       endpoints: [`http://127.0.0.1:${deadPort}`],
       prefix: "/aisix-never-loaded",
-      dial_timeout_ms: 2000,
-      request_timeout_ms: 2000,
     },
     proxy: {
       addr: `127.0.0.1:${proxyPort}`,

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -303,11 +303,14 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
     ...(fileMode
       ? { resources_file: resourcesPath }
       : {
+          // No `dial_timeout_ms` / `request_timeout_ms`: unset is the
+          // shipped default and means unbounded. A suite-wide bound on
+          // the configuration range read would be a source of flakes
+          // that no case is asking for; the cases that ARE about those
+          // keys set them through `extra`.
           etcd: {
             endpoints: [etcdEndpoint()],
             prefix: etcdPrefix,
-            dial_timeout_ms: 5000,
-            request_timeout_ms: 5000,
           },
         }),
     proxy: {


### PR DESCRIPTION
## What was wrong

`etcd.dial_timeout_ms` and `etcd.request_timeout_ms` have never taken effect. Both were parsed into `EtcdConfig`, both defaulted to `5000`, and both were then read by nothing — `EtcdConfig::dial_timeout()` and `EtcdConfig::request_timeout()` had no call sites anywhere in the workspace.

The consequence that matters is the configuration range read. `EtcdConfigProvider::load_all` was unbounded in every deployment, so an etcd that accepted the connection and then never answered left the gateway waiting on a future that would never resolve. The supervisor was not backing off and retrying — there was nothing to back off from, and no error to explain the silence. Since #1131 the proxy listener waits for the first configuration apply, so that state is now an instance that never opens its port at all.

## What each key governs now

Both keys are **optional and default to unset, and unset means unbounded**. There is no implicit `5000`.

- **`dial_timeout_ms`**, when set, is the TCP connect timeout (`ConnectOptions::with_connect_timeout` → `Endpoint::connect_timeout` → hyper's connector). It bounds the TCP handshake and nothing after it.
- **`request_timeout_ms`**, when set, bounds each **unary** etcd call: the configuration range read in `EtcdConfigProvider::load_all`, and the admin store's `get_one` / `list_range`. An expiry is retried on the supervisor's existing reconnect backoff, the same as any other failure of that read. It is reported as `ProviderError::Range` to match the variant the call's transport failures already use, so the warn line attributes the abort to the range read and names `etcd.request_timeout_ms` as what bounded it — attribution, not control flow.
- **The watch stream is deliberately exempt**, whatever the key is set to. It is long-lived by construction: a bound on it expires on every interval quiet enough to produce no event, which for a configuration that changes rarely is every interval, and the gateway would spend its life reconnecting instead of watching.

Unset-means-unbounded is the deliberate choice, not an omission. The range read's cost scales with the size of the configuration set, so a bound short enough to be useful on a small deployment aborts the read on a large one — and the supervisor then re-issues the identical read forever, which is a worse failure than the one a timeout is meant to prevent. It also matches the reference LLM proxy this project baselines against, whose connect and socket timeouts are both unset by default and whose socket timeout, once set, applies to in-flight operations generally rather than to a carved-out subset.

The bound is applied per call with `tokio::time::timeout` rather than `ConnectOptions::with_timeout`. That option is channel-wide, so it would also bound opening the watch; and it bounds only the response *future* — tonic's `GrpcTimeout` races the deadline against the arrival of response headers and then lets the body stream run untimed, so an etcd that answers a range request and stalls part-way through a large body would still hang forever. Wrapping the call bounds it whole, body included.

## Upgrade hazard — read this before upgrading a large deployment

**`config.example.yaml` and `config.managed.yaml` shipped both keys set to `5000`, uncommented and active.** They were harmless while the keys reached nothing. They are not harmless now.

Any configuration copied from those files carries `request_timeout_ms: 5000`, and on this release that becomes a 5-second bound on the configuration range read. A deployment whose configuration set does not fit in 5 seconds — the large-configuration case is exactly where this bites — will fail that read, retry it, fail it again, and **never bind its proxy port**. The gateway does not degrade; it does not start serving.

Both files now have the keys commented out, with the reasoning inline, so new deployments inherit nothing. That does not help a configuration file already on disk. **Operators upgrading should check their `etcd:` block and remove `request_timeout_ms` unless they specifically want a slow etcd to fail fast** — and if they do want that, size it against their own configuration set, not against the number that used to be in the example.

`dial_timeout_ms: 5000` carries no comparable risk: 5 seconds to establish a connection is generous, and its expiry lands on the connect-retry path that already existed.

## Scope, and what is still unbounded

`request_timeout_ms` covers the unary etcd calls the gateway makes on its own config path: the range read, and `EtcdConfigStore`'s admin reads. The `export` CLI subcommand stays unbounded — it takes endpoints on the command line rather than from a config file, so there is no `etcd.request_timeout_ms` for it to honour, and an operator can interrupt it.

Three request/response-shaped calls are **not** covered, and an etcd that stalls on any of them still hangs with no error, exactly as before this change. None are regressions — they are the boundary of what this PR closes, stated so nobody reads the change as sealing the whole class:

- **The `Authenticate` call inside `Client::connect`**, issued when `etcd.user` / `etcd.password_env` are set. `dial_timeout_ms` does not reach it — `Endpoint::connect_timeout` stops at the TCP handshake — so a boot against an etcd that accepts the connection and never answers `Authenticate` hangs before the connect-retry policy can see an error.
- **The TLS handshake**, for the same reason: it is layered above hyper's connector, outside `connect_timeout`. This is the `https://` path — managed mode and mTLS etcd.
- **The watch-create handshake.** `WatchClient::watch` awaits response headers and then the create confirmation before any stream exists; it is request/response-shaped, not the long-lived stream the exemption is about. An etcd that answers the range read but never confirms the watch leaves the gateway serving its first snapshot forever, seeing no further changes, while `/status/config` still reports connected.

Bounding these would extend what each key governs beyond what was specified for this change, so they are called out rather than fixed here.

## Tests

Three e2e specs in `tests/e2e/src/cases/etcd-request-timeout-e2e.test.ts`, over the TCP relay from #1131 (`hold()` accepts the connection and forwards nothing, which is what makes a read that never completes reproducible):

- With `request_timeout_ms` set, a black-holed read is aborted and the supervisor's backoff retry loop is reached — asserted on **two** occurrences of the backoff line, so a single abort that then gave up would not pass — and the gateway recovers on its own when the relay is released.
- With it unset, the read stays in flight past 12 seconds with neither an abort nor a backoff, well past the `5000` this key was previously documented as defaulting to. This is the guard against an implicit default being reintroduced.
- With it set, a quiet interval many times the bound does not disturb the watch, and an event written after that interval still propagates.

Each was confirmed to fail under a mutation that removes exactly its fix: unbinding `load_all`, restoring a `Some(5000)` serde default, and applying a bound to the watch stream respectively.

Plus unit coverage that the keys default to `None` and parse as milliseconds when set, and that an expiry reaches the operator as a diagnosable failure naming both the call it aborted and the config key that bounded it.

The e2e harness and four existing specs carried the same cargo-culted `dial_timeout_ms: 5000` / `request_timeout_ms: 5000` that the example files did. Those are dropped, so the suite runs unbounded the way a default deployment does rather than acquiring a suite-wide bound on the range read.

## Docs

The published reference documents both keys as "Defaults to `5000`", which this change makes wrong. The paired documentation update is being handled separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * etcd dial and request timeouts are now optional and unbounded by default.
  * Configured request timeouts now limit individual reads, with expired requests reported as backend errors.
  * Request timeouts apply to unary reads and do not interrupt watch streams.
* **Documentation**
  * Clarified that dial timeouts cover TCP connection setup only, excluding TLS and authentication.
  * Clarified the distinction between request timeouts and connection retry behavior.
* **Tests**
  * Added end-to-end coverage for bounded, unbounded, and watch-stream timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->