### PR TITLE
fix(etcd): wait out an etcd it cannot reach, exit only on refused credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,14 @@ jobs:
       ADMIN_TEST_ETCD_URL: http://127.0.0.1:2379
       # Picked up by crates/aisix-etcd/tests/watch_integration.rs.
       ETCD_TEST_URL: http://127.0.0.1:2379
+      # Picked up by crates/aisix-etcd/tests/auth_connect_integration.rs.
+      # A SECOND cluster, started with authentication ON by the step
+      # below: enabling auth is cluster-wide, so doing it on the service
+      # above would lock every other etcd test out of it. Same
+      # skip-if-unset / no-AISIX_-prefix rules.
+      ETCD_AUTH_TEST_URL: http://127.0.0.1:2479
+      ETCD_AUTH_TEST_USER: root
+      ETCD_AUTH_TEST_PASSWORD: aisix-ci-etcd
     steps:
       - uses: actions/checkout@v6
         with:
@@ -161,6 +169,29 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Start an authenticated etcd
+        # Not a service container: a user has to be created and
+        # `auth enable` called after the server is up, which service
+        # containers cannot do.
+        run: |
+          docker run -d --name etcd-auth -p 2479:2479 quay.io/coreos/etcd:v3.5.18 \
+            /usr/local/bin/etcd --name auth1 \
+            --listen-client-urls http://0.0.0.0:2479 \
+            --advertise-client-urls http://127.0.0.1:2479 \
+            --listen-peer-urls http://0.0.0.0:2480 \
+            --initial-advertise-peer-urls http://127.0.0.1:2480 \
+            --initial-cluster auth1=http://127.0.0.1:2480
+          for _ in $(seq 30); do
+            docker exec -e ETCDCTL_API=3 -e ETCDCTL_ENDPOINTS=http://127.0.0.1:2479 \
+              etcd-auth etcdctl endpoint health && break
+            sleep 1
+          done
+          docker exec -e ETCDCTL_API=3 -e ETCDCTL_ENDPOINTS=http://127.0.0.1:2479 \
+            etcd-auth etcdctl user add root:aisix-ci-etcd
+          docker exec -e ETCDCTL_API=3 -e ETCDCTL_ENDPOINTS=http://127.0.0.1:2479 \
+            etcd-auth etcdctl user grant-role root root
+          docker exec -e ETCDCTL_API=3 -e ETCDCTL_ENDPOINTS=http://127.0.0.1:2479 \
+            etcd-auth etcdctl auth enable
       - name: Start Redis Cluster + Sentinel
         # The `redis` service above covers single-node. Here we bring up a
         # 3-node cluster (7000-7002) and a sentinel (26379) monitoring the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "etcd-client",
  "futures",
  "h2",
+ "http 1.4.0",
  "serde",
  "serde_ignored",
  "serde_json",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,8 +13,10 @@ etcd:
   # one out: it falls back to the next level of a resolution chain these
   # flat startup settings do not have.)
   #
-  # `dial_timeout_ms` bounds the TCP connect — not the TLS handshake
-  # after it, and not the authentication exchange when `user` is set.
+  # `dial_timeout_ms` bounds the whole dial: the TCP connect, the TLS
+  # handshake after it, and the authentication exchange when `user` is
+  # set. An expired dial is treated as an etcd that is not reachable —
+  # the gateway keeps retrying it rather than exiting.
   # `request_timeout_ms` bounds a single request/response call — the
   # configuration range read at boot and on every reconnect, creating the
   # watch, and the admin API's reads. It deliberately does not apply to

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -41,8 +41,10 @@ etcd:
   # means unbounded as well — the same reading a model's `timeout: 0`
   # gets. (A model's `stream_timeout: 0` instead falls back to the next
   # level of a resolution chain these flat startup keys do not have.)
-  # `dial_timeout_ms` bounds the TCP connect only, not the TLS handshake
-  # layered above it; `request_timeout_ms` bounds a
+  # `dial_timeout_ms` bounds the whole dial — the TCP connect, the TLS
+  # handshake above it and the authentication exchange when `user` is
+  # set — and an expired dial is retried, not fatal;
+  # `request_timeout_ms` bounds a
   # single request/response call (the configuration range read, creating
   # the watch, the admin reads) but never the established watch stream. A
   # `request_timeout_ms` the range read cannot finish inside makes the

--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -84,11 +84,14 @@ impl EtcdConfigStore {
     }
 
     /// The KV sub-client for one read, connecting first when the boot
-    /// dial had not reached etcd yet.
+    /// dial had not reached etcd yet. Under the same `request_timeout`
+    /// as the read itself: with etcd credentials configured the dial
+    /// includes an `Authenticate` round trip, and an endpoint that
+    /// accepts TCP and answers nothing would otherwise hang the admin
+    /// request — and every other read behind this client's connect.
     async fn kv(&self) -> Result<etcd_client::KvClient, StoreError> {
-        self.client
-            .kv()
-            .await
+        self.bound(self.client.kv())
+            .await?
             .map_err(|e| StoreError::Backend(e.to_string()))
     }
 

--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -24,11 +24,11 @@ use aisix_core::{
     A2aAgent, ApiKey, CachePolicy, Guardrail, McpServer, Model, ObservabilityExporter,
     PassthroughRoute, ProviderKey,
 };
-use aisix_etcd::kv_client;
-use etcd_client::{Client, GetOptions, KvClient};
+use aisix_etcd::LazyEtcdClient;
+use etcd_client::GetOptions;
 use serde::de::DeserializeOwned;
+use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Mutex;
 
 use crate::store::{ConfigStore, StoreError};
 
