### PR TITLE
feat(a2a): forward inbound client headers to an upstream A2A agent

### DIFF
--- a/crates/aisix-a2a/src/bridge.rs
+++ b/crates/aisix-a2a/src/bridge.rs
@@ -31,6 +31,7 @@ use std::time::{Duration, Instant};
 use aisix_core::{A2aAgent, A2aAuthType, A2aProtocolVersion};
 use async_trait::async_trait;
 use futures::StreamExt;
+use http::{HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 
 use crate::error::A2aError;
@@ -210,6 +211,34 @@ fn warn_cleartext_credential(agent: &A2aAgent) {
     }
 }
 
+/// Header slots the A2A protocol itself owns on this hop.
+///
+/// `a2a-version` is the gateway's OWN announcement of the wire version the
+/// agent is pinned to in `protocol_version`, and the agent reads it to pick
+/// the envelope shape it answers in. A caller's copy relayed alongside would
+/// let the caller override that pin — the agent would answer in a format the
+/// operator did not configure, or refuse the call outright — so it is refused
+/// however broad the pattern is.
+pub const A2A_PROTOCOL_HEADERS: &[&str] = &["a2a-version"];
+
+/// The inbound client headers `agent` forwards out of `client_headers`.
+///
+/// `None` — a gateway operation with no calling request behind it — forwards
+/// nothing.
+pub fn forwarded_client_headers(
+    agent: &A2aAgent,
+    client_headers: Option<&http::HeaderMap>,
+) -> Vec<(HeaderName, HeaderValue)> {
+    let Some(client) = client_headers else {
+        return Vec::new();
+    };
+    aisix_core::resolve_forwarded_client_headers(
+        &agent.forward_client_headers,
+        client,
+        A2A_PROTOCOL_HEADERS,
+    )
+}
+
 /// Build an [`A2aUpstream`] from a registered [`A2aAgent`] resource.
 pub fn upstream_from_a2a_agent(agent: &A2aAgent) -> A2aUpstream {
     warn_cleartext_credential(agent);
@@ -275,7 +304,6 @@ pub trait A2aBridge: Send + Sync {
 }
 
 /// The default [`A2aBridge`], built on the workspace HTTP client.
-#[derive(Debug)]
 pub struct HttpBridge {
     upstream: A2aUpstream,
     /// The agent's JSON-RPC endpoint, parsed once process-wide instead of
@@ -283,6 +311,36 @@ pub struct HttpBridge {
     /// is one cache lookup per request in place of one `Url` parse.
     endpoint: aisix_gateway::url_cache::EndpointUrl,
     client: reqwest::Client,
+    /// Inbound client headers this agent's `forward_client_headers` admits,
+    /// resolved per request against the calling client's own request. Empty
+    /// when the agent configures none, or when nothing the caller sent
+    /// matched.
+    ///
+    /// Independent of the upstream's `auth`, which stays the gateway's own
+    /// credential — except when both name the same header, where the
+    /// forwarded value wins and the gateway's is not sent at all.
+    forwarded_client_headers: Vec<(HeaderName, HeaderValue)>,
+}
+
+// Manual so a forwarded value — which may be the caller's own credential —
+// cannot leak through `Debug`, and so the gateway-held credential keeps the
+// redaction `A2aUpstream`'s own impl gives it.
+impl std::fmt::Debug for HttpBridge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpBridge")
+            .field("upstream", &self.upstream)
+            .field(
+                // Names only: the slot stays diagnosable, the value never
+                // prints.
+                "forwarded_client_headers",
+                &self
+                    .forwarded_client_headers
+                    .iter()
+                    .map(|(name, _)| name.as_str())
+                    .collect::<Vec<_>>(),
+            )
+            .finish_non_exhaustive()
+    }
 }
 
 impl HttpBridge {
@@ -294,20 +352,47 @@ impl HttpBridge {
             endpoint: aisix_gateway::url_cache::cached_url(&upstream.url),
             upstream,
             client: shared_client(),
+            forwarded_client_headers: Vec::new(),
         }
     }
 
-    /// Apply the gateway-held upstream credential and announce the wire version
-    /// this agent is pinned to. Both belong on every outgoing request: the
-    /// credential because the gateway is the one holding it, the version
-    /// because an agent that receives no `A2A-Version` must assume `0.3`.
+    /// Deliver the client headers this agent forwards, as already resolved
+    /// against the inbound request by [`forwarded_client_headers`].
+    pub fn with_forwarded_client_headers(
+        mut self,
+        forwarded: Vec<(HeaderName, HeaderValue)>,
+    ) -> Self {
+        self.forwarded_client_headers = forwarded;
+        self
+    }
+
+    /// Apply the gateway-held upstream credential, announce the wire version
+    /// this agent is pinned to, and deliver the forwarded client headers. All
+    /// three belong on every outgoing request: the credential because the
+    /// gateway is the one holding it, the version because an agent that
+    /// receives no `A2A-Version` must assume `0.3`, and the forward because it
+    /// is configured per agent rather than per operation.
+    ///
+    /// The gateway credential and the forward can name the same slot: an
+    /// operator who lists `authorization` in `forward_client_headers` is
+    /// choosing the caller's own credential over the gateway's, and the agent
+    /// must receive exactly one of them. `reqwest`'s `header` APPENDS, so
+    /// suppressing the gateway's is the only way to keep a single value on the
+    /// wire — the claimed set is read before anything fills a slot, so the
+    /// suppression and the delivery cannot disagree.
     fn prepare(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let forwarded = &self.forwarded_client_headers;
+        let claims = |name: &str| forwarded.iter().any(|(n, _)| n.as_str() == name);
         let req = req.header(VERSION_HEADER, self.upstream.protocol_version.as_wire_str());
-        match &self.upstream.auth {
+        let req = match &self.upstream.auth {
             A2aAuth::None => req,
-            A2aAuth::Bearer(token) => req.bearer_auth(token),
-            A2aAuth::ApiKey(key) => req.header(API_KEY_HEADER, key),
-        }
+            A2aAuth::Bearer(token) if !claims("authorization") => req.bearer_auth(token),
+            A2aAuth::ApiKey(key) if !claims(API_KEY_HEADER) => req.header(API_KEY_HEADER, key),
+            A2aAuth::Bearer(_) | A2aAuth::ApiKey(_) => req,
+        };
+        forwarded.iter().fold(req, |req, (name, value)| {
+            req.header(name.clone(), value.clone())
+        })
     }
 
     /// Candidate agent-card URIs, most specific first: each well-known path

