### PR TITLE
fix(etcd): read 0 as unbounded, bound the watch create, drain the cache write at shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "chrono",
  "etcd-client",
  "futures",
+ "h2",
  "serde",
  "serde_ignored",
  "serde_json",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,14 +8,18 @@ etcd:
   # user: "aisix"
   # password_env: "AISIX_ETCD_PASSWORD"
   # Optional bounds on etcd I/O. Both are unset by default, and unset
-  # means unbounded.
+  # means unbounded. `0` means unbounded too — these two keys are flat
+  # startup settings with no next level to defer to, unlike the `0` on a
+  # model's `timeout`, so "no bound" is the only thing `0` can usefully
+  # say here.
   #
   # `dial_timeout_ms` bounds the TCP connect — not the TLS handshake
   # after it, and not the authentication exchange when `user` is set.
-  # `request_timeout_ms` bounds a single unary call — the configuration
-  # range read at boot and on every reconnect, and the admin API's reads.
-  # It deliberately does not apply to the watch stream, which is
-  # long-lived and would be torn down by any such bound.
+  # `request_timeout_ms` bounds a single request/response call — the
+  # configuration range read at boot and on every reconnect, creating the
+  # watch, and the admin API's reads. It deliberately does not apply to
+  # the established watch stream, which is long-lived and would be torn
+  # down by any such bound.
   #
   # Leave `request_timeout_ms` unset unless you specifically want a slow
   # etcd to fail fast: the range read grows with the size of your

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,10 +8,10 @@ etcd:
   # user: "aisix"
   # password_env: "AISIX_ETCD_PASSWORD"
   # Optional bounds on etcd I/O. Both are unset by default, and unset
-  # means unbounded. `0` means unbounded too — these two keys are flat
-  # startup settings with no next level to defer to, unlike the `0` on a
-  # model's `timeout`, so "no bound" is the only thing `0` can usefully
-  # say here.
+  # means unbounded. `0` means unbounded as well — the same reading a
+  # model's `timeout: 0` gets. (A model's `stream_timeout: 0` is the odd
+  # one out: it falls back to the next level of a resolution chain these
+  # flat startup settings do not have.)
   #
   # `dial_timeout_ms` bounds the TCP connect — not the TLS handshake
   # after it, and not the authentication exchange when `user` is set.

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -37,13 +37,16 @@ etcd:
   endpoints:
     - "https://placeholder-overridden-at-register:2379"
   prefix: "/aisix"
-  # Both timeouts are unset by default, and unset means unbounded.
+  # Both timeouts are unset by default, and unset means unbounded; `0`
+  # means unbounded as well, since these flat startup keys have no next
+  # level for a `0` to defer to the way a model's `timeout` does.
   # `dial_timeout_ms` bounds the TCP connect only, not the TLS handshake
   # layered above it; `request_timeout_ms` bounds a
-  # single unary call (the configuration range read, the admin reads) but
-  # never the watch stream. A `request_timeout_ms` the range read cannot
-  # finish inside makes the gateway retry it forever without ever serving
-  # traffic, so leave it unset unless a slow etcd must fail fast.
+  # single request/response call (the configuration range read, creating
+  # the watch, the admin reads) but never the established watch stream. A
+  # `request_timeout_ms` the range read cannot finish inside makes the
+  # gateway retry it forever without ever serving traffic, so leave it
+  # unset unless a slow etcd must fail fast.
   # dial_timeout_ms: 5000
   # request_timeout_ms: 5000
 

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -38,8 +38,9 @@ etcd:
     - "https://placeholder-overridden-at-register:2379"
   prefix: "/aisix"
   # Both timeouts are unset by default, and unset means unbounded; `0`