@@ -45,10 +45,15 @@ pub const A2A_AGENTS_SUBKEY: &str = "a2a_agents";
 pub const PASSTHROUGH_ROUTES_SUBKEY: &str = "passthrough_routes";
 
 pub struct EtcdConfigStore {
-    /// A KV client carrying the gateway's raised gRPC decode limit, not the
-    /// `Client` handed in: `Client::get` reads through a sub-client that
-    /// keeps tonic's 4 MiB default, which a full configuration set outgrows.
-    client: Mutex<KvClient>,
+    /// The connection, dialled on the first read that needs it. Its KV
+    /// sub-client carries the gateway's raised gRPC decode limit, which
+    /// `Client::get` would not: that reads through a sub-client keeping
+    /// tonic's 4 MiB default, which a full configuration set outgrows.
+    ///
+    /// Lazy for the same reason the config provider is: with etcd
+    /// credentials configured, dialling at boot made an unreachable etcd
+    /// end the process instead of being waited out.
+    client: Arc<LazyEtcdClient>,
     prefix: String,
     /// `etcd.request_timeout_ms`, applied per call. `None` — the default
     /// — leaves the reads unbounded, which is what they were before the
@@ -66,16 +71,25 @@ impl std::fmt::Debug for EtcdConfigStore {
 
 impl EtcdConfigStore {
     pub fn new(
-        client: Client,
+        client: Arc<LazyEtcdClient>,
         prefix: impl Into<String>,
         request_timeout: Option<Duration>,
     ) -> Self {
         let prefix = prefix.into().trim_end_matches('/').to_string();
         Self {
-            client: Mutex::new(kv_client(&client)),
+            client,
             prefix,
             request_timeout,
         }
+    }
+
+    /// The KV sub-client for one read, connecting first when the boot
+    /// dial had not reached etcd yet.
+    async fn kv(&self) -> Result<etcd_client::KvClient, StoreError> {
+        self.client
+            .kv()
+            .await
+            .map_err(|e| StoreError::Backend(e.to_string()))
     }
 
     pub fn prefix(&self) -> &str {
@@ -116,7 +130,7 @@ impl EtcdConfigStore {
         key: &str,
     ) -> Result<Option<(T, i64)>, StoreError> {
         let resp = {
-            let mut client = self.client.lock().await;
+            let mut client = self.kv().await?;
             self.bound(client.get(key.as_bytes().to_vec(), None))
                 .await?
         }
@@ -135,10 +149,10 @@ impl EtcdConfigStore {
         kind: &str,
     ) -> Result<Vec<(String, T, i64)>, StoreError> {
         let prefix = self.range_prefix(kind);
-        // Scoped so the guard covers the call and not the decode loop
+        // Scoped so the bound covers the call and not the decode loop
         // below, which is where it sat before the bound was introduced.
         let resp = {
-            let mut client = self.client.lock().await;
+            let mut client = self.kv().await?;
             self.bound(client.get(
                 prefix.as_bytes().to_vec(),
                 Some(GetOptions::new().with_prefix()),
@@ -350,19 +364,19 @@ mod tests {
     use super::*;
 
     // Build a store *without* a real client so pure helper tests don't
-    // pay a Docker tax. The client is never used by these tests.
+    // pay a Docker tax. Nothing is dialled until a read needs it, and
+    // these tests never issue one.
+    fn store_for(prefix: &str) -> EtcdConfigStore {
+        let client = Arc::new(LazyEtcdClient::new(
+            vec!["http://127.0.0.1:59999".to_string()],
+            None,
+            None,
+        ));
+        EtcdConfigStore::new(client, prefix, None)
+    }
+
     fn dummy_store() -> EtcdConfigStore {
-        // We can't construct `etcd_client::Client` without connecting, so
-        // build a "real" one pointing at a bogus endpoint — the connect
-        // is lazy and these tests never issue a request.
-        let client_fut = etcd_client::Client::connect(["http://127.0.0.1:59999"], None);
-        let client = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(client_fut)
-            .expect("lazy connect never fails synchronously");
-        EtcdConfigStore::new(client, "/aisix", None)
+        store_for("/aisix")
     }
 
     #[test]
@@ -393,16 +407,7 @@ mod tests {
 
     #[test]
     fn prefix_trailing_slash_is_trimmed_at_construction() {
-        let client = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(etcd_client::Client::connect(
-                ["http://127.0.0.1:59999"],
-                None,
-            ))
-            .expect("lazy connect never fails synchronously");
-        let store = EtcdConfigStore::new(client, "/aisix/", None);
+        let store = store_for("/aisix/");
         assert_eq!(store.prefix(), "/aisix");
         assert_eq!(store.key_for("models", "a"), "/aisix/models/a");
     }
@@ -429,10 +434,14 @@ mod tests {
             .expect("container port");
         let endpoint = format!("http://127.0.0.1:{port}");
 
-        let mut client = etcd_client::Client::connect([endpoint], None)
+        let mut client = etcd_client::Client::connect([endpoint.clone()], None)
             .await
             .expect("etcd client");
-        let store = EtcdConfigStore::new(client.clone(), "/aisix-it", None);
+        let store = EtcdConfigStore::new(
+            Arc::new(LazyEtcdClient::new(vec![endpoint], None, None)),
+            "/aisix-it",
+            None,
+        );
 
         // Resources reach etcd by direct writes (the declarative path);
         // the store is the read side. Seed a model the way an operator

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -56,14 +56,23 @@ fn unique_prefix() -> String {
     .replace(['(', ')', ' '], "")
 }
 
+fn lazy_client_for(url: &str) -> Arc<aisix_etcd::LazyEtcdClient> {
+    Arc::new(aisix_etcd::LazyEtcdClient::new(
+        vec![url.to_string()],
+        None,
+        None,
+    ))
+}
+
 async fn etcd_client_for(url: &str) -> etcd_client::Client {
     etcd_client::Client::connect([url], None)
         .await
         .expect("etcd connect")
 }
 
-async fn build_state(client: etcd_client::Client, prefix: &str) -> AdminState {
-    let store: Arc<dyn ConfigStore> = Arc::new(EtcdConfigStore::new(client, prefix, None));
+async fn build_state(url: &str, prefix: &str) -> AdminState {
+    let store: Arc<dyn ConfigStore> =
+        Arc::new(EtcdConfigStore::new(lazy_client_for(url), prefix, None));
     let handle = SnapshotHandle::new(AisixSnapshot::new());
     let cfg = AdminConfig {
         enabled: true,
@@ -125,7 +134,7 @@ async fn direct_write_read_round_trip(
 ) {
     let prefix = unique_prefix();
     let mut client = etcd_client_for(url).await;
-    let state = build_state(client.clone(), &prefix).await;
+    let state = build_state(url, &prefix).await;
 
     seed(&mut client, &prefix, kind, id, &payload).await;
 
@@ -193,7 +202,7 @@ async fn model_list_reads_a_range_larger_than_the_default_decode_limit() {
 
     let prefix = unique_prefix();
     let mut client = etcd_client_for(&url).await;
-    let store = EtcdConfigStore::new(client.clone(), &prefix, None);
+    let store = EtcdConfigStore::new(lazy_client_for(&url), &prefix, None);
 
     // etcd caps a transaction at 128 operations, so the fixture is written
     // in batches of that rather than one round trip per key.
@@ -401,7 +410,7 @@ async fn admin_writes_are_refused_against_real_etcd() {
     };
     let prefix = unique_prefix();
     let mut client = etcd_client_for(&url).await;
-    let state = build_state(client.clone(), &prefix).await;
+    let state = build_state(&url, &prefix).await;
 
     let payload = json!({
         "display_name": "sneaky",

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -124,16 +124,17 @@ pub struct EtcdConfig {
     /// read at connect time — never stored in the config struct.
     #[serde(default)]
     pub password_env: Option<String>,
-    /// Bound on the TCP connect to etcd, in milliseconds. Unset — the
-    /// default — and `0` both mean unbounded (see the note on `0` under
+    /// Bound on dialling etcd, in milliseconds. Unset — the default —
+    /// and `0` both mean unbounded (see the note on `0` under
     /// [`EtcdConfig::request_timeout`]), leaving it to the OS TCP stack.
     ///
-    /// It reaches hyper's connector via `Endpoint::connect_timeout`, so
-    /// it covers the TCP handshake and nothing after it. Two later steps
-    /// of "connecting" are outside it and remain unbounded: the TLS
-    /// handshake, which is layered above the connector, and the
-    /// `Authenticate` call etcd-client issues inside `Client::connect`
-    /// when `user` / `password_env` are set.
+    /// When set it covers the whole dial: it reaches hyper's connector
+    /// via `Endpoint::connect_timeout` for the TCP handshake, and the
+    /// gateway wraps `Client::connect` in it as well, so the TLS
+    /// handshake layered above the connector and the `Authenticate` call
+    /// etcd-client issues when `user` / `password_env` are set are
+    /// bounded too. An expired dial reports an etcd that could not be
+    /// reached, which the gateway retries rather than exits on.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dial_timeout_ms: Option<u64>,
     /// Bound on a single request/response etcd call, in milliseconds.
@@ -141,9 +142,10 @@ pub struct EtcdConfig {
     /// `0` below).
     ///
     /// When set it covers the configuration range read (`load_all`), the
-    /// watch-create handshake, and the admin surface's reads. It does not
-    /// reach the `Authenticate` inside `Client::connect`, which is still
-    /// unbounded. It deliberately does NOT cover the established watch
+    /// watch-create handshake, and the admin surface's reads — including
+    /// the dial each of those has to make when the connection is not up
+    /// yet, `Authenticate` included. It deliberately does NOT cover the
+    /// established watch
     /// stream either: that stream is long-lived by construction, so a
     /// bound on it would expire on every interval quiet enough to produce
     /// no event and leave the gateway reconnecting instead of watching.

--- a/crates/aisix-etcd/Cargo.toml
+++ b/crates/aisix-etcd/Cargo.toml
@@ -28,6 +28,9 @@ tempfile.workspace = true
 # and then never answers it — the shape of an etcd that is reachable but
 # never confirms a call. See the `etcd_provider` tests.
 h2.workspace = true
+# Builds the responses that h2 server sends back — a trailers-only gRPC
+# error is how a test stands in for an etcd that answered and refused.
+http.workspace = true
 # `test-util` drives the shutdown-drain bound on a paused clock, so the
 # test asserts the bound without spending it.
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/aisix-etcd/src/client.rs
+++ b/crates/aisix-etcd/src/client.rs
@@ -48,6 +48,27 @@ pub fn watch_client(client: &Client) -> WatchClient {
 /// the real cause (`getaddrinfo: Name or service not known`, TLS
 /// handshake reason, …) hides in `.source()`. The supervisor logs
 /// the returned string, so CI triage gets the full picture.
+/// The readable cause of one `etcd-client` failure.
+///
+/// `etcd_client::Error` implements `Error` without `source()`, so
+/// [`format_error_chain`] alone stops at its own `Display` and the cause
+/// that matters — the transport error under a tonic `Status`, and the
+/// `getaddrinfo` / TLS reason under that — never appears. Reach into the
+/// payload to get there.
+pub(crate) fn format_etcd_error(err: &EtcdError) -> String {
+    let mut out = format_error_chain(err);
+    if let EtcdError::GRpcStatus(status) = err {
+        if let Some(source) = StdError::source(status) {
+            let chain = format_error_chain(source);
+            if !chain.is_empty() && !out.ends_with(&chain) {
+                out.push_str(": ");
+                out.push_str(&chain);
+            }
+        }
+    }
+    out
+}
+
 pub(crate) fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
     let mut out = err.to_string();
     let mut cur = err.source();
@@ -89,8 +110,11 @@ pub enum ConnectError {
 /// (<https://grpc.io/docs/guides/status-codes/>). Compared numerically so
 /// this crate does not have to depend on — and keep in step with — the
 /// exact `tonic` release `etcd-client` builds against.
+const GRPC_CANCELLED: i32 = 1;
 const GRPC_UNKNOWN: i32 = 2;
 const GRPC_DEADLINE_EXCEEDED: i32 = 4;
+const GRPC_RESOURCE_EXHAUSTED: i32 = 8;
+const GRPC_ABORTED: i32 = 10;
 const GRPC_INTERNAL: i32 = 13;
 const GRPC_UNAVAILABLE: i32 = 14;
 
@@ -115,8 +139,16 @@ impl ConnectError {
 /// / "tls handshake eof"), while a wrong password arrives as
 /// `InvalidArgument` carrying etcd's own "authentication failed, invalid
 /// user ID or password".
-fn classify(err: &EtcdError) -> ConnectError {
-    let detail = format_error_chain(err);
+///
+/// Used on the reads too, not only on the dial. Which failures etcd
+/// answers *where* is not something a caller can assume: a user whose
+/// password is wrong is refused by `Authenticate`, but a user who
+/// authenticates and lacks the permission is refused by the range read
+/// (`PermissionDenied`), and a token invalidated by an etcd restart is
+/// refused by every later call (`Unauthenticated`). Classifying only the
+/// dial would report those as ordinary transport trouble.
+pub(crate) fn classify(err: &EtcdError) -> ConnectError {
+    let detail = format_etcd_error(err);
     match err {
         // The call never reached a server.
         EtcdError::TransportError(_) | EtcdError::IoError(_) => ConnectError::Unreachable(detail),
@@ -125,12 +157,21 @@ fn classify(err: &EtcdError) -> ConnectError {
             // failure to reach a server and what etcd itself answers
             // while it has no leader or is stopping. `DeadlineExceeded`
             // is a call that ran out of time. `Unknown` and `Internal`
-            // are what a connection broken mid-call surfaces as. None of
-            // them is an answer about the credentials, and all of them
-            // can heal on their own.
-            GRPC_UNAVAILABLE | GRPC_DEADLINE_EXCEEDED | GRPC_UNKNOWN | GRPC_INTERNAL => {
-                ConnectError::Unreachable(detail)
-            }
+            // are what a connection broken mid-call surfaces as.
+            // `Cancelled` and `Aborted` are what a peer or an
+            // intermediary resetting the stream produces — an ingress in
+            // front of etcd restarting looks like this — and
+            // `ResourceExhausted` is an etcd throttling a fleet of
+            // gateways that all restarted at once. None of them is an
+            // answer about the credentials, and all of them heal on
+            // their own.
+            GRPC_UNAVAILABLE
+            | GRPC_DEADLINE_EXCEEDED
+            | GRPC_UNKNOWN
+            | GRPC_INTERNAL
+            | GRPC_CANCELLED
+            | GRPC_ABORTED
+            | GRPC_RESOURCE_EXHAUSTED => ConnectError::Unreachable(detail),
             // Everything else is etcd having evaluated the request and
             // said no: `InvalidArgument` for a wrong user or password,
             // `PermissionDenied` for a user without the rights,
@@ -289,6 +330,33 @@ mod tests {
         // empty endpoint list dialable — so it is fatal, not a wait.
         let err = EtcdError::InvalidArgs("empty endpoints".to_string());
         assert!(matches!(classify(&err), ConnectError::Rejected(_)));
+    }
+
+    #[tokio::test]
+    async fn the_cause_under_a_status_reaches_the_message() {
+        // `etcd_client::Error` has no `source()`, so walking the chain
+        // from it alone stops at its own `Display` and the reason the
+        // dial failed — which lives under the tonic `Status` — never
+        // reaches the log line the supervisor prints.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let err = match Client::connect(
+            [format!("http://{addr}")],
+            Some(ConnectOptions::new().with_user("u", "p")),
+        )
+        .await
+        {
+            Err(err) => err,
+            Ok(_) => panic!("nothing is listening on {addr}"),
+        };
+
+        let shallow = format_error_chain(&err);
+        let deep = format_etcd_error(&err);
+        assert!(
+            deep.len() > shallow.len() && deep.starts_with(&shallow),
+            "the payload's own cause chain must be appended: {deep:?} vs {shallow:?}",
+        );
     }
 
     #[test]

--- a/crates/aisix-etcd/src/client.rs
+++ b/crates/aisix-etcd/src/client.rs
@@ -7,7 +7,10 @@
 //! built here so no call site can drift back onto tonic's default; test
 //! fixtures that talk to etcd directly are their own business.
 
-use etcd_client::{Client, KvClient, WatchClient};
+use etcd_client::{Client, ConnectOptions, Error as EtcdError, KvClient, WatchClient};
+use std::error::Error as StdError;
+use std::time::Duration;
+use tokio::sync::Mutex;
 
 /// Maximum size, in bytes, of a gRPC message decoded from etcd.
 ///
@@ -38,4 +41,259 @@ pub fn watch_client(client: &Client) -> WatchClient {
     client
         .watch_client()
         .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE)
+}
+
+/// Flatten an error and its source chain into a single readable line.
+/// Without this, tonic surfaces opaque strings like "dns error" while
+/// the real cause (`getaddrinfo: Name or service not known`, TLS
+/// handshake reason, …) hides in `.source()`. The supervisor logs
+/// the returned string, so CI triage gets the full picture.
+pub(crate) fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
+    let mut out = err.to_string();
+    let mut cur = err.source();
+    while let Some(next) = cur {
+        let s = next.to_string();
+        if !s.is_empty() && !out.ends_with(&s) {
+            out.push_str(": ");
+            out.push_str(&s);
+        }
+        cur = next.source();
+    }
+    out
+}
+
+/// Why a dial failed, split by the only distinction that changes what the
+/// gateway should do about it.
+///
+/// The two are not interchangeable. An etcd that cannot be reached comes
+/// back on its own and the gateway must wait for it; credentials etcd has
+/// refused never start working, and waiting on them turns a configuration
+/// mistake into a gateway that is up and permanently empty.
+#[derive(Debug, thiserror::Error)]
+pub enum ConnectError {
+    /// No server answered: TCP refused, DNS failure, TLS handshake
+    /// failure, an expired `etcd.dial_timeout_ms`, or an etcd that is up
+    /// but cannot serve (no leader, shutting down). Retryable.
+    #[error("etcd did not answer: {0}")]
+    Unreachable(String),
+    /// etcd answered and refused — a wrong user or password, a user
+    /// without the required permission, credentials sent to a cluster
+    /// with authentication disabled — or the endpoints are not usable at
+    /// all (unparseable URI, empty list). Retrying cannot change any of
+    /// these, so they are fatal at boot.
+    #[error("etcd refused the connection: {0}")]
+    Rejected(String),
+}
+
+/// Canonical gRPC status codes, as sent on the wire
+/// (<https://grpc.io/docs/guides/status-codes/>). Compared numerically so
+/// this crate does not have to depend on — and keep in step with — the
+/// exact `tonic` release `etcd-client` builds against.
+const GRPC_UNKNOWN: i32 = 2;
+const GRPC_DEADLINE_EXCEEDED: i32 = 4;
+const GRPC_INTERNAL: i32 = 13;
+const GRPC_UNAVAILABLE: i32 = 14;
+
+impl ConnectError {
+    /// The flattened cause, without this type's own framing — so a
+    /// caller that re-reports it under its own wording does not stack
+    /// two prefixes in front of what etcd actually said.
+    pub fn detail(&self) -> &str {
+        match self {
+            Self::Unreachable(detail) | Self::Rejected(detail) => detail,
+        }
+    }
+}
+
+/// Sort one `etcd-client` failure into [`ConnectError`].
+///
+/// The split is structural, on the gRPC status code — never on the text
+/// of a message. Verified against etcd 3.5 and etcd-client 0.14: a
+/// refused TCP connect, a DNS failure and a failed TLS handshake all
+/// arrive as `GRpcStatus` with code `Unavailable` (tonic manufactures
+/// the status locally; the message is "tcp connect error" / "dns error"
+/// / "tls handshake eof"), while a wrong password arrives as
+/// `InvalidArgument` carrying etcd's own "authentication failed, invalid
+/// user ID or password".
+fn classify(err: &EtcdError) -> ConnectError {
+    let detail = format_error_chain(err);
+    match err {
+        // The call never reached a server.
+        EtcdError::TransportError(_) | EtcdError::IoError(_) => ConnectError::Unreachable(detail),
+        EtcdError::GRpcStatus(status) => match status.code() as i32 {
+            // `Unavailable` is both what tonic synthesises for every
+            // failure to reach a server and what etcd itself answers
+            // while it has no leader or is stopping. `DeadlineExceeded`
+            // is a call that ran out of time. `Unknown` and `Internal`
+            // are what a connection broken mid-call surfaces as. None of
+            // them is an answer about the credentials, and all of them
+            // can heal on their own.
+            GRPC_UNAVAILABLE | GRPC_DEADLINE_EXCEEDED | GRPC_UNKNOWN | GRPC_INTERNAL => {
+                ConnectError::Unreachable(detail)
+            }
+            // Everything else is etcd having evaluated the request and
+            // said no: `InvalidArgument` for a wrong user or password,
+            // `PermissionDenied` for a user without the rights,
+            // `FailedPrecondition` for credentials sent to a cluster
+            // that has authentication disabled.
+            _ => ConnectError::Rejected(detail),
+        },
+        // Unparseable endpoints, an empty endpoint list, a bad header
+        // value: configuration, not reachability.
+        _ => ConnectError::Rejected(detail),
+    }
+}
+
+/// An etcd connection established on demand, and kept once it is.
+///
+/// `Client::connect` only performs I/O when credentials are configured —
+/// it issues the `Authenticate` RPC — so without them a client is handed
+/// back before anything has been dialled and every failure surfaces later,
+/// on the read, where the watch supervisor retries it. Connecting through
+/// this type gives the authenticated deployment the same shape: a dial
+/// that could not reach etcd leaves the connection pending instead of
+/// failing the caller, so the gateway boots, waits for its first
+/// configuration and picks etcd up when it comes back.
+pub struct LazyEtcdClient {
+    endpoints: Vec<String>,
+    options: Option<ConnectOptions>,
+    /// `etcd.dial_timeout_ms`. Wraps the whole of `Client::connect`, not
+    /// just the TCP connect that `ConnectOptions::with_connect_timeout`
+    /// bounds: the TLS handshake and the `Authenticate` round trip sit
+    /// outside that option, so an endpoint that completes TCP and then
+    /// goes silent would otherwise hang the dial with no bound at all.
+    /// `None` — the default, and what `0` means — leaves it unbounded.
+    dial_timeout: Option<Duration>,
+    connected: Mutex<Option<Client>>,
+}
+
+impl std::fmt::Debug for LazyEtcdClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LazyEtcdClient")
+            .field("endpoints", &self.endpoints)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LazyEtcdClient {
+    pub fn new(
+        endpoints: Vec<String>,
+        options: Option<ConnectOptions>,
+        dial_timeout: Option<Duration>,
+    ) -> Self {
+        Self {
+            endpoints,
+            options,
+            dial_timeout,
+            connected: Mutex::new(None),
+        }
+    }
+
+    /// Dial now, so a caller that wants to classify the failure itself —
+    /// the boot path, which exits on [`ConnectError::Rejected`] — can do
+    /// it before anything else is started. A successful dial is cached
+    /// like any other.
+    pub async fn connect_now(&self) -> Result<(), ConnectError> {
+        self.client().await.map(|_| ())
+    }
+
+    /// The connection, dialling if this is the first call to get there.
+    ///
+    /// The lock is held across the dial on purpose: concurrent first
+    /// calls wait for the one dial rather than opening a connection each.
+    pub async fn client(&self) -> Result<Client, ConnectError> {
+        let mut slot = self.connected.lock().await;
+        if let Some(client) = slot.as_ref() {
+            return Ok(client.clone());
+        }
+        let client = self.dial().await?;
+        *slot = Some(client.clone());
+        Ok(client)
+    }
+
+    /// KV sub-client for reads, under [`MAX_DECODING_MESSAGE_SIZE`].
+    pub async fn kv(&self) -> Result<KvClient, ConnectError> {
+        Ok(kv_client(&self.client().await?))
+    }
+
+    /// Watch sub-client, under [`MAX_DECODING_MESSAGE_SIZE`].
+    pub async fn watch(&self) -> Result<WatchClient, ConnectError> {
+        Ok(watch_client(&self.client().await?))
+    }
+
+    async fn dial(&self) -> Result<Client, ConnectError> {
+        let connect = Client::connect(&self.endpoints, self.options.clone());
+        let outcome = match self.dial_timeout {
+            None => connect.await,
+            Some(d) => match tokio::time::timeout(d, connect).await {
+                Ok(outcome) => outcome,
+                // An endpoint that accepts the TCP connection and then
+                // answers nothing is unreachable in every sense that
+                // matters here, so this joins the retry path rather than
+                // ending the boot.
+                Err(_) => {
+                    return Err(ConnectError::Unreachable(format!(
+                        "connect exceeded etcd.dial_timeout_ms ({} ms)",
+                        d.as_millis()
+                    )))
+                }
+            },
+        };
+        outcome.map_err(|err| classify(&err))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_error_chain_joins_sources_without_duplicating() {
+        #[derive(Debug)]
+        struct Inner;
+        impl std::fmt::Display for Inner {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("Name or service not known")
+            }
+        }
+        impl StdError for Inner {}
+
+        #[derive(Debug)]
+        struct Outer {
+            inner: Inner,
+        }
+        impl std::fmt::Display for Outer {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("dns error")
+            }
+        }
+        impl StdError for Outer {
+            fn source(&self) -> Option<&(dyn StdError + 'static)> {
+                Some(&self.inner)
+            }
+        }
+
+        let joined = format_error_chain(&Outer { inner: Inner });
+        assert_eq!(joined, "dns error: Name or service not known");
+    }
+
+    #[test]
+    fn format_error_chain_handles_empty_source() {
+        let err = std::io::Error::other("bare");
+        assert_eq!(format_error_chain(&err), "bare");
+    }
+
+    #[test]
+    fn unusable_endpoints_are_rejected_not_retried() {
+        // No server was ever involved, and no retry ladder can make an
+        // empty endpoint list dialable — so it is fatal, not a wait.
+        let err = EtcdError::InvalidArgs("empty endpoints".to_string());
+        assert!(matches!(classify(&err), ConnectError::Rejected(_)));
+    }
+
+    #[test]
+    fn a_local_io_failure_is_reachability_not_refusal() {
+        let err = EtcdError::IoError(std::io::Error::other("connection reset by peer"));
+        assert!(matches!(classify(&err), ConnectError::Unreachable(_)));
+    }
 }

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -1,45 +1,26 @@
 //! Real [`ConfigProvider`] backed by `etcd-client`.
 //!
 //! Connection sequence (spec §2):
-//! - Fixed-interval retry on initial connect: 5s × up to 5 attempts
+//! - The initial connect splits its failures by cause: an etcd that never
+//!   answered leaves the connection pending for the supervisor's retry
+//!   loop, while credentials etcd refused are returned to the caller. The
+//!   fixed-interval 5s × 5 ladder is now only the `export` CLI's
+//!   ([`EtcdConfigProvider::connect_with_policy`])
 //! - On success, `get` with prefix to bootstrap
 //! - `watch` with `start_revision = range_revision + 1` to avoid a gap
 //! - Compaction errors map to [`ProviderError::Compacted`] so the
 //!   supervisor can trigger a full resync
 
 use async_trait::async_trait;
-use etcd_client::{
-    Client, ConnectOptions, Error as EtcdError, EventType, GetOptions, KvClient, WatchClient,
-    WatchOptions,
-};
+use etcd_client::{ConnectOptions, EventType, GetOptions, WatchOptions};
 use futures::{Stream, StreamExt};
 use std::collections::VecDeque;
-use std::error::Error as StdError;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use tokio::sync::Mutex;
 
-/// Flatten an error and its source chain into a single readable line.
-/// Without this, tonic surfaces opaque strings like "dns error" while
-/// the real cause (`getaddrinfo: Name or service not known`, TLS
-/// handshake reason, …) hides in `.source()`. The supervisor logs
-/// the returned string, so CI triage gets the full picture.
-fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
-    let mut out = err.to_string();
-    let mut cur = err.source();
-    while let Some(next) = cur {
-        let s = next.to_string();
-        if !s.is_empty() && !out.ends_with(&s) {
-            out.push_str(": ");
-            out.push_str(&s);
-        }
-        cur = next.source();
-    }
-    out
-}
-
-use crate::client::{kv_client, watch_client};
+use crate::client::{format_error_chain, ConnectError, LazyEtcdClient};
 use crate::provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 
 /// Fixed-interval retry: 5s × 5 attempts (spec §2).
@@ -64,14 +45,13 @@ impl Default for ConnectPolicy {
 }
 
 pub struct EtcdConfigProvider {
-    /// The sub-clients are `Clone`-cheap (internally Arc'd), but we still
-    /// serialise access through a Mutex because their RPC methods take
-    /// `&mut self`. They are held rather than derived from a `Client` per
-    /// call so the raised decode limit cannot be lost by a later call site
-    /// reaching for `Client::get` / `Client::watch`, which keep tonic's
-    /// 4 MiB default.
-    kv: Mutex<KvClient>,
-    watch: Mutex<WatchClient>,
+    /// The connection, which may not have been established yet: an etcd
+    /// that could not be reached at boot is dialled again by whichever
+    /// call the supervisor's retry loop makes next. Sub-clients are taken
+    /// from it per call — they are `Clone`-cheap (internally Arc'd) and
+    /// carry the raised decode limit, which `Client::get` /
+    /// `Client::watch` would not.
+    client: Arc<LazyEtcdClient>,
     prefix: String,
     /// Bound applied to each request/response call this provider makes —
     /// the range read in [`Self::load_all`] and the watch-create
@@ -99,53 +79,95 @@ impl std::fmt::Debug for EtcdConfigProvider {
 }
 
 impl EtcdConfigProvider {
-    /// Connect with the spec §2 default retry policy.
+    /// Connect for a gateway boot, splitting the failure by cause.
+    ///
+    /// A dial that etcd never answered is not an error here: the provider
+    /// comes back with its connection still pending and the watch
+    /// supervisor's retry loop dials again, which is what an
+    /// unauthenticated deployment has always done (`Client::connect` does
+    /// no I/O without credentials, so every failure lands on the first
+    /// read). The gateway boots, holds the proxy listener closed and binds
+    /// as soon as a configuration arrives.
+    ///
+    /// Credentials etcd has refused are fatal and returned as
+    /// [`ProviderError::Rejected`] on the first answer — no retry ladder,
+    /// because no amount of waiting turns a wrong password into a right
+    /// one, and a boot that hangs on one is worse than a boot that stops
+    /// and says so.
     pub async fn connect(
         endpoints: &[String],
         prefix: impl Into<String>,
         options: Option<ConnectOptions>,
         request_timeout: Option<Duration>,
+        dial_timeout: Option<Duration>,
     ) -> Result<Self, ProviderError> {
-        Self::connect_with_policy(
-            endpoints,
-            prefix,
+        let prefix = prefix.into();
+        let client = Arc::new(LazyEtcdClient::new(
+            endpoints.to_vec(),
             options,
+            dial_timeout,
+        ));
+        match client.connect_now().await {
+            Ok(()) => tracing::info!(prefix = %prefix, "etcd connected"),
+            Err(ConnectError::Unreachable(detail)) => tracing::warn!(
+                error = %detail,
+                prefix = %prefix,
+                "etcd is not reachable yet — starting anyway and retrying in the background; \
+                 the proxy listener stays closed until a configuration is applied",
+            ),
+            Err(err @ ConnectError::Rejected(_)) => {
+                return Err(ProviderError::Rejected(err.detail().to_string()))
+            }
+        }
+        Ok(Self {
+            client,
+            prefix,
             request_timeout,
-            ConnectPolicy::default(),
-        )
-        .await
+        })
     }
 
-    /// Connect with a caller-chosen retry policy. Returns the last-seen
-    /// error on failure to surface useful context in the bootstrap logs.
+    /// Connect eagerly, retrying an unreachable etcd on `policy` and
+    /// failing once it is exhausted. For callers that cannot wait for a
+    /// source to come back — the `export` CLI — rather than the gateway,
+    /// which uses [`Self::connect`] and defers to the supervisor.
+    ///
+    /// Refused credentials end it on the first answer, as they do there.
     pub async fn connect_with_policy(
         endpoints: &[String],
         prefix: impl Into<String>,
         options: Option<ConnectOptions>,
         request_timeout: Option<Duration>,
+        dial_timeout: Option<Duration>,
         policy: ConnectPolicy,
     ) -> Result<Self, ProviderError> {
         let prefix = prefix.into();
-        let mut last_err: Option<EtcdError> = None;
+        let client = Arc::new(LazyEtcdClient::new(
+            endpoints.to_vec(),
+            options,
+            dial_timeout,
+        ));
+        let mut last_err: Option<String> = None;
         for attempt in 1..=policy.attempts {
-            match Client::connect(endpoints, options.clone()).await {
-                Ok(client) => {
+            match client.connect_now().await {
+                Ok(()) => {
                     tracing::info!(attempt, prefix = %prefix, "etcd connected");
                     return Ok(Self {
-                        kv: Mutex::new(kv_client(&client)),
-                        watch: Mutex::new(watch_client(&client)),
+                        client,
                         prefix,
                         request_timeout,
                     });
                 }
-                Err(err) => {
+                Err(err @ ConnectError::Rejected(_)) => {
+                    return Err(ProviderError::Rejected(err.detail().to_string()))
+                }
+                Err(ConnectError::Unreachable(detail)) => {
                     tracing::warn!(
                         attempt,
                         max = policy.attempts,
-                        error = %format_error_chain(&err),
+                        error = %detail,
                         "etcd connect failed — retrying",
                     );
-                    last_err = Some(err);
+                    last_err = Some(detail);
                     if attempt < policy.attempts {
                         tokio::time::sleep(policy.interval).await;
                     }
@@ -153,15 +175,24 @@ impl EtcdConfigProvider {
             }
         }
         Err(ProviderError::Connect(
-            last_err
-                .as_ref()
-                .map(|e| format_error_chain(e))
-                .unwrap_or_else(|| "exhausted retries".to_string()),
+            last_err.unwrap_or_else(|| "exhausted retries".to_string()),
         ))
     }
 
     pub fn prefix(&self) -> &str {
         &self.prefix
+    }
+}
+
+impl From<ConnectError> for ProviderError {
+    /// Both classes reach the supervisor, which backs off and retries
+    /// whichever it gets — the split is what the boot path acts on, and
+    /// what the operator reads in the warn line.
+    fn from(err: ConnectError) -> Self {
+        match &err {
+            ConnectError::Unreachable(detail) => ProviderError::Connect(detail.clone()),
+            ConnectError::Rejected(detail) => ProviderError::Rejected(detail.clone()),
+        }
     }
 }
 
@@ -193,7 +224,7 @@ async fn bound<T>(
 #[async_trait]
 impl ConfigProvider for EtcdConfigProvider {
     async fn load_all(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
-        let mut kv = self.kv.lock().await;
+        let mut kv = self.client.kv().await?;
         let read = kv.get(
             self.prefix.as_bytes(),
             Some(GetOptions::new().with_prefix()),
@@ -229,7 +260,7 @@ impl ConfigProvider for EtcdConfigProvider {
         Box<dyn Stream<Item = Result<WatchEvent, ProviderError>> + Send + Unpin>,
         ProviderError,
     > {
-        let mut watch = self.watch.lock().await;
+        let mut watch = self.client.watch().await?;
         let opts = WatchOptions::new()
             .with_prefix()
             .with_start_revision(start_revision);
@@ -341,6 +372,307 @@ impl Stream for EtcdWatchStream {
 mod tests {
     use super::*;
 
+    /// Credentials for a dial. Any user is enough to make
+    /// `Client::connect` issue the `Authenticate` RPC, which is the only
+    /// thing that makes it perform I/O — and the reason an authenticated
+    /// deployment used to exit on an etcd an unauthenticated one waits for.
+    fn credentials() -> Option<ConnectOptions> {
+        Some(ConnectOptions::new().with_user("root", "rootpw"))
+    }
+
+    /// An address nothing is listening on: every dial is refused.
+    async fn closed_endpoint() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        format!("http://{addr}")
+    }
+
+    /// An etcd that answers every call with one gRPC status and nothing
+    /// else — a trailers-only response, which is how a real server
+    /// reports a refusal. `code` is the wire number: 3 is
+    /// `InvalidArgument`, what etcd answers a wrong password with; 14 is
+    /// `Unavailable`, what it answers while it has no leader.
+    async fn spawn_grpc_status_server(code: u16, message: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((socket, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let Ok(mut conn) = h2::server::handshake(socket).await else {
+                        return;
+                    };
+                    while let Some(Ok((_req, mut respond))) = conn.accept().await {
+                        let response = http::Response::builder()
+                            .status(200)
+                            .header("content-type", "application/grpc")
+                            .header("grpc-status", code.to_string())
+                            .header("grpc-message", message)
+                            .body(())
+                            .unwrap();
+                        let _ = respond.send_response(response, true);
+                    }
+                });
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_authenticated_etcd_does_not_end_the_boot() {
+        // The bug: with `etcd.user` set, `Client::connect` issues the
+        // `Authenticate` RPC, so an etcd that is down failed the connect
+        // — and the boot path exited on it. An unauthenticated
+        // deployment, whose connect performs no I/O, has always started
+        // and waited. Both must wait.
+        let endpoint = closed_endpoint().await;
+        let started = std::time::Instant::now();
+        let provider = tokio::time::timeout(
+            Duration::from_secs(5),
+            EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None),
+        )
+        .await
+        .expect("an unreachable etcd must not hold the boot path")
+        .expect("an unreachable etcd must not fail the boot");
+        assert!(
+            started.elapsed() < CONNECT_RETRY_INTERVAL,
+            "the boot must not spend a retry ladder before starting: {:?}",
+            started.elapsed(),
+        );
+
+        // …and the failure lands where the supervisor already retries it.
+        let err = provider.load_all().await.expect_err("etcd is not there");
+        assert!(
+            matches!(err, ProviderError::Connect(_)),
+            "an unreachable etcd must stay retryable, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_etcd_connects_on_the_first_call_that_reaches_it() {
+        // The other half of deferring: the connection is pending, not
+        // abandoned. Nothing about the provider has to be rebuilt for the
+        // gateway to pick etcd up once it answers — which is what lets
+        // the supervisor's retry loop bind a configuration on its own.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let provider = EtcdConfigProvider::connect(
+            &[format!("http://{addr}")],
+            "/aisix",
+            credentials(),
+            Some(Duration::from_secs(2)),
+            None,
+        )
+        .await
+        .expect("an unreachable etcd must not fail the boot");
+        assert!(matches!(
+            provider.load_all().await,
+            Err(ProviderError::Connect(_))
+        ));
+
+        // The endpoint comes back — as a server that refuses the
+        // credentials, which is an answer, and so proves the dial was
+        // re-attempted rather than short-circuited by the first failure.
+        let server = tokio::net::TcpListener::bind(addr).await.unwrap();
+        tokio::spawn(async move {
+            while let Ok((socket, _)) = server.accept().await {
+                tokio::spawn(async move {
+                    let Ok(mut conn) = h2::server::handshake(socket).await else {
+                        return;
+                    };
+                    while let Some(Ok((_req, mut respond))) = conn.accept().await {
+                        let response = http::Response::builder()
+                            .status(200)
+                            .header("content-type", "application/grpc")
+                            .header("grpc-status", "3")
+                            .header("grpc-message", "etcdserver: authentication failed")
+                            .body(())
+                            .unwrap();
+                        let _ = respond.send_response(response, true);
+                    }
+                });
+            }
+        });
+        let err = provider
+            .load_all()
+            .await
+            .expect_err("the credentials are refused");
+        assert!(
+            matches!(err, ProviderError::Rejected(_)),
+            "a re-dial that reached the server must report its answer, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn credentials_the_server_refuses_end_the_boot_on_the_first_answer() {
+        // The other class: etcd answered. Waiting cannot turn a wrong
+        // password into a right one, so the boot stops and names the
+        // cause instead of retrying — and it stops on the first answer,
+        // not after the connect ladder.
+        let endpoint = spawn_grpc_status_server(
+            3,
+            "etcdserver: authentication failed, invalid user ID or password",
+        )
+        .await;
+        let started = std::time::Instant::now();
+        let err = EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None)
+            .await
+            .expect_err("refused credentials cannot produce a usable provider");
+        let ProviderError::Rejected(msg) = err else {
+            panic!("a refusal must be its own class, got {err:?}");
+        };
+        assert!(
+            msg.contains("authentication failed"),
+            "the error must carry what etcd said: {msg}",
+        );
+        assert!(
+            started.elapsed() < CONNECT_RETRY_INTERVAL,
+            "a refusal must not walk the retry ladder: {:?}",
+            started.elapsed(),
+        );
+    }
+
+    #[tokio::test]
+    async fn the_export_path_stops_on_a_refusal_instead_of_retrying_it() {
+        // Same split on the CLI's eager path, which does retry an
+        // unreachable etcd: three attempts a second apart would be
+        // visible in the elapsed time if a refusal walked the ladder.
+        let endpoint = spawn_grpc_status_server(7, "etcdserver: permission denied").await;
+        let policy = ConnectPolicy {
+            interval: Duration::from_secs(1),
+            attempts: 3,
+        };
+        let started = std::time::Instant::now();
+        let err = EtcdConfigProvider::connect_with_policy(
+            &[endpoint],
+            "/aisix",
+            credentials(),
+            None,
+            None,
+            policy,
+        )
+        .await
+        .expect_err("refused credentials cannot produce a usable provider");
+        assert!(matches!(err, ProviderError::Rejected(_)), "got {err:?}");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "a refusal must not walk the retry ladder: {:?}",
+            started.elapsed(),
+        );
+    }
+
+    #[tokio::test]
+    async fn a_server_that_cannot_serve_yet_is_treated_as_unreachable() {
+        // etcd answers `Unavailable` while it has no leader or is
+        // stopping, and tonic manufactures the same code for a refused
+        // TCP connect. Both heal on their own, so neither may end a boot
+        // — and classifying on the status code rather than the message
+        // is what keeps them together.
+        let endpoint = spawn_grpc_status_server(14, "etcdserver: no leader").await;
+        let provider =
+            EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None)
+                .await
+                .expect("an etcd that cannot serve yet must not fail the boot");
+        assert!(matches!(
+            provider.load_all().await,
+            Err(ProviderError::Connect(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn the_dial_timeout_bounds_an_authenticated_connect_that_is_never_answered() {
+        // `ConnectOptions::with_connect_timeout` bounds the TCP connect
+        // only. An endpoint that completes TCP and then goes silent
+        // leaves the TLS handshake and the `Authenticate` round trip
+        // unbounded, so the dial hangs — and with it the boot, before any
+        // listener is up. `etcd.dial_timeout_ms` has to cover the whole
+        // dial, and its expiry is a reachability failure: retried, not
+        // fatal.
+        let endpoint = spawn_silent_h2_server().await;
+        let provider = tokio::time::timeout(
+            Duration::from_secs(10),
+            EtcdConfigProvider::connect(
+                &[endpoint],
+                "/aisix",
+                credentials(),
+                None,
+                Some(Duration::from_millis(300)),
+            ),
+        )
+        .await
+        .expect("the dial must be bounded; without the bound this hangs")
+        .expect("an endpoint that never answers must not fail the boot");
+
+        let err = provider
+            .load_all()
+            .await
+            .expect_err("a dial that never completes cannot read");
+        let ProviderError::Connect(msg) = err else {
+            panic!("an expired dial must stay retryable, got {err:?}");
+        };
+        assert!(
+            msg.contains("etcd.dial_timeout_ms"),
+            "the message must name the key that bounded it: {msg}",
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unset_dial_timeout_leaves_the_dial_unbounded() {
+        // `0` and unset both mean unbounded (#1134), and that has to keep
+        // meaning it here: a bound reintroduced as a default would abort
+        // dials an operator asked to leave alone.
+        let endpoint = spawn_silent_h2_server().await;
+        let deferred = tokio::time::timeout(
+            Duration::from_millis(750),
+            EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None),
+        )
+        .await;
+        assert!(
+            deferred.is_err(),
+            "with no dial timeout the connect must still be in flight",
+        );
+    }
+
+    #[tokio::test]
+    async fn each_status_code_lands_on_one_side_deliberately() {
+        // The whole fix rests on telling "no answer" from "answered and
+        // refused", so the split is pinned per wire code against a server
+        // that really sends them. The retryable set is an allowlist:
+        // anything outside it ends the boot, which is what keeps a wrong
+        // password from being waited out forever.
+        //
+        // 2 Unknown, 4 DeadlineExceeded, 13 Internal and 14 Unavailable
+        // are what a call that never got a usable answer arrives as —
+        // tonic manufactures Unavailable for a refused connect, a DNS
+        // failure and a failed TLS handshake, and etcd answers it while
+        // it has no leader.
+        for code in [2u16, 4, 13, 14] {
+            let endpoint = spawn_grpc_status_server(code, "no answer").await;
+            let provider =
+                EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None)
+                    .await
+                    .unwrap_or_else(|e| panic!("code {code} must be waited out, got {e:?}"));
+            assert!(matches!(
+                provider.load_all().await,
+                Err(ProviderError::Connect(_))
+            ));
+        }
+        // 3 InvalidArgument (etcd's answer to a wrong user or password),
+        // 7 PermissionDenied, 9 FailedPrecondition (credentials sent to a
+        // cluster with authentication disabled), 16 Unauthenticated.
+        for code in [3u16, 7, 9, 16] {
+            let endpoint = spawn_grpc_status_server(code, "refused").await;
+            let err = EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None)
+                .await
+                .expect_err("a refusal must end the boot");
+            assert!(
+                matches!(err, ProviderError::Rejected(_)),
+                "code {code} must be fatal, got {err:?}",
+            );
+        }
+    }
+
     #[test]
     fn connect_retry_constants_match_spec() {
         assert_eq!(CONNECT_RETRY_INTERVAL, Duration::from_secs(5));
@@ -355,20 +687,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn connect_with_malformed_endpoint_returns_connect_error() {
-        // Empty endpoint list is treated as a parse failure by etcd-client,
-        // which lets us exercise the retry loop's error branch without
-        // waiting on a real TCP timeout. A compressed policy keeps the
-        // test sub-millisecond.
-        let policy = ConnectPolicy {
-            interval: Duration::from_millis(1),
-            attempts: 1,
-        };
+    async fn endpoints_that_cannot_be_used_at_all_end_the_boot() {
+        // An empty endpoint list is a parse failure inside etcd-client,
+        // not a reachability one: no retry ladder can turn it into a
+        // usable endpoint, so it must reach the caller as a refusal
+        // rather than deferring to a supervisor that would dial it
+        // forever.
         let endpoints: Vec<String> = vec![];
-        let err = EtcdConfigProvider::connect_with_policy(&endpoints, "/aisix", None, None, policy)
+        let err = EtcdConfigProvider::connect(&endpoints, "/aisix", None, None, None)
             .await
             .unwrap_err();
-        assert!(matches!(err, ProviderError::Connect(_)));
+        assert!(
+            matches!(err, ProviderError::Rejected(_)),
+            "unusable endpoints must be fatal, got {err:?}",
+        );
     }
 
     /// An etcd that is reachable and answers nothing.
@@ -416,6 +748,7 @@ mod tests {
             "/aisix",
             None,
             Some(Duration::from_millis(300)),
+            None,
         )
         .await
         .expect("connect is lazy without credentials");
@@ -450,6 +783,7 @@ mod tests {
             "/aisix",
             None,
             Some(Duration::from_millis(300)),
+            None,
         )
         .await
         .expect("connect is lazy without credentials");
@@ -502,41 +836,5 @@ mod tests {
             msg.contains("range read") && msg.contains("etcd.request_timeout_ms"),
             "the message must name the call and the key that bounded it: {msg}"
         );
-    }
-
-    #[test]
-    fn format_error_chain_joins_sources_without_duplicating() {
-        #[derive(Debug)]
-        struct Inner;
-        impl std::fmt::Display for Inner {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.write_str("Name or service not known")
-            }
-        }
-        impl StdError for Inner {}
-
-        #[derive(Debug)]
-        struct Outer {
-            inner: Inner,
-        }
-        impl std::fmt::Display for Outer {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.write_str("dns error")
-            }
-        }
-        impl StdError for Outer {
-            fn source(&self) -> Option<&(dyn StdError + 'static)> {
-                Some(&self.inner)
-            }
-        }
-
-        let joined = format_error_chain(&Outer { inner: Inner });
-        assert_eq!(joined, "dns error: Name or service not known");
-    }
-
-    #[test]
-    fn format_error_chain_handles_empty_source() {
-        let err = std::io::Error::other("bare");
-        assert_eq!(format_error_chain(&err), "bare");
     }
 }

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use crate::client::{format_error_chain, ConnectError, LazyEtcdClient};
+use crate::client::{classify, format_etcd_error, ConnectError, LazyEtcdClient};
 use crate::provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 
 /// Fixed-interval retry: 5s × 5 attempts (spec §2).
@@ -204,6 +204,23 @@ impl From<ConnectError> for ProviderError {
 /// attribution, not control flow: `Supervisor::run` routes every
 /// `ProviderError` out of a cycle to the same reconnect-with-backoff
 /// path, so the aborted call is retried whichever variant carries it.
+/// Report one failed etcd call.
+///
+/// A refusal is reported as such wherever etcd hands it over, not only
+/// on the dial: a user who authenticates but lacks the permission is
+/// refused by the range read, and a token an etcd restart invalidated is
+/// refused by every call after it. Those never heal by retrying, and
+/// reporting them as ordinary transport trouble is what buries them in a
+/// warn line that repeats forever. Everything else keeps the variant
+/// naming the call that failed, which is what the supervisor's backoff
+/// line says.
+fn call_error(err: &etcd_client::Error, into_err: fn(String) -> ProviderError) -> ProviderError {
+    match classify(err) {
+        ConnectError::Rejected(detail) => ProviderError::Rejected(detail),
+        ConnectError::Unreachable(_) => into_err(format_etcd_error(err)),
+    }
+}
+
 async fn bound<T>(
     timeout: Option<Duration>,
     what: &str,
@@ -224,7 +241,20 @@ async fn bound<T>(
 #[async_trait]
 impl ConfigProvider for EtcdConfigProvider {
     async fn load_all(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
-        let mut kv = self.client.kv().await?;
+        // The dial is bounded like the call it is part of. Without
+        // credentials there is nothing to dial here — the channel
+        // connects inside the `get` below, under the same bound — but
+        // with them the `Authenticate` round trip happens on the way in,
+        // and an endpoint that accepts TCP and answers nothing would
+        // otherwise hold this read open forever: no backoff, no failure
+        // recorded, and `/status/config` still reporting connected.
+        let mut kv = bound(
+            self.request_timeout,
+            "etcd connect",
+            ProviderError::Connect,
+            self.client.kv(),
+        )
+        .await??;
         let read = kv.get(
             self.prefix.as_bytes(),
             Some(GetOptions::new().with_prefix()),
@@ -236,7 +266,7 @@ impl ConfigProvider for EtcdConfigProvider {
             read,
         )
         .await?
-        .map_err(|e| ProviderError::Range(format_error_chain(&e)))?;
+        .map_err(|e| call_error(&e, ProviderError::Range))?;
 
         let revision = resp.header().map(|h| h.revision()).unwrap_or(0);
 
@@ -260,7 +290,13 @@ impl ConfigProvider for EtcdConfigProvider {
         Box<dyn Stream<Item = Result<WatchEvent, ProviderError>> + Send + Unpin>,
         ProviderError,
     > {
-        let mut watch = self.client.watch().await?;
+        let mut watch = bound(
+            self.request_timeout,
+            "etcd connect",
+            ProviderError::Connect,
+            self.client.watch(),
+        )
+        .await??;
         let opts = WatchOptions::new()
             .with_prefix()
             .with_start_revision(start_revision);
@@ -282,7 +318,7 @@ impl ConfigProvider for EtcdConfigProvider {
             create,
         )
         .await?
-        .map_err(|e| ProviderError::Watch(format_error_chain(&e)))?;
+        .map_err(|e| call_error(&e, ProviderError::Watch))?;
 
         Ok(Box::new(EtcdWatchStream {
             inner: stream,
@@ -341,7 +377,7 @@ impl Stream for EtcdWatchStream {
                 {
                     Poll::Ready(Some(Err(ProviderError::Compacted)))
                 } else {
-                    Poll::Ready(Some(Err(ProviderError::Watch(format_error_chain(&err)))))
+                    Poll::Ready(Some(Err(call_error(&err, ProviderError::Watch))))
                 }
             }
             Poll::Ready(Some(Ok(resp))) => {
@@ -618,6 +654,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_refusal_the_read_meets_is_reported_as_a_refusal() {
+        // Where etcd refuses is not the caller's choice. A wrong password
+        // is refused by `Authenticate`, but a user who authenticates and
+        // then lacks the permission is refused by the range read, and a
+        // token an etcd restart invalidated is refused by every call
+        // after it. Classifying only the dial would report those as
+        // ordinary transport trouble and bury them in a warn line that
+        // repeats forever.
+        //
+        // No credentials here on purpose: that is the shape where the
+        // dial cannot classify anything at all, because it does no I/O.
+        let endpoint = spawn_grpc_status_server(7, "etcdserver: permission denied").await;
+        let provider = EtcdConfigProvider::connect(&[endpoint], "/aisix", None, None, None)
+            .await
+            .expect("connect is lazy without credentials");
+
+        let err = provider
+            .load_all()
+            .await
+            .expect_err("a refused read cannot succeed");
+        let ProviderError::Rejected(msg) = err else {
+            panic!("a refusal on the read must be its own class, got {err:?}");
+        };
+        assert!(
+            msg.contains("permission denied"),
+            "the error must carry what etcd said: {msg}",
+        );
+    }
+
+    #[tokio::test]
+    async fn the_request_timeout_also_bounds_the_dial_a_read_has_to_make() {
+        // Without credentials there is nothing to dial on the way into a
+        // read: the channel connects inside the `get`, under
+        // `etcd.request_timeout_ms` like the rest of the call. With them
+        // the `Authenticate` round trip happens first, so a dial left
+        // outside that bound would hold the read open forever against an
+        // endpoint that accepts TCP and answers nothing — no backoff, no
+        // recorded failure, and a `/status/config` still reporting
+        // connected. No `dial_timeout_ms` here on purpose: the operator
+        // set one bound, and it has to cover the whole read.
+        //
+        // The endpoint is refused at connect time and only becomes the
+        // silent one afterwards, so the dial under test is the read's.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let provider = EtcdConfigProvider::connect(
+            &[format!("http://{addr}")],
+            "/aisix",
+            credentials(),
+            Some(Duration::from_millis(300)),
+            None,
+        )
+        .await
+        .expect("an unreachable etcd must not fail the boot");
+
+        serve_silently(tokio::net::TcpListener::bind(addr).await.unwrap());
+
+        let err = tokio::time::timeout(Duration::from_secs(10), provider.load_all())
+            .await
+            .expect("the dial the read makes must be bounded; without it this hangs")
+            .expect_err("a dial that never completes cannot read");
+        let ProviderError::Connect(msg) = err else {
+            panic!("an expired dial must stay retryable, got {err:?}");
+        };
+        assert!(
+            msg.contains("etcd connect") && msg.contains("etcd.request_timeout_ms"),
+            "the message must name the call and the key that bounded it: {msg}",
+        );
+    }
+
+    #[tokio::test]
     async fn an_unset_dial_timeout_leaves_the_dial_unbounded() {
         // `0` and unset both mean unbounded (#1134), and that has to keep
         // meaning it here: a bound reintroduced as a default would abort
@@ -646,8 +754,10 @@ mod tests {
         // are what a call that never got a usable answer arrives as —
         // tonic manufactures Unavailable for a refused connect, a DNS
         // failure and a failed TLS handshake, and etcd answers it while
-        // it has no leader.
-        for code in [2u16, 4, 13, 14] {
+        // it has no leader. 1 Cancelled and 10 Aborted are a peer or an
+        // intermediary resetting the stream; 8 ResourceExhausted is
+        // throttling. All of them heal without anyone editing a config.
+        for code in [1u16, 2, 4, 8, 10, 13, 14] {
             let endpoint = spawn_grpc_status_server(code, "no answer").await;
             let provider =
                 EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None)
@@ -714,6 +824,13 @@ mod tests {
     async fn spawn_silent_h2_server() -> String {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        serve_silently(listener);
+        format!("http://{addr}")
+    }
+
+    /// The silent server on a listener the caller owns, so a test can
+    /// leave a port dead first and make it silent afterwards.
+    fn serve_silently(listener: tokio::net::TcpListener) {
         tokio::spawn(async move {
             while let Ok((socket, _)) = listener.accept().await {
                 tokio::spawn(async move {
@@ -730,7 +847,6 @@ mod tests {
                 });
             }
         });
-        format!("http://{addr}")
     }
 
     #[tokio::test]

--- a/crates/aisix-etcd/src/lib.rs
+++ b/crates/aisix-etcd/src/lib.rs
@@ -4,7 +4,8 @@
 //! (see `aisix-core`). This crate is what *populates* that handle, running
 //! a single supervisor task that:
 //!
-//! 1. Connects to etcd (5s × 5 retries on bootstrap — spec §2)
+//! 1. Connects to etcd — an etcd that cannot be reached is left to this
+//!    loop rather than failing the boot; credentials it refuses are fatal
 //! 2. Performs a full range read under the configured prefix
 //! 3. Opens a watch stream from the next revision
 //! 4. Applies Put / Delete events by copy-on-write replacing the snapshot
@@ -29,7 +30,9 @@ pub mod snapshot_cache;
 pub mod supervisor;
 
 pub use backoff::{ExpBackoff, BASE_MS, MAX_MS};
-pub use client::{kv_client, watch_client, MAX_DECODING_MESSAGE_SIZE};
+pub use client::{
+    kv_client, watch_client, ConnectError, LazyEtcdClient, MAX_DECODING_MESSAGE_SIZE,
+};
 pub use etcd_provider::{
     ConnectPolicy, EtcdConfigProvider, EtcdWatchStream, CONNECT_MAX_ATTEMPTS,
     CONNECT_RETRY_INTERVAL,

--- a/crates/aisix-etcd/src/provider.rs
+++ b/crates/aisix-etcd/src/provider.rs
@@ -42,6 +42,13 @@ pub enum WatchEvent {
 pub enum ProviderError {
     #[error("etcd connection failed: {0}")]
     Connect(String),
+    /// etcd answered and refused the connection — wrong credentials, a
+    /// user without the required permission, or endpoints that cannot be
+    /// used at all. Distinct from [`ProviderError::Connect`] because it
+    /// does not heal by waiting: the boot path exits on it instead of
+    /// joining the retry loop.
+    #[error("etcd rejected the connection: {0}")]
+    Rejected(String),
     #[error("etcd range request failed: {0}")]
     Range(String),
     #[error("etcd watch stream failed: {0}")]

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -1116,11 +1116,26 @@ impl<P: ConfigProvider> Supervisor<P> {
                     // The last-good applied snapshot keeps serving.
                     self.config_status.record_fetch_failure();
                     let delay = backoff.next_delay();
-                    tracing::warn!(
-                        error = %err,
-                        backoff_ms = delay.as_millis() as u64,
-                        "etcd watch failed; backing off before reconnect",
-                    );
+                    // A refusal is not a transport hiccup: etcd answered
+                    // and said no, and no amount of backing off changes
+                    // that. The boot path exits on one, but by here the
+                    // process is already up (etcd was unreachable when it
+                    // started), so the loop keeps going and says loudly
+                    // why nothing is being applied.
+                    if matches!(err, ProviderError::Rejected(_)) {
+                        tracing::error!(
+                            error = %err,
+                            backoff_ms = delay.as_millis() as u64,
+                            "etcd refused this gateway's credentials — no configuration can be \
+                             read until they are fixed; still retrying",
+                        );
+                    } else {
+                        tracing::warn!(
+                            error = %err,
+                            backoff_ms = delay.as_millis() as u64,
+                            "etcd watch failed; backing off before reconnect",
+                        );
+                    }
                     tokio::select! {
                         _ = tokio::time::sleep(delay) => {}
                         _ = cancel.changed() => {

--- a/crates/aisix-etcd/tests/auth_connect_integration.rs
+++ b/crates/aisix-etcd/tests/auth_connect_integration.rs
@@ -1,0 +1,184 @@
+//! Connecting to an etcd that really has authentication enabled.
+//!
+//! Bracketed by `ETCD_AUTH_TEST_URL` (the pattern
+//! `crates/aisix-admin/tests/etcd_integration.rs` uses for
+//! `ADMIN_TEST_ETCD_URL`): the tests no-op when it is unset so a local
+//! `cargo test` without docker still passes. CI starts the cluster and
+//! sets the variables in `.github/workflows/ci.yml`.
+//!
+//! Two things need a server that answers rather than a stub. The wording
+//! and status code etcd really returns for a wrong password is what the
+//! whole "refused, not unreachable" split rests on; and the recovery
+//! path — an etcd that was unreachable at connect time coming back, being
+//! authenticated on the retry, and the gateway applying a configuration
+//! from it — is only meaningful end to end.
+
+#![allow(clippy::expect_used)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use aisix_etcd::{EtcdConfigProvider, ProviderError, Supervisor};
+use etcd_client::ConnectOptions;
+
+fn auth_etcd() -> Option<(String, String, String)> {
+    let url = std::env::var("ETCD_AUTH_TEST_URL").ok()?;
+    let user = std::env::var("ETCD_AUTH_TEST_USER").ok()?;
+    let password = std::env::var("ETCD_AUTH_TEST_PASSWORD").ok()?;
+    Some((url, user, password))
+}
+
+fn unique_prefix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    format!("/aisix-auth-it-{nanos}")
+}
+
+fn host_port(url: &str) -> String {
+    url.trim_start_matches("http://")
+        .trim_start_matches("https://")
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Accept on `listen` and pipe both directions to `target`, from the
+/// moment this is called — so a test can leave the endpoint dead first
+/// and bring it up afterwards.
+async fn start_forwarder(listen: std::net::SocketAddr, target: String) {
+    let listener = tokio::net::TcpListener::bind(listen)
+        .await
+        .expect("relay bind");
+    tokio::spawn(async move {
+        while let Ok((mut client, _)) = listener.accept().await {
+            let target = target.clone();
+            tokio::spawn(async move {
+                let Ok(mut upstream) = tokio::net::TcpStream::connect(&target).await else {
+                    return;
+                };
+                let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await;
+            });
+        }
+    });
+}
+
+/// A dead endpoint: bound to learn a free port, then released.
+async fn dead_endpoint() -> std::net::SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("probe bind");
+    let addr = listener.local_addr().expect("probe addr");
+    drop(listener);
+    addr
+}
+
+#[tokio::test]
+async fn a_wrong_password_is_refused_by_the_real_server() {
+    let Some((url, user, _password)) = auth_etcd() else {
+        eprintln!("skipping: ETCD_AUTH_TEST_URL not set");
+        return;
+    };
+    let options = ConnectOptions::new().with_user(user, "definitely-not-the-password");
+    let err = EtcdConfigProvider::connect(
+        &[url],
+        unique_prefix(),
+        Some(options),
+        None,
+        Some(Duration::from_secs(5)),
+    )
+    .await
+    .expect_err("a wrong password cannot produce a usable provider");
+
+    let ProviderError::Rejected(msg) = err else {
+        panic!("a real etcd's refusal must be classified as refused, got {err:?}");
+    };
+    // etcd 3.5 answers `Authenticate` with InvalidArgument and this
+    // message. The classification is on the status code, not on the
+    // text, but the text is what an operator reads out of the boot
+    // failure — so it has to survive to the error.
+    assert!(
+        msg.contains("authentication failed"),
+        "the error must carry what etcd said: {msg}",
+    );
+}
+
+#[tokio::test]
+async fn an_etcd_that_comes_back_is_authenticated_and_applied() {
+    let Some((url, user, password)) = auth_etcd() else {
+        eprintln!("skipping: ETCD_AUTH_TEST_URL not set");
+        return;
+    };
+    let prefix = unique_prefix();
+
+    // Seed one model the way an operator or the control plane would,
+    // before the gateway has anything to read it through.
+    let mut writer = etcd_client::Client::connect(
+        [url.clone()],
+        Some(ConnectOptions::new().with_user(user.clone(), password.clone())),
+    )
+    .await
+    .expect("seed client");
+    writer
+        .put(
+            format!("{prefix}/models/m-auth-1"),
+            r#"{"display_name":"auth-it-model","provider":"openai","model_name":"gpt-4o-mini","provider_key_id":"11111111-1111-1111-1111-111111111111"}"#,
+            None,
+        )
+        .await
+        .expect("seed put");
+
+    // The gateway starts against an endpoint nothing is listening on.
+    // With credentials configured this used to fail the connect and end
+    // the process; it now leaves the connection pending.
+    let addr = dead_endpoint().await;
+    let provider = Arc::new(
+        EtcdConfigProvider::connect(
+            &[format!("http://{addr}")],
+            prefix.clone(),
+            Some(ConnectOptions::new().with_user(user, password)),
+            Some(Duration::from_secs(5)),
+            Some(Duration::from_secs(5)),
+        )
+        .await
+        .expect("an unreachable etcd must not fail the connect"),
+    );
+
+    let supervisor = Arc::new(Supervisor::new(provider, prefix.clone()));
+    let status = supervisor.config_status();
+    let handle = supervisor.handle();
+    let (_cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    let task = tokio::spawn(supervisor.run(cancel_rx));
+
+    // Nothing is applied while the source is away — which is what holds
+    // the proxy listener closed for the whole of this window.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    assert!(
+        !status.is_ready(),
+        "no configuration can be applied from an etcd that is not there",
+    );
+
+    // The source comes back. Nothing is restarted or rebuilt: the
+    // supervisor's own retry loop dials again, authenticates, and applies.
+    start_forwarder(addr, host_port(&url)).await;
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while !status.is_ready() && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        status.is_ready(),
+        "the gateway must apply a configuration once etcd answers",
+    );
+    assert_eq!(
+        handle.load().models.len(),
+        1,
+        "the applied snapshot must carry the seeded model",
+    );
+
+    writer
+        .delete(format!("{prefix}/models/m-auth-1"), None)
+        .await
+        .expect("cleanup");
+    task.abort();
+}

--- a/crates/aisix-etcd/tests/watch_integration.rs
+++ b/crates/aisix-etcd/tests/watch_integration.rs
@@ -48,7 +48,7 @@ async fn watch_stream_delivers_events_after_put() {
 
     let prefix = unique_prefix();
     let endpoints = vec![url.clone()];
-    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None, None)
+    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None, None, None)
         .await
         .expect("connect");
 
@@ -109,7 +109,7 @@ async fn supervisor_applied_revision_catches_up_to_writer_revision() {
 
     let prefix = unique_prefix();
     let endpoints = vec![url.clone()];
-    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None, None)
+    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None, None, None)
         .await
         .expect("connect");
     let supervisor = std::sync::Arc::new(aisix_etcd::Supervisor::new(
@@ -178,7 +178,7 @@ async fn watch_stream_delivers_all_events_from_batched_response() {
 
     let prefix = unique_prefix();
     let endpoints = vec![url.clone()];
-    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None, None)
+    let provider = EtcdConfigProvider::connect(&endpoints, prefix.clone(), None, None, None)
         .await
         .expect("connect");
 

--- a/crates/aisix-server/src/export/mod.rs
+++ b/crates/aisix-server/src/export/mod.rs
@@ -39,8 +39,9 @@ pub struct ExportArgs {
     pub output: Option<PathBuf>,
 }
 
-/// A CLI-appropriate connect policy: fail after a few quick attempts
-/// rather than the gateway's 25s boot budget.
+/// A CLI-appropriate connect policy: fail after a few quick attempts.
+/// The gateway leaves an unreachable etcd to its supervisor instead; a
+/// one-shot command has nothing to wait with.
 const CLI_CONNECT_POLICY: ConnectPolicy = ConnectPolicy {
     interval: Duration::from_secs(1),
     attempts: 3,
@@ -59,8 +60,10 @@ pub async fn run(args: ExportArgs) -> anyhow::Result<()> {
         &args.prefix,
         None,
         // The export CLI takes endpoints on the command line, not a
-        // config file, so there is no `etcd.request_timeout_ms` to honour
-        // — and an operator can interrupt it. The read stays unbounded.
+        // config file, so there is no `etcd.request_timeout_ms` or
+        // `etcd.dial_timeout_ms` to honour — and an operator can
+        // interrupt it. Both stay unbounded.
+        None,
         None,
         CLI_CONNECT_POLICY,
     )

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -753,10 +753,11 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 .await
                 .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?,
             );
-            // Separate client for the admin read surface — only needed when
-            // the admin listener is bound. We could share a single underlying
-            // connection via `Client::clone()` but keeping two is cleaner:
-            // admin reads and the watch stream don't contend on the same mutex.
+            // Separate connection for the admin read surface — only needed
+            // when the admin listener is bound. It could share the config
+            // provider's, but keeping two means an admin read and the watch
+            // stream never queue behind the same connect, and neither can
+            // stall the other's channel.
             // Skipped whenever the admin listener is not bound — managed mode,
             // or `admin.enabled = false` — so admin-off doesn't pay for (or
             // fail boot on) a connection it immediately drops; `/status/models`

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -738,12 +738,17 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             // (env_id populated from the register response above), bare
             // `<prefix>` in self-hosted dev where env_id is empty.
             let etcd_prefix = cfg.etcd.effective_prefix();
+            // Only a refusal ends the boot here: an etcd that cannot be
+            // reached leaves the connection pending and the supervisor
+            // dials it again, so the gateway waits for its source instead
+            // of exiting on it. See `EtcdConfigProvider::connect`.
             let provider = Arc::new(
                 EtcdConfigProvider::connect(
                     &cfg.etcd.endpoints,
                     etcd_prefix.clone(),
                     connect_options.clone(),
                     cfg.etcd.request_timeout(),
+                    cfg.etcd.dial_timeout(),
                 )
                 .await
                 .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?,
@@ -760,9 +765,11 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 None
             } else {
                 Some((
-                    etcd_client::Client::connect(&cfg.etcd.endpoints, connect_options.clone())
-                        .await
-                        .map_err(|e| anyhow::anyhow!("etcd admin client connect failed: {e}"))?,
+                    Arc::new(aisix_etcd::LazyEtcdClient::new(
+                        cfg.etcd.endpoints.clone(),
+                        connect_options.clone(),
+                        cfg.etcd.dial_timeout(),
+                    )),
                     etcd_prefix.clone(),
                     cfg.etcd.request_timeout(),
                 ))

--- a/tests/e2e/src/cases/etcd-auth-connect-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-auth-connect-e2e.test.ts
@@ -33,6 +33,8 @@ const BACKOFF_LINE = "etcd watch failed; backing off before reconnect";
 const DEFERRED_LINE = "etcd is not reachable yet";
 /** What a refusal has to be reported as, whatever etcd's own message says. */
 const REFUSED_LINE = "etcd rejected the connection";
+/** The supervisor's line for a refusal it meets after the boot is past. */
+const REFUSED_AFTER_BOOT_LINE = "etcd refused this gateway's credentials";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
@@ -161,6 +163,38 @@ describe("etcd credentials: unreachable is waited out, refused is not", () => {
     expect(app.output()).toContain("etcd.dial_timeout_ms");
     expect(await waitForOutput(app, BACKOFF_LINE, 30_000, 2)).toBeGreaterThanOrEqual(2);
 
+    const metrics = await fetch(`${app.metricsUrl}/metrics`);
+    expect(metrics.status).toBe(200);
+  }, 120_000);
+
+  test("a refusal that only arrives after boot is reported, not buried", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    // The boot can only exit on a refusal it is given. Scheduled before
+    // its etcd — the ordering this whole change is about — it takes the
+    // unreachable branch instead, and a refusal that lands later reaches
+    // the supervisor rather than the boot path. The process is up and
+    // serving from whatever it has by then, so it keeps retrying; what it
+    // must not do is file "your credentials are wrong" under the same
+    // routine warn line as "etcd is restarting", which is how a
+    // configuration mistake stays invisible for a day.
+    const prefix = `/aisix-e2e-etcd-auth-late-${randomUUID()}`;
+    const relay = await startEtcdRelay();
+    relays.push(relay);
+    await relay.refuse();
+
+    const app = await spawnAuthenticated(relay.endpoint, prefix);
+    expect(app.output()).toContain(DEFERRED_LINE);
+
+    // The endpoint comes back — as the suite's own etcd, which has
+    // authentication disabled and therefore answers the credentials with
+    // a refusal rather than going quiet.
+    await relay.release();
+    expect(await waitForOutput(app, REFUSED_AFTER_BOOT_LINE, 60_000)).toBeGreaterThanOrEqual(1);
+
+    // Still up: a refusal after boot is loud, not fatal.
     const metrics = await fetch(`${app.metricsUrl}/metrics`);
     expect(metrics.status).toBe(200);
   }, 120_000);

--- a/tests/e2e/src/cases/etcd-auth-connect-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-auth-connect-e2e.test.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "node:crypto";
+import { connect } from "node:net";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  etcdEndpoint,
+  spawnApp,
+  startEtcdRelay,
+  type EtcdRelay,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// `Client::connect` performs I/O only when etcd credentials are
+// configured — it issues the `Authenticate` RPC — so the same gateway
+// used to start in two opposite ways depending on a key that has nothing
+// to do with reachability. Without credentials it started, held the proxy
+// listener closed and waited for etcd however long that took; with them,
+// an etcd that was down failed the connect and the process exited.
+//
+// These specs pin the split that replaced it. An etcd that never
+// answered is waited out on the supervisor's retry loop, exactly as the
+// unauthenticated deployment is. Credentials etcd answered and refused
+// still end the boot, because no amount of waiting fixes them.
+//
+// The password is real config here: the gateway reads it from the env
+// var `etcd.password_env` names.
+const ETCD_USER = "e2e-auth-probe";
+const PASSWORD_ENV = "ETCD_E2E_PASSWORD";
+
+/** The supervisor's retry log line, emitted at WARN on every failed cycle. */
+const BACKOFF_LINE = "etcd watch failed; backing off before reconnect";
+/** The boot's own wording for "not reachable, carrying on anyway". */
+const DEFERRED_LINE = "etcd is not reachable yet";
+/** What a refusal has to be reported as, whatever etcd's own message says. */
+const REFUSED_LINE = "etcd rejected the connection";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Poll the captured output until `needle` appears at least `count` times. */
+async function waitForOutput(
+  app: SpawnedApp,
+  needle: string,
+  timeoutMs: number,
+  count = 1,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const seen = app.output().split(needle).length - 1;
+    if (seen >= count || Date.now() >= deadline) return seen;
+    await sleep(100);
+  }
+}
+
+/** True when a TCP connection to `port` on loopback is accepted. */
+function tcpAccepts(port: number, timeoutMs = 1_000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = connect(port, "127.0.0.1");
+    const settle = (accepted: boolean) => {
+      sock.destroy();
+      resolve(accepted);
+    };
+    sock.once("connect", () => settle(true));
+    sock.once("error", () => settle(false));
+    sock.setTimeout(timeoutMs, () => settle(false));
+  });
+}
+
+describe("etcd credentials: unreachable is waited out, refused is not", () => {
+  let etcdReachable = false;
+  const apps: SpawnedApp[] = [];
+  const relays: EtcdRelay[] = [];
+
+  beforeAll(async () => {
+    etcdReachable = await new EtcdClient().ping();
+  });
+
+  afterEach(async () => {
+    await Promise.all(apps.splice(0).map((a) => a.exit()));
+    await Promise.all(relays.splice(0).map((r) => r.stop()));
+  });
+
+  /**
+   * Spawn a gateway that authenticates to etcd. `awaitProxyListener` is
+   * off throughout: every case here keeps the first configuration from
+   * ever landing, which is exactly when the listener stays closed.
+   */
+  async function spawnAuthenticated(
+    endpoint: string,
+    prefix: string,
+    etcdExtra: Record<string, unknown> = {},
+  ): Promise<SpawnedApp> {
+    const app = await spawnApp({
+      etcdPrefix: prefix,
+      awaitProxyListener: false,
+      // The supervisor's backoff line and the boot's deferral line are
+      // both WARN, which this level keeps.
+      logLevel: "warn",
+      extraEnv: { [PASSWORD_ENV]: "not-the-password-etcd-has" },
+      extra: {
+        etcd: {
+          endpoints: [endpoint],
+          prefix,
+          user: ETCD_USER,
+          password_env: PASSWORD_ENV,
+          ...etcdExtra,
+        },
+      },
+    });
+    apps.push(app);
+    return app;
+  }
+
+  test("an etcd that never answers no longer ends the boot", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    const prefix = `/aisix-e2e-etcd-auth-refused-${randomUUID()}`;
+    const relay = await startEtcdRelay();
+    relays.push(relay);
+    // Not listening: every dial is refused, which is what a gateway
+    // scheduled before its etcd — or during an etcd restart — meets.
+    await relay.refuse();
+
+    // Reaching this line is most of the assertion: the boot used to
+    // spend 5s × 5 attempts here and then exit.
+    const app = await spawnAuthenticated(relay.endpoint, prefix);
+    expect(app.output()).toContain(DEFERRED_LINE);
+
+    // Two occurrences, not one: a single line would also be produced by
+    // a connection that failed once and gave up. The loop is the subject.
+    expect(await waitForOutput(app, BACKOFF_LINE, 30_000, 2)).toBeGreaterThanOrEqual(2);
+
+    // Still up, and still refusing to serve: the metrics listener is
+    // bound (it answered during spawn) while the proxy listener stays
+    // closed because no configuration has been applied.
+    const metrics = await fetch(`${app.metricsUrl}/metrics`);
+    expect(metrics.status).toBe(200);
+    expect(await tcpAccepts(Number(new URL(app.proxyUrl).port))).toBe(false);
+  }, 120_000);
+
+  test("a silent endpoint is bounded by dial_timeout_ms and retried", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    const prefix = `/aisix-e2e-etcd-auth-silent-${randomUUID()}`;
+    const relay = await startEtcdRelay();
+    relays.push(relay);
+    // Connection accepted, nothing forwarded: TCP completes and the
+    // `Authenticate` round trip is never answered. `dial_timeout_ms`
+    // reached only the TCP connect, so this hung the boot outright —
+    // before any listener was up and with no line saying why.
+    await relay.hold();
+
+    const app = await spawnAuthenticated(relay.endpoint, prefix, { dial_timeout_ms: 1000 });
+    expect(app.output()).toContain(DEFERRED_LINE);
+    // …and the abort was the dial bound, not some other failure.
+    expect(app.output()).toContain("etcd.dial_timeout_ms");
+    expect(await waitForOutput(app, BACKOFF_LINE, 30_000, 2)).toBeGreaterThanOrEqual(2);
+
+    const metrics = await fetch(`${app.metricsUrl}/metrics`);
+    expect(metrics.status).toBe(200);
+  }, 120_000);
+
+  test("credentials the cluster refuses end the boot, promptly and by name", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    // Straight at the real etcd, which has authentication disabled, so
+    // it answers the `Authenticate` call with a refusal rather than
+    // going quiet. That is the half that must NOT be waited out: an
+    // instance that hung here would be a configuration mistake turned
+    // into a gateway that is up and permanently empty.
+    const prefix = `/aisix-e2e-etcd-auth-refusal-${randomUUID()}`;
+    const started = Date.now();
+    await expect(spawnAuthenticated(etcdEndpoint(), prefix)).rejects.toThrow(
+      new RegExp(REFUSED_LINE),
+    );
+    // The old path reached the same exit only after 5s × 5 attempts.
+    expect(Date.now() - started).toBeLessThan(15_000);
+  }, 120_000);
+});


### PR DESCRIPTION
## The problem

`Client::connect` performs real I/O only when etcd credentials are configured — it issues the `Authenticate` RPC. So the same gateway started in two opposite ways depending on a key that says nothing about reachability:

- **No credentials.** The connect returns before anything is dialled. The gateway starts, the metrics listener answers `/status/ready` 503, the proxy listener stays closed, the watch supervisor retries on its 1→60s backoff, and the instance binds as soon as a configuration arrives. An etcd that is slow to come up costs nothing.
- **`etcd.user` + `etcd.password_env` set.** An etcd that could not be reached failed the connect, the boot path bubbled it out of `run()`, and **the process exited after roughly 20-25 seconds** (5s × 5 attempts). The first-config gate was never reached, none of its wait lines were written, the backoff ladder never started, and a 300s startup budget in the chart was irrelevant to it.

Separately, `etcd.dial_timeout_ms` reached only the TCP connect, through `ConnectOptions::with_connect_timeout`. The TLS handshake and the `Authenticate` round trip sit outside it, so an endpoint that completes TCP and then goes silent hung the boot with no bound at all — before any listener was up, and with no line saying why.

## The split

Failures are now sorted by cause, and the two halves are treated as opposites.

**Cannot reach etcd — waited out, never fatal.** TCP refused, DNS failure, TLS handshake failure, an expired dial bound, or an etcd that is up but cannot serve. The provider is returned with its connection still pending, the supervisor's retry loop dials again, and an authenticated deployment now behaves exactly like an unauthenticated one: it starts, holds the proxy listener closed, and binds as soon as a configuration is applied.

**Credentials etcd refused — fatal on the first answer.** A wrong user or password, a user without the required permission, or credentials sent to a cluster with authentication disabled. The boot stops and reports etcd's own message. There is no retry ladder in front of it: waiting cannot turn a wrong password into a right one, and turning a configuration mistake into a gateway that is up and permanently empty would be worse than the exit it replaces. Endpoints that cannot be used at all — an unparseable URI, an empty list — join this half for the same reason.

### How the two are told apart

Structurally, on the gRPC status code, never on the text of a message (`crates/aisix-etcd/src/client.rs::classify`). Verified against etcd 3.5 and etcd-client 0.14:

| what happened | what arrives | class |
| --- | --- | --- |
| TCP refused / DNS failure / TLS handshake failure | status manufactured locally by tonic, code `Unavailable` | cannot reach |
| etcd has no leader, is stopping, or the call ran out of time | `Unavailable` / `DeadlineExceeded` from the server | cannot reach |
| connection broken mid-call | `Unknown` / `Internal` | cannot reach |
| an intermediary resets the stream, or etcd throttles | `Cancelled` / `Aborted` / `ResourceExhausted` | cannot reach |
| wrong user or password | `InvalidArgument`, "etcdserver: authentication failed, invalid user ID or password" | refused |
| user lacks the permission (on the read — see below) | `PermissionDenied` | refused |
| a token an etcd restart invalidated (on the read) | `Unauthenticated` | refused |
| credentials against a cluster with auth disabled | `FailedPrecondition`, "etcdserver: authentication is not enabled" | refused |

**Where** etcd refuses is not the caller's choice, so the same classifier runs on the reads, not only on the dial. A wrong password is refused by `Authenticate`; a user who authenticates and then lacks the permission is refused by the range read; a token an etcd restart invalidated is refused by every call after it. Classifying only the dial would report those two as ordinary transport trouble and repeat them in a warn line forever. `etcd.request_timeout_ms` covers the dial a read has to make, too — with credentials that dial includes the `Authenticate` round trip, and left outside the bound it would hold the read open with no backoff, no recorded failure and `/status/config` still reporting connected.

The retryable set is an **allowlist** (`Unknown`, `DeadlineExceeded`, `Internal`, `Unavailable`, plus the transport/IO error variants). A code nobody classified therefore ends the boot rather than being waited out in silence, which is the safer direction for a class whose whole purpose is to not hide a configuration error. The codes are compared as their wire numbers so the crate does not have to depend on — and track — the exact `tonic` release `etcd-client` builds against.

## The dial bound

When `etcd.dial_timeout_ms` is set to a non-zero value it now wraps the whole of `Client::connect`, so the TLS handshake and the `Authenticate` round trip are covered rather than only the TCP connect. An expiry classifies as **cannot reach**: it is retried, not fatal. `0` and unset both still mean unbounded, unchanged from #1134 — no expired deadline is reintroduced, and there is no implicit default.

## When a refusal arrives after the boot

The boot can only exit on a refusal it is given. A gateway scheduled before its etcd takes the unreachable branch, so a refusal that lands later reaches the supervisor instead — the process is already up and serving whatever it has. It keeps retrying, and it says so at ERROR naming the credentials rather than sharing the routine backoff line with "etcd is restarting". Whether that case should terminate the process, as the boot path does, is deliberately left as it is here.

## Known limits

- **A dial with no bound at all still hangs the boot.** With `etcd.dial_timeout_ms` unset (the shipped default, where unset and `0` both mean unbounded) and an endpoint that completes TCP and then goes silent, `Client::connect` never returns and the boot blocks before any listener binds. That is the behaviour on `main` today and this PR does not change it; setting the key is what closes it. Giving the boot dial an implicit bound would contradict the "no implicit default" rule the two timeout keys were given, so it is not done here.
- **A connection, once established, is never re-authenticated.** etcd-client authenticates inside `Client::connect` only, so a token invalidated by an etcd restart stays invalid until the process restarts — unchanged from before this PR, and the subject of separate in-flight work. What changes is that such a refusal is now reported as one, at ERROR, instead of as a generic transport warning.
- **Managed mode sets no `etcd.user`**, so its dial performs no I/O and none of the credential classification applies to it; its etcd identity is the mTLS bundle, whose failures are TLS handshake failures and therefore retried.

## Also in this PR

The admin read surface opens a second etcd connection, and it had the identical boot-fatal dial: with credentials configured, `admin.enabled` alone could end the boot on an unreachable etcd. It is now established on the first read that needs it, through the same shared lazy connection type, so that path cannot reintroduce the exit this removes.

## Behaviour changes

- An authenticated gateway no longer exits when etcd is unreachable at boot. It starts, logs `etcd is not reachable yet …`, keeps the proxy listener closed, and binds when a configuration arrives. Anything that relied on the process exiting to signal "etcd is down" should read `/status/ready` (503 throughout) instead.
- An authenticated gateway now exits **faster** when etcd refuses the credentials: on the first answer, rather than after the 5s × 5 ladder.
- `etcd.dial_timeout_ms` bounds more than it did. A deployment that set it low enough to be exceeded by a TLS handshake or the auth round trip will now see the dial retried on the supervisor's backoff instead of completing slowly. The `config.example.yaml` / `config.managed.yaml` annotations were updated to say what it covers.
- The `export` CLI is unchanged in shape: it keeps its own eager 3 × 1s ladder, since a one-shot command has nothing to wait with. It too stops on the first refusal.

## Comparison with the mainstream gateway baseline

The mainstream gateway we take as the baseline for this area does **not** distinguish the two classes at startup, so there is no equivalent behaviour to match here. Its configuration/state store is a relational database rather than etcd, and its startup connect wraps a retry decorator that catches every exception alike — three attempts or ten seconds, whichever comes first — and then re-raises. That exception propagates out of the application's startup handler, so the process fails to start. A connection that was refused and a password the database rejected therefore take the identical path and the identical outcome; the only error inspection anywhere near it looks for migration-state markers, which is an unrelated failure mode. Its cache store sits at the other extreme: a failed connection is logged and swallowed at construction, with no retry and no exit, whatever the cause.

Our design deliberately diverges from both halves of that, and the divergence is the point of this change. Neither "exit on any store failure" nor "always degrade quietly" fits a gateway whose configuration source is the thing being connected to: exiting on an unreachable source is the bug being fixed here, since the source comes back on its own and the instance has a first-config gate built to wait for it; and swallowing a refusal would leave a gateway up, reachable, and permanently empty for a reason no operator would think to look for. Splitting on the cause gives each failure the response it actually needs.

## Tests

Every case below fails on the unfixed code; the mutation used is named with it.

**Provider level** (`crates/aisix-etcd/src/etcd_provider.rs`, `client.rs`):
- an unreachable authenticated etcd returns a provider rather than an error, inside the old ladder's own budget, and its first read reports a retryable failure — fails when the unreachable branch returns `Err`, and when `Unavailable` is classified as refused;
- the pending connection is really re-dialled, not abandoned: the endpoint comes back as a server that refuses, and the refusal reaches the caller;
- a refusal ends the connect on the first answer and carries etcd's message — fails when refusals are classified as unreachable;
- each wire status code lands on its intended side, driven by a server that really sends them (trailers-only gRPC error responses);
- the dial bound covers a TCP-accepting, never-answering endpoint — the test hangs without the outer wrap — and an unset bound leaves the dial in flight.

**Against a real authenticated etcd** (`crates/aisix-etcd/tests/auth_connect_integration.rs`, gated on `ETCD_AUTH_TEST_URL` the way the existing etcd/Redis integration tests are gated, with a new CI step starting a second cluster with authentication enabled — enabling auth is cluster-wide, so it cannot be done on the shared service):
- a wrong password against a real server is classified as refused and carries etcd's real wording;
- an etcd that was unreachable at connect time comes back, is authenticated on the retry, and the supervisor applies the seeded configuration — the recovery path end to end.

**DP e2e** (`tests/e2e/src/cases/etcd-auth-connect-e2e.test.ts`, driving the real binary through the existing etcd relay):
- an authenticated gateway pointed at a refusing endpoint does not exit: it logs the deferral, produces repeated supervisor backoff lines, keeps serving `/metrics` and keeps the proxy port closed;
- with `dial_timeout_ms` set, a TCP-accepting silent endpoint is bounded and retried rather than hanging the boot (unfixed: the binary never binds anything at all);
- credentials the cluster refuses still end the boot, promptly and by name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authenticated etcd connection support with clearer handling of unreachable services and rejected credentials.
  - Gateway startup now retries unreachable or temporarily unavailable etcd endpoints and connects when they recover.
  - etcd connections are established on demand for improved resilience.
  - Added configurable dial timeouts covering TCP, TLS, and authentication.

- **Bug Fixes**
  - Improved etcd error details and retry handling for transient connection failures.

- **Documentation**
  - Clarified timeout behavior, retry handling, and startup outcomes for etcd connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->