--- a/crates/aisix-a2a/src/lib.rs
+++ b/crates/aisix-a2a/src/lib.rs
@@ -23,8 +23,9 @@ pub mod error;
 pub mod telemetry;
 
 pub use bridge::{
-    upstream_from_a2a_agent, A2aAuth, A2aBridge, A2aEvent, A2aEventStream, A2aUpstream, AgentCard,
-    HttpBridge, DEFAULT_UPSTREAM_TIMEOUT,
+    forwarded_client_headers, upstream_from_a2a_agent, A2aAuth, A2aBridge, A2aEvent,
+    A2aEventStream, A2aUpstream, AgentCard, HttpBridge, A2A_PROTOCOL_HEADERS,
+    DEFAULT_UPSTREAM_TIMEOUT,
 };
 pub use error::A2aError;
 pub use telemetry::{

--- a/crates/aisix-a2a/tests/upstream_roundtrip.rs
+++ b/crates/aisix-a2a/tests/upstream_roundtrip.rs
@@ -770,10 +770,16 @@ async fn a_streaming_call_forwards_too() {
     use futures::StreamExt;
 
     let addr = spawn_streaming_agent().await;
+    // `["*"]` and a caller that really sends `accept`: this call negotiates
+    // its own response shape and then parses SSE, so the assertion below is
+    // about the blocked set rather than about a pattern that never matched.
     let bridge = HttpBridge::new(upstream(format!("http://{addr}/a2a"), A2aAuth::None))
         .with_forwarded_client_headers(resolved(
-            &["x-user-jwt"],
-            &[("x-user-jwt", "eyJhbGciOi.caller")],
+            &["*"],
+            &[
+                ("x-user-jwt", "eyJhbGciOi.caller"),
+                ("accept", "application/json"),
+            ],
         ));
 
     let events: Vec<Value> = bridge
@@ -788,7 +794,11 @@ async fn a_streaming_call_forwards_too() {
         seen(&events[0]["result"]["headers"], "x-user-jwt"),
         vec!["eyJhbGciOi.caller"]
     );
-    // The streaming call still asks for SSE with its own `accept`, which the
-    // forward's blocked set is what keeps a caller from overriding.
-    assert_eq!(events[0]["result"]["accept"], "text/event-stream");
+    // The arity is what pins it: the builder APPENDS, so a caller's `accept`
+    // that got through would ride behind the gateway's and leave the agent
+    // choosing which body shape to send.
+    assert_eq!(
+        seen(&events[0]["result"]["headers"], "accept"),
+        vec!["text/event-stream"]
+    );
 }

--- a/crates/aisix-a2a/tests/upstream_roundtrip.rs
+++ b/crates/aisix-a2a/tests/upstream_roundtrip.rs
@@ -30,6 +30,23 @@ fn upstream(url: String, auth: A2aAuth) -> A2aUpstream {
     }
 }
 
+/// Every header an inbound request carried, name -> the list of values sent
+/// under it. A list rather than one value on purpose: a gateway that appended
+/// its own credential behind a forwarded one would still read correctly under
+/// `get`, and only the arity shows it.
+fn header_dump(headers: &HeaderMap) -> Value {
+    let mut out = serde_json::Map::new();
+    for name in headers.keys() {
+        let values: Vec<Value> = headers
+            .get_all(name)
+            .iter()
+            .map(|v| Value::String(v.to_str().unwrap_or("<non-ascii>").to_string()))
+            .collect();
+        out.insert(name.as_str().to_string(), Value::Array(values));
+    }
+    Value::Object(out)
+}
+
 /// Read back the `A2A-Version` an inbound request carried, or `null`.
 fn seen_version(headers: &HeaderMap) -> Value {
     headers
@@ -50,6 +67,7 @@ async fn spawn_agent() -> SocketAddr {
             "version": "1.0.0",
             "skills": [{"id": "echo", "name": "Echo"}],
             "echoed_version": seen_version(&headers),
+            "echoed_headers": header_dump(&headers),
         }))
     }
 
@@ -72,6 +90,7 @@ async fn spawn_agent() -> SocketAddr {
                 "echoed_auth": auth,
                 "echoed_api_key": api_key,
                 "echoed_version": seen_version(&headers),
+                "echoed_headers": header_dump(&headers),
             }
         }))
     }