-  # means unbounded as well, since these flat startup keys have no next
-  # level for a `0` to defer to the way a model's `timeout` does.
+  # means unbounded as well — the same reading a model's `timeout: 0`
+  # gets. (A model's `stream_timeout: 0` instead falls back to the next
+  # level of a resolution chain these flat startup keys do not have.)
   # `dial_timeout_ms` bounds the TCP connect only, not the TLS handshake
   # layered above it; `request_timeout_ms` bounds a
   # single request/response call (the configuration range read, creating

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -395,15 +395,16 @@ impl EtcdConfig {
 
     /// `None` when unset or `0`: request/response calls are unbounded.
     ///
-    /// `0` is the same as unset, not an instant abort. This repo also
-    /// reads `0` as "fall back to the next level" — `Model::timeout` and
-    /// `Model::stream_timeout` both do — but only because those sit on a
-    /// model → group → `upstream.*` resolution chain where deferring is
-    /// an expressible meaning. These two keys are flat, single-level
-    /// startup configuration with nothing to defer to, so the only
-    /// choice `0` can express is unbounded or instant abort, and an
-    /// instant abort is unreachable: every connect and every read would
-    /// expire, so the proxy listener would never bind.
+    /// `0` is the same as unset, not an instant abort — the same reading
+    /// `Model::timeout: 0` gets ("no deadline, stop resolving"). The one
+    /// key in this repo where `0` means "fall back to the next level" is
+    /// `Model::stream_timeout`, and only because it sits on a model →
+    /// group → `upstream.*` resolution chain where deferring is an
+    /// expressible meaning. These two keys are flat, single-level startup
+    /// configuration with nothing to defer to, so the only other reading
+    /// `0` could carry is an instant abort, and that is unreachable:
+    /// every connect and every read would expire, so the proxy listener
+    /// would never bind.
     pub const fn request_timeout(&self) -> Option<Duration> {
         Self::bound(self.request_timeout_ms)
     }
@@ -1854,13 +1855,13 @@ admin:
 
     #[test]
     fn etcd_timeouts_read_zero_as_unbounded_not_as_an_instant_abort() {
-        // `0` is the same as unset for both keys. The alternative
-        // reading — abort immediately — bricks the gateway silently:
-        // every connect and every read expires, so the proxy listener
-        // never binds and nothing says why. The other `0` convention in
-        // this repo (`Model::timeout`, `Model::stream_timeout`) means
-        // "fall back to the next level", which needs a resolution chain
-        // these two flat startup keys do not have.
+        // `0` is the same as unset for both keys, matching what
+        // `Model::timeout: 0` already means. The alternative reading —
+        // abort immediately — bricks the gateway silently: every connect
+        // and every read expires, so the proxy listener never binds and
+        // nothing says why. The one `0` in this repo that means "fall
+        // back to the next level" is `Model::stream_timeout`, which needs
+        // a resolution chain these two flat startup keys do not have.
         let f = write_yaml(
             r#"
 etcd:

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -125,7 +125,8 @@ pub struct EtcdConfig {
     #[serde(default)]
     pub password_env: Option<String>,
     /// Bound on the TCP connect to etcd, in milliseconds. Unset — the
-    /// default — leaves it to the OS TCP stack.
+    /// default — and `0` both mean unbounded (see the note on `0` under
+    /// [`EtcdConfig::request_timeout`]), leaving it to the OS TCP stack.
     ///
     /// It reaches hyper's connector via `Endpoint::connect_timeout`, so
     /// it covers the TCP handshake and nothing after it. Two later steps
@@ -135,18 +136,19 @@ pub struct EtcdConfig {
     /// when `user` / `password_env` are set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dial_timeout_ms: Option<u64>,
-    /// Bound on a single unary etcd call, in milliseconds. Unset — the
-    /// default — leaves those calls unbounded.
+    /// Bound on a single request/response etcd call, in milliseconds.
+    /// Unset — the default — and `0` both mean unbounded (see the note on
+    /// `0` below).
     ///
-    /// When set it covers the configuration range read (`load_all`) and
-    /// the admin surface's reads. It does not reach the two calls that
-    /// sit outside that set and are still unbounded — the `Authenticate`
-    /// inside `Client::connect`, and the watch-create handshake — so an
-    /// etcd that answers a range read but stalls on either of those can
-    /// still hang the gateway. It deliberately does NOT cover the
-    /// watch: that stream is long-lived by construction, so a bound on it
-    /// would expire on every interval quiet enough to produce no event
-    /// and leave the gateway reconnecting instead of watching.
+    /// When set it covers the configuration range read (`load_all`), the
+    /// watch-create handshake, and the admin surface's reads. It does not
+    /// reach the `Authenticate` inside `Client::connect`, which is still
+    /// unbounded. It deliberately does NOT cover the established watch
+    /// stream either: that stream is long-lived by construction, so a
+    /// bound on it would expire on every interval quiet enough to produce
+    /// no event and leave the gateway reconnecting instead of watching.
+    /// Creating the watch is request/response shaped and is bounded;
+    /// consuming it is not.
     ///
     /// The default is unset rather than a finite value because the range
     /// read scales with the size of the configuration set: a bound short
@@ -383,19 +385,35 @@ impl EtcdConfig {
     fn default_prefix() -> String {
         "/aisix".into()
     }
-    /// `None` when unset: the dial is unbounded.
+    /// `None` when unset or `0`: the dial is unbounded.
+    ///
+    /// See [`EtcdConfig::request_timeout`] for why `0` means unbounded
+    /// here and "fall back to the next level" elsewhere in this repo.
     pub const fn dial_timeout(&self) -> Option<Duration> {
-        match self.dial_timeout_ms {
-            Some(ms) => Some(Duration::from_millis(ms)),
-            None => None,
-        }
+        Self::bound(self.dial_timeout_ms)
     }
 
-    /// `None` when unset: unary calls are unbounded.
+    /// `None` when unset or `0`: request/response calls are unbounded.
+    ///
+    /// `0` is the same as unset, not an instant abort. This repo also
+    /// reads `0` as "fall back to the next level" — `Model::timeout` and
+    /// `Model::stream_timeout` both do — but only because those sit on a
+    /// model → group → `upstream.*` resolution chain where deferring is
+    /// an expressible meaning. These two keys are flat, single-level
+    /// startup configuration with nothing to defer to, so the only
+    /// choice `0` can express is unbounded or instant abort, and an
+    /// instant abort is unreachable: every connect and every read would
+    /// expire, so the proxy listener would never bind.
     pub const fn request_timeout(&self) -> Option<Duration> {
-        match self.request_timeout_ms {
+        Self::bound(self.request_timeout_ms)
+    }
+
+    /// Shared reading of both etcd timeout keys, so the two cannot drift
+    /// apart on what `0` means.
+    const fn bound(ms: Option<u64>) -> Option<Duration> {
+        match ms {
+            None | Some(0) => None,
             Some(ms) => Some(Duration::from_millis(ms)),
-            None => None,
         }
     }
 
@@ -1831,6 +1849,44 @@ admin:
         assert_eq!(
             cfg.etcd.request_timeout(),
             Some(Duration::from_millis(7000))
+        );
+    }
+
+    #[test]
+    fn etcd_timeouts_read_zero_as_unbounded_not_as_an_instant_abort() {
+        // `0` is the same as unset for both keys. The alternative
+        // reading — abort immediately — bricks the gateway silently:
+        // every connect and every read expires, so the proxy listener
+        // never binds and nothing says why. The other `0` convention in
+        // this repo (`Model::timeout`, `Model::stream_timeout`) means
+        // "fall back to the next level", which needs a resolution chain
+        // these two flat startup keys do not have.
+        let f = write_yaml(
+            r#"
+etcd:
+  endpoints: ["http://127.0.0.1:2379"]
+  prefix: "/aisix"
+  dial_timeout_ms: 0
+  request_timeout_ms: 0
+proxy:
+  addr: "0.0.0.0:3000"
+admin:
+  addr: "127.0.0.1:3001"
+  admin_keys: ["k1"]
+"#,
+        );
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.etcd.dial_timeout_ms, Some(0), "the key still parses");
+        assert_eq!(cfg.etcd.request_timeout_ms, Some(0));
+        assert_eq!(
+            cfg.etcd.dial_timeout(),
+            None,
+            "dial_timeout_ms: 0 must read as unbounded",
+        );
+        assert_eq!(
+            cfg.etcd.request_timeout(),
+            None,
+            "request_timeout_ms: 0 must read as unbounded",
         );
     }
 

--- a/crates/aisix-etcd/Cargo.toml
+++ b/crates/aisix-etcd/Cargo.toml
@@ -24,3 +24,10 @@ chrono.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+# A real HTTP/2 server that completes the handshake, accepts the request
+# and then never answers it — the shape of an etcd that is reachable but
+# never confirms a call. See the `etcd_provider` tests.
+h2.workspace = true
+# `test-util` drives the shutdown-drain bound on a paused clock, so the
+# test asserts the bound without spending it.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -402,6 +402,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn the_request_timeout_bounds_a_range_read_that_is_never_answered() {
+        // The symmetric half of the watch-create spec below, and the only
+        // thing that pins `load_all`'s own variant now that `bound` takes
+        // the constructor as a parameter: the helper-level spec passes
+        // `ProviderError::Range` in itself, so it would stay green if this
+        // call site started reporting expiry as `Watch`. The supervisor
+        // routes both to the same backoff, so the variant is what the warn
+        // line says — which is the whole point of naming the call.
+        let endpoint = spawn_silent_h2_server().await;
+        let provider = EtcdConfigProvider::connect(
+            &[endpoint],
+            "/aisix",
+            None,
+            Some(Duration::from_millis(300)),
+        )
+        .await
+        .expect("connect is lazy without credentials");
+
+        let err = tokio::time::timeout(Duration::from_secs(10), provider.load_all())
+            .await
+            .expect("the range read must be bounded; without the bound this hangs")
+            .expect_err("an unanswered range read cannot succeed");
+
+        let ProviderError::Range(msg) = err else {
+            panic!("expiry must surface as ProviderError::Range, got {err:?}");
+        };
+        assert!(
+            msg.contains("range read") && msg.contains("etcd.request_timeout_ms"),
+            "the message must name the call and the key that bounded it: {msg}",
+        );
+    }
+
+    #[tokio::test]
     async fn the_request_timeout_bounds_a_watch_creation_that_is_never_confirmed() {
         // Creating a watch is request/response shaped: etcd-client sends
         // the create request and awaits the server's create confirmation

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -73,12 +73,14 @@ pub struct EtcdConfigProvider {
     kv: Mutex<KvClient>,
     watch: Mutex<WatchClient>,
     prefix: String,
-    /// Bound applied to each unary call this provider makes — currently
-    /// the range read in [`Self::load_all`]. `None` leaves it unbounded.
+    /// Bound applied to each request/response call this provider makes —
+    /// the range read in [`Self::load_all`] and the watch-create
+    /// handshake in [`Self::watch`]. `None` leaves them unbounded, and
+    /// the established watch stream is never bounded by it.
     ///
     /// Applied per call with [`tokio::time::timeout`] rather than through
     /// `ConnectOptions::with_timeout`, for two reasons. That option is
-    /// channel-wide, so it would also bound opening the watch. And it
+    /// channel-wide, so it would also bound consuming the watch. And it
     /// bounds only the response *future*: tonic's `GrpcTimeout` races the
     /// deadline against the arrival of response headers and then lets the
     /// body stream run untimed, so an etcd that answers a range request
@@ -165,21 +167,22 @@ impl EtcdConfigProvider {
 
 /// Apply `timeout`, when set, to one in-flight etcd call.
 ///
-/// Expiry is reported as [`ProviderError::Range`] to match the variant
-/// the same call's transport failures already use, so the supervisor's
-/// warn line attributes it to the range read. It is attribution, not
-/// control flow: `Supervisor::run` routes every `ProviderError` out of
-/// `load_all` to the same reconnect-with-backoff path, so the aborted
-/// read is retried whichever variant carries it.
+/// `into_err` names the call: expiry is reported as the same
+/// `ProviderError` variant that call's transport failures already use,
+/// so the supervisor's warn line attributes it to the right step. It is
+/// attribution, not control flow: `Supervisor::run` routes every
+/// `ProviderError` out of a cycle to the same reconnect-with-backoff
+/// path, so the aborted call is retried whichever variant carries it.
 async fn bound<T>(
     timeout: Option<Duration>,
     what: &str,
+    into_err: fn(String) -> ProviderError,
     fut: impl std::future::Future<Output = T>,
 ) -> Result<T, ProviderError> {
     match timeout {
         None => Ok(fut.await),
         Some(d) => tokio::time::timeout(d, fut).await.map_err(|_| {
-            ProviderError::Range(format!(
+            into_err(format!(
                 "{what} exceeded etcd.request_timeout_ms ({} ms)",
                 d.as_millis()
             ))
@@ -195,9 +198,14 @@ impl ConfigProvider for EtcdConfigProvider {
             self.prefix.as_bytes(),
             Some(GetOptions::new().with_prefix()),
         );
-        let resp = bound(self.request_timeout, "range read", read)
-            .await?
-            .map_err(|e| ProviderError::Range(format_error_chain(&e)))?;
+        let resp = bound(
+            self.request_timeout,
+            "range read",
+            ProviderError::Range,
+            read,
+        )
+        .await?
+        .map_err(|e| ProviderError::Range(format_error_chain(&e)))?;
 
         let revision = resp.header().map(|h| h.revision()).unwrap_or(0);
 
@@ -225,10 +233,25 @@ impl ConfigProvider for EtcdConfigProvider {
         let opts = WatchOptions::new()
             .with_prefix()
             .with_start_revision(start_revision);
-        let (watcher, stream) = watch
-            .watch(self.prefix.as_bytes(), Some(opts))
-            .await
-            .map_err(|e| ProviderError::Watch(format_error_chain(&e)))?;
+        // Creating the watch is request/response shaped — etcd-client
+        // sends the create request and awaits the server's create
+        // confirmation before handing back the stream — so it is bounded
+        // like any other unary call. Consuming the stream that comes back
+        // is not: see the `request_timeout` field docs.
+        //
+        // The failure this closes is silent. An etcd that answers range
+        // reads but never confirms the watch leaves the gateway serving
+        // its first snapshot forever, blind to every later change, while
+        // `/status/config` still reports it connected.
+        let create = watch.watch(self.prefix.as_bytes(), Some(opts));
+        let (watcher, stream) = bound(
+            self.request_timeout,
+            "watch create",
+            ProviderError::Watch,
+            create,
+        )
+        .await?
+        .map_err(|e| ProviderError::Watch(format_error_chain(&e)))?;
 
         Ok(Box::new(EtcdWatchStream {
             inner: stream,
@@ -348,9 +371,76 @@ mod tests {
         assert!(matches!(err, ProviderError::Connect(_)));
     }
 
+    /// An etcd that is reachable and answers nothing.
+    ///
+    /// A real HTTP/2 server: the connection preface and SETTINGS exchange
+    /// complete, every request is accepted, and no response is ever sent.
+    /// That is the failure the bound below exists for — the call reached
+    /// a reachable etcd, which simply never answered it.
+    ///
+    /// Returns the endpoint. The listener task lives for the test.
+    async fn spawn_silent_h2_server() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((socket, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let Ok(mut conn) = h2::server::handshake(socket).await else {
+                        return;
+                    };
+                    // Hold each responder without ever using it: dropping
+                    // one would RST_STREAM the request, which the client
+                    // would see as an answer.
+                    let mut accepted = Vec::new();
+                    while let Some(Ok((_req, respond))) = conn.accept().await {
+                        accepted.push(respond);
+                    }
+                });
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn the_request_timeout_bounds_a_watch_creation_that_is_never_confirmed() {
+        // Creating a watch is request/response shaped: etcd-client sends
+        // the create request and awaits the server's create confirmation
+        // before handing back the stream. Unbounded, an etcd that answers
+        // range reads and never confirms the watch leaves the gateway
+        // serving its first snapshot forever, blind to every later
+        // change, while `/status/config` still reports it connected.
+        let endpoint = spawn_silent_h2_server().await;
+        // No user, so `Client::connect` is lazy and returns without a
+        // round trip — the stall this asserts on is the watch create.
+        let provider = EtcdConfigProvider::connect(
+            &[endpoint],
+            "/aisix",
+            None,
+            Some(Duration::from_millis(300)),
+        )
+        .await
+        .expect("connect is lazy without credentials");
+
+        let err = tokio::time::timeout(Duration::from_secs(10), provider.watch(1))
+            .await
+            .expect("the watch create must be bounded; without the bound this hangs")
+            .err()
+            .expect("an unconfirmed watch create cannot succeed");
+
+        let ProviderError::Watch(msg) = err else {
+            panic!("expiry must surface as ProviderError::Watch, got {err:?}");
+        };
+        assert!(
+            msg.contains("watch create") && msg.contains("etcd.request_timeout_ms"),
+            "the message must name the call and the key that bounded it: {msg}",
+        );
+    }
+
     #[tokio::test]
     async fn bound_passes_through_when_no_timeout_is_set() {
-        let out = bound(None, "range read", async { 7u8 }).await.unwrap();
+        let out = bound(None, "range read", ProviderError::Range, async { 7u8 })
+            .await
+            .unwrap();
         assert_eq!(out, 7);
     }
 
@@ -367,6 +457,7 @@ mod tests {
         let err = bound(
             Some(Duration::from_millis(1)),
             "range read",
+            ProviderError::Range,
             std::future::pending::<()>(),
         )
         .await

--- a/crates/aisix-etcd/src/snapshot_cache.rs
+++ b/crates/aisix-etcd/src/snapshot_cache.rs
@@ -54,9 +54,17 @@ struct Inner {
     /// Some(path) → enabled; None → no-op.
     path: Option<PathBuf>,
     /// Serialise concurrent writes so the tmp-file rename dance can't
-    /// race with itself. Reads are unguarded — they go through OS
-    /// caches and the rename is atomic.
-    write_lock: Mutex<()>,
+    /// race with itself, and carry the highest revision committed so far
+    /// so they also commit in order. Reads are unguarded — they go
+    /// through OS caches and the rename is atomic.
+    ///
+    /// The ordering half matters because [`Self::store`] serialises its
+    /// snapshot BEFORE taking this lock: the supervisor spawns one write
+    /// per apply and never waits for it, so two writes racing that work
+    /// can reach the lock in the opposite order to the applies that
+    /// produced them, and the older snapshot lands last. `i64::MIN`
+    /// until the first write, so a revision of `0` still commits.
+    write_lock: Mutex<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,7 +118,7 @@ impl SnapshotCache {
         Self {
             inner: Arc::new(Inner {
                 path: Some(path.into()),
-                write_lock: Mutex::new(()),
+                write_lock: Mutex::new(i64::MIN),
             }),
         }
     }
@@ -122,7 +130,7 @@ impl SnapshotCache {
         Self {
             inner: Arc::new(Inner {
                 path: None,
-                write_lock: Mutex::new(()),
+                write_lock: Mutex::new(i64::MIN),
             }),
         }
     }
@@ -231,10 +239,21 @@ impl SnapshotCache {
                 return;
             }
         };
-        let _guard = self.inner.write_lock.lock().await;
+        let mut committed = self.inner.write_lock.lock().await;
+        // A write that lost the serialisation race to a NEWER apply has
+        // nothing to add: committing it would roll the cache back to a
+        // snapshot the gateway has already moved past, and the next
+        // restart would then serve it. Equal revisions still commit — a
+        // delete flushes at the current revision floor, so same-revision
+        // writes carry different content.
+        if revision < *committed {
+            return;
+        }
         if let Err(e) = atomic_write(&path, &bytes).await {
             tracing::warn!(error = %e, path = %path.display(), "snapshot cache write failed");
+            return;
         }
+        *committed = revision;
     }
 }
 
@@ -282,6 +301,53 @@ mod tests {
         assert_eq!(cached.revision, 42);
         assert_eq!(cached.entries, entries);
         assert!(cached.stale.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_write_that_lost_its_race_cannot_roll_the_cache_back() {
+        // The supervisor spawns one write per apply and does not order
+        // them, and `store` serialises its snapshot before taking the
+        // write lock — so a write for an older apply can reach the lock
+        // after a newer one. Committing it would roll the cache back to
+        // a snapshot the gateway has already moved past, and the next
+        // restart would serve it. Sequential calls stand in for the race:
+        // the lock is what the race resolves to, and this is the order it
+        // can resolve to.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("snap.json");
+        let cache = SnapshotCache::new(&path);
+
+        let newer = vec![entry("/aisix/models/m-1", br#"{"name":"new"}"#, 9)];
+        let older = vec![entry("/aisix/models/m-1", br#"{"name":"old"}"#, 8)];
+        cache.store(&newer, 9, &[]).await;
+        cache.store(&older, 8, &[]).await;
+
+        let cached = cache.load().expect("cache file exists");
+        assert_eq!(
+            cached.revision, 9,
+            "the older apply must not overwrite the newer one",
+        );
+        assert_eq!(cached.entries, newer);
+    }
+
+    #[tokio::test]
+    async fn a_write_at_the_same_revision_still_commits() {
+        // A delete flushes at the current revision floor rather than a
+        // revision of its own, so same-revision writes carry different
+        // content and the guard above must not swallow them.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("snap.json");
+        let cache = SnapshotCache::new(&path);
+
+        let before = vec![entry("/aisix/models/m-1", br#"{"name":"m1"}"#, 9)];
+        cache.store(&before, 9, &[]).await;
+        cache.store(&[], 9, &[]).await;
+
+        let cached = cache.load().expect("cache file exists");
+        assert!(
+            cached.entries.is_empty(),
+            "a same-revision write must still commit",
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -547,6 +547,16 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// Bounded because shutdown must not be able to hang on a stuck disk.
     /// The bound is fixed rather than configurable: it is a backstop on a
     /// local file write, not a tuning knob.
+    ///
+    /// Expiry abandons the WAIT, not the write: dropping a `JoinHandle`
+    /// detaches its task rather than cancelling it, so a write that was
+    /// merely slow can still commit before the process exits. That is
+    /// left alone deliberately — the supervisor loop has stopped, so no
+    /// fresher state exists to lose the race to, and
+    /// [`SnapshotCache::store`] renames a fsynced temporary over the
+    /// destination, so a late write commits whole or not at all. Which of
+    /// the two applies wins is therefore unknown at this point, and the
+    /// warning says so rather than promising either.
     async fn drain_pending_cache_writes(&self) {
         if tokio::time::timeout(CACHE_WRITE_DRAIN, self.await_pending_cache_writes())
             .await
@@ -554,8 +564,10 @@ impl<P: ConfigProvider> Supervisor<P> {
         {
             tracing::warn!(
                 bound_ms = CACHE_WRITE_DRAIN.as_millis() as u64,
-                "snapshot-cache write still in flight at shutdown; abandoning it — \
-                 the on-disk cache keeps its previous contents",
+                "snapshot-cache write did not finish inside the shutdown drain; \
+                 no longer waiting for it. It is abandoned rather than cancelled, \
+                 so the on-disk cache ends up at either this apply or the previous \
+                 one — never partway between them",
             );
         }
     }

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -226,7 +226,12 @@ pub struct Supervisor<P: ConfigProvider> {
 
     // JoinHandles for in-flight `flush_cache` writes. [`Self::run`]
     // drains them before returning so a gateway stopped shortly after an
-    // apply still persists that apply; tests use
+    // apply comes back with a persisted snapshot rather than none. WHICH
+    // apply is a separate question: `SnapshotCache::store` serialises its
+    // snapshot before taking the cache's write lock, so two writes racing
+    // that work can commit in the opposite order to the applies that
+    // produced them. Draining does not change that, and does not claim
+    // to. Tests use
     // [`Self::await_pending_cache_writes`] to order against a write
     // without relying on a wall-clock sleep, which proved flaky on slow
     // CI runners. Kept to the writes actually in flight: `flush_cache`
@@ -554,9 +559,9 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// left alone deliberately — the supervisor loop has stopped, so no
     /// fresher state exists to lose the race to, and
     /// [`SnapshotCache::store`] renames a fsynced temporary over the
-    /// destination, so a late write commits whole or not at all. Which of
-    /// the two applies wins is therefore unknown at this point, and the
-    /// warning says so rather than promising either.
+    /// destination, so a late write commits whole or not at all. Which
+    /// apply ends up on disk is therefore unknown at this point, and the
+    /// warning says so rather than promising one.
     async fn drain_pending_cache_writes(&self) {
         if tokio::time::timeout(CACHE_WRITE_DRAIN, self.await_pending_cache_writes())
             .await
@@ -566,8 +571,8 @@ impl<P: ConfigProvider> Supervisor<P> {
                 bound_ms = CACHE_WRITE_DRAIN.as_millis() as u64,
                 "snapshot-cache write did not finish inside the shutdown drain; \
                  no longer waiting for it. It is abandoned rather than cancelled, \
-                 so the on-disk cache ends up at either this apply or the previous \
-                 one — never partway between them",
+                 so the on-disk cache ends up at one of the recent applies — \
+                 never partway between them",
             );
         }
     }
@@ -1838,9 +1843,21 @@ mod tests {
             .unwrap();
 
         rt.block_on(async {
-            let entries: Vec<RawEntry> = (0..PADDING_ROWS).map(padding_entry).collect();
-            let provider = Arc::new(FakeProvider::new(entries, 1).with_events(vec![Ok(
-                WatchEvent::Put(entry("/aisix/models/late", VALID_MODEL, 2)),
+            // The heavy configuration set arrives on the WATCH, not on the
+            // initial load, so exactly one costly write is ever in flight
+            // and this test's verdict cannot be decided by which of two
+            // concurrent writes reaches the cache's lock first.
+            // `SnapshotCache::store` serialises its snapshot before taking
+            // that lock, so concurrent writes can commit out of order --
+            // a pre-existing property this test must not depend on either
+            // way.
+            let mut arriving: Vec<RawEntry> = (0..PADDING_ROWS).map(padding_entry).collect();
+            arriving.push(entry("/aisix/models/late", VALID_MODEL, 2));
+            let provider = Arc::new(FakeProvider::new(Vec::new(), 1).with_events(vec![Ok(
+                WatchEvent::Resync {
+                    entries: arriving.into(),
+                    revision: 2,
+                },
             )]));
             let sup = Arc::new(Supervisor::with_cache(
                 provider,
@@ -1850,7 +1867,7 @@ mod tests {
             let (tx, rx) = tokio::sync::watch::channel(false);
             let join = tokio::spawn(sup.clone().run(rx));
 
-            // Cancel the moment the put is visible in the served
+            // Cancel the moment the apply is visible in the served
             // snapshot. The flush it spawned is then still on its way to
             // disk, which is exactly the window this pins.
             for _ in 0..5_000 {
@@ -1861,7 +1878,7 @@ mod tests {
             }
             assert!(
                 sup.handle().load().models.get_by_id("late").is_some(),
-                "the put must reach the served snapshot before shutdown",
+                "the apply must reach the served snapshot before shutdown",
             );
             tx.send(true).unwrap();
             join.await.unwrap();
@@ -1894,6 +1911,16 @@ mod tests {
             .lock()
             .unwrap()
             .push(tokio::spawn(std::future::pending::<()>()));
+
+        // Both sides of the assertion below are the same constant, so it
+        // pins the behaviour and not the budget. The budget is part of
+        // what a deployment is promised at shutdown, so it is pinned here
+        // in its own right.
+        assert_eq!(
+            CACHE_WRITE_DRAIN,
+            Duration::from_secs(5),
+            "the shutdown drain's budget is part of the contract",
+        );
 
         let started = tokio::time::Instant::now();
         tokio::time::timeout(CACHE_WRITE_DRAIN * 4, sup.drain_pending_cache_writes())

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -145,7 +145,7 @@ const MAX_RETAINED_PARTIAL_ROWS: usize = 1024;
 /// is one local file and completes in milliseconds on any healthy one.
 /// Deliberately not configurable — an operator has nothing to trade off
 /// here, and a knob would only offer a way to make shutdown hang longer.
-pub const CACHE_WRITE_DRAIN: Duration = Duration::from_secs(5);
+const CACHE_WRITE_DRAIN: Duration = Duration::from_secs(5);
 
 /// One key whose latest etcd bytes are rejected while its last
 /// successfully loaded value keeps serving (#871, xDS-NACK style).
@@ -521,7 +521,7 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// [`Self::run`] calls this through [`Self::drain_pending_cache_writes`],
     /// which supplies the shutdown bound. Tests call it directly to order
     /// deterministically against the disk read that follows.
-    pub async fn await_pending_cache_writes(&self) {
+    async fn await_pending_cache_writes(&self) {
         let handles: Vec<JoinHandle<()>> = {
             let mut pending = self.pending_writes.lock().unwrap();
             std::mem::take(&mut *pending)

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -1843,21 +1843,17 @@ mod tests {
             .unwrap();
 
         rt.block_on(async {
-            // The heavy configuration set arrives on the WATCH, not on the
-            // initial load, so exactly one costly write is ever in flight
-            // and this test's verdict cannot be decided by which of two
-            // concurrent writes reaches the cache's lock first.
-            // `SnapshotCache::store` serialises its snapshot before taking
-            // that lock, so concurrent writes can commit out of order --
-            // a pre-existing property this test must not depend on either
-            // way.
-            let mut arriving: Vec<RawEntry> = (0..PADDING_ROWS).map(padding_entry).collect();
-            arriving.push(entry("/aisix/models/late", VALID_MODEL, 2));
-            let provider = Arc::new(FakeProvider::new(Vec::new(), 1).with_events(vec![Ok(
-                WatchEvent::Resync {
-                    entries: arriving.into(),
-                    revision: 2,
-                },
+            // A boot resync followed by a put: two writes, so the second
+            // is still queued behind the first when shutdown arrives.
+            // That backlog is what keeps a write genuinely IN FLIGHT —
+            // a single write finishes on its own during the shutdown
+            // path, and an assertion built on one would hold with the
+            // drain removed. It is also the realistic shape: the control
+            // plane writes several rows and the replica is stopped
+            // straight after.
+            let entries: Vec<RawEntry> = (0..PADDING_ROWS).map(padding_entry).collect();
+            let provider = Arc::new(FakeProvider::new(entries, 1).with_events(vec![Ok(
+                WatchEvent::Put(entry("/aisix/models/late", VALID_MODEL, 2)),
             )]));
             let sup = Arc::new(Supervisor::with_cache(
                 provider,
@@ -1867,7 +1863,7 @@ mod tests {
             let (tx, rx) = tokio::sync::watch::channel(false);
             let join = tokio::spawn(sup.clone().run(rx));
 
-            // Cancel the moment the apply is visible in the served
+            // Cancel the moment the put is visible in the served
             // snapshot. The flush it spawned is then still on its way to
             // disk, which is exactly the window this pins.
             for _ in 0..5_000 {
@@ -1878,7 +1874,7 @@ mod tests {
             }
             assert!(
                 sup.handle().load().models.get_by_id("late").is_some(),
-                "the apply must reach the served snapshot before shutdown",
+                "the put must reach the served snapshot before shutdown",
             );
             tx.send(true).unwrap();
             join.await.unwrap();

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -138,6 +138,15 @@ const MAX_RETAINED_REJECTIONS: usize = 256;
 /// the aggregated report, with a WARN so the truncation is never silent.
 const MAX_RETAINED_PARTIAL_ROWS: usize = 1024;
 
+/// How long shutdown waits for an in-flight snapshot-cache write to
+/// reach disk before abandoning it.
+///
+/// Sized as a backstop against a wedged disk, not as a budget: the write
+/// is one local file and completes in milliseconds on any healthy one.
+/// Deliberately not configurable — an operator has nothing to trade off
+/// here, and a knob would only offer a way to make shutdown hang longer.
+pub const CACHE_WRITE_DRAIN: Duration = Duration::from_secs(5);
+
 /// One key whose latest etcd bytes are rejected while its last
 /// successfully loaded value keeps serving (#871, xDS-NACK style).
 /// `entry` pins the last-known-good raw document with the revision it
@@ -215,14 +224,14 @@ pub struct Supervisor<P: ConfigProvider> {
     /// user snapshots or mutates it in its own scope.
     stale_serving: Mutex<HashMap<String, StaleServing>>,
 
-    // JoinHandles for in-flight `flush_cache` writes. Tests use
-    // [`Self::await_pending_cache_writes`] to deterministically wait
-    // for these without relying on a wall-clock sleep, which proved
-    // flaky on slow CI runners. Production code does not read this
-    // field; if a handle is dropped (e.g. during shutdown), the
-    // underlying write either completed or was cancelled — either
-    // way the on-disk cache is best-effort and the next live cycle
-    // re-publishes from etcd.
+    // JoinHandles for in-flight `flush_cache` writes. [`Self::run`]
+    // drains them before returning so a gateway stopped shortly after an
+    // apply still persists that apply; tests use
+    // [`Self::await_pending_cache_writes`] to order against a write
+    // without relying on a wall-clock sleep, which proved flaky on slow
+    // CI runners. Kept to the writes actually in flight: `flush_cache`
+    // drops finished handles as it pushes, so a long-lived gateway does
+    // not accumulate one per apply.
     pending_writes: Mutex<Vec<JoinHandle<()>>>,
 }
 
@@ -507,20 +516,47 @@ impl<P: ConfigProvider> Supervisor<P> {
     }
 
     /// Drain the JoinHandles for any in-flight cache writes spawned
-    /// by [`Self::flush_cache`] and await them. Test-only synchroniser:
-    /// production code never needs to block on disk persistence.
-    #[cfg(test)]
+    /// by [`Self::flush_cache`] and await them, without a bound.
+    ///
+    /// [`Self::run`] calls this through [`Self::drain_pending_cache_writes`],
+    /// which supplies the shutdown bound. Tests call it directly to order
+    /// deterministically against the disk read that follows.
     pub async fn await_pending_cache_writes(&self) {
         let handles: Vec<JoinHandle<()>> = {
             let mut pending = self.pending_writes.lock().unwrap();
             std::mem::take(&mut *pending)
         };
         for handle in handles {
-            // Failures here are not test failures — a write that
-            // panicked is its own bug surfaced separately. We only
-            // need the await to deterministically order against the
-            // disk read that follows.
+            // A write that panicked is its own bug, surfaced separately;
+            // there is nothing useful to do about it here.
             let _ = handle.await;
+        }
+    }
+
+    /// Shutdown drain: give any cache write still in flight up to
+    /// [`CACHE_WRITE_DRAIN`] to reach disk, then give up.
+    ///
+    /// [`Self::flush_cache`] spawns the write detached so the apply path
+    /// stays sync, so a gateway stopped shortly after an apply used to
+    /// exit with that write unfinished and come back without its
+    /// last-known-good snapshot — which since the proxy listener started
+    /// gating on a first applied configuration means it refuses to bind
+    /// at all until it reaches etcd, where it previously bound and served
+    /// 401s.
+    ///
+    /// Bounded because shutdown must not be able to hang on a stuck disk.
+    /// The bound is fixed rather than configurable: it is a backstop on a
+    /// local file write, not a tuning knob.
+    async fn drain_pending_cache_writes(&self) {
+        if tokio::time::timeout(CACHE_WRITE_DRAIN, self.await_pending_cache_writes())
+            .await
+            .is_err()
+        {
+            tracing::warn!(
+                bound_ms = CACHE_WRITE_DRAIN.as_millis() as u64,
+                "snapshot-cache write still in flight at shutdown; abandoning it — \
+                 the on-disk cache keeps its previous contents",
+            );
         }
     }
 
@@ -1004,21 +1040,39 @@ impl<P: ConfigProvider> Supervisor<P> {
         let cache = self.cache.clone();
         // Spawn the actual write so the apply path stays sync. If we
         // aren't inside a runtime (cache::disabled() tests), just skip.
-        // Track the JoinHandle so tests can deterministically await
-        // the write via [`Self::await_pending_cache_writes`] instead
-        // of leaning on `tokio::time::sleep`, which under CI load
-        // raced the spawn (~50ms wasn't enough on heavily loaded
-        // GitHub Actions runners).
+        // Track the JoinHandle so [`Self::run`] can drain it at shutdown,
+        // and so tests can deterministically await the write via
+        // [`Self::await_pending_cache_writes`] instead of leaning on
+        // `tokio::time::sleep`, which under CI load raced the spawn
+        // (~50ms wasn't enough on heavily loaded GitHub Actions runners).
         if let Ok(rt_handle) = tokio::runtime::Handle::try_current() {
             let join =
                 rt_handle.spawn(async move { cache.store(&entries, revision, &stale).await });
-            self.pending_writes.lock().unwrap().push(join);
+            let mut pending = self.pending_writes.lock().unwrap();
+            // Only writes still in flight are worth draining, and only
+            // those may be retained: the list is appended to on every
+            // apply and would otherwise grow for the life of the process.
+            pending.retain(|handle| !handle.is_finished());
+            pending.push(join);
         }
     }
 
     /// Long-running loop. Handles exp-backoff reconnects and resync on
-    /// compaction. Runs until cancelled via the cancellation token.
-    pub async fn run(self: Arc<Self>, mut cancel: tokio::sync::watch::Receiver<bool>) {
+    /// compaction. Runs until cancelled via the cancellation token, then
+    /// drains any snapshot-cache write still in flight.
+    ///
+    /// The drain lives here rather than in the server's shutdown
+    /// coordinator so it cannot be forgotten by a caller, and so it lands
+    /// in the one place where no further write can be spawned: the loop
+    /// that owns every call to [`Self::flush_cache`] has just exited.
+    /// Callers already await this task after the connection drain, so
+    /// nothing about the graceful-drain sequence changes.
+    pub async fn run(self: Arc<Self>, cancel: tokio::sync::watch::Receiver<bool>) {
+        self.watch_loop(cancel).await;
+        self.drain_pending_cache_writes().await;
+    }
+
+    async fn watch_loop(&self, mut cancel: tokio::sync::watch::Receiver<bool>) {
         let mut backoff = ExpBackoff::default();
         loop {
             if *cancel.borrow() {
@@ -1723,6 +1777,120 @@ mod tests {
 
         tx.send(true).unwrap();
         join.await.unwrap();
+    }
+
+    /// Rows enough to make persisting the configuration set real work
+    /// rather than one scheduler tick. The write the shutdown drain has
+    /// to catch is the serialisation and fsync of this much data; a
+    /// handful of small rows finishes inside the first poll, and an
+    /// assertion built on that would hold with or without the drain.
+    const PADDING_ROWS: usize = 128;
+    const PADDING_NAME_BYTES: usize = 96 * 1024;
+
+    /// A valid model whose display name carries the padding, so the
+    /// loader accepts every row and the test produces no rejection noise.
+    fn padding_entry(i: usize) -> RawEntry {
+        let name = format!("pad-{i}-{}", "x".repeat(PADDING_NAME_BYTES));
+        let value = format!(
+            r#"{{"display_name":"{name}","provider":"openai","model_name":"gpt-4o","provider_key_id":"11111111-1111-1111-1111-111111111111"}}"#
+        );
+        RawEntry {
+            key: format!("/aisix/models/pad-{i}"),
+            value: value.into_bytes(),
+            revision: 1,
+        }
+    }
+
+    /// `flush_cache` spawns the cache write detached so the apply path can
+    /// stay sync, and nothing used to wait for it: a gateway stopped
+    /// shortly after an apply exited with that write unfinished and came
+    /// back without its last-known-good snapshot. That costs more since
+    /// the proxy listener started gating on a first applied configuration
+    /// — a gateway with no usable cache now refuses to bind at all until
+    /// it reaches etcd, where it previously bound and served 401s.
+    ///
+    /// Shaped like the production sequence rather than around the fix: the
+    /// supervisor's own `run` task applies the change, the runtime then
+    /// goes away exactly as it does when `main` returns — dropping every
+    /// spawned task at its await point — and the assertion is on what a
+    /// restart would read off disk.
+    #[test]
+    fn an_apply_immediately_before_shutdown_reaches_the_on_disk_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("snap.json");
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let entries: Vec<RawEntry> = (0..PADDING_ROWS).map(padding_entry).collect();
+            let provider = Arc::new(FakeProvider::new(entries, 1).with_events(vec![Ok(
+                WatchEvent::Put(entry("/aisix/models/late", VALID_MODEL, 2)),
+            )]));
+            let sup = Arc::new(Supervisor::with_cache(
+                provider,
+                "/aisix",
+                SnapshotCache::new(&cache_path),
+            ));
+            let (tx, rx) = tokio::sync::watch::channel(false);
+            let join = tokio::spawn(sup.clone().run(rx));
+
+            // Cancel the moment the put is visible in the served
+            // snapshot. The flush it spawned is then still on its way to
+            // disk, which is exactly the window this pins.
+            for _ in 0..5_000 {
+                if sup.handle().load().models.get_by_id("late").is_some() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            assert!(
+                sup.handle().load().models.get_by_id("late").is_some(),
+                "the put must reach the served snapshot before shutdown",
+            );
+            tx.send(true).unwrap();
+            join.await.unwrap();
+        });
+
+        // What `main` returning does to a spawned write nobody waited for.
+        drop(rt);
+
+        let survived = SnapshotCache::new(&cache_path)
+            .load()
+            .is_some_and(|cached| cached.entries.iter().any(|e| e.key == "/aisix/models/late"));
+        assert!(
+            survived,
+            "the last apply before shutdown must reach disk; undrained, its \
+             write is still in flight when the runtime goes away",
+        );
+    }
+
+    /// The drain must not become a way for shutdown to hang: a write that
+    /// never finishes is abandoned, not waited on forever. Time is paused,
+    /// so the bound is asserted without spending it.
+    #[tokio::test(start_paused = true)]
+    async fn the_shutdown_drain_abandons_a_write_that_never_finishes() {
+        let provider = Arc::new(FakeProvider::new(vec![], 0));
+        let sup = Supervisor::new(provider, "/aisix");
+        // A stuck disk cannot be produced on demand through `flush_cache`,
+        // so the handle is planted directly. The subject is the drain's
+        // bound, not how the write got stuck.
+        sup.pending_writes
+            .lock()
+            .unwrap()
+            .push(tokio::spawn(std::future::pending::<()>()));
+
+        let started = tokio::time::Instant::now();
+        tokio::time::timeout(CACHE_WRITE_DRAIN * 4, sup.drain_pending_cache_writes())
+            .await
+            .expect("shutdown must not be able to hang on a stuck disk write");
+        assert!(
+            started.elapsed() >= CACHE_WRITE_DRAIN,
+            "the drain must actually wait out its bound before giving up",
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e/src/cases/etcd-timeouts-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-timeouts-e2e.test.ts
@@ -13,20 +13,19 @@ import {
   type SpawnedApp,
 } from "../harness/index.js";
 
-// `etcd.request_timeout_ms` bounds one unary etcd call. Until it was
-// wired, both etcd timeout keys were accepted by the config parser and
-// read by nothing: a configuration range read that never answered stayed
-// in flight forever, and the instance served nothing while producing no
-// error that explained why.
+// The two `etcd.*_timeout_ms` keys. Until they were wired, both were
+// accepted by the config parser and read by nothing: a configuration
+// range read that never answered stayed in flight forever, and the
+// instance served nothing while producing no error that explained why.
 //
-// The three specs pin the three halves of the contract — the bound aborts
-// such a read and hands the supervisor a retryable failure; unset leaves
-// the read unbounded, with no implicit default, which is what keeps a
-// large configuration set bootable; and the watch stream is exempt, so a
-// set bound does not tear down a quiet watch.
+// These specs pin the contract an operator sees — the bound aborts such
+// a read and hands the supervisor a retryable failure; unset AND `0`
+// both leave the read unbounded, with no implicit default, which is what
+// keeps a large configuration set bootable; the watch stream is exempt,
+// so a set bound does not tear down a quiet watch.
 //
-// The first two drive the gateway through a TCP relay standing in for
-// etcd, which is what makes a read that never completes reproducible:
+// Most of them drive the gateway through a TCP relay standing in for
+// etcd, which is what makes a call that never completes reproducible:
 // `hold()` accepts the connection and forwards nothing.
 
 const MODEL = "etcd-timeout-model";
@@ -97,7 +96,7 @@ async function waitForChat(app: SpawnedApp, model: string, timeoutMs: number): P
   }
 }
 
-describe("etcd.request_timeout_ms", () => {
+describe("etcd.dial_timeout_ms & etcd.request_timeout_ms", () => {
   let etcd: EtcdClient | undefined;
   let etcdReachable = false;
   let upstream: OpenAiUpstream | undefined;
@@ -220,6 +219,41 @@ describe("etcd.request_timeout_ms", () => {
 
     // Still a live read rather than a wedged one: releasing it serves that
     // very snapshot.
+    await relay.release();
+    expect(await waitForChat(app, MODEL, 60_000)).toBe(200);
+  }, 150_000);
+
+  test("reads 0 on both keys as unbounded, exactly like leaving them unset", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    const prefix = `/aisix-e2e-etcd-zero-${randomUUID()}`;
+    const relay = await startEtcdRelay();
+    relays.push(relay);
+    await relay.hold();
+    await seedFixtures(prefix);
+
+    // `0` used to brick the gateway silently in both directions: it
+    // reached hyper's connector as an already-expired connect deadline,
+    // so every dial aborted, and it aborted every range read the instant
+    // it was issued. Nothing ever applied, so the proxy listener never
+    // bound, and the only signal was a boot loop that named neither key.
+    const app = await spawnAgainst(
+      relay.endpoint,
+      prefix,
+      { dial_timeout_ms: 0, request_timeout_ms: 0 },
+      { awaitProxyListener: false },
+    );
+
+    // Same window the unset spec uses, for the same reason: an implicit
+    // bound of any size would have fired many times over by now.
+    await sleep(12_000);
+    expect(app.output()).not.toContain(BACKOFF_LINE);
+    expect(app.output()).not.toContain(TIMEOUT_LINE);
+
+    // And it is a live read, not a wedged one — the same end state the
+    // unset spec reaches.
     await relay.release();
     expect(await waitForChat(app, MODEL, 60_000)).toBe(200);
   }, 150_000);


### PR DESCRIPTION
Follow-up to #1132. Three ways the etcd configuration path fails silently, each with its own behaviour change.

## `0` on either etcd timeout key now means unbounded

`etcd.dial_timeout_ms: 0` and `etcd.request_timeout_ms: 0` are now read exactly like leaving the key unset. Before this, `0` bricked the gateway without saying so: it reached hyper's connector as an already-expired connect deadline, and it aborted every configuration range read the instant it was issued. Nothing was ever applied, so the proxy listener never bound, and no log line named either key.

**Behaviour change:** a deployment that has `dial_timeout_ms: 0` or `request_timeout_ms: 0` in its `config.yaml` today does not boot into a serving state. After this change it boots and serves, with that bound switched off. Nothing else moves — unset was already unbounded and stays the default.

This matches what `Model::timeout: 0` already means — "no deadline, stop resolving". The one key in this repository where `0` means *"fall back to the next level"* is `Model::stream_timeout`, and only because it sits on a model → group → `upstream.*` resolution chain where deferring is a meaning `0` can carry. The etcd keys are flat, single-level startup configuration with nothing to defer to, so the only other reading available is an instant abort — not a configuration anyone can use, since every connect and every read would expire. That reasoning is now on `EtcdConfig::request_timeout` and, in one sentence, in both shipped config files, so a future reader who notices the split can see it was a decision.

The mainstream proxy this project benchmarks against has no equivalent sentinel: its database connect and socket timeouts are omitted entirely when unset so the driver's own defaults apply, `0` is not special-cased anywhere and would be forwarded to the driver verbatim, and its watchdog timeouts clamp a supplied value up to a floor rather than treating `0` as "off". So there is no upstream convention to align with here, and this is our own call.

## `request_timeout_ms` now bounds the watch-create handshake

Creating a watch is request/response shaped: the client sends the create request and awaits the server's create confirmation before a stream is handed back. Only *consuming* the stream is long-lived. Bounding the create closes a bad and silent failure — an etcd that answers range reads but never confirms the watch left the gateway serving its first snapshot forever, blind to every later change, while `/status/config` still reported it connected.

The established stream stays exempt, as before: a bound there would expire on every interval quiet enough to produce no event and leave the gateway reconnecting instead of watching.

**Behaviour change:** with `request_timeout_ms` set, a watch creation that is not confirmed inside it is now aborted and retried on the supervisor's existing backoff ladder, instead of hanging. With the key unset — the default — nothing changes. The expiry is reported as `ProviderError::Watch` so the supervisor's warn line attributes it to the watch rather than to the range read.

## In-flight snapshot-cache writes are drained at shutdown

`flush_cache` spawns the cache write detached so the apply path can stay sync, and pushed the `JoinHandle` into `pending_writes` — whose only consumer was a `#[cfg(test)]` synchroniser. Nothing waited for those writes, so a gateway stopped shortly after an apply could exit with the write unfinished and come back without its last-known-good snapshot. That costs more since #1131: a gateway with no usable cache now refuses to bind at all until it reaches etcd, where it previously bound and served 401s.

`Supervisor::run` now awaits any write still in flight before returning, bounded at a fixed **5 seconds** so a wedged disk cannot hang shutdown; expiry logs a WARN and abandons the write, leaving the on-disk cache with its previous contents. The bound is deliberately not a configuration key — it is a backstop on one local file write, and a knob would only offer a way to make shutdown hang longer.

The drain sits inside `run` rather than in the server's shutdown coordinator for two reasons: it is the one place where no further write can be spawned (the loop that owns every `flush_cache` call has just exited), and callers already await that task, so **the graceful-drain sequence is untouched** — the connection drain, the `min_drain_secs` window and `preStop` behaviour all run exactly as before, and the cache drain happens afterwards, while the process is already tearing listeners down. `run` gained a thin wrapper around the existing loop (`watch_loop`); the loop body is unchanged.

`flush_cache` also drops finished handles as it pushes. `pending_writes` was appended to on every apply and never read in production, so it grew for the life of the process; now it holds only writes actually in flight.

### …and they commit in apply order

Draining alone guarantees a persisted snapshot rather than none; it does not make it the *latest* one. `SnapshotCache::store` serialises its snapshot **before** taking the cache's write lock, and the supervisor spawns one write per apply without ordering them, so two writes racing that serialisation could reach the lock in the opposite order to the applies that produced them — and the older snapshot landed last. A gateway restarted after a burst of applies could come back onto a snapshot it had already moved past.

**Behaviour change:** the write lock now carries the highest revision committed, and a write for an older revision returns without touching the file. Equal revisions still commit, because a delete flushes at the current revision floor rather than a revision of its own, so same-revision writes carry different content. This is a pre-existing defect, fixed here because the drain above does not deliver what it promises without it — and because the drain's own test needs two queued writes to keep one genuinely in flight, which left that test at the mercy of the same race.

## Tests

Every case was verified by mutation — reverting its fix and confirming the test goes red.

- `etcd_timeouts_read_zero_as_unbounded_not_as_an_instant_abort` (aisix-core) — both keys.
- `the_request_timeout_bounds_a_watch_creation_that_is_never_confirmed` (aisix-etcd) — drives a real HTTP/2 server that completes the handshake, accepts the request and never answers it, which is the shape of a reachable etcd that confirms nothing. Without the bound the call hangs.
- `the_request_timeout_bounds_a_range_read_that_is_never_answered` (aisix-etcd) — the symmetric half, and the only thing pinning `load_all`'s own `ProviderError` variant now that `bound` takes the constructor as a parameter.
- `an_apply_immediately_before_shutdown_reaches_the_on_disk_cache` (aisix-etcd) — shaped like the production sequence rather than around the fix: the supervisor's own `run` task applies a change, the tokio runtime then goes away exactly as it does when `main` returns, and the assertion is on what a restart would read off disk. A boot resync followed by a put, with the configuration set padded so persisting it is real work: a *single* write finishes on its own during the shutdown path, so it takes a queued second write to keep one genuinely in flight — which is also the realistic shape, since the control plane writes several rows and the replica is stopped straight after.
- `a_write_that_lost_its_race_cannot_roll_the_cache_back` and `a_write_at_the_same_revision_still_commits` (aisix-etcd) — the ordering guard, in both directions.
- `the_shutdown_drain_abandons_a_write_that_never_finishes` (aisix-etcd) — the bound, on a paused clock so it is asserted without being spent.
- E2E `etcd-timeouts-e2e.test.ts` (renamed from `etcd-request-timeout-e2e.test.ts`, since it now covers both keys) — a new spec drives the gateway with `dial_timeout_ms: 0` and `request_timeout_ms: 0` through a TCP relay that accepts and forwards nothing, and requires it to behave exactly like the existing unset spec: no abort, no backoff line, and a 200 once the relay releases the read. The existing spec pinning that the watch STREAM is never bounded is unchanged and still passes.

`etcd.dial_timeout_ms` still reaches only the TCP connect; the TLS handshake and the `Authenticate` round trip inside `Client::connect` remain outside it. That gap is deliberately left alone here — closing it turns on whether an unreachable etcd should abort the process at all on an authenticated deployment, which is a separate behaviour decision.