@@ -357,6 +376,7 @@ async fn the_card_fetch_deadline_covers_the_whole_candidate_walk() {
 /// across chunk boundaries rather than assuming one chunk is one event.
 async fn spawn_streaming_agent() -> SocketAddr {
     async fn stream(headers: HeaderMap) -> impl IntoResponse {
+        let seen_headers = header_dump(&headers).to_string();
         let seen_version = seen_version(&headers).to_string();
         let accept = headers
             .get("accept")
@@ -365,7 +385,7 @@ async fn spawn_streaming_agent() -> SocketAddr {
             .to_string();
         let chunks: Vec<Result<String, std::convert::Infallible>> = vec![
             Ok(format!(
-                ": open\ndata: {{\"jsonrpc\":\"2.0\",\"id\":\"s\",\"result\":{{\"seq\":1,\"version\":{seen_version},\"accept\":\"{accept}\"}}}}\n\n\
+                ": open\ndata: {{\"jsonrpc\":\"2.0\",\"id\":\"s\",\"result\":{{\"seq\":1,\"version\":{seen_version},\"accept\":\"{accept}\",\"headers\":{seen_headers}}}}}\n\n\
                  event: status-update\ndata: {{\"jsonrpc\":\"2.0\",\"id\":\"s\",\"result\":{{\"seq\":2}}}}\n\n"
             )),
             Ok("data: {\"jsonrpc\":\"2.0\",\"id\":\"s\",\"resu".to_string()),
@@ -541,4 +561,234 @@ async fn a_malformed_final_line_fails_the_stream() {
         events[1].is_err(),
         "a truncated trailing event must fail the stream, not end it quietly"
     );
+}
+
+// ---------------------------------------------------------------------------
+// `forward_client_headers` — the operator names inbound client headers that
+// must reach this agent. The gateway rebuilds the outbound JSON-RPC message,
+// so the shared resolver applies both blocking tiers; `a2a-version` is the one
+// slot this surface owns on top of them.
+// ---------------------------------------------------------------------------
+
+/// A registered agent forwarding `patterns`.
+fn agent_forwarding(patterns: &[&str]) -> aisix_core::A2aAgent {
+    serde_json::from_value(json!({
+        "name": "fwd",
+        "url": "https://agents.example.com/a2a",
+        "forward_client_headers": patterns,
+    }))
+    .expect("agent deserialises")
+}
+
+/// The headers a caller sent to the gateway.
+fn client_sent(pairs: &[(&str, &str)]) -> HeaderMap {
+    let mut map = HeaderMap::new();
+    for (name, value) in pairs {
+        map.insert(
+            axum::http::HeaderName::try_from(*name).expect("header name"),
+            axum::http::HeaderValue::from_str(value).expect("header value"),
+        );
+    }
+    map
+}
+
+/// What the gateway resolves out of a caller's request for that agent — the
+/// exact call the `/a2a` handlers make.
+fn resolved(
+    patterns: &[&str],
+    sent: &[(&str, &str)],
+) -> Vec<(axum::http::HeaderName, axum::http::HeaderValue)> {
+    aisix_a2a::forwarded_client_headers(&agent_forwarding(patterns), Some(&client_sent(sent)))
+}
+
+/// Values the upstream saw under `name`, from an echoed header dump.
+fn seen(dump: &Value, name: &str) -> Vec<String> {
+    dump.get(name)
+        .and_then(Value::as_array)
+        .map(|vs| {
+            vs.iter()
+                .map(|v| v.as_str().unwrap_or_default().to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// A forwarded client header reaches the upstream agent on a JSON-RPC call.
+#[tokio::test]
+async fn a_forwarded_client_header_reaches_the_upstream_agent() {
+    let addr = spawn_agent().await;
+    let bridge = HttpBridge::new(upstream(format!("http://{addr}/a2a"), A2aAuth::None))
+        .with_forwarded_client_headers(resolved(
+            &["x-user-jwt"],
+            &[("x-user-jwt", "eyJhbGciOi.caller")],
+        ));
+
+    let resp = bridge.send(&message_send("f-1")).await.unwrap();
+    assert_eq!(
+        seen(&resp["result"]["echoed_headers"], "x-user-jwt"),
+        vec!["eyJhbGciOi.caller"]
+    );
+}
+
+/// Forwarding `authorization` hands the agent the caller's own credential
+/// INSTEAD of the gateway-held bearer — exactly one credential on the wire.
+#[tokio::test]
+async fn a_forwarded_authorization_replaces_the_gateway_bearer() {
+    let addr = spawn_agent().await;
+    let bridge = HttpBridge::new(upstream(
+        format!("http://{addr}/a2a"),
+        A2aAuth::Bearer("gateway-held-secret".into()),
+    ))
+    .with_forwarded_client_headers(resolved(
+        &["authorization"],
+        &[("authorization", "Bearer caller-token")],
+    ));
+
+    let resp = bridge.send(&message_send("f-2")).await.unwrap();
+    // The arity is the assertion: `reqwest`'s `header` appends, so a gateway
+    // credential that failed to stand aside would ride behind the caller's and
+    // read correctly under the first value alone.
+    assert_eq!(
+        seen(&resp["result"]["echoed_headers"], "authorization"),
+        vec!["Bearer caller-token"]
+    );
+}
+
+/// The same, in the other credential slot: `api_key` auth sends `x-api-key`,
+/// and a forwarded copy displaces it rather than joining it.
+#[tokio::test]
+async fn a_forwarded_api_key_replaces_the_gateway_key() {
+    let addr = spawn_agent().await;
+    let bridge = HttpBridge::new(upstream(
+        format!("http://{addr}/a2a"),
+        A2aAuth::ApiKey("gateway-held-key".into()),
+    ))
+    .with_forwarded_client_headers(resolved(
+        &["x-api-key"],
+        &[("x-api-key", "callers-own-key")],
+    ));
+
+    let resp = bridge.send(&message_send("f-3")).await.unwrap();
+    assert_eq!(
+        seen(&resp["result"]["echoed_headers"], "x-api-key"),
+        vec!["callers-own-key"]
+    );
+}
+
+/// An agent forwarding nothing still gets the gateway's own credential and
+/// nothing else — the default every registered agent keeps.
+#[tokio::test]
+async fn without_a_forward_the_gateway_bearer_is_still_the_only_credential() {
+    let addr = spawn_agent().await;
+    let bridge = HttpBridge::new(upstream(
+        format!("http://{addr}/a2a"),
+        A2aAuth::Bearer("gateway-held-secret".into()),
+    ))
+    .with_forwarded_client_headers(resolved(&[], &[("authorization", "Bearer caller-token")]));
+
+    let resp = bridge.send(&message_send("f-4")).await.unwrap();
+    assert_eq!(
+        seen(&resp["result"]["echoed_headers"], "authorization"),
+        vec!["Bearer gateway-held-secret"]
+    );
+}
+
+/// A forwarded value never reaches a log through `Debug` — it may be the
+/// caller's own credential, and the dispatch path formats the bridge on error.
+#[test]
+fn a_forwarded_value_is_redacted_in_debug() {
+    let bridge = HttpBridge::new(upstream("http://x/a2a".into(), A2aAuth::None))
+        .with_forwarded_client_headers(resolved(
+            &["x-user-jwt"],
+            &[("x-user-jwt", "eyJhbGciOi.caller")],
+        ));
+    let rendered = format!("{bridge:?}");
+    assert!(
+        rendered.contains("x-user-jwt"),
+        "the slot stays diagnosable: {rendered}"
+    );
+    assert!(
+        !rendered.contains("eyJhbGciOi.caller"),
+        "the value must not print: {rendered}"
+    );
+}
+
+/// `a2a-version` is the gateway's own announcement of the pinned wire version,
+/// so a caller cannot claim it — not even under `["*"]`, which admits every
+/// ordinary header beside it.
+#[tokio::test]
+async fn the_version_announcement_is_never_forwardable() {
+    let sent = &[("a2a-version", "0.3"), ("x-plain", "kept")][..];
+    let names: Vec<String> = resolved(&["*"], sent)
+        .into_iter()
+        .map(|(n, _)| n.as_str().to_string())
+        .collect();
+    assert_eq!(names, vec!["x-plain"], "a glob must not reach a2a-version");
+    // Named exactly, it is still refused: unlike a credential slot, this one
+    // is the gateway's own assertion rather than an identity the operator may
+    // delegate.
+    assert!(resolved(&["a2a-version"], sent).is_empty());
+
+    // And on the wire the agent sees the pinned version, once.
+    let addr = spawn_agent().await;
+    let bridge = HttpBridge::new(upstream(format!("http://{addr}/a2a"), A2aAuth::None))
+        .with_forwarded_client_headers(resolved(&["*"], sent));
+    let resp = bridge.send(&message_send("f-5")).await.unwrap();
+    assert_eq!(
+        seen(&resp["result"]["echoed_headers"], "a2a-version"),
+        vec!["1.0"]
+    );
+    assert_eq!(
+        seen(&resp["result"]["echoed_headers"], "x-plain"),
+        vec!["kept"]
+    );
+}
+
+/// The card fetch is an upstream call like any other, so it forwards too — an
+/// agent that gates card discovery on the end user's own credential is exactly
+/// the deployment this capability exists for.
+#[tokio::test]
+async fn the_agent_card_fetch_forwards_too() {
+    let addr = spawn_agent().await;
+    let bridge = HttpBridge::new(upstream(format!("http://{addr}/a2a"), A2aAuth::None))
+        .with_forwarded_client_headers(resolved(
+            &["x-user-jwt"],
+            &[("x-user-jwt", "eyJhbGciOi.caller")],
+        ));
+
+    let card = bridge.fetch_agent_card().await.unwrap();
+    assert_eq!(
+        seen(&card.rest["echoed_headers"], "x-user-jwt"),
+        vec!["eyJhbGciOi.caller"]
+    );
+}
+
+/// And so does the streaming path, which opens its request at a different call
+/// site than the buffered one.
+#[tokio::test]
+async fn a_streaming_call_forwards_too() {
+    use futures::StreamExt;
+
+    let addr = spawn_streaming_agent().await;
+    let bridge = HttpBridge::new(upstream(format!("http://{addr}/a2a"), A2aAuth::None))
+        .with_forwarded_client_headers(resolved(
+            &["x-user-jwt"],
+            &[("x-user-jwt", "eyJhbGciOi.caller")],
+        ));
+
+    let events: Vec<Value> = bridge
+        .send_stream(&json!({"jsonrpc":"2.0","id":"s","method":"message/stream"}))
+        .await
+        .expect("stream opens")
+        .map(|e| e.expect("event parses"))
+        .collect()
+        .await;
+
+    assert_eq!(
+        seen(&events[0]["result"]["headers"], "x-user-jwt"),
+        vec!["eyJhbGciOi.caller"]
+    );
+    // The streaming call still asks for SSE with its own `accept`, which the
+    // forward's blocked set is what keeps a caller from overriding.
+    assert_eq!(events[0]["result"]["accept"], "text/event-stream");
 }

--- a/crates/aisix-core/src/forwarded_headers.rs
+++ b/crates/aisix-core/src/forwarded_headers.rs
@@ -1,16 +1,19 @@
 //! Forwarding inbound client headers to an upstream.
 //!
-//! Three resources let an operator name headers that must reach the
+//! Four resources let an operator name headers that must reach the
 //! upstream — `provider_key`'s `request.forward_client_headers`, and the
-//! same field on `passthrough_route` and `mcp_server` — because the
-//! gateway fronts upstreams on three different surfaces and the choice is
-//! made per upstream, never gateway-wide: the same deployment reaches
-//! internal services that need the caller's own credentials and claims AND
-//! public model providers that must never see them.
+//! same field on `passthrough_route`, `mcp_server` and `a2a_agent` —
+//! because the gateway fronts upstreams on four different surfaces and the
+//! choice is made per upstream, never gateway-wide: the same deployment
+//! reaches internal services that need the caller's own credentials and
+//! claims AND public model providers that must never see them.
 //!
 //! The rule lives here rather than at each call site so every surface
 //! answers "may this header be forwarded, and does the pattern name it"
 //! the same way — the drift this repo's handler-family rule warns about.
+//! The list above is that rule's own census: a new surface belongs in it,
+//! or the next reader cannot tell which faces have been checked against a
+//! change made here.
 //!
 //! ## What is blocked, and why only this much
 //!
@@ -151,9 +154,9 @@ pub const TRACE_CONTEXT_HEADERS: &[&str] = &["traceparent", "tracestate"];
 ///
 /// The list here is the one every surface shares, and it is complete only
 /// where the caller's credential always arrives in a slot it names — on
-/// `/v1/*` and MCP the gateway reads `authorization` or `x-api-key` and
-/// nothing else. A surface where the OPERATOR chooses the slot has to add
-/// its own; see [`exact_match_only_with`].
+/// `/v1/*`, MCP and `/a2a/*` the gateway reads `authorization` or
+/// `x-api-key` and nothing else. A surface where the OPERATOR chooses the
+/// slot has to add its own; see [`exact_match_only_with`].
 pub fn exact_match_only(name: &str) -> bool {
     CREDENTIAL_SLOT_HEADERS.contains(&name) || TRACE_CONTEXT_HEADERS.contains(&name)
 }
@@ -375,6 +378,12 @@ mod tests {
         assert!(!header_forward_blocked("content-type"));
         assert!(!client_header_forwardable("x-stainless-lang"));
         assert!(!client_header_forwardable("anthropic-version"));
+        // Named rather than left to the list: a surface that negotiates its
+        // own response shape relies on this one — the A2A streaming path
+        // asks for `text/event-stream` and then parses SSE, so a caller's
+        // `accept` reaching the upstream changes a body it has to read.
+        assert!(!client_header_forwardable("accept"));
+        assert!(!header_forward_blocked("accept"));
         assert!(client_header_forwardable("anthropic-beta"));
     }
 

--- a/crates/aisix-core/src/models/a2a_agent.rs
+++ b/crates/aisix-core/src/models/a2a_agent.rs
@@ -57,8 +57,11 @@ pub struct A2aAgent {
     pub protocol_version: A2aProtocolVersion,
 
     /// How the gateway authenticates to the upstream agent. The credential is
-    /// held by the gateway and is never forwarded from or exposed to the calling
-    /// client.
+    /// held by the gateway and is not exposed to the calling client. The one
+    /// case where the agent sees a caller-supplied credential instead is when
+    /// `forward_client_headers` names the slot this `auth_type` fills, which
+    /// substitutes the caller's own value for the gateway's rather than
+    /// sending both.
     #[serde(default)]
     pub auth_type: A2aAuthType,
 
@@ -81,6 +84,39 @@ pub struct A2aAgent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 1))]
     pub timeout_ms: Option<u64>,
+
+    /// Inbound client headers forwarded to this agent, as single-`*` glob
+    /// patterns matched case-insensitively against the header name
+    /// (`"x-trace-*"`, `"authorization"`). Empty — the default — forwards
+    /// nothing. Applies to the agent-card fetch at
+    /// `/a2a/<name>/.well-known/agent-card.json` as well as to every JSON-RPC
+    /// method served at `/a2a/<name>`, so an agent receives them on
+    /// `message/send`, `message/stream` and every task operation alike.
+    ///
+    /// A header named here reaches the agent whatever the gateway would
+    /// otherwise do with it. Naming the credential slot `auth_type` would
+    /// fill — `authorization` for `bearer`, `x-api-key` for `api_key` — hands
+    /// the agent the caller's own credential in place of the gateway's, never
+    /// both. That is what lets an internal agent that already authorizes on
+    /// the end user's `Authorization` keep doing so unchanged. An agent that
+    /// validates the `aud` claim will reject a token minted for the gateway.
+    ///
+    /// A credential slot, and `traceparent` / `tracestate`, are forwarded only
+    /// when a pattern names them exactly — a glob such as `"*"` or `"x-*"` is
+    /// a statement about the operator's own headers, not consent to hand a
+    /// third party the caller's credential or to graft the caller's trace
+    /// onto that party's telemetry.
+    ///
+    /// Headers whose forwarding would break the exchange rather than change
+    /// who it comes from are never forwarded whatever the patterns say:
+    /// `host`, the hop-by-hop headers that describe the caller's own
+    /// connection, the gateway's `x-aisix-*` namespace, the headers
+    /// describing a body this gateway re-serializes (`content-type`,
+    /// `content-length`, `accept`), and `a2a-version`, which is the gateway's
+    /// own announcement of the wire version pinned in `protocol_version` and
+    /// which a caller's value would override.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub forward_client_headers: Vec<String>,
 
     /// Whether this agent is active. When `false`, it is not served and cannot
     /// be reached.
@@ -209,6 +245,31 @@ mod tests {
             crate::models::schema::validate_a2a_agent(&doc)
                 .expect_err("bearer needs a non-empty string secret");
         }
+    }
+
+    #[test]
+    fn the_client_header_forward_is_a_free_list_of_patterns() {
+        use crate::models::schema::{validate_a2a_agent, validate_a2a_agent_lenient};
+
+        let with = |patterns: Value| {
+            let mut v = json!({"name": "invoices", "url": "https://x/a2a"});
+            v["forward_client_headers"] = patterns;
+            v
+        };
+
+        // Credential slots are the point of the field, not an oversight: the
+        // runtime decides what is deliverable, so the schema does not
+        // second-guess an operator naming one.
+        validate_a2a_agent(&with(json!([
+            "authorization",
+            "x-api-key",
+            "x-trace-*",
+            "*"
+        ])))
+        .expect("credential slots and globs are both accepted");
+        validate_a2a_agent(&with(json!([]))).expect("an empty list is the default, spelled out");
+        validate_a2a_agent_lenient(&with(json!(["authorization"])))
+            .expect("the read path must not cost the row over a pattern");
     }
 
     #[test]
@@ -401,10 +462,15 @@ mod tests {
             auth_type: A2aAuthType::None,
             secret: None,
             timeout_ms: None,
+            forward_client_headers: Vec::new(),
             enabled: true,
             runtime_id: String::new(),
         };
         let s = serde_json::to_string(&original).unwrap();
+        assert!(
+            !s.contains("forward_client_headers"),
+            "an empty forward is the default and must not be written back: {s}"
+        );
         let back: A2aAgent = serde_json::from_str(&s).unwrap();
         assert_eq!(original, back);
     }

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -44,7 +44,7 @@ use aisix_a2a::{
 use aisix_obs::{content_capture_cap, AccessLog, CapturedContent, UsageEvent};
 use axum::body::to_bytes;
 use axum::extract::{Request, State};
-use axum::http::{header, HeaderMap, StatusCode};
+use axum::http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use futures::StreamExt;
 
@@ -232,7 +232,11 @@ async fn dispatch(
 
     let upstream = upstream_from_a2a_agent(&entry.value);
 
-    let (_parts, body) = request.into_parts();
+    let (parts, body) = request.into_parts();
+    // Resolved here rather than inside the bridge: the inbound headers exist
+    // only on this side, and the same resolved set serves the buffered and the
+    // streaming dispatch below.
+    let forwarded = aisix_a2a::forwarded_client_headers(&entry.value, Some(&parts.headers));
     let bytes = match to_bytes(
         body,
         crate::error::body_read_cap(state.request_body_limit_bytes),
@@ -361,6 +365,7 @@ async fn dispatch(
             request_id,
             trace.clone(),
             upstream,
+            forwarded,
             value,
             call,
             rpc_id,
@@ -370,7 +375,7 @@ async fn dispatch(
     }
     let _reservation = reservation;
 
-    let bridge = HttpBridge::new(upstream);
+    let bridge = HttpBridge::new(upstream).with_forwarded_client_headers(forwarded);
     let started = Instant::now();
     let result = bridge.send(&value).await;
     let latency = started.elapsed();
@@ -502,13 +507,14 @@ async fn dispatch_stream(
     request_id: &str,
     trace: Option<std::sync::Arc<aisix_obs::RequestTraceBundle>>,
     upstream: aisix_a2a::A2aUpstream,
+    forwarded: Vec<(HeaderName, HeaderValue)>,
     request: serde_json::Value,
     call: A2aCall,
     rpc_id: Option<serde_json::Value>,
     reservation: aisix_ratelimit::MultiReservation,
 ) -> Response {
     let started = Instant::now();
-    let bridge = HttpBridge::new(upstream);
+    let bridge = HttpBridge::new(upstream).with_forwarded_client_headers(forwarded);
     let events = match bridge.send_stream(&request).await {
         Ok(events) => events,
         // The upstream refused before any event: the headers have not gone out,
@@ -661,7 +667,9 @@ pub async fn a2a_agent_card(
 
     let upstream = upstream_from_a2a_agent(&entry.value);
 
-    let bridge = HttpBridge::new(upstream);
+    let bridge = HttpBridge::new(upstream).with_forwarded_client_headers(
+        aisix_a2a::forwarded_client_headers(&entry.value, Some(&headers)),
+    );
     let mut card = match bridge.fetch_agent_card().await {
         Ok(card) => card,
         Err(err) => {

--- a/schemas/resources/a2a_agent.schema.json
+++ b/schemas/resources/a2a_agent.schema.json
@@ -123,7 +123,7 @@
         }
       ],
       "default": "none",
-      "description": "How the gateway authenticates to the upstream agent. The credential is held by the gateway and is never forwarded from or exposed to the calling client."
+      "description": "How the gateway authenticates to the upstream agent. The credential is held by the gateway and is not exposed to the calling client. The one case where the agent sees a caller-supplied credential instead is when `forward_client_headers` names the slot this `auth_type` fills, which substitutes the caller's own value for the gateway's rather than sending both."
     },
     "display_name": {
       "description": "Accepted as an alternative spelling of `name`. Provide the label under exactly one of the two names.",
@@ -135,6 +135,13 @@
       "default": true,
       "description": "Whether this agent is active. When `false`, it is not served and cannot be reached.",
       "type": "boolean"
+    },
+    "forward_client_headers": {
+      "description": "Inbound client headers forwarded to this agent, as single-`*` glob patterns matched case-insensitively against the header name (`\"x-trace-*\"`, `\"authorization\"`). Empty — the default — forwards nothing. Applies to the agent-card fetch at `/a2a/<name>/.well-known/agent-card.json` as well as to every JSON-RPC method served at `/a2a/<name>`, so an agent receives them on `message/send`, `message/stream` and every task operation alike.\n\nA header named here reaches the agent whatever the gateway would otherwise do with it. Naming the credential slot `auth_type` would fill — `authorization` for `bearer`, `x-api-key` for `api_key` — hands the agent the caller's own credential in place of the gateway's, never both. That is what lets an internal agent that already authorizes on the end user's `Authorization` keep doing so unchanged. An agent that validates the `aud` claim will reject a token minted for the gateway.\n\nA credential slot, and `traceparent` / `tracestate`, are forwarded only when a pattern names them exactly — a glob such as `\"*\"` or `\"x-*\"` is a statement about the operator's own headers, not consent to hand a third party the caller's credential or to graft the caller's trace onto that party's telemetry.\n\nHeaders whose forwarding would break the exchange rather than change who it comes from are never forwarded whatever the patterns say: `host`, the hop-by-hop headers that describe the caller's own connection, the gateway's `x-aisix-*` namespace, the headers describing a body this gateway re-serializes (`content-type`, `content-length`, `accept`), and `a2a-version`, which is the gateway's own announcement of the wire version pinned in `protocol_version` and which a caller's value would override.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
     },
     "name": {
       "description": "Operator-facing label, unique within the gateway. It is the path segment under which the agent is exposed to callers as `/a2a/<name>`, so it must be a single non-empty URL path segment. The name is interpolated into the advertised agent-card URL without percent-encoding, so `/`, `?`, `#`, `%` and whitespace are rejected: `a?b` would advertise a URL whose path is just `/a2a/a`, and the lookup is an exact match on the stored name.",

--- a/tests/e2e/src/cases/forward-client-headers-e2e.test.ts
+++ b/tests/e2e/src/cases/forward-client-headers-e2e.test.ts
@@ -24,7 +24,7 @@ import {
 // hands that service the end user's own credentials and context — the
 // service keeps reading the header it always read.
 //
-// Three faces build their outbound headers in completely different code,
+// Four faces build their outbound headers in completely different code,
 // which is why each gets its own coverage here:
 //
 //   1. /v1/*             — ProviderKey `request.forward_client_headers`,
@@ -687,7 +687,10 @@ describe("forward_client_headers e2e: one capability across every proxy face", (
       }),
     });
 
-  /** The last request the A2A stub saw on `method`, since `mark`. */
+  /**
+   * Every request the A2A stub saw since `mark` under `httpMethod` — the card
+   * fetch is a GET and the JSON-RPC call a POST, and one test drives both.
+   */
   const a2aSince = (mark: number, httpMethod: "GET" | "POST") =>
     a2aUpstream!.requests.slice(mark).filter((r) => r.httpMethod === httpMethod);
 

--- a/tests/e2e/src/cases/forward-client-headers-e2e.test.ts
+++ b/tests/e2e/src/cases/forward-client-headers-e2e.test.ts
@@ -4,9 +4,11 @@ import {
   EtcdClient,
   SeedClient,
   spawnApp,
+  startA2aUpstream,
   startMcpUpstream,
   startOpenAiUpstream,
   waitConfigPropagation,
+  type A2aUpstream,
   type McpUpstream,
   type OpenAiUpstream,
   type ReceivedRequest,
@@ -35,6 +37,9 @@ import {
 //   3. /passthrough/*    — the `passthrough_route` field, where the
 //                          default is the opposite (forward everything)
 //                          and the list OVERRIDES a strip.
+//   4. /a2a/*            — the `a2a_agent` field, on the JSON-RPC call,
+//                          its streaming variant, and the agent-card
+//                          fetch, which is an upstream hop of its own.
 //
 // And beside them, the sub-dispatch paths of the model kinds that do NOT
 // go through the one convergence point the faces above share: an
@@ -60,6 +65,9 @@ const ENSEMBLE_MEMBER_A = "fwd-ensemble-member-a";
 const ENSEMBLE_MEMBER_B = "fwd-ensemble-member-b";
 const ENSEMBLE_JUDGE = "fwd-ensemble-judge";
 const ROUTE_PREFIX = "/passthrough/fwd";
+const A2A_AGENT = "fwdagent";
+const A2A_PLAIN_AGENT = "fwdplainagent";
+const A2A_GATEWAY_SECRET = "gateway-held-a2a-secret";
 const GATEWAY_KEY_HEADER = "x-gw-key";
 const CUSTOM_HEADER = "x-user-jwt";
 const CALLER_CREDENTIAL = "Bearer callers-own-credential";
@@ -96,13 +104,14 @@ describe("forward_client_headers e2e: one capability across every proxy face", (
   let upstream: OpenAiUpstream | undefined;
   let anthropicUpstream: OpenAiUpstream | undefined;
   let mcpUpstream: McpUpstream | undefined;
+  let a2aUpstream: A2aUpstream | undefined;
   let etcdReachable = false;
 
   const since = (mark: number): ReceivedRequest[] =>
     upstream!.receivedRequests.slice(mark);
 
   /** How many times `name` arrived on the wire, occurrences not values. */
-  const occurrences = (req: ReceivedRequest, name: string): number =>
+  const occurrences = (req: { headerNames: string[] }, name: string): number =>
     req.headerNames.filter((n) => n === name).length;
 
   const bodyOf = async (res: Response, what: string): Promise<string> => {
@@ -190,6 +199,9 @@ describe("forward_client_headers e2e: one capability across every proxy face", (
     upstream = await startOpenAiUpstream();
     anthropicUpstream = await startOpenAiUpstream({ nonStreamBody: ANTHROPIC_BODY });
     mcpUpstream = await startMcpUpstream("fwd");
+    // No `token`: this stub gates on the gateway's bearer when given one, and
+    // the point here is to READ what arrived rather than to be refused for it.
+    a2aUpstream = await startA2aUpstream();
     app = await spawnApp({});
     const seed = new SeedClient(etcd, app.etcdPrefix);
 
@@ -328,10 +340,32 @@ describe("forward_client_headers e2e: one capability across every proxy face", (
       forward_client_headers: [CUSTOM_HEADER, "*"],
     });
 
+    // Two A2A agents behind one stub: one opted in, one with the default.
+    // `"*"` beside the named entries is what proves the version announcement
+    // resists a glob rather than simply never matching a pattern.
+    await seed.update("a2a_agents", randomUUID(), {
+      name: A2A_AGENT,
+      url: a2aUpstream.url,
+      protocol_version: "1.0",
+      auth_type: "bearer",
+      secret: A2A_GATEWAY_SECRET,
+      forward_client_headers: [CUSTOM_HEADER, "authorization", "*"],
+      enabled: true,
+    });
+    await seed.update("a2a_agents", randomUUID(), {
+      name: A2A_PLAIN_AGENT,
+      url: a2aUpstream.url,
+      protocol_version: "1.0",
+      auth_type: "bearer",
+      secret: A2A_GATEWAY_SECRET,
+      enabled: true,
+    });
+
     const callerKey = await seed.createApiKey({
       key_hash: CALLER_HASH,
       allowed_models: ["*"],
       allowed_routes: ["*"],
+      allowed_agents: ["*"],
       mcp_access: { allow: ["*"] },
     });
 
@@ -389,6 +423,7 @@ describe("forward_client_headers e2e: one capability across every proxy face", (
     await upstream?.close();
     await anthropicUpstream?.close();
     await mcpUpstream?.close();
+    await a2aUpstream?.close();
   });
 
   test("a named header reaches an LLM upstream that opted in", async () => {
@@ -623,6 +658,124 @@ describe("forward_client_headers e2e: one capability across every proxy face", (
       expect(h["mcp-session-id"] ?? "").not.toContain("callers-own-session");
       expect(h["last-event-id"] ?? "").not.toContain("callers-own-event");
     }
+  });
+
+  /** A JSON-RPC call to an agent through the gateway. */
+  const a2aCall = async (
+    agent: string,
+    method: string,
+    headers: Record<string, string> = {},
+  ): Promise<Response> =>
+    fetch(`${app!.proxyUrl}/a2a/${agent}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_KEY}`,
+        "content-type": "application/json",
+        ...headers,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "fwd-1",
+        method,
+        params: {
+          message: {
+            role: "user",
+            parts: [{ kind: "text", text: "probe" }],
+            messageId: "m-fwd",
+          },
+        },
+      }),
+    });
+
+  /** The last request the A2A stub saw on `method`, since `mark`. */
+  const a2aSince = (mark: number, httpMethod: "GET" | "POST") =>
+    a2aUpstream!.requests.slice(mark).filter((r) => r.httpMethod === httpMethod);
+
+  test("an A2A agent receives a named header, and a forwarded credential rides alone", async () => {
+    if (!etcdReachable) return;
+    const mark = a2aUpstream!.requests.length;
+
+    await a2aCall(A2A_AGENT, "message/send", {
+      [CUSTOM_HEADER]: "carried.verbatim",
+    }).then((r) => bodyOf(r, "/a2a message/send"));
+
+    const seen = a2aSince(mark, "POST").at(-1)!;
+    expect(seen.headers[CUSTOM_HEADER]).toBe("carried.verbatim");
+    // The caller authenticates to the GATEWAY with its own AISIX key; the
+    // operator has declared that this agent reads the caller's credential
+    // rather than the one the gateway holds for it.
+    expect(seen.headers.authorization).toBe(`Bearer ${CALLER_KEY}`);
+    // And ALONE: node keeps only the FIRST `authorization`, so a gateway
+    // credential appended behind the caller's would be invisible in the
+    // collapsed value and only the occurrence count shows it stood aside.
+    expect(occurrences(seen, "authorization")).toBe(1);
+    expect(seen.headers.authorization).not.toContain(A2A_GATEWAY_SECRET);
+  });
+
+  test("an A2A agent nobody opted in receives nothing", async () => {
+    if (!etcdReachable) return;
+    const mark = a2aUpstream!.requests.length;
+
+    await a2aCall(A2A_PLAIN_AGENT, "message/send", {
+      [CUSTOM_HEADER]: "carried.verbatim",
+    }).then((r) => bodyOf(r, "/a2a on the un-opted-in agent"));
+
+    const seen = a2aSince(mark, "POST").at(-1)!;
+    expect(seen.headers[CUSTOM_HEADER]).toBeUndefined();
+    expect(seen.headers.authorization).toBe(`Bearer ${A2A_GATEWAY_SECRET}`);
+  });
+
+  test("the A2A agent-card fetch forwards them too", async () => {
+    if (!etcdReachable) return;
+    const mark = a2aUpstream!.requests.length;
+
+    // Card discovery is an upstream hop of its own, built at a different call
+    // site than the JSON-RPC one — an agent that gates discovery on the end
+    // user's own credential is exactly what this capability is for.
+    await fetch(
+      `${app!.proxyUrl}/a2a/${A2A_AGENT}/.well-known/agent-card.json`,
+      { headers: { authorization: `Bearer ${CALLER_KEY}`, [CUSTOM_HEADER]: "carried.verbatim" } },
+    ).then((r) => bodyOf(r, "the A2A agent card"));
+
+    const card = a2aSince(mark, "GET").at(-1)!;
+    expect(card.headers[CUSTOM_HEADER]).toBe("carried.verbatim");
+    expect(card.headers.authorization).toBe(`Bearer ${CALLER_KEY}`);
+    expect(occurrences(card, "authorization")).toBe(1);
+  });
+
+  test("an A2A streaming call forwards them too", async () => {
+    if (!etcdReachable) return;
+    const mark = a2aUpstream!.requests.length;
+
+    // `message/stream` opens its upstream request at a different call site
+    // than the buffered one, and only this path exercises it.
+    await a2aCall(A2A_AGENT, "message/stream", {
+      [CUSTOM_HEADER]: "carried.verbatim",
+    }).then((r) => bodyOf(r, "/a2a message/stream"));
+
+    const seen = a2aSince(mark, "POST").at(-1)!;
+    expect(seen.headers[CUSTOM_HEADER]).toBe("carried.verbatim");
+    expect(seen.headers.authorization).toBe(`Bearer ${CALLER_KEY}`);
+  });
+
+  test("a glob never sweeps the A2A version the gateway announces", async () => {
+    if (!etcdReachable) return;
+    const mark = a2aUpstream!.requests.length;
+
+    await a2aCall(A2A_AGENT, "message/send", {
+      // Both MATCH the configured `*`, so what separates them is the rule
+      // under test rather than a pattern that failed to fire.
+      "a2a-version": "0.3",
+      "x-allowed": "yes",
+    }).then((r) => bodyOf(r, "the A2A glob case"));
+
+    const seen = a2aSince(mark, "POST").at(-1)!;
+    expect(seen.headers["x-allowed"]).toBe("yes");
+    // The version is the gateway's own announcement of the agent's pinned
+    // wire format. A relayed copy would let the caller pick the envelope
+    // shape the agent answers in, or make it refuse the call outright.
+    expect(seen.version).toBe("1.0");
+    expect(occurrences(seen, "a2a-version")).toBe(1);
   });
 
   test("an ensemble's panel and judge each forward on their own upstream", async () => {

--- a/tests/e2e/src/harness/upstream-a2a.ts
+++ b/tests/e2e/src/harness/upstream-a2a.ts
@@ -13,6 +13,15 @@ export interface A2aReceivedRequest {
   version: string | null;
   authorization: string | null;
   apiKey: string | null;
+  /** Every inbound header, lowercased, a repeated name joined with `,`. */
+  headers: Record<string, string>;
+  /**
+   * Header names as they arrived, one entry per occurrence and in wire
+   * order. `headers` collapses a repeated name (node keeps only the first
+   * `authorization`), so an assertion that a slot carries EXACTLY ONE
+   * value — the shape a doubled credential breaks — has to count here.
+   */
+  headerNames: string[];
   body?: Record<string, unknown>;
 }
 
@@ -183,6 +192,15 @@ async function handle(
     version: header("a2a-version"),
     authorization: header("authorization"),
     apiKey: header("x-api-key"),
+    headers: Object.fromEntries(
+      Object.entries(req.headers).map(([k, v]) => [
+        k,
+        Array.isArray(v) ? v.join(",") : (v ?? ""),
+      ]),
+    ),
+    headerNames: req.rawHeaders
+      .filter((_, i) => i % 2 === 0)
+      .map((n) => n.toLowerCase()),
     body,
   });
 


### PR DESCRIPTION
`forward_client_headers` today lets an operator name inbound client headers that must reach a `provider_key`'s upstream, a `passthrough_route`'s target, or an `mcp_server`. This adds the fourth proxy surface: `a2a_agent`.

Fixes api7/aisix#1130

## What changes

A new `forward_client_headers` array on the `a2a_agent` resource, shaped and behaving exactly like the `mcp_server` one — single-`*` glob patterns matched case-insensitively against the header name, empty (the default) forwards nothing, `[]` clears an existing list.

It applies to every upstream hop the `/a2a` surface makes:

- every JSON-RPC method served at `POST /a2a/<name>` — `message/send`, `message/stream`, `tasks/get|list|cancel|resubscribe`, `tasks/pushNotificationConfig/*` and the 1.0 PascalCase spellings, which all share one handler;
- the streaming variant, which opens its upstream request at a different call site than the buffered one;
- the agent-card fetch at `GET /a2a/<name>/.well-known/agent-card.json`, which is an upstream hop of its own.

Resolution goes through the shared `resolve_forwarded_client_headers`, so all three existing surfaces and this one answer "may this header be forwarded, and does the pattern name it" identically. Because the `/a2a` surface rebuilds the outbound JSON-RPC message rather than relaying a body verbatim, the resolver's second blocking tier applies — the same one MCP takes, and not the `/passthrough/*` one.

### The credential slot

A forwarded header that lands in the slot the agent's `auth_type` fills — `authorization` for `bearer`, `x-api-key` for `api_key` — hands the agent the caller's own credential **in place of** the gateway-held one, never both. That is what lets an internal agent which already authorizes on the end user's `Authorization` keep doing so unchanged, and one credential on the wire is what stops the agent choosing between two. The suppression matters mechanically as well: the outbound builder appends rather than overwrites, so a gateway credential that did not stand aside would ride behind the caller's and be invisible in the collapsed value.

A credential slot is only ever reached by a pattern that spells it out. A `"*"` or `"x-*"` glob is a statement about the operator's own headers, not consent to hand a third party the caller's credential — the same rule every other surface enforces, and the reason an already-configured broad pattern keeps meaning what it meant when it was written.

### The blocked set

On top of what the shared lists refuse (`host`, hop-by-hop headers, the `x-aisix-*` namespace, and the framing headers describing a body this gateway re-serializes), this surface owns one slot of its own: `a2a-version`. It is the gateway's announcement of the wire version pinned in the agent's `protocol_version`, and the agent reads it to pick the envelope shape it answers in — so a relayed caller copy would let the caller override the operator's pin, or make the agent refuse the call outright. It is refused however broad the pattern is.

## Behavior changes

- The `auth_type` description previously asserted the gateway credential "is never forwarded from or exposed to the calling client". With this feature an operator can deliberately have the caller's own credential fill that slot instead, so the sentence has been reworded to say what actually holds: the credential is not exposed to the caller, and the one case where the agent sees a caller-supplied credential is when `forward_client_headers` names the slot.
- No existing agent changes behavior: the field defaults to empty and an empty list forwards nothing. An agent document written before this change keeps sending only the gateway's own credential and version header.

## Compatibility

Additive and optional, with a serde default, so a document carrying it still loads on the previous release (unknown fields are tolerated and reported), and a document without it loads here. An older data plane that meets a newer control plane simply does not forward — the feature is off, which is the fail-closed direction for a header-forwarding capability.

## Control plane

This is a user-configurable surface, so it is half a cross-plane feature: `cp-admin.yaml` holds closed schemas and will reject `forward_client_headers` on an `a2a_agent` until the paired control-plane change lands (schema + regenerated bindings, typed model + validation + projection, dashboard form + i18n, tests). That work is tracked separately and is dispatched off this PR.

## Comparison with mainstream gateways

One established AI gateway exposes the equivalent on its own agent object as a list of client header **names** to copy onto the upstream call. Two differences are deliberate here, both toward the stricter side:

- It applies no transport or framing blocklist and no protection for its own namespace, and it additionally honours a caller-named convention that needs no operator opt-in at all. This implementation forwards only what an operator named, and refuses the headers whose relay would corrupt the exchange or forge a gateway assertion.
- Its credential precedence is the opposite: a configured upstream credential wins and the caller's forwarded copy is dropped, so the capability cannot be used to delegate the end user's identity — and where no credential is configured, the caller's gateway key travels upstream verbatim. This implementation displaces instead, which is the semantics the three surfaces already shipped here use, and which is what the internal-service case in #1130 asks for. That divergence is called out rather than silently taken.

## Tests

`crates/aisix-a2a/tests/upstream_roundtrip.rs`, against a locally spawned real agent over real HTTP: a forwarded header reaches the agent; a forwarded `authorization` replaces the gateway bearer and rides alone; the same for `x-api-key`; without a forward the gateway credential is still the only one; a forwarded value is redacted in `Debug`; `a2a-version` is not forwardable even under `["*"]`, nor when named exactly; the agent-card fetch forwards; the streaming path forwards.

`crates/aisix-core/src/models/a2a_agent.rs`: patterns naming credential slots and globs are accepted by both the strict and the lenient schema, and an empty list is not written back.

`tests/e2e/src/cases/forward-client-headers-e2e.test.ts` gains the A2A face of the existing cross-face suite, driven through a real gateway + etcd + a stub agent: a named header arrives and a forwarded credential rides alone; an agent nobody opted in receives nothing; the card fetch forwards; the streaming call forwards; a glob never sweeps the version announcement. The stub agent now records the full inbound header map and per-occurrence header names, so a doubled credential cannot hide behind the collapsed value node reports.
