### PR TITLE
fix(etcd): re-authenticate when etcd rejects the connection's auth token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,11 @@ jobs:
               etcdctl endpoint health && break
               sleep 1
             done
+            # Fail here rather than let the three `etcdctl` calls below
+            # fail one at a time with a connection error that says
+            # nothing about which cluster never came up.
+            etcdctl endpoint health \
+              || { echo "::error::$name never became ready on $client"; exit 1; }
             etcdctl user add root:aisix-ci-etcd
             etcdctl user grant-role root root
             etcdctl auth enable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,21 @@ jobs:
       ETCD_AUTH_TEST_URL: http://127.0.0.1:2479
       ETCD_AUTH_TEST_USER: root
       ETCD_AUTH_TEST_PASSWORD: aisix-ci-etcd
+      # Picked up by crates/aisix-etcd/tests/auth_token_recovery.rs and
+      # crates/aisix-admin/tests/etcd_integration.rs. A THIRD cluster,
+      # authenticated like the one above but with an auth token that
+      # expires in seconds instead of the five-minute default, so a test
+      # can sit out a real expiry. Kept separate because that TTL would
+      # otherwise make every authenticated test depend on the recovery
+      # being tested, and because one test here turns authentication off
+      # and on again to make etcd discard the tokens it has issued. The
+      # container and this short-TTL approach come from community PR
+      # api7/aisix#763 (okaybase). `ETCD_AUTH_TTL_TEST_SECS` must match
+      # the `--auth-token-ttl` below — the tests sleep past it.
+      ETCD_AUTH_TTL_TEST_URL: http://127.0.0.1:2579
+      ETCD_AUTH_TTL_TEST_USER: root
+      ETCD_AUTH_TTL_TEST_PASSWORD: aisix-ci-etcd
+      ETCD_AUTH_TTL_TEST_SECS: 5
     steps:
       - uses: actions/checkout@v6
         with:
@@ -169,29 +184,44 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Start an authenticated etcd
-        # Not a service container: a user has to be created and
+      - name: Start the authenticated etcds
+        # Not service containers: a user has to be created and
         # `auth enable` called after the server is up, which service
         # containers cannot do.
+        #
+        # Two of them, on 2479 and 2579. The second differs only in its
+        # `--auth-token-ttl`, short enough for a test to sit out a real
+        # token expiry; it is a cluster of its own so that TTL — and the
+        # test that makes etcd discard its tokens — cannot reach the
+        # first.
         run: |
-          docker run -d --name etcd-auth -p 2479:2479 quay.io/coreos/etcd:v3.5.18 \
-            /usr/local/bin/etcd --name auth1 \
-            --listen-client-urls http://0.0.0.0:2479 \
-            --advertise-client-urls http://127.0.0.1:2479 \
-            --listen-peer-urls http://0.0.0.0:2480 \
-            --initial-advertise-peer-urls http://127.0.0.1:2480 \
-            --initial-cluster auth1=http://127.0.0.1:2480
-          for _ in $(seq 30); do
-            docker exec -e ETCDCTL_API=3 -e ETCDCTL_ENDPOINTS=http://127.0.0.1:2479 \
-              etcd-auth etcdctl endpoint health && break
-            sleep 1
-          done
-          docker exec -e ETCDCTL_API=3 -e ETCDCTL_ENDPOINTS=http://127.0.0.1:2479 \
-            etcd-auth etcdctl user add root:aisix-ci-etcd
-          docker exec -e ETCDCTL_API=3 -e ETCDCTL_ENDPOINTS=http://127.0.0.1:2479 \
-            etcd-auth etcdctl user grant-role root root
-          docker exec -e ETCDCTL_API=3 -e ETCDCTL_ENDPOINTS=http://127.0.0.1:2479 \
-            etcd-auth etcdctl auth enable
+          start_auth_etcd() {
+            name=$1
+            client=$2
+            peer=$3
+            shift 3
+            docker run -d --name "$name" -p "$client:$client" quay.io/coreos/etcd:v3.5.18 \
+              /usr/local/bin/etcd --name "$name" "$@" \
+              --listen-client-urls "http://0.0.0.0:$client" \
+              --advertise-client-urls "http://127.0.0.1:$client" \
+              --listen-peer-urls "http://0.0.0.0:$peer" \
+              --initial-advertise-peer-urls "http://127.0.0.1:$peer" \
+              --initial-cluster "$name=http://127.0.0.1:$peer"
+            etcdctl() {
+              docker exec -e ETCDCTL_API=3 -e ETCDCTL_ENDPOINTS="http://127.0.0.1:$client" \
+                "$name" etcdctl "$@"
+            }
+            for _ in $(seq 30); do
+              etcdctl endpoint health && break
+              sleep 1
+            done
+            etcdctl user add root:aisix-ci-etcd
+            etcdctl user grant-role root root
+            etcdctl auth enable
+          }
+          start_auth_etcd etcd-auth 2479 2480
+          # Keep in step with ETCD_AUTH_TTL_TEST_SECS above.
+          start_auth_etcd etcd-auth-ttl 2579 2580 --auth-token-ttl 5
       - name: Start Redis Cluster + Sentinel
         # The `redis` service above covers single-node. Here we bring up a
         # 3-node cluster (7000-7002) and a sentinel (26379) monitoring the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,15 +156,17 @@ jobs:
       ETCD_AUTH_TEST_PASSWORD: aisix-ci-etcd
       # Picked up by crates/aisix-etcd/tests/auth_token_recovery.rs and
       # crates/aisix-admin/tests/etcd_integration.rs. A THIRD cluster,
-      # authenticated like the one above but with an auth token that
-      # expires in seconds instead of the five-minute default, so a test
-      # can sit out a real expiry. Kept separate because that TTL would
-      # otherwise make every authenticated test depend on the recovery
-      # being tested, and because one test here turns authentication off
-      # and on again to make etcd discard the tokens it has issued. The
-      # container and this short-TTL approach come from community PR
+      # authenticated like the one above but differing in two ways that
+      # the token-recovery tests need and that no other test should have
+      # to live with: its tokens expire in seconds instead of the
+      # five-minute default, so a test can sit out a real expiry; and it
+      # runs `--auth-token jwt` instead of the default `simple`, which is
+      # the only mode in which an auth-store revision change refuses a
+      # token that was already issued. Tests here also change that auth
+      # store, which stales every token the cluster has handed out. The
+      # container and this short-lifetime approach come from community PR
       # api7/aisix#763 (okaybase). `ETCD_AUTH_TTL_TEST_SECS` must match
-      # the `--auth-token-ttl` below — the tests sleep past it.
+      # the `ttl=` below — the tests sleep past it.
       ETCD_AUTH_TTL_TEST_URL: http://127.0.0.1:2579
       ETCD_AUTH_TTL_TEST_USER: root
       ETCD_AUTH_TTL_TEST_PASSWORD: aisix-ci-etcd
@@ -189,18 +191,25 @@ jobs:
         # `auth enable` called after the server is up, which service
         # containers cannot do.
         #
-        # Two of them, on 2479 and 2579. The second differs only in its
-        # `--auth-token-ttl`, short enough for a test to sit out a real
-        # token expiry; it is a cluster of its own so that TTL — and the
-        # test that makes etcd discard its tokens — cannot reach the
-        # first.
+        # Two of them, on 2479 and 2579. The second issues JWT tokens
+        # with a lifetime short enough for a test to sit out a real
+        # expiry. It is a cluster of its own so that neither that
+        # lifetime, nor the auth-store changes those tests make, can
+        # reach the first.
         run: |
+          # Signing key for the JWT cluster below. Generated per run and
+          # thrown away with the runner: it authenticates nothing outside
+          # this job.
+          mkdir -p /tmp/etcd-jwt
+          openssl genpkey -algorithm RSA -out /tmp/etcd-jwt/jwt.key -pkeyopt rsa_keygen_bits:2048
+          openssl rsa -in /tmp/etcd-jwt/jwt.key -pubout -out /tmp/etcd-jwt/jwt.pub
           start_auth_etcd() {
             name=$1
             client=$2
             peer=$3
             shift 3
-            docker run -d --name "$name" -p "$client:$client" quay.io/coreos/etcd:v3.5.18 \
+            docker run -d --name "$name" -p "$client:$client" -v /tmp/etcd-jwt:/keys \
+              quay.io/coreos/etcd:v3.5.18 \
               /usr/local/bin/etcd --name "$name" "$@" \
               --listen-client-urls "http://0.0.0.0:$client" \
               --advertise-client-urls "http://127.0.0.1:$client" \
@@ -225,8 +234,9 @@ jobs:
             etcdctl auth enable
           }
           start_auth_etcd etcd-auth 2479 2480
-          # Keep in step with ETCD_AUTH_TTL_TEST_SECS above.
-          start_auth_etcd etcd-auth-ttl 2579 2580 --auth-token-ttl 5
+          # Keep `ttl=` in step with ETCD_AUTH_TTL_TEST_SECS above.
+          start_auth_etcd etcd-auth-ttl 2579 2580 \
+            --auth-token 'jwt,pub-key=/keys/jwt.pub,priv-key=/keys/jwt.key,sign-method=RS256,ttl=5s'
       - name: Start Redis Cluster + Sentinel
         # The `redis` service above covers single-node. Here we bring up a
         # 3-node cluster (7000-7002) and a sentinel (26379) monitoring the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -24,7 +24,7 @@ use aisix_core::{
     A2aAgent, ApiKey, CachePolicy, Guardrail, McpServer, Model, ObservabilityExporter,
     PassthroughRoute, ProviderKey,
 };
-use aisix_etcd::LazyEtcdClient;
+use aisix_etcd::{kv_client, CallError, LazyEtcdClient};
 use etcd_client::GetOptions;
 use serde::de::DeserializeOwned;
 use std::sync::Arc;
@@ -83,18 +83,6 @@ impl EtcdConfigStore {
         }
     }
 
-    /// The KV sub-client for one read, connecting first when the boot
-    /// dial had not reached etcd yet. Under the same `request_timeout`
-    /// as the read itself: with etcd credentials configured the dial
-    /// includes an `Authenticate` round trip, and an endpoint that
-    /// accepts TCP and answers nothing would otherwise hang the admin
-    /// request — and every other read behind this client's connect.
-    async fn kv(&self) -> Result<etcd_client::KvClient, StoreError> {
-        self.bound(self.client.kv())
-            .await?
-            .map_err(|e| StoreError::Backend(e.to_string()))
-    }
-
     pub fn prefix(&self) -> &str {
         &self.prefix
     }
@@ -115,29 +103,50 @@ impl EtcdConfigStore {
         full_key.strip_prefix(&needle)
     }
 
-    /// Apply `request_timeout`, when set, to one in-flight read.
-    async fn bound<T>(&self, fut: impl std::future::Future<Output = T>) -> Result<T, StoreError> {
-        match self.request_timeout {
-            None => Ok(fut.await),
-            Some(d) => tokio::time::timeout(d, fut).await.map_err(|_| {
-                StoreError::Backend(format!(
-                    "etcd read exceeded etcd.request_timeout_ms ({} ms)",
-                    d.as_millis()
-                ))
-            }),
-        }
+    /// One read against etcd, through the connection this store shares
+    /// with the config provider.
+    ///
+    /// Everything the admin GET surface reads goes through here, for two
+    /// reasons that are easy to lose if a call site is written by hand.
+    /// `request_timeout` bounds the read *and* the dial it may have to
+    /// make first — with etcd credentials configured that dial includes
+    /// an `Authenticate` round trip, and an endpoint that accepts TCP and
+    /// answers nothing would otherwise hang the admin request and every
+    /// other read queued behind the same connect. And a token etcd has
+    /// forgotten — it restarted, or `--auth-token-ttl` elapsed while the
+    /// admin listener was idle, which is exactly when it does — is
+    /// re-authenticated and retried instead of failing every admin read
+    /// until the gateway is restarted.
+    async fn read<T, F, Fut>(&self, op: F) -> Result<T, StoreError>
+    where
+        F: FnMut(etcd_client::Client) -> Fut,
+        Fut: std::future::Future<Output = Result<T, etcd_client::Error>>,
+    {
+        self.client
+            .call(self.request_timeout, op)
+            .await
+            .map_err(|err| match err {
+                CallError::ConnectTimeout(d) | CallError::CallTimeout(d) => {
+                    StoreError::Backend(format!(
+                        "etcd read exceeded etcd.request_timeout_ms ({} ms)",
+                        d.as_millis()
+                    ))
+                }
+                CallError::Connect(err) => StoreError::Backend(err.to_string()),
+                CallError::Call(err) => StoreError::Backend(err.to_string()),
+            })
     }
 
     async fn get_one<T: DeserializeOwned>(
         &self,
         key: &str,
     ) -> Result<Option<(T, i64)>, StoreError> {
-        let resp = {
-            let mut client = self.kv().await?;
-            self.bound(client.get(key.as_bytes().to_vec(), None))
-                .await?
-        }
-        .map_err(|e| StoreError::Backend(e.to_string()))?;
+        let resp = self
+            .read(move |client| {
+                let key = key.as_bytes().to_vec();
+                async move { kv_client(&client).get(key, None).await }
+            })
+            .await?;
         let kv = match resp.kvs().first() {
             Some(kv) => kv,
             None => return Ok(None),
@@ -152,17 +161,18 @@ impl EtcdConfigStore {
         kind: &str,
     ) -> Result<Vec<(String, T, i64)>, StoreError> {
         let prefix = self.range_prefix(kind);
-        // Scoped so the bound covers the call and not the decode loop
-        // below, which is where it sat before the bound was introduced.
-        let resp = {
-            let mut client = self.kv().await?;
-            self.bound(client.get(
-                prefix.as_bytes().to_vec(),
-                Some(GetOptions::new().with_prefix()),
-            ))
-            .await?
-        }
-        .map_err(|e| StoreError::Backend(e.to_string()))?;
+        // The bound covers the call and not the decode loop below,
+        // which is where it sat before the bound was introduced.
+        let resp = self
+            .read(move |client| {
+                let prefix = prefix.as_bytes().to_vec();
+                async move {
+                    kv_client(&client)
+                        .get(prefix, Some(GetOptions::new().with_prefix()))
+                        .await
+                }
+            })
+            .await?;
 
         let mut out = Vec::with_capacity(resp.kvs().len());
         for kv in resp.kvs() {

--- a/crates/aisix-admin/src/etcd_store.rs
+++ b/crates/aisix-admin/src/etcd_store.rs
@@ -103,8 +103,11 @@ impl EtcdConfigStore {
         full_key.strip_prefix(&needle)
     }
 
-    /// One read against etcd, through the connection this store shares
-    /// with the config provider.
+    /// One read against etcd, on this store's own connection — separate
+    /// from the config provider's, so neither queues behind the other's
+    /// connect (`aisix-server` builds the two deliberately). Each
+    /// recovers on its own, and this is where that happens for the admin
+    /// side.
     ///
     /// Everything the admin GET surface reads goes through here, for two
     /// reasons that are easy to lose if a call site is written by hand.
@@ -113,8 +116,8 @@ impl EtcdConfigStore {
     /// an `Authenticate` round trip, and an endpoint that accepts TCP and
     /// answers nothing would otherwise hang the admin request and every
     /// other read queued behind the same connect. And a token etcd has
-    /// forgotten — it restarted, or `--auth-token-ttl` elapsed while the
-    /// admin listener was idle, which is exactly when it does — is
+    /// stopped holding — `--auth-token-ttl` elapses while the admin
+    /// listener is idle, which is what an admin listener mostly is — is
     /// re-authenticated and retried instead of failing every admin read
     /// until the gateway is restarted.
     async fn read<T, F, Fut>(&self, op: F) -> Result<T, StoreError>

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -604,3 +604,97 @@ async fn loader_picks_up_every_direct_write() {
     assert_eq!(snap.mcp_servers.len(), 1);
     assert_eq!(snap.a2a_agents.len(), 1);
 }
+
+/// The admin read path against an etcd whose auth token stops working
+/// under it.
+///
+/// `etcd-client` authenticates once, inside `Client::connect`, and never
+/// again, so the token a store dialled with is the only one it will ever
+/// have. An admin listener is idle for long stretches by nature — nobody
+/// is calling `GET /apisix/admin/models` every second — which is exactly
+/// the state in which etcd's `--auth-token-ttl` elapses. Every later
+/// admin read was then refused until the gateway was restarted.
+///
+/// Bracketed by `ETCD_AUTH_TTL_TEST_URL`, the short-TTL authenticated
+/// cluster `.github/workflows/ci.yml` starts (the container and the
+/// short-TTL approach come from community PR api7/aisix#763, `okaybase`);
+/// no-ops when it is unset, like every other integration test here.
+#[tokio::test]
+async fn admin_reads_survive_a_token_the_server_forgets() {
+    let (Ok(url), Ok(user), Ok(password), Ok(ttl)) = (
+        std::env::var("ETCD_AUTH_TTL_TEST_URL"),
+        std::env::var("ETCD_AUTH_TTL_TEST_USER"),
+        std::env::var("ETCD_AUTH_TTL_TEST_PASSWORD"),
+        std::env::var("ETCD_AUTH_TTL_TEST_SECS"),
+    ) else {
+        eprintln!("skipping: ETCD_AUTH_TTL_TEST_URL not set");
+        return;
+    };
+    let ttl: u64 = ttl.parse().expect("ETCD_AUTH_TTL_TEST_SECS is a number");
+    let credentials =
+        || Some(etcd_client::ConnectOptions::new().with_user(user.clone(), password.clone()));
+
+    let prefix = unique_prefix();
+    let mut writer = etcd_client::Client::connect([url.clone()], credentials())
+        .await
+        .expect("seed client");
+    seed(
+        &mut writer,
+        &prefix,
+        "models",
+        "m-token",
+        &json!({
+            "display_name": "token-it",
+            "provider": "openai",
+            "model_name": "gpt-4o-mini",
+            "provider_key_id": "11111111-1111-1111-1111-111111111111"
+        }),
+    )
+    .await;
+
+    let store = EtcdConfigStore::new(
+        Arc::new(aisix_etcd::LazyEtcdClient::new(
+            vec![url.clone()],
+            credentials(),
+            Some(std::time::Duration::from_secs(10)),
+        )),
+        &prefix,
+        Some(std::time::Duration::from_secs(10)),
+    );
+    assert_eq!(
+        store
+            .list_models()
+            .await
+            .expect("the first read works")
+            .len(),
+        1,
+    );
+
+    // etcd's token TTL is refreshed by use, so it is only ever an idle
+    // admin listener that reaches it — which is the failure as reported.
+    tokio::time::sleep(std::time::Duration::from_secs(ttl + 4)).await;
+
+    let models = store
+        .list_models()
+        .await
+        .expect("an expired token must be replaced, not fail the admin read");
+    assert_eq!(
+        models.len(),
+        1,
+        "the read after re-authenticating must return the same configuration",
+    );
+    assert_eq!(models[0].id, "m-token");
+
+    // A writer of its own: this one's token expired during the sleep too,
+    // and nothing re-authenticates a bare `etcd_client::Client`.
+    let mut writer = etcd_client::Client::connect([url], credentials())
+        .await
+        .expect("cleanup client");
+    writer
+        .delete(
+            format!("{prefix}/models/m-token"),
+            Some(DeleteOptions::new().with_prefix()),
+        )
+        .await
+        .expect("cleanup");
+}

--- a/crates/aisix-etcd/Cargo.toml
+++ b/crates/aisix-etcd/Cargo.toml
@@ -34,3 +34,7 @@ http.workspace = true
 # `test-util` drives the shutdown-drain bound on a paused clock, so the
 # test asserts the bound without spending it.
 tokio = { workspace = true, features = ["test-util"] }
+# Captures the log lines a test asserts on — the periodic "still
+# connecting" line is the whole of what a hanging boot dial produces, so
+# it is asserted on directly rather than through its effects.
+tracing-subscriber.workspace = true

--- a/crates/aisix-etcd/src/client.rs
+++ b/crates/aisix-etcd/src/client.rs
@@ -170,12 +170,18 @@ impl ConnectError {
 /// by every later call (`Unauthenticated`). Classifying only the dial
 /// would report those as ordinary transport trouble.
 ///
-/// The `Unauthenticated` / `InvalidArgument` split is the whole safety
-/// condition behind re-authenticating: etcd answers a wrong user or
-/// password on `Authenticate` with `InvalidArgument`, and reserves
-/// `Unauthenticated` for a token it does not recognise (`etcdserver:
-/// invalid auth token`). So a credential etcd has refused can never
-/// reach the retry path, however many times it is presented.
+/// This is what the safety condition behind re-authenticating rests on.
+/// A wrong user or password is answered on `Authenticate` with
+/// `InvalidArgument` (`etcdserver: authentication failed, invalid user ID
+/// or password`) and a user without the rights with `PermissionDenied`,
+/// so neither can reach the retry path however many times it is
+/// presented. `Unauthenticated` is what etcd answers a token it does not
+/// recognise (`etcdserver: invalid auth token`), and that is the only
+/// code routed there.
+///
+/// Note the implication does not run backwards: `InvalidArgument` covers
+/// more than refused credentials, and telling its members apart would
+/// take the message text rather than the code.
 pub(crate) fn classify(err: &EtcdError) -> ConnectError {
     let detail = format_etcd_error(err);
     match err {

--- a/crates/aisix-etcd/src/client.rs
+++ b/crates/aisix-etcd/src/client.rs
@@ -9,6 +9,8 @@
 
 use etcd_client::{Client, ConnectOptions, Error as EtcdError, KvClient, WatchClient};
 use std::error::Error as StdError;
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::sync::Mutex;
 
@@ -104,6 +106,19 @@ pub enum ConnectError {
     /// these, so they are fatal at boot.
     #[error("etcd refused the connection: {0}")]
     Rejected(String),
+    /// etcd answered and refused *the token this connection is using*,
+    /// not the configured credentials: the gateway authenticated once
+    /// and etcd has since forgotten that token — it restarted (the token
+    /// store is in memory), or the token's `--auth-token-ttl` elapsed.
+    ///
+    /// Kept apart from [`Self::Rejected`] because the two need opposite
+    /// handling. A refused credential never becomes a good one, so
+    /// waiting on it is what turns a typo into a permanently empty
+    /// gateway. A forgotten token is cured by the one thing the gateway
+    /// has not done since it started: authenticate again. See
+    /// [`LazyEtcdClient::call`].
+    #[error("etcd rejected the connection's auth token: {0}")]
+    Unauthenticated(String),
 }
 
 /// Canonical gRPC status codes, as sent on the wire
@@ -117,6 +132,7 @@ const GRPC_RESOURCE_EXHAUSTED: i32 = 8;
 const GRPC_ABORTED: i32 = 10;
 const GRPC_INTERNAL: i32 = 13;
 const GRPC_UNAVAILABLE: i32 = 14;
+const GRPC_UNAUTHENTICATED: i32 = 16;
 
 impl ConnectError {
     /// The flattened cause, without this type's own framing — so a
@@ -124,7 +140,9 @@ impl ConnectError {
     /// two prefixes in front of what etcd actually said.
     pub fn detail(&self) -> &str {
         match self {
-            Self::Unreachable(detail) | Self::Rejected(detail) => detail,
+            Self::Unreachable(detail) | Self::Rejected(detail) | Self::Unauthenticated(detail) => {
+                detail
+            }
         }
     }
 }
@@ -147,6 +165,13 @@ impl ConnectError {
 /// (`PermissionDenied`), and a token invalidated by an etcd restart is
 /// refused by every later call (`Unauthenticated`). Classifying only the
 /// dial would report those as ordinary transport trouble.
+///
+/// The `Unauthenticated` / `InvalidArgument` split is the whole safety
+/// condition behind re-authenticating: etcd answers a wrong user or
+/// password on `Authenticate` with `InvalidArgument`, and reserves
+/// `Unauthenticated` for a token it does not recognise (`etcdserver:
+/// invalid auth token`). So a credential etcd has refused can never
+/// reach the retry path, however many times it is presented.
 pub(crate) fn classify(err: &EtcdError) -> ConnectError {
     let detail = format_etcd_error(err);
     match err {
@@ -172,6 +197,11 @@ pub(crate) fn classify(err: &EtcdError) -> ConnectError {
             | GRPC_CANCELLED
             | GRPC_ABORTED
             | GRPC_RESOURCE_EXHAUSTED => ConnectError::Unreachable(detail),
+            // etcd knows the call arrived with a token it no longer
+            // holds — it restarted, or the token's TTL elapsed. The
+            // configured credentials are not what it is complaining
+            // about, so this one heals by authenticating again.
+            GRPC_UNAUTHENTICATED => ConnectError::Unauthenticated(detail),
             // Everything else is etcd having evaluated the request and
             // said no: `InvalidArgument` for a wrong user or password,
             // `PermissionDenied` for a user without the rights,
@@ -182,6 +212,75 @@ pub(crate) fn classify(err: &EtcdError) -> ConnectError {
         // Unparseable endpoints, an empty endpoint list, a bad header
         // value: configuration, not reachability.
         _ => ConnectError::Rejected(detail),
+    }
+}
+
+/// Why one [`LazyEtcdClient::call`] attempt failed.
+///
+/// Split by step so a caller can attribute it in its own error type: the
+/// connect and the call it carries are separate lines in an operator's
+/// log, and each carries a different one of the two `etcd.*_timeout_ms`
+/// keys.
+#[derive(Debug, thiserror::Error)]
+pub enum CallError {
+    /// The connection could not be established.
+    #[error(transparent)]
+    Connect(ConnectError),
+    /// Establishing the connection outran the caller's bound.
+    #[error("etcd connect exceeded its bound ({} ms)", .0.as_millis())]
+    ConnectTimeout(Duration),
+    /// The connection was there and etcd failed the call.
+    #[error("{0}")]
+    Call(EtcdError),
+    /// The call outran the caller's bound.
+    #[error("the etcd call exceeded its bound ({} ms)", .0.as_millis())]
+    CallTimeout(Duration),
+}
+
+/// How often a dial that has not finished says so.
+///
+/// Mirrors `FIRST_CONFIG_WAIT_LOG_INTERVAL` in `aisix-server`, which
+/// reports the other half of the same wait: that gate explains why the
+/// proxy listener is still closed, this one explains why no configuration
+/// has arrived to open it.
+const DIAL_WAIT_LOG_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Run `fut`, saying every `interval` that it has not finished yet.
+///
+/// What this closes is a silence, not a hang. `Client::connect` waits for
+/// the `Authenticate` round trip, and against an endpoint that accepts the
+/// TCP connection and then answers nothing it waits for as long as
+/// `etcd.dial_timeout_ms` allows — unset, the shipped default, means
+/// forever. The gateway is then stuck before any listener binds and, until
+/// this, wrote not one line about it: an operator saw a process with no
+/// port and no explanation. The bound itself is deliberately unchanged;
+/// this only makes the wait visible.
+///
+/// First tick one interval in, not immediately, so a healthy dial — which
+/// finishes in milliseconds — logs nothing at all.
+async fn announce_while_pending<T>(
+    interval: Duration,
+    endpoints: &[String],
+    fut: impl Future<Output = T>,
+) -> T {
+    tokio::pin!(fut);
+    let mut ticker = tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
+    let mut waited = Duration::ZERO;
+    loop {
+        tokio::select! {
+            // `biased` so a dial that completes in the same wakeup as a
+            // tick reports success rather than one last complaint.
+            biased;
+            outcome = &mut fut => return outcome,
+            _ = ticker.tick() => {
+                waited += interval;
+                tracing::warn!(
+                    endpoints = ?endpoints,
+                    waited_secs = waited.as_secs(),
+                    "still connecting to etcd — no configuration can be read until it answers",
+                );
+            }
+        }
     }
 }
 
@@ -205,7 +304,22 @@ pub struct LazyEtcdClient {
     /// goes silent would otherwise hang the dial with no bound at all.
     /// `None` — the default, and what `0` means — leaves it unbounded.
     dial_timeout: Option<Duration>,
-    connected: Mutex<Option<Client>>,
+    connected: Mutex<Option<Connected>>,
+    /// Handed to the next connection [`LazyEtcdClient::dial`] establishes.
+    /// See [`Connected::generation`].
+    next_generation: AtomicU64,
+}
+
+/// One established connection, tagged so a caller whose call etcd refused
+/// can ask for *that* connection to be replaced.
+struct Connected {
+    client: Client,
+    /// Which dial produced this connection. A burst of calls that all
+    /// failed on the same invalidated token quote the same generation, so
+    /// the first to arrive replaces it and the rest see a connection that
+    /// is already newer than the one they failed on and reuse it — one
+    /// re-authentication for the burst, not one per call.
+    generation: u64,
 }
 
 impl std::fmt::Debug for LazyEtcdClient {
@@ -227,6 +341,7 @@ impl LazyEtcdClient {
             options,
             dial_timeout,
             connected: Mutex::new(None),
+            next_generation: AtomicU64::new(0),
         }
     }
 
@@ -235,35 +350,115 @@ impl LazyEtcdClient {
     /// it before anything else is started. A successful dial is cached
     /// like any other.
     pub async fn connect_now(&self) -> Result<(), ConnectError> {
-        self.client().await.map(|_| ())
+        self.connection().await.map(|_| ())
     }
 
-    /// The connection, dialling if this is the first call to get there.
+    /// The connection, dialling if this is the first call to get there,
+    /// and the generation it belongs to — what [`Self::invalidate`] needs
+    /// to replace exactly this connection.
     ///
     /// The lock is held across the dial on purpose: concurrent first
     /// calls wait for the one dial rather than opening a connection each.
-    pub async fn client(&self) -> Result<Client, ConnectError> {
+    async fn connection(&self) -> Result<(Client, u64), ConnectError> {
         let mut slot = self.connected.lock().await;
-        if let Some(client) = slot.as_ref() {
-            return Ok(client.clone());
+        if let Some(connected) = slot.as_ref() {
+            return Ok((connected.client.clone(), connected.generation));
         }
         let client = self.dial().await?;
-        *slot = Some(client.clone());
-        Ok(client)
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        *slot = Some(Connected {
+            client: client.clone(),
+            generation,
+        });
+        Ok((client, generation))
     }
 
-    /// KV sub-client for reads, under [`MAX_DECODING_MESSAGE_SIZE`].
-    pub async fn kv(&self) -> Result<KvClient, ConnectError> {
-        Ok(kv_client(&self.client().await?))
+    /// Discard the connection `stale` names so the next call dials a new
+    /// one, which authenticates on the way in.
+    ///
+    /// A no-op once someone else has already replaced that generation —
+    /// see [`Connected::generation`].
+    async fn invalidate(&self, stale: u64) {
+        let mut slot = self.connected.lock().await;
+        if slot.as_ref().is_some_and(|c| c.generation == stale) {
+            *slot = None;
+        }
     }
 
-    /// Watch sub-client, under [`MAX_DECODING_MESSAGE_SIZE`].
-    pub async fn watch(&self) -> Result<WatchClient, ConnectError> {
-        Ok(watch_client(&self.client().await?))
+    /// Run one etcd call on the shared connection, authenticating again
+    /// and retrying it **once** if etcd rejects the connection's auth
+    /// token.
+    ///
+    /// This is how a gateway survives an etcd restart or an elapsed
+    /// `--auth-token-ttl`: `etcd-client` authenticates inside
+    /// `Client::connect` and never again, so the token this connection
+    /// carries is the only one it will ever have, and once etcd forgets
+    /// it every later call is refused until the process is restarted.
+    /// Rebuilding the client is what re-runs `Authenticate`.
+    ///
+    /// The retry is bounded at one attempt, and reached only from
+    /// [`ConnectError::Unauthenticated`] — never from
+    /// [`ConnectError::Rejected`]. Credentials etcd has refused
+    /// therefore fail on the first answer, exactly as they did before:
+    /// a wrong password cannot spin here, and neither can a token etcd
+    /// keeps refusing, which surfaces after the second attempt.
+    ///
+    /// `timeout` bounds each attempt — the dial and the call separately,
+    /// as [`CallError`]'s two timeout variants say — rather than the pair
+    /// of them together, so a re-authenticated retry gets the same window
+    /// the original call had instead of whatever was left of it.
+    pub async fn call<T, F, Fut>(
+        &self,
+        timeout: Option<Duration>,
+        mut op: F,
+    ) -> Result<T, CallError>
+    where
+        F: FnMut(Client) -> Fut,
+        Fut: Future<Output = Result<T, EtcdError>>,
+    {
+        let mut reauthenticated = false;
+        loop {
+            let (client, generation) = match timeout {
+                None => self.connection().await,
+                Some(d) => tokio::time::timeout(d, self.connection())
+                    .await
+                    .map_err(|_| CallError::ConnectTimeout(d))?,
+            }
+            .map_err(CallError::Connect)?;
+
+            let call = op(client);
+            let outcome = match timeout {
+                None => call.await,
+                Some(d) => tokio::time::timeout(d, call)
+                    .await
+                    .map_err(|_| CallError::CallTimeout(d))?,
+            };
+
+            match outcome {
+                Ok(value) => return Ok(value),
+                Err(err) if !reauthenticated => {
+                    let ConnectError::Unauthenticated(detail) = classify(&err) else {
+                        return Err(CallError::Call(err));
+                    };
+                    tracing::info!(
+                        error = %detail,
+                        "etcd no longer accepts this connection's auth token — \
+                         authenticating again and retrying",
+                    );
+                    self.invalidate(generation).await;
+                    reauthenticated = true;
+                }
+                Err(err) => return Err(CallError::Call(err)),
+            }
+        }
     }
 
     async fn dial(&self) -> Result<Client, ConnectError> {
-        let connect = Client::connect(&self.endpoints, self.options.clone());
+        let connect = announce_while_pending(
+            DIAL_WAIT_LOG_INTERVAL,
+            &self.endpoints,
+            Client::connect(&self.endpoints, self.options.clone()),
+        );
         let outcome = match self.dial_timeout {
             None => connect.await,
             Some(d) => match tokio::time::timeout(d, connect).await {
@@ -363,5 +558,268 @@ mod tests {
     fn a_local_io_failure_is_reachability_not_refusal() {
         let err = EtcdError::IoError(std::io::Error::other("connection reset by peer"));
         assert!(matches!(classify(&err), ConnectError::Unreachable(_)));
+    }
+}
+
+#[cfg(test)]
+mod reauth_tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    /// A server that answers each call with the next gRPC status in its
+    /// script — trailers-only, which is how a real server reports a
+    /// refusal — and counts both the calls it was asked and the TCP
+    /// connections it was asked them on.
+    ///
+    /// The connection count is what separates "the call was retried" from
+    /// "the client was rebuilt": re-authenticating means a new
+    /// `Client::connect`, and a new `Client::connect` means a second
+    /// connection here. A retry on the same channel would carry the same
+    /// token and change nothing.
+    struct ScriptedEtcd {
+        endpoint: String,
+        connections: Arc<AtomicUsize>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    async fn spawn_scripted_etcd(script: &[(u16, &'static str)]) -> ScriptedEtcd {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connections = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let remaining = Arc::new(StdMutex::new(script.to_vec()));
+        let (conns, reqs) = (connections.clone(), calls.clone());
+        tokio::spawn(async move {
+            while let Ok((socket, _)) = listener.accept().await {
+                conns.fetch_add(1, Ordering::Relaxed);
+                let (reqs, remaining) = (reqs.clone(), remaining.clone());
+                tokio::spawn(async move {
+                    let Ok(mut conn) = h2::server::handshake(socket).await else {
+                        return;
+                    };
+                    while let Some(Ok((_req, mut respond))) = conn.accept().await {
+                        reqs.fetch_add(1, Ordering::Relaxed);
+                        let mut script = remaining.lock().unwrap();
+                        // Past the end of the script the server keeps
+                        // answering, so an unexpected extra call shows up
+                        // as a count rather than as a hang.
+                        let (code, message) = if script.is_empty() {
+                            (14, "off the end of the script")
+                        } else {
+                            script.remove(0)
+                        };
+                        drop(script);
+                        let response = http::Response::builder()
+                            .status(200)
+                            .header("content-type", "application/grpc")
+                            .header("grpc-status", code.to_string())
+                            .header("grpc-message", message)
+                            .body(())
+                            .unwrap();
+                        let _ = respond.send_response(response, true);
+                    }
+                });
+            }
+        });
+        ScriptedEtcd {
+            endpoint: format!("http://{addr}"),
+            connections,
+            calls,
+        }
+    }
+
+    /// One range read through [`LazyEtcdClient::call`], unbounded.
+    ///
+    /// No credentials, so `Client::connect` performs no I/O and every
+    /// answer in the script lands on the read — the shape a token that
+    /// went stale after the dial has.
+    async fn read_once(endpoint: &str) -> Result<(), CallError> {
+        let client = LazyEtcdClient::new(vec![endpoint.to_string()], None, None);
+        client
+            .call(None, |c| async move {
+                kv_client(&c).get("/aisix", None).await.map(|_| ())
+            })
+            .await
+    }
+
+    #[tokio::test]
+    async fn a_stale_token_is_retried_on_a_freshly_authenticated_connection() {
+        // etcd forgot the token this connection authenticated with — it
+        // restarted, or `--auth-token-ttl` elapsed. Nothing about the
+        // configured credentials changed, and `etcd-client` never
+        // authenticates again on its own, so without rebuilding the
+        // client every later call is refused until the gateway is
+        // restarted. The second answer is `Unavailable` only so the
+        // retry is distinguishable from the first attempt.
+        let etcd = spawn_scripted_etcd(&[
+            (16, "etcdserver: invalid auth token"),
+            (14, "etcdserver: no leader"),
+        ])
+        .await;
+
+        let err = read_once(&etcd.endpoint)
+            .await
+            .expect_err("both scripted answers are failures");
+        let CallError::Call(err) = err else {
+            panic!("the server answered, so this is a call failure: {err:?}");
+        };
+        assert!(
+            matches!(classify(&err), ConnectError::Unreachable(_)),
+            "the retry's own answer is what surfaces, not the stale token: {err:?}",
+        );
+        assert_eq!(
+            etcd.calls.load(Ordering::Relaxed),
+            2,
+            "a stale token must be retried exactly once",
+        );
+        assert_eq!(
+            etcd.connections.load(Ordering::Relaxed),
+            2,
+            "the retry must run on a new connection — that is what re-authenticates",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_token_etcd_keeps_refusing_stops_after_one_retry() {
+        // The safety condition, at the mechanism: however etcd came to
+        // refuse the token, one re-authentication is all it gets. A
+        // second refusal ends the call instead of dialling again.
+        let etcd = spawn_scripted_etcd(&[
+            (16, "etcdserver: invalid auth token"),
+            (16, "etcdserver: invalid auth token"),
+        ])
+        .await;
+
+        let err = read_once(&etcd.endpoint).await.expect_err("both refuse");
+        let CallError::Call(err) = err else {
+            panic!("the server answered, so this is a call failure: {err:?}");
+        };
+        assert!(matches!(classify(&err), ConnectError::Unauthenticated(_)));
+        assert_eq!(
+            etcd.calls.load(Ordering::Relaxed),
+            2,
+            "re-authenticating must not become a loop",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refused_credential_is_answered_once_and_never_retried() {
+        // The other half of the safety condition, and the reason the
+        // split is on the status code: etcd answers a wrong user or
+        // password with `InvalidArgument`, never with `Unauthenticated`.
+        // So a credential it has refused fails on the first answer, as
+        // it did before any of this — no re-authentication, no second
+        // connection, nothing for an operator's typo to spin on.
+        let etcd = spawn_scripted_etcd(&[(
+            3,
+            "etcdserver: authentication failed, invalid user ID or password",
+        )])
+        .await;
+
+        let err = read_once(&etcd.endpoint).await.expect_err("refused");
+        let CallError::Call(err) = err else {
+            panic!("the server answered, so this is a call failure: {err:?}");
+        };
+        assert!(
+            matches!(classify(&err), ConnectError::Rejected(_)),
+            "a refused credential must stay refused: {err:?}",
+        );
+        assert_eq!(
+            etcd.calls.load(Ordering::Relaxed),
+            1,
+            "a refused credential must not be presented a second time",
+        );
+        assert_eq!(
+            etcd.connections.load(Ordering::Relaxed),
+            1,
+            "a refused credential must not cause a re-dial",
+        );
+    }
+
+    /// A writer every clone of which appends to the same buffer, so a
+    /// test can read back what was logged.
+    #[derive(Clone)]
+    struct SharedBuf(Arc<StdMutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl tracing_subscriber::fmt::MakeWriter<'_> for SharedBuf {
+        type Writer = Self;
+        fn make_writer(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn a_dial_that_never_finishes_says_so_while_it_waits() {
+        // `etcd.dial_timeout_ms` unset — the shipped default — against an
+        // endpoint that accepts the TCP connection and then answers
+        // nothing. `Client::connect` waits for the `Authenticate` round
+        // trip forever, so the gateway is stuck before any listener
+        // binds; until this line it wrote nothing at all, and an operator
+        // saw a process with no port and no explanation.
+        //
+        // The bound is deliberately untouched: what is asserted here is
+        // that the wait is audible, not that it ends.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((socket, _)) = listener.accept().await {
+                // Held, never spoken to: closing the socket would be an
+                // answer, and the dial would end.
+                held.push(socket);
+            }
+        });
+
+        let logs = Arc::new(StdMutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(SharedBuf(logs.clone()))
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let client = LazyEtcdClient::new(
+            vec![format!("http://{addr}")],
+            Some(ConnectOptions::new().with_user("root", "rootpw")),
+            None,
+        );
+        let dial = client.connect_now();
+        tokio::pin!(dial);
+
+        tokio::time::pause();
+        assert!(
+            futures::poll!(&mut dial).is_pending(),
+            "a silent endpoint cannot complete a dial",
+        );
+        assert!(
+            logs.lock().unwrap().is_empty(),
+            "a dial that has only just started says nothing — a line on every \
+             healthy boot is one operators learn to filter out",
+        );
+
+        tokio::time::advance(DIAL_WAIT_LOG_INTERVAL + Duration::from_secs(1)).await;
+        assert!(
+            futures::poll!(&mut dial).is_pending(),
+            "the endpoint is still silent",
+        );
+
+        let logged = String::from_utf8(logs.lock().unwrap().clone()).unwrap();
+        assert!(
+            logged.contains("still connecting to etcd"),
+            "an outstanding dial must report itself: {logged:?}",
+        );
+        assert!(
+            logged.contains(&addr.to_string()),
+            "the line must name the endpoint it is waiting on: {logged:?}",
+        );
     }
 }

--- a/crates/aisix-etcd/src/client.rs
+++ b/crates/aisix-etcd/src/client.rs
@@ -108,8 +108,12 @@ pub enum ConnectError {
     Rejected(String),
     /// etcd answered and refused *the token this connection is using*,
     /// not the configured credentials: the gateway authenticated once
-    /// and etcd has since forgotten that token — it restarted (the token
-    /// store is in memory), or the token's `--auth-token-ttl` elapsed.
+    /// and etcd has since forgotten that token. Either the token's
+    /// `--auth-token-ttl` elapsed — it is refreshed by use, so only an
+    /// idle connection reaches it — or etcd's token store was cleared:
+    /// authentication re-enabled on the cluster, a JWT signing key
+    /// regenerated at startup, a member brought up on an empty data
+    /// directory.
     ///
     /// Kept apart from [`Self::Rejected`] because the two need opposite
     /// handling. A refused credential never becomes a good one, so
@@ -162,9 +166,9 @@ impl ConnectError {
 /// answers *where* is not something a caller can assume: a user whose
 /// password is wrong is refused by `Authenticate`, but a user who
 /// authenticates and lacks the permission is refused by the range read
-/// (`PermissionDenied`), and a token invalidated by an etcd restart is
-/// refused by every later call (`Unauthenticated`). Classifying only the
-/// dial would report those as ordinary transport trouble.
+/// (`PermissionDenied`), and a token etcd has stopped holding is refused
+/// by every later call (`Unauthenticated`). Classifying only the dial
+/// would report those as ordinary transport trouble.
 ///
 /// The `Unauthenticated` / `InvalidArgument` split is the whole safety
 /// condition behind re-authenticating: etcd answers a wrong user or
@@ -198,8 +202,8 @@ pub(crate) fn classify(err: &EtcdError) -> ConnectError {
             | GRPC_ABORTED
             | GRPC_RESOURCE_EXHAUSTED => ConnectError::Unreachable(detail),
             // etcd knows the call arrived with a token it no longer
-            // holds — it restarted, or the token's TTL elapsed. The
-            // configured credentials are not what it is complaining
+            // holds — the TTL elapsed, or its token store was cleared.
+            // The configured credentials are not what it is complaining
             // about, so this one heals by authenticating again.
             GRPC_UNAUTHENTICATED => ConnectError::Unauthenticated(detail),
             // Everything else is etcd having evaluated the request and
@@ -265,7 +269,13 @@ async fn announce_while_pending<T>(
 ) -> T {
     tokio::pin!(fut);
     let mut ticker = tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
-    let mut waited = Duration::ZERO;
+    // A runtime stalled past several ticks — a suspended host, a starved
+    // scheduler — would otherwise wake to a burst of identical lines
+    // under the default `Burst` behaviour. One line per interval that
+    // actually elapsed is the whole point; the count of ticks missed
+    // while nobody was running is not information.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let started = tokio::time::Instant::now();
     loop {
         tokio::select! {
             // `biased` so a dial that completes in the same wakeup as a
@@ -273,11 +283,11 @@ async fn announce_while_pending<T>(
             biased;
             outcome = &mut fut => return outcome,
             _ = ticker.tick() => {
-                waited += interval;
                 tracing::warn!(
                     endpoints = ?endpoints,
-                    waited_secs = waited.as_secs(),
-                    "still connecting to etcd — no configuration can be read until it answers",
+                    waited_secs = started.elapsed().as_secs(),
+                    "still connecting to etcd — nothing waiting on this connection can \
+                     proceed until it answers",
                 );
             }
         }
@@ -389,8 +399,9 @@ impl LazyEtcdClient {
     /// and retrying it **once** if etcd rejects the connection's auth
     /// token.
     ///
-    /// This is how a gateway survives an etcd restart or an elapsed
-    /// `--auth-token-ttl`: `etcd-client` authenticates inside
+    /// This is how a gateway survives an elapsed `--auth-token-ttl`, or
+    /// an etcd that has stopped holding its token at all:
+    /// `etcd-client` authenticates inside
     /// `Client::connect` and never again, so the token this connection
     /// carries is the only one it will ever have, and once etcd forgets
     /// it every later call is refused until the process is restarted.

--- a/crates/aisix-etcd/src/client.rs
+++ b/crates/aisix-etcd/src/client.rs
@@ -136,7 +136,45 @@ const GRPC_RESOURCE_EXHAUSTED: i32 = 8;
 const GRPC_ABORTED: i32 = 10;
 const GRPC_INTERNAL: i32 = 13;
 const GRPC_UNAVAILABLE: i32 = 14;
+const GRPC_INVALID_ARGUMENT: i32 = 3;
 const GRPC_UNAUTHENTICATED: i32 = 16;
+
+/// etcd's own error strings for the two answers that mean "the token you
+/// sent is stale" but arrive as `InvalidArgument`, sharing a status code
+/// with "your password is wrong".
+///
+/// **Do not replace these with a status-code check, and do not delete
+/// them as a fragile string match.** The text *is* the signal here.
+/// etcd's own reference client recovers these errors the same way: its
+/// `rpctypes.Error()` maps a gRPC error back to a typed one through a
+/// table keyed on the error string, and `shouldRefreshToken` in the v3
+/// client's retry interceptor then treats exactly these two, plus
+/// `Unauthenticated`, as "re-authenticate and retry" — while
+/// deliberately leaving `authentication failed, invalid user ID or
+/// password` out. This match is that list, matched the way the
+/// reference implementation matches it.
+///
+/// - `revision of auth store is old` — the deployment-facing one, and
+///   the reason this matters. Under `--auth-token jwt` (what a
+///   multi-member cluster runs) **any** change to the auth store bumps
+///   its revision, and every token issued before it is refused from that
+///   moment: one `etcdctl user add` on the cluster and a gateway can no
+///   longer read its configuration until it authenticates again.
+///   Verified against etcd 3.5.18.
+/// - `user name is empty` — carried for parity with the reference
+///   client, which refreshes on it too. No reachable scenario was
+///   constructed for it here; it is included because it fails in the
+///   safe direction (one extra re-authentication) and because a list
+///   that silently drops one of upstream's three arms is the kind of
+///   difference nobody finds later.
+const STALE_TOKEN_MESSAGES: [&str; 2] = [
+    "etcdserver: revision of auth store is old",
+    "etcdserver: user name is empty",
+];
+
+fn is_stale_token(message: &str) -> bool {
+    STALE_TOKEN_MESSAGES.iter().any(|m| message.contains(m))
+}
 
 impl ConnectError {
     /// The flattened cause, without this type's own framing — so a
@@ -172,16 +210,13 @@ impl ConnectError {
 ///
 /// This is what the safety condition behind re-authenticating rests on.
 /// A wrong user or password is answered on `Authenticate` with
-/// `InvalidArgument` (`etcdserver: authentication failed, invalid user ID
-/// or password`) and a user without the rights with `PermissionDenied`,
-/// so neither can reach the retry path however many times it is
-/// presented. `Unauthenticated` is what etcd answers a token it does not
-/// recognise (`etcdserver: invalid auth token`), and that is the only
-/// code routed there.
+/// `InvalidArgument` carrying `etcdserver: authentication failed, invalid
+/// user ID or password`, and a user without the rights with
+/// `PermissionDenied`; neither can reach the retry path however many
+/// times it is presented.
 ///
-/// Note the implication does not run backwards: `InvalidArgument` covers
-/// more than refused credentials, and telling its members apart would
-/// take the message text rather than the code.
+/// `InvalidArgument` is not only that, though, which is why two of its
+/// members are named by message below. See [`STALE_TOKEN_MESSAGES`].
 pub(crate) fn classify(err: &EtcdError) -> ConnectError {
     let detail = format_etcd_error(err);
     match err {
@@ -212,11 +247,17 @@ pub(crate) fn classify(err: &EtcdError) -> ConnectError {
             // The configured credentials are not what it is complaining
             // about, so this one heals by authenticating again.
             GRPC_UNAUTHENTICATED => ConnectError::Unauthenticated(detail),
+            // The two `InvalidArgument` answers that mean the same
+            // thing. See [`STALE_TOKEN_MESSAGES`] for why they are
+            // matched by message and why that is not a workaround.
+            GRPC_INVALID_ARGUMENT if is_stale_token(status.message()) => {
+                ConnectError::Unauthenticated(detail)
+            }
             // Everything else is etcd having evaluated the request and
-            // said no: `InvalidArgument` for a wrong user or password,
-            // `PermissionDenied` for a user without the rights,
-            // `FailedPrecondition` for credentials sent to a cluster
-            // that has authentication disabled.
+            // said no: the rest of `InvalidArgument` — a wrong user or
+            // password — `PermissionDenied` for a user without the
+            // rights, `FailedPrecondition` for credentials sent to a
+            // cluster that has authentication disabled.
             _ => ConnectError::Rejected(detail),
         },
         // Unparseable endpoints, an empty endpoint list, a bad header
@@ -721,12 +762,65 @@ mod reauth_tests {
     }
 
     #[tokio::test]
+    async fn a_stale_auth_store_revision_is_retried_like_an_invalid_token() {
+        // `revision of auth store is old` is `InvalidArgument`, the same
+        // code as a wrong password, and it is the one a deployment
+        // actually meets: under `--auth-token jwt` any change to the
+        // auth store — one `etcdctl user add` — bumps the revision and
+        // every token issued before it is refused from that moment. Only
+        // etcd's message separates the two, which is why the message is
+        // matched. Second answer is `Unavailable` so the retry is
+        // distinguishable from the first attempt.
+        let etcd = spawn_scripted_etcd(&[
+            (3, "etcdserver: revision of auth store is old"),
+            (14, "etcdserver: no leader"),
+        ])
+        .await;
+
+        let err = read_once(&etcd.endpoint).await.expect_err("both fail");
+        let CallError::Call(err) = err else {
+            panic!("the server answered, so this is a call failure: {err:?}");
+        };
+        assert!(
+            matches!(classify(&err), ConnectError::Unreachable(_)),
+            "the retry's own answer is what surfaces: {err:?}",
+        );
+        assert_eq!(
+            etcd.calls.load(Ordering::Relaxed),
+            2,
+            "an auth-store revision change must be re-authenticated, not reported as a \
+             wrong password",
+        );
+        assert_eq!(
+            etcd.connections.load(Ordering::Relaxed),
+            2,
+            "the retry must run on a new connection — that is what re-authenticates",
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_user_name_is_retried_like_an_invalid_token() {
+        // Carried for parity with etcd's own reference client, which
+        // refreshes its token on this too. No reachable scenario was
+        // constructed for it — this pins the wiring, not a reproduction.
+        let etcd = spawn_scripted_etcd(&[
+            (3, "etcdserver: user name is empty"),
+            (14, "etcdserver: no leader"),
+        ])
+        .await;
+
+        read_once(&etcd.endpoint).await.expect_err("both fail");
+        assert_eq!(etcd.calls.load(Ordering::Relaxed), 2);
+        assert_eq!(etcd.connections.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
     async fn a_refused_credential_is_answered_once_and_never_retried() {
-        // The other half of the safety condition, and the reason the
-        // split is on the status code: etcd answers a wrong user or
-        // password with `InvalidArgument`, never with `Unauthenticated`.
-        // So a credential it has refused fails on the first answer, as
-        // it did before any of this — no re-authentication, no second
+        // The safety condition, and the one line in this file that must
+        // never move: a wrong user or password shares `InvalidArgument`
+        // with the two stale-token answers above, and is told apart from
+        // them by etcd's own message. It must fail on the first answer,
+        // as it did before any of this — no re-authentication, no second
         // connection, nothing for an operator's typo to spin on.
         let etcd = spawn_scripted_etcd(&[(
             3,

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -242,15 +242,13 @@ fn provider_error(
             d.as_millis()
         )),
         CallError::Call(err) => match classify(&err) {
-            // An `Unauthenticated` reaching here has already been
-            // retried on a freshly authenticated connection and was
-            // refused again, so it belongs with the refusals: waiting
-            // does not fix a token etcd will not accept however new it
-            // is, and reporting it as ordinary transport trouble is what
-            // buries it in a warn line that repeats forever.
-            ConnectError::Rejected(detail) | ConnectError::Unauthenticated(detail) => {
-                ProviderError::Rejected(detail)
-            }
+            ConnectError::Rejected(detail) => ProviderError::Rejected(detail),
+            // Already retried on a freshly authenticated connection and
+            // refused again, so it does not belong on the routine warn
+            // path — but it does not belong under "your credentials are
+            // wrong" either, since etcd just accepted them. Its own
+            // variant, and its own line.
+            ConnectError::Unauthenticated(detail) => ProviderError::TokenRefused(detail),
             ConnectError::Unreachable(_) => into_err(format_etcd_error(&err)),
         },
     }
@@ -815,11 +813,16 @@ mod tests {
                 Err(ProviderError::Connect(_))
             ));
         }
-        // 3 InvalidArgument (etcd's answer to a wrong user or password),
-        // 7 PermissionDenied, 9 FailedPrecondition (credentials sent to a
-        // cluster with authentication disabled).
+        // 3 InvalidArgument *with etcd's wrong-password message* — the
+        // code alone is not enough, see `STALE_TOKEN_MESSAGES` — plus
+        // 7 PermissionDenied and 9 FailedPrecondition (credentials sent
+        // to a cluster with authentication disabled).
         for code in [3u16, 7, 9] {
-            let endpoint = spawn_grpc_status_server(code, "refused").await;
+            let endpoint = spawn_grpc_status_server(
+                code,
+                "etcdserver: authentication failed, invalid user ID or password",
+            )
+            .await;
             let err = EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None)
                 .await
                 .expect_err("a refusal must end the boot");
@@ -991,14 +994,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_freshly_authenticated_connection_etcd_still_refuses_is_a_refusal() {
+    async fn a_freshly_authenticated_connection_etcd_still_refuses_gets_its_own_report() {
         // By the time a call's `Unauthenticated` reaches `provider_error`
         // it has already been retried on a connection that authenticated
         // moments earlier. Whatever is wrong with it is not something
-        // another 60s of backoff fixes, so it gets the refusal line an
-        // operator can act on rather than the routine one they filter
-        // out. No credentials here, so the dial is lazy and both attempts
-        // land on the read — which is where the retry lives.
+        // another 60s of backoff fixes — but it is not `Rejected`
+        // either, because etcd issued the token it is refusing, so the
+        // credentials an operator would be sent to check are fine. No
+        // credentials here, so the dial is lazy and both attempts land
+        // on the read, which is where the retry lives.
         let endpoint = spawn_grpc_status_server(16, "etcdserver: invalid auth token").await;
         let provider = EtcdConfigProvider::connect(&[endpoint], "/aisix", None, None, None)
             .await
@@ -1008,9 +1012,28 @@ mod tests {
             .await
             .expect_err("a server that only answers 16 cannot serve a read");
         assert!(
-            matches!(err, ProviderError::Rejected(_)),
-            "a re-authenticated call etcd refused again must be loud, got {err:?}",
+            matches!(err, ProviderError::TokenRefused(_)),
+            "a re-authenticated call etcd refused again is not a credentials problem, \
+             got {err:?}",
         );
+    }
+
+    #[tokio::test]
+    async fn an_auth_store_revision_change_is_waited_out_not_treated_as_a_bad_password() {
+        // `revision of auth store is old` shares `InvalidArgument` with a
+        // wrong password, and before it was told apart, one `etcdctl user
+        // add` on a JWT cluster ended the boot of every gateway pointed
+        // at it. It must reach the same place `Unauthenticated` does.
+        let endpoint =
+            spawn_grpc_status_server(3, "etcdserver: revision of auth store is old").await;
+        let provider =
+            EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None)
+                .await
+                .expect("an auth-store change must not end the boot");
+        assert!(matches!(
+            provider.load_all().await,
+            Err(ProviderError::Connect(_))
+        ));
     }
 
     #[test]

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -20,7 +20,9 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use crate::client::{classify, format_etcd_error, ConnectError, LazyEtcdClient};
+use crate::client::{
+    classify, format_etcd_error, kv_client, watch_client, CallError, ConnectError, LazyEtcdClient,
+};
 use crate::provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 
 /// Fixed-interval retry: 5s × 5 attempts (spec §2).
@@ -109,12 +111,18 @@ impl EtcdConfigProvider {
         ));
         match client.connect_now().await {
             Ok(()) => tracing::info!(prefix = %prefix, "etcd connected"),
-            Err(ConnectError::Unreachable(detail)) => tracing::warn!(
-                error = %detail,
-                prefix = %prefix,
-                "etcd is not reachable yet — starting anyway and retrying in the background; \
-                 the proxy listener stays closed until a configuration is applied",
-            ),
+            // A token etcd will not accept is grouped with an etcd that
+            // did not answer, not with a refused credential: nothing
+            // about the configured user is in question, and the next
+            // call dials again and authenticates again.
+            Err(err @ (ConnectError::Unreachable(_) | ConnectError::Unauthenticated(_))) => {
+                tracing::warn!(
+                    error = %err.detail(),
+                    prefix = %prefix,
+                    "etcd is not reachable yet — starting anyway and retrying in the background; \
+                     the proxy listener stays closed until a configuration is applied",
+                )
+            }
             Err(err @ ConnectError::Rejected(_)) => {
                 return Err(ProviderError::Rejected(err.detail().to_string()))
             }
@@ -160,7 +168,8 @@ impl EtcdConfigProvider {
                 Err(err @ ConnectError::Rejected(_)) => {
                     return Err(ProviderError::Rejected(err.detail().to_string()))
                 }
-                Err(ConnectError::Unreachable(detail)) => {
+                Err(err @ (ConnectError::Unreachable(_) | ConnectError::Unauthenticated(_))) => {
+                    let detail = err.detail().to_string();
                     tracing::warn!(
                         attempt,
                         max = policy.attempts,
@@ -185,88 +194,92 @@ impl EtcdConfigProvider {
 }
 
 impl From<ConnectError> for ProviderError {
-    /// Both classes reach the supervisor, which backs off and retries
+    /// Every class reaches the supervisor, which backs off and retries
     /// whichever it gets — the split is what the boot path acts on, and
     /// what the operator reads in the warn line.
     fn from(err: ConnectError) -> Self {
         match &err {
             ConnectError::Unreachable(detail) => ProviderError::Connect(detail.clone()),
             ConnectError::Rejected(detail) => ProviderError::Rejected(detail.clone()),
+            // A token etcd has forgotten is not a refused credential:
+            // `LazyEtcdClient::call` has already authenticated again and
+            // retried by the time one reaches here, so what is left is a
+            // condition to retry, not one to report as a configuration
+            // mistake that will never heal.
+            ConnectError::Unauthenticated(detail) => ProviderError::Connect(detail.clone()),
         }
     }
 }
 
-/// Apply `timeout`, when set, to one in-flight etcd call.
+/// Report one failed etcd call.
 ///
-/// `into_err` names the call: expiry is reported as the same
-/// `ProviderError` variant that call's transport failures already use,
-/// so the supervisor's warn line attributes it to the right step. It is
+/// `into_err` names the call — the range read, the watch create — so the
+/// supervisor's warn line attributes the failure to the right step. It is
 /// attribution, not control flow: `Supervisor::run` routes every
 /// `ProviderError` out of a cycle to the same reconnect-with-backoff
 /// path, so the aborted call is retried whichever variant carries it.
-/// Report one failed etcd call.
 ///
-/// A refusal is reported as such wherever etcd hands it over, not only
-/// on the dial: a user who authenticates but lacks the permission is
-/// refused by the range read, and a token an etcd restart invalidated is
-/// refused by every call after it. Those never heal by retrying, and
-/// reporting them as ordinary transport trouble is what buries them in a
-/// warn line that repeats forever. Everything else keeps the variant
-/// naming the call that failed, which is what the supervisor's backoff
-/// line says.
-fn call_error(err: &etcd_client::Error, into_err: fn(String) -> ProviderError) -> ProviderError {
-    match classify(err) {
-        ConnectError::Rejected(detail) => ProviderError::Rejected(detail),
-        ConnectError::Unreachable(_) => into_err(format_etcd_error(err)),
-    }
-}
-
-async fn bound<T>(
-    timeout: Option<Duration>,
+/// A refusal is reported as such wherever etcd hands it over, not only on
+/// the dial: a user who authenticates but lacks the permission is refused
+/// by the range read. That never heals by retrying, and reporting it as
+/// ordinary transport trouble is what buries it in a warn line that
+/// repeats forever.
+fn provider_error(
+    err: CallError,
     what: &str,
     into_err: fn(String) -> ProviderError,
-    fut: impl std::future::Future<Output = T>,
-) -> Result<T, ProviderError> {
-    match timeout {
-        None => Ok(fut.await),
-        Some(d) => tokio::time::timeout(d, fut).await.map_err(|_| {
-            into_err(format!(
-                "{what} exceeded etcd.request_timeout_ms ({} ms)",
-                d.as_millis()
-            ))
-        }),
+) -> ProviderError {
+    match err {
+        CallError::Connect(err) => err.into(),
+        CallError::ConnectTimeout(d) => ProviderError::Connect(format!(
+            "etcd connect exceeded etcd.request_timeout_ms ({} ms)",
+            d.as_millis()
+        )),
+        CallError::CallTimeout(d) => into_err(format!(
+            "{what} exceeded etcd.request_timeout_ms ({} ms)",
+            d.as_millis()
+        )),
+        CallError::Call(err) => match classify(&err) {
+            ConnectError::Rejected(detail) => ProviderError::Rejected(detail),
+            // Retryable, and by here already retried once on a freshly
+            // authenticated connection: an `Unauthenticated` that
+            // survived that is etcd still catching up on its own auth
+            // revision, not a credential it has refused.
+            ConnectError::Unreachable(_) | ConnectError::Unauthenticated(_) => {
+                into_err(format_etcd_error(&err))
+            }
+        },
     }
 }
 
 #[async_trait]
 impl ConfigProvider for EtcdConfigProvider {
     async fn load_all(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
-        // The dial is bounded like the call it is part of. Without
-        // credentials there is nothing to dial here — the channel
-        // connects inside the `get` below, under the same bound — but
-        // with them the `Authenticate` round trip happens on the way in,
-        // and an endpoint that accepts TCP and answers nothing would
+        // Through `LazyEtcdClient::call`, so the read is bounded, and so
+        // a token etcd has forgotten — it restarted, or the token's TTL
+        // elapsed — is re-authenticated and retried here instead of
+        // failing every cycle until the gateway is restarted.
+        //
+        // The dial it may have to make first is bounded like the call it
+        // is part of. Without credentials there is nothing to dial here —
+        // the channel connects inside the `get`, under the same bound —
+        // but with them the `Authenticate` round trip happens on the way
+        // in, and an endpoint that accepts TCP and answers nothing would
         // otherwise hold this read open forever: no backoff, no failure
         // recorded, and `/status/config` still reporting connected.
-        let mut kv = bound(
-            self.request_timeout,
-            "etcd connect",
-            ProviderError::Connect,
-            self.client.kv(),
-        )
-        .await??;
-        let read = kv.get(
-            self.prefix.as_bytes(),
-            Some(GetOptions::new().with_prefix()),
-        );
-        let resp = bound(
-            self.request_timeout,
-            "range read",
-            ProviderError::Range,
-            read,
-        )
-        .await?
-        .map_err(|e| call_error(&e, ProviderError::Range))?;
+        let prefix = self.prefix.as_bytes().to_vec();
+        let resp = self
+            .client
+            .call(self.request_timeout, move |client| {
+                let prefix = prefix.clone();
+                async move {
+                    kv_client(&client)
+                        .get(prefix, Some(GetOptions::new().with_prefix()))
+                        .await
+                }
+            })
+            .await
+            .map_err(|e| provider_error(e, "range read", ProviderError::Range))?;
 
         let revision = resp.header().map(|h| h.revision()).unwrap_or(0);
 
@@ -290,16 +303,7 @@ impl ConfigProvider for EtcdConfigProvider {
         Box<dyn Stream<Item = Result<WatchEvent, ProviderError>> + Send + Unpin>,
         ProviderError,
     > {
-        let mut watch = bound(
-            self.request_timeout,
-            "etcd connect",
-            ProviderError::Connect,
-            self.client.watch(),
-        )
-        .await??;
-        let opts = WatchOptions::new()
-            .with_prefix()
-            .with_start_revision(start_revision);
+        let prefix = self.prefix.as_bytes().to_vec();
         // Creating the watch is request/response shaped — etcd-client
         // sends the create request and awaits the server's create
         // confirmation before handing back the stream — so it is bounded
@@ -310,15 +314,19 @@ impl ConfigProvider for EtcdConfigProvider {
         // reads but never confirms the watch leaves the gateway serving
         // its first snapshot forever, blind to every later change, while
         // `/status/config` still reports it connected.
-        let create = watch.watch(self.prefix.as_bytes(), Some(opts));
-        let (watcher, stream) = bound(
-            self.request_timeout,
-            "watch create",
-            ProviderError::Watch,
-            create,
-        )
-        .await?
-        .map_err(|e| call_error(&e, ProviderError::Watch))?;
+        let (watcher, stream) = self
+            .client
+            .call(self.request_timeout, move |client| {
+                let prefix = prefix.clone();
+                async move {
+                    let opts = WatchOptions::new()
+                        .with_prefix()
+                        .with_start_revision(start_revision);
+                    watch_client(&client).watch(prefix, Some(opts)).await
+                }
+            })
+            .await
+            .map_err(|e| provider_error(e, "watch create", ProviderError::Watch))?;
 
         Ok(Box::new(EtcdWatchStream {
             inner: stream,
@@ -377,7 +385,16 @@ impl Stream for EtcdWatchStream {
                 {
                     Poll::Ready(Some(Err(ProviderError::Compacted)))
                 } else {
-                    Poll::Ready(Some(Err(call_error(&err, ProviderError::Watch))))
+                    // No re-authentication here: an established stream
+                    // cannot be moved onto a new connection, and a poll
+                    // is not a place to dial one. Ending the stream is
+                    // the recovery — the supervisor re-enters its cycle,
+                    // and `load_all` re-authenticates on the way through.
+                    Poll::Ready(Some(Err(provider_error(
+                        CallError::Call(err),
+                        "watch stream",
+                        ProviderError::Watch,
+                    ))))
                 }
             }
             Poll::Ready(Some(Ok(resp))) => {
@@ -768,10 +785,29 @@ mod tests {
                 Err(ProviderError::Connect(_))
             ));
         }
+        // 16 Unauthenticated is the third class: etcd answered, and what
+        // it refused is the token rather than the credentials — it
+        // restarted, or `--auth-token-ttl` elapsed. Dialling again is
+        // what cures that, so the boot waits like the codes above rather
+        // than ending. On a call rather than a dial,
+        // `LazyEtcdClient::call` re-authenticates and retries it; here
+        // it is the dial itself that is refused, and there is nothing
+        // left to re-authenticate.
+        {
+            let endpoint = spawn_grpc_status_server(16, "etcdserver: invalid auth token").await;
+            let provider =
+                EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None)
+                    .await
+                    .expect("an invalid token must be waited out, not fatal");
+            assert!(matches!(
+                provider.load_all().await,
+                Err(ProviderError::Connect(_))
+            ));
+        }
         // 3 InvalidArgument (etcd's answer to a wrong user or password),
         // 7 PermissionDenied, 9 FailedPrecondition (credentials sent to a
-        // cluster with authentication disabled), 16 Unauthenticated.
-        for code in [3u16, 7, 9, 16] {
+        // cluster with authentication disabled).
+        for code in [3u16, 7, 9] {
             let endpoint = spawn_grpc_status_server(code, "refused").await;
             let err = EtcdConfigProvider::connect(&[endpoint], "/aisix", credentials(), None, None)
                 .await
@@ -919,16 +955,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn bound_passes_through_when_no_timeout_is_set() {
-        let out = bound(None, "range read", ProviderError::Range, async { 7u8 })
-            .await
-            .unwrap();
-        assert_eq!(out, 7);
-    }
-
-    #[tokio::test]
-    async fn expiry_reports_the_call_and_the_key_that_bounded_it() {
+    #[test]
+    fn expiry_reports_the_call_and_the_key_that_bounded_it() {
         // An expiry has to reach the operator as a diagnosable failure,
         // not as a bare cancellation: the message names both the call it
         // aborted and the config key that set the bound, so a boot loop
@@ -937,20 +965,38 @@ mod tests {
         // failures already use — the supervisor sends every
         // `ProviderError` from `load_all` down the same backoff path, so
         // the variant is what the warn line says, not what it does.
-        let err = bound(
-            Some(Duration::from_millis(1)),
+        let err = provider_error(
+            CallError::CallTimeout(Duration::from_millis(1)),
             "range read",
             ProviderError::Range,
-            std::future::pending::<()>(),
-        )
-        .await
-        .unwrap_err();
+        );
         let ProviderError::Range(msg) = err else {
             panic!("expiry must surface as ProviderError::Range, got {err:?}");
         };
         assert!(
             msg.contains("range read") && msg.contains("etcd.request_timeout_ms"),
             "the message must name the call and the key that bounded it: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_dial_that_ran_out_of_time_is_attributed_to_the_connect() {
+        // The connect is bounded separately from the call it carries, so
+        // an operator reading the warn line can tell "etcd never finished
+        // answering the dial" from "etcd never finished the read" —
+        // different causes, and after a re-authentication both are
+        // reachable from the same `load_all`.
+        let err = provider_error(
+            CallError::ConnectTimeout(Duration::from_millis(1)),
+            "range read",
+            ProviderError::Range,
+        );
+        let ProviderError::Connect(msg) = err else {
+            panic!("a dial expiry must surface as ProviderError::Connect, got {err:?}");
+        };
+        assert!(
+            msg.contains("etcd connect") && msg.contains("etcd.request_timeout_ms"),
+            "the message must name the step and the key that bounded it: {msg}"
         );
     }
 }

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -394,11 +394,18 @@ impl Stream for EtcdWatchStream {
                     // is not a place to dial one. Ending the stream is
                     // the recovery — the supervisor re-enters its cycle,
                     // and `load_all` re-authenticates on the way through.
-                    Poll::Ready(Some(Err(provider_error(
-                        CallError::Call(err),
-                        "watch stream",
-                        ProviderError::Watch,
-                    ))))
+                    //
+                    // Which is why this does not go through
+                    // `provider_error`: that one reports an
+                    // `Unauthenticated` as a refusal *because* it has
+                    // already been retried on a fresh connection, and
+                    // this is the one call site where that is not true.
+                    Poll::Ready(Some(Err(match classify(&err) {
+                        ConnectError::Rejected(detail) => ProviderError::Rejected(detail),
+                        ConnectError::Unreachable(_) | ConnectError::Unauthenticated(_) => {
+                            ProviderError::Watch(format_etcd_error(&err))
+                        }
+                    })))
                 }
             }
             Poll::Ready(Some(Ok(resp))) => {

--- a/crates/aisix-etcd/src/etcd_provider.rs
+++ b/crates/aisix-etcd/src/etcd_provider.rs
@@ -201,11 +201,13 @@ impl From<ConnectError> for ProviderError {
         match &err {
             ConnectError::Unreachable(detail) => ProviderError::Connect(detail.clone()),
             ConnectError::Rejected(detail) => ProviderError::Rejected(detail.clone()),
-            // A token etcd has forgotten is not a refused credential:
-            // `LazyEtcdClient::call` has already authenticated again and
-            // retried by the time one reaches here, so what is left is a
-            // condition to retry, not one to report as a configuration
-            // mistake that will never heal.
+            // Only the DIAL reaches here with this — a call's has been
+            // re-authenticated and retried first (see `provider_error`).
+            // A dial refused with `Unauthenticated` has nothing to
+            // re-authenticate: it just tried. Retryable rather than
+            // fatal, because a cluster whose authentication was being
+            // re-enabled as the gateway dialled answers exactly this and
+            // then starts working.
             ConnectError::Unauthenticated(detail) => ProviderError::Connect(detail.clone()),
         }
     }
@@ -240,14 +242,16 @@ fn provider_error(
             d.as_millis()
         )),
         CallError::Call(err) => match classify(&err) {
-            ConnectError::Rejected(detail) => ProviderError::Rejected(detail),
-            // Retryable, and by here already retried once on a freshly
-            // authenticated connection: an `Unauthenticated` that
-            // survived that is etcd still catching up on its own auth
-            // revision, not a credential it has refused.
-            ConnectError::Unreachable(_) | ConnectError::Unauthenticated(_) => {
-                into_err(format_etcd_error(&err))
+            // An `Unauthenticated` reaching here has already been
+            // retried on a freshly authenticated connection and was
+            // refused again, so it belongs with the refusals: waiting
+            // does not fix a token etcd will not accept however new it
+            // is, and reporting it as ordinary transport trouble is what
+            // buries it in a warn line that repeats forever.
+            ConnectError::Rejected(detail) | ConnectError::Unauthenticated(detail) => {
+                ProviderError::Rejected(detail)
             }
+            ConnectError::Unreachable(_) => into_err(format_etcd_error(&err)),
         },
     }
 }
@@ -976,6 +980,29 @@ mod tests {
         assert!(
             msg.contains("range read") && msg.contains("etcd.request_timeout_ms"),
             "the message must name the call and the key that bounded it: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_freshly_authenticated_connection_etcd_still_refuses_is_a_refusal() {
+        // By the time a call's `Unauthenticated` reaches `provider_error`
+        // it has already been retried on a connection that authenticated
+        // moments earlier. Whatever is wrong with it is not something
+        // another 60s of backoff fixes, so it gets the refusal line an
+        // operator can act on rather than the routine one they filter
+        // out. No credentials here, so the dial is lazy and both attempts
+        // land on the read — which is where the retry lives.
+        let endpoint = spawn_grpc_status_server(16, "etcdserver: invalid auth token").await;
+        let provider = EtcdConfigProvider::connect(&[endpoint], "/aisix", None, None, None)
+            .await
+            .expect("connect is lazy without credentials");
+        let err = provider
+            .load_all()
+            .await
+            .expect_err("a server that only answers 16 cannot serve a read");
+        assert!(
+            matches!(err, ProviderError::Rejected(_)),
+            "a re-authenticated call etcd refused again must be loud, got {err:?}",
         );
     }
 

--- a/crates/aisix-etcd/src/lib.rs
+++ b/crates/aisix-etcd/src/lib.rs
@@ -31,7 +31,7 @@ pub mod supervisor;
 
 pub use backoff::{ExpBackoff, BASE_MS, MAX_MS};
 pub use client::{
-    kv_client, watch_client, ConnectError, LazyEtcdClient, MAX_DECODING_MESSAGE_SIZE,
+    kv_client, watch_client, CallError, ConnectError, LazyEtcdClient, MAX_DECODING_MESSAGE_SIZE,
 };
 pub use etcd_provider::{
     ConnectPolicy, EtcdConfigProvider, EtcdWatchStream, CONNECT_MAX_ATTEMPTS,

--- a/crates/aisix-etcd/src/provider.rs
+++ b/crates/aisix-etcd/src/provider.rs
@@ -49,6 +49,18 @@ pub enum ProviderError {
     /// joining the retry loop.
     #[error("etcd rejected the connection: {0}")]
     Rejected(String),
+    /// etcd refused the auth token on a connection that had authenticated
+    /// moments earlier — the call was already retried on a freshly
+    /// authenticated connection and refused again.
+    ///
+    /// Kept apart from [`ProviderError::Rejected`] because it points
+    /// somewhere else entirely. A `Rejected` is a configuration mistake
+    /// an operator can go and fix; this one says the credentials are
+    /// being accepted and the token still is not, which is nobody's
+    /// username and password. Sending an operator to check a password
+    /// that is fine is how a real cause stays unfound.
+    #[error("etcd refused an auth token it had just issued: {0}")]
+    TokenRefused(String),
     #[error("etcd range request failed: {0}")]
     Range(String),
     #[error("etcd watch stream failed: {0}")]

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -1129,6 +1129,24 @@ impl<P: ConfigProvider> Supervisor<P> {
                             "etcd refused this gateway's credentials — no configuration can be \
                              read until they are fixed; still retrying",
                         );
+                    } else if matches!(err, ProviderError::TokenRefused(_)) {
+                        // Deliberately NOT the line above. etcd accepted
+                        // the credentials — it issued the token being
+                        // refused — so pointing at the username and
+                        // password sends an operator somewhere there is
+                        // nothing to find. The causes are the auth store
+                        // changing faster than the gateway can
+                        // re-authenticate, and, under `--auth-token jwt`,
+                        // a token that is already outside its `ttl` when
+                        // it arrives because the two clocks disagree.
+                        tracing::error!(
+                            error = %err,
+                            backoff_ms = delay.as_millis() as u64,
+                            "etcd would not accept an auth token it had just issued to this \
+                             gateway — the credentials are fine; check whether etcd's auth \
+                             store is being changed continuously, and whether this host's \
+                             clock agrees with etcd's; still retrying",
+                        );
                     } else {
                         tracing::warn!(
                             error = %err,

--- a/crates/aisix-etcd/tests/auth_token_recovery.rs
+++ b/crates/aisix-etcd/tests/auth_token_recovery.rs
@@ -1,0 +1,259 @@
+//! Surviving an etcd auth token the server no longer accepts.
+//!
+//! `etcd-client` authenticates once, inside `Client::connect`, and never
+//! again. The token it gets there is the only one that connection will
+//! ever carry, and etcd stops accepting it in two ordinary situations:
+//! the server restarts (its token store is in memory), or the token's
+//! `--auth-token-ttl` elapses while nothing is using it. Every later call
+//! is then refused, and before this the only cure was restarting the
+//! gateway.
+//!
+//! Both need a server that really issues and forgets tokens — the status
+//! code, the wording and the *timing* are etcd's, not something a stub
+//! can stand in for. Bracketed by `ETCD_AUTH_TTL_TEST_URL` (the pattern
+//! `auth_connect_integration.rs` uses): the tests no-op when it is unset,
+//! so a local `cargo test` without docker still passes. CI starts the
+//! cluster and sets the variables in `.github/workflows/ci.yml`.
+//!
+//! The cluster this file uses is a **third** etcd, separate from the
+//! `ETCD_AUTH_TEST_URL` one, for two reasons: its `--auth-token-ttl` is
+//! seconds rather than the five-minute default, which would make every
+//! other authenticated test depend on this feature; and one test here
+//! momentarily turns authentication off on it, which no other test can
+//! be reading through.
+//!
+//! The container and short-TTL cluster this needs were built by community
+//! PR api7/aisix#763 (`okaybase`), which proposed the scheduled-refresh
+//! fix these tests replace.
+
+#![allow(clippy::expect_used)]
+
+use std::sync::LazyLock;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use aisix_etcd::{ConfigProvider, EtcdConfigProvider, ProviderError};
+use etcd_client::ConnectOptions;
+
+/// One test here turns the cluster's authentication off and on again,
+/// which every other test in this file is reading through, so they take
+/// turns. Test binaries are run one at a time, so nothing outside this
+/// file is talking to it.
+static ETCD: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+struct AuthEtcd {
+    url: String,
+    user: String,
+    password: String,
+    /// The cluster's `--auth-token-ttl`. Read from the environment rather
+    /// than assumed, so the sleep below tracks whatever CI started.
+    token_ttl: Duration,
+}
+
+fn auth_ttl_etcd() -> Option<AuthEtcd> {
+    Some(AuthEtcd {
+        url: std::env::var("ETCD_AUTH_TTL_TEST_URL").ok()?,
+        user: std::env::var("ETCD_AUTH_TTL_TEST_USER").ok()?,
+        password: std::env::var("ETCD_AUTH_TTL_TEST_PASSWORD").ok()?,
+        token_ttl: Duration::from_secs(
+            std::env::var("ETCD_AUTH_TTL_TEST_SECS")
+                .ok()
+                .and_then(|s| s.parse().ok())?,
+        ),
+    })
+}
+
+fn unique_prefix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    format!("/aisix-token-it-{nanos}")
+}
+
+impl AuthEtcd {
+    fn credentials(&self) -> ConnectOptions {
+        ConnectOptions::new().with_user(self.user.clone(), self.password.clone())
+    }
+
+    /// A client of this cluster that is not the one under test — used to
+    /// seed the configuration the gateway then reads.
+    async fn writer(&self) -> etcd_client::Client {
+        etcd_client::Client::connect([self.url.clone()], Some(self.credentials()))
+            .await
+            .expect("seed client")
+    }
+
+    async fn provider(&self, prefix: &str) -> EtcdConfigProvider {
+        EtcdConfigProvider::connect(
+            std::slice::from_ref(&self.url),
+            prefix,
+            Some(self.credentials()),
+            Some(Duration::from_secs(10)),
+            Some(Duration::from_secs(10)),
+        )
+        .await
+        .expect("the cluster is up and the credentials are good")
+    }
+}
+
+const SEEDED_MODEL: &str = r#"{"display_name":"token-it-model","provider":"openai","model_name":"gpt-4o-mini","provider_key_id":"11111111-1111-1111-1111-111111111111"}"#;
+
+/// Long enough past the TTL that etcd's own expiry sweep has run.
+fn idle_past_expiry(ttl: Duration) -> Duration {
+    ttl + Duration::from_secs(4)
+}
+
+#[tokio::test]
+async fn a_token_that_expired_while_idle_is_replaced_without_a_restart() {
+    let Some(etcd) = auth_ttl_etcd() else {
+        eprintln!("skipping: ETCD_AUTH_TTL_TEST_URL not set");
+        return;
+    };
+    let _serialised = ETCD.lock().await;
+    let prefix = unique_prefix();
+    let mut writer = etcd.writer().await;
+    writer
+        .put(format!("{prefix}/models/m-token-1"), SEEDED_MODEL, None)
+        .await
+        .expect("seed put");
+
+    let provider = etcd.provider(&prefix).await;
+    let (entries, _) = provider.load_all().await.expect("the first read works");
+    assert_eq!(entries.len(), 1, "the seeded model must be readable");
+
+    // A gateway whose configuration is not changing makes no etcd calls,
+    // which is exactly the state in which etcd forgets its token — the
+    // TTL is refreshed by use, so only an idle connection ever reaches
+    // it. This is the shape of the reported failure: a gateway that was
+    // fine all day stops being able to read the moment anything changes.
+    tokio::time::sleep(idle_past_expiry(etcd.token_ttl)).await;
+
+    let (entries, _) = provider
+        .load_all()
+        .await
+        .expect("an expired token must be replaced, not fail the read");
+    assert_eq!(
+        entries.len(),
+        1,
+        "the read after re-authenticating must return the same configuration",
+    );
+
+    // A fresh writer: this one's own token expired during the sleep too,
+    // and nothing re-authenticates a bare `etcd_client::Client` — which
+    // is the whole bug, seen from the other side.
+    let mut writer = etcd.writer().await;
+    writer
+        .delete(format!("{prefix}/models/m-token-1"), None)
+        .await
+        .expect("cleanup");
+}
+
+#[tokio::test]
+async fn a_token_the_server_has_discarded_is_replaced_without_a_restart() {
+    let Some(etcd) = auth_ttl_etcd() else {
+        eprintln!("skipping: ETCD_AUTH_TTL_TEST_URL not set");
+        return;
+    };
+    let _serialised = ETCD.lock().await;
+    let prefix = unique_prefix();
+    let mut writer = etcd.writer().await;
+    writer
+        .put(format!("{prefix}/models/m-token-2"), SEEDED_MODEL, None)
+        .await
+        .expect("seed put");
+
+    let provider = etcd.provider(&prefix).await;
+    let (entries, _) = provider.load_all().await.expect("the first read works");
+    assert_eq!(entries.len(), 1);
+
+    // The other half of the failure, and the one no schedule could have
+    // covered: the token stops being valid at a moment nothing on the
+    // client can predict. Toggling authentication clears etcd's token
+    // store, which is what an operator re-enabling auth, a JWT signing
+    // key regenerated at startup, and a member brought up on an empty
+    // data directory all do to the tokens already handed out. Unlike an
+    // expiry this never comes back on its own — the read keeps being
+    // refused until something authenticates again.
+    discard_every_token(&etcd).await;
+
+    let (entries, _) = provider
+        .load_all()
+        .await
+        .expect("a discarded token must be replaced, not fail the read");
+    assert_eq!(
+        entries.len(),
+        1,
+        "the read after re-authenticating must return the same configuration",
+    );
+
+    let mut writer = etcd.writer().await;
+    writer
+        .delete(format!("{prefix}/models/m-token-2"), None)
+        .await
+        .expect("cleanup");
+}
+
+#[tokio::test]
+async fn a_user_etcd_refuses_is_answered_once_and_not_re_authenticated() {
+    let Some(etcd) = auth_ttl_etcd() else {
+        eprintln!("skipping: ETCD_AUTH_TTL_TEST_URL not set");
+        return;
+    };
+    let _serialised = ETCD.lock().await;
+
+    // A user that authenticates and is then refused by the read itself —
+    // the only way a real etcd refuses a *call* rather than a dial, and
+    // so the case the new retry path could have turned into a spin. It
+    // must fail on the first answer, the way a wrong password does at the
+    // dial.
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let user = format!("norole-{nanos}");
+    let password = "norole-pw";
+    let mut root = etcd.writer().await;
+    root.user_add(user.clone(), password, None)
+        .await
+        .expect("add a user with no roles");
+
+    let prefix = unique_prefix();
+    let provider = EtcdConfigProvider::connect(
+        std::slice::from_ref(&etcd.url),
+        &prefix,
+        Some(ConnectOptions::new().with_user(user.clone(), password)),
+        Some(Duration::from_secs(10)),
+        Some(Duration::from_secs(10)),
+    )
+    .await
+    .expect("the credentials themselves are good — the dial succeeds");
+
+    let started = Instant::now();
+    let err = provider
+        .load_all()
+        .await
+        .expect_err("a user with no roles cannot read");
+    assert!(
+        matches!(err, ProviderError::Rejected(_)),
+        "a refusal must stay a refusal, got {err:?}",
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "a refusal must be answered, not retried until something times out: {:?}",
+        started.elapsed(),
+    );
+
+    root.user_delete(user).await.expect("cleanup");
+}
+
+/// Make etcd forget every token it has issued, this one included.
+///
+/// `auth disable` drops the token store and `auth enable` starts a fresh
+/// one, so the token the provider holds is refused from here on with
+/// `Unauthenticated` — the same answer an elapsed TTL produces, from a
+/// cause that never heals by waiting.
+async fn discard_every_token(etcd: &AuthEtcd) {
+    let mut admin = etcd.writer().await;
+    admin.auth_disable().await.expect("auth disable");
+    admin.auth_enable().await.expect("auth enable");
+}

--- a/crates/aisix-etcd/tests/auth_token_recovery.rs
+++ b/crates/aisix-etcd/tests/auth_token_recovery.rs
@@ -3,10 +3,11 @@
 //! `etcd-client` authenticates once, inside `Client::connect`, and never
 //! again. The token it gets there is the only one that connection will
 //! ever carry, and etcd stops accepting it in two ordinary situations:
-//! the server restarts (its token store is in memory), or the token's
-//! `--auth-token-ttl` elapses while nothing is using it. Every later call
-//! is then refused, and before this the only cure was restarting the
-//! gateway.
+//! the token's `--auth-token-ttl` elapses while nothing is using it, or
+//! etcd's token store is cleared out from under the connection —
+//! authentication re-enabled, a JWT signing key regenerated at startup, a
+//! member brought up on an empty data directory. Every later call is then
+//! refused, and before this the only cure was restarting the gateway.
 //!
 //! Both need a server that really issues and forgets tokens — the status
 //! code, the wording and the *timing* are etcd's, not something a stub
@@ -54,10 +55,14 @@ fn auth_ttl_etcd() -> Option<AuthEtcd> {
         url: std::env::var("ETCD_AUTH_TTL_TEST_URL").ok()?,
         user: std::env::var("ETCD_AUTH_TTL_TEST_USER").ok()?,
         password: std::env::var("ETCD_AUTH_TTL_TEST_PASSWORD").ok()?,
+        // Parsed strictly on purpose: a typo in the workflow would
+        // otherwise turn every test in this file into a silent skip,
+        // which on a check is the same colour as a pass.
         token_ttl: Duration::from_secs(
             std::env::var("ETCD_AUTH_TTL_TEST_SECS")
-                .ok()
-                .and_then(|s| s.parse().ok())?,
+                .ok()?
+                .parse()
+                .expect("ETCD_AUTH_TTL_TEST_SECS must be a whole number of seconds"),
         ),
     })
 }
@@ -243,6 +248,11 @@ async fn a_user_etcd_refuses_is_answered_once_and_not_re_authenticated() {
         started.elapsed(),
     );
 
+    // A writer of its own. This cluster's token TTL is seconds, and the
+    // connect and read above can outlast it on a loaded runner — a
+    // cleanup on the original `root` would then fail for a reason that
+    // has nothing to do with what this test asserts.
+    let mut root = etcd.writer().await;
     root.user_delete(user).await.expect("cleanup");
 }
 
@@ -254,6 +264,12 @@ async fn a_user_etcd_refuses_is_answered_once_and_not_re_authenticated() {
 /// cause that never heals by waiting.
 async fn discard_every_token(etcd: &AuthEtcd) {
     let mut admin = etcd.writer().await;
-    admin.auth_disable().await.expect("auth disable");
-    admin.auth_enable().await.expect("auth enable");
+    // Both calls are made before either is asserted on: a panic between
+    // them would leave the shared cluster with authentication off, which
+    // does not fail this test — it silently guts the one below it, whose
+    // whole subject is a user etcd refuses.
+    let disabled = admin.auth_disable().await;
+    let enabled = admin.auth_enable().await;
+    disabled.expect("auth disable");
+    enabled.expect("auth enable");
 }

--- a/crates/aisix-etcd/tests/auth_token_recovery.rs
+++ b/crates/aisix-etcd/tests/auth_token_recovery.rs
@@ -3,11 +3,20 @@
 //! `etcd-client` authenticates once, inside `Client::connect`, and never
 //! again. The token it gets there is the only one that connection will
 //! ever carry, and etcd stops accepting it in two ordinary situations:
-//! the token's `--auth-token-ttl` elapses while nothing is using it, or
-//! etcd's token store is cleared out from under the connection —
-//! authentication re-enabled, a JWT signing key regenerated at startup, a
-//! member brought up on an empty data directory. Every later call is then
-//! refused, and before this the only cure was restarting the gateway.
+//!
+//! 1. **The token's TTL elapses.** Answered `Unauthenticated`
+//!    (`etcdserver: invalid auth token`).
+//! 2. **The auth store's revision changes** — someone runs `etcdctl user
+//!    add`, grants a role, edits a permission. Every token issued before
+//!    that is refused from the moment it lands, and answered
+//!    `InvalidArgument` (`etcdserver: revision of auth store is old`),
+//!    sharing a status code with a wrong password.
+//!
+//! Every later call is then refused, and before this the only cure was
+//! restarting the gateway. Note what is *not* on the list: an etcd
+//! restart on its own does not invalidate anything, because
+//! `Authenticate` is a raft entry and replaying the WAL re-registers the
+//! tokens it minted.
 //!
 //! Both need a server that really issues and forgets tokens — the status
 //! code, the wording and the *timing* are etcd's, not something a stub
@@ -17,11 +26,13 @@
 //! cluster and sets the variables in `.github/workflows/ci.yml`.
 //!
 //! The cluster this file uses is a **third** etcd, separate from the
-//! `ETCD_AUTH_TEST_URL` one, for two reasons: its `--auth-token-ttl` is
+//! `ETCD_AUTH_TEST_URL` one, for two reasons. Its token lifetime is
 //! seconds rather than the five-minute default, which would make every
-//! other authenticated test depend on this feature; and one test here
-//! momentarily turns authentication off on it, which no other test can
-//! be reading through.
+//! other authenticated test depend on this feature. And it runs
+//! `--auth-token jwt` rather than the default `simple`, which is what
+//! reaches case 2 above: under `simple` the auth revision is read at
+//! request time, so only JWT — what a multi-member cluster runs anyway —
+//! refuses a token for it.
 //!
 //! The container and short-TTL cluster this needs were built by community
 //! PR api7/aisix#763 (`okaybase`), which proposed the scheduled-refresh
@@ -35,18 +46,19 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use aisix_etcd::{ConfigProvider, EtcdConfigProvider, ProviderError};
 use etcd_client::ConnectOptions;
 
-/// One test here turns the cluster's authentication off and on again,
-/// which every other test in this file is reading through, so they take
-/// turns. Test binaries are run one at a time, so nothing outside this
-/// file is talking to it.
+/// Two tests here change the cluster's auth store, which stales every
+/// token every other test in this file is holding, so they take turns.
+/// Test binaries are run one at a time, so nothing outside this file is
+/// talking to it.
 static ETCD: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 struct AuthEtcd {
     url: String,
     user: String,
     password: String,
-    /// The cluster's `--auth-token-ttl`. Read from the environment rather
-    /// than assumed, so the sleep below tracks whatever CI started.
+    /// The lifetime of a token this cluster issues (the `ttl` inside its
+    /// `--auth-token`). Read from the environment rather than assumed, so
+    /// the sleep below tracks whatever CI started.
     token_ttl: Duration,
 }
 
@@ -67,12 +79,15 @@ fn auth_ttl_etcd() -> Option<AuthEtcd> {
     })
 }
 
-fn unique_prefix() -> String {
-    let nanos = SystemTime::now()
+fn unique_suffix() -> u128 {
+    SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
-        .unwrap_or_default();
-    format!("/aisix-token-it-{nanos}")
+        .unwrap_or_default()
+}
+
+fn unique_prefix() -> String {
+    format!("/aisix-token-it-{}", unique_suffix())
 }
 
 impl AuthEtcd {
@@ -154,7 +169,7 @@ async fn a_token_that_expired_while_idle_is_replaced_without_a_restart() {
 }
 
 #[tokio::test]
-async fn a_token_the_server_has_discarded_is_replaced_without_a_restart() {
+async fn a_token_an_auth_store_change_staled_is_replaced_without_a_restart() {
     let Some(etcd) = auth_ttl_etcd() else {
         eprintln!("skipping: ETCD_AUTH_TTL_TEST_URL not set");
         return;
@@ -171,31 +186,39 @@ async fn a_token_the_server_has_discarded_is_replaced_without_a_restart() {
     let (entries, _) = provider.load_all().await.expect("the first read works");
     assert_eq!(entries.len(), 1);
 
-    // The other half of the failure, and the one no schedule could have
-    // covered: the token stops being valid at a moment nothing on the
-    // client can predict. Toggling authentication clears etcd's token
-    // store, which is what an operator re-enabling auth, a JWT signing
-    // key regenerated at startup, and a member brought up on an empty
-    // data directory all do to the tokens already handed out. Unlike an
-    // expiry this never comes back on its own — the read keeps being
-    // refused until something authenticates again.
-    discard_every_token(&etcd).await;
+    // The half no schedule could have covered: adding a user bumps the
+    // auth store's revision, and from that instant every token issued
+    // before it is refused — nothing about it is predictable from the
+    // client, and it does not come back on its own. It is also refused
+    // with `InvalidArgument`, the same status code as a wrong password,
+    // so this is the test that keeps those two apart end to end: if the
+    // gateway treated it as a wrong password it would stop reading its
+    // configuration for good, over an operator adding a user.
+    let stale_user = format!("stale-{}", unique_suffix());
+    let mut admin = etcd.writer().await;
+    admin
+        .user_add(stale_user.clone(), "stale-pw", None)
+        .await
+        .expect("bump the auth store revision");
 
     let (entries, _) = provider
         .load_all()
         .await
-        .expect("a discarded token must be replaced, not fail the read");
+        .expect("a staled token must be replaced, not fail the read");
     assert_eq!(
         entries.len(),
         1,
         "the read after re-authenticating must return the same configuration",
     );
 
+    // Key first, user second: deleting the user bumps the revision
+    // again and stales this writer's own token, so nothing may follow it.
     let mut writer = etcd.writer().await;
     writer
         .delete(format!("{prefix}/models/m-token-2"), None)
         .await
         .expect("cleanup");
+    writer.user_delete(stale_user).await.expect("cleanup user");
 }
 
 #[tokio::test]
@@ -211,11 +234,7 @@ async fn a_user_etcd_refuses_is_answered_once_and_not_re_authenticated() {
     // so the case the new retry path could have turned into a spin. It
     // must fail on the first answer, the way a wrong password does at the
     // dial.
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or_default();
-    let user = format!("norole-{nanos}");
+    let user = format!("norole-{}", unique_suffix());
     let password = "norole-pw";
     let mut root = etcd.writer().await;
     root.user_add(user.clone(), password, None)
@@ -254,22 +273,4 @@ async fn a_user_etcd_refuses_is_answered_once_and_not_re_authenticated() {
     // has nothing to do with what this test asserts.
     let mut root = etcd.writer().await;
     root.user_delete(user).await.expect("cleanup");
-}
-
-/// Make etcd forget every token it has issued, this one included.
-///
-/// `auth disable` drops the token store and `auth enable` starts a fresh
-/// one, so the token the provider holds is refused from here on with
-/// `Unauthenticated` — the same answer an elapsed TTL produces, from a
-/// cause that never heals by waiting.
-async fn discard_every_token(etcd: &AuthEtcd) {
-    let mut admin = etcd.writer().await;
-    // Both calls are made before either is asserted on: a panic between
-    // them would leave the shared cluster with authentication off, which
-    // does not fail this test — it silently guts the one below it, whose
-    // whole subject is a user etcd refuses.
-    let disabled = admin.auth_disable().await;
-    let enabled = admin.auth_enable().await;
-    disabled.expect("auth disable");
-    enabled.expect("auth enable");
 }

--- a/tests/e2e/src/cases/etcd-auth-connect-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-auth-connect-e2e.test.ts
@@ -194,8 +194,11 @@ describe("etcd credentials: unreachable is waited out, refused is not", () => {
     // would produce. The repetition is what tells an operator the
     // gateway is still waiting rather than having given up.
     expect(await waitForOutput(app, STILL_DIALLING_LINE, 60_000, 2)).toBeGreaterThanOrEqual(2);
-    // …and it is still inside the dial, which is the point: no listener
-    // came up while it was reporting.
+    // …and it is still inside the dial, which is the point: it is
+    // running, and no listener came up while it was reporting. The
+    // running half is not redundant — a process that logged twice and
+    // then died would satisfy the closed-port assertions too.
+    await expect(app.waitForExit(1_000)).rejects.toThrow();
     expect(await tcpAccepts(Number(new URL(app.metricsUrl).port))).toBe(false);
     expect(await tcpAccepts(Number(new URL(app.proxyUrl).port))).toBe(false);
   }, 120_000);

--- a/tests/e2e/src/cases/etcd-auth-connect-e2e.test.ts
+++ b/tests/e2e/src/cases/etcd-auth-connect-e2e.test.ts
@@ -35,6 +35,8 @@ const DEFERRED_LINE = "etcd is not reachable yet";
 const REFUSED_LINE = "etcd rejected the connection";
 /** The supervisor's line for a refusal it meets after the boot is past. */
 const REFUSED_AFTER_BOOT_LINE = "etcd refused this gateway's credentials";
+/** What an outstanding dial repeats while it is still outstanding. */
+const STILL_DIALLING_LINE = "still connecting to etcd";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
@@ -92,10 +94,11 @@ describe("etcd credentials: unreachable is waited out, refused is not", () => {
     endpoint: string,
     prefix: string,
     etcdExtra: Record<string, unknown> = {},
+    awaitListeners = true,
   ): Promise<SpawnedApp> {
     const app = await spawnApp({
       etcdPrefix: prefix,
-      awaitProxyListener: false,
+      ...(awaitListeners ? { awaitProxyListener: false } : { awaitListeners: false }),
       // The supervisor's backoff line and the boot's deferral line are
       // both WARN, which this level keeps.
       logLevel: "warn",
@@ -165,6 +168,36 @@ describe("etcd credentials: unreachable is waited out, refused is not", () => {
 
     const metrics = await fetch(`${app.metricsUrl}/metrics`);
     expect(metrics.status).toBe(200);
+  }, 120_000);
+
+  test("an unbounded dial that hangs says so instead of going silent", async (ctx) => {
+    if (!etcdReachable) {
+      ctx.skip();
+      return;
+    }
+    // The same silent endpoint as the spec above, but with
+    // `dial_timeout_ms` left unset — the shipped default, and the only
+    // configuration in which the dial has no bound at all. The gateway
+    // is then stuck inside `Client::connect` before any listener binds,
+    // and it used to write NOTHING: an operator saw a process with no
+    // port, no log line and nothing to grep for. The bound is unchanged
+    // — what is asserted is that the wait is audible.
+    const prefix = `/aisix-e2e-etcd-auth-hang-${randomUUID()}`;
+    const relay = await startEtcdRelay();
+    relays.push(relay);
+    await relay.hold();
+
+    // Nothing to wait for: the proxy, admin and metrics listeners are
+    // all still unopened, which is the defect.
+    const app = await spawnAuthenticated(relay.endpoint, prefix, {}, false);
+    // Two lines, not one: a single line is also what a one-off warning
+    // would produce. The repetition is what tells an operator the
+    // gateway is still waiting rather than having given up.
+    expect(await waitForOutput(app, STILL_DIALLING_LINE, 60_000, 2)).toBeGreaterThanOrEqual(2);
+    // …and it is still inside the dial, which is the point: no listener
+    // came up while it was reporting.
+    expect(await tcpAccepts(Number(new URL(app.metricsUrl).port))).toBe(false);
+    expect(await tcpAccepts(Number(new URL(app.proxyUrl).port))).toBe(false);
   }, 120_000);
 
   test("a refusal that only arrives after boot is reported, not buried", async (ctx) => {

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -132,6 +132,19 @@ export interface AppOverrides {
    */
   awaitProxyListener?: boolean;
   /**
+   * Whether readiness waits for ANY listener. **Defaults to `true`.**
+   *
+   * `false` returns as soon as the process is spawned, for the one shape
+   * `awaitProxyListener` cannot express: a gateway that binds nothing at
+   * all. The boot dials etcd before any listener is opened, so an
+   * endpoint that accepts TCP and then goes silent — with
+   * `dial_timeout_ms` unset, which is the shipped default — leaves the
+   * process running with no port at all. A spec that opts out has only
+   * `output()` to assert on, so it must poll for the line it expects
+   * rather than assume the binary got anywhere.
+   */
+  awaitListeners?: boolean;
+  /**
    * `managed.snapshot_cache_path` — enables the on-disk snapshot cache
    * (#871) without managed mode. Point two sequential apps (same
    * `etcdPrefix`) at one path to exercise cache-restored restarts.
@@ -263,6 +276,12 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   if (overrides.extra && "admin" in overrides.extra) {
     throw new Error(
       "spawnApp: control the admin listener with the `admin` boolean override, not `extra.admin`",
+    );
+  }
+  if (overrides.awaitListeners === false && overrides.awaitProxyListener === false) {
+    throw new Error(
+      "spawnApp: awaitListeners:false already skips every readiness gate — " +
+        "drop the awaitProxyListener override",
     );
   }
   if (overrides.awaitProxyListener === false) {
@@ -411,36 +430,40 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   const metricsUrl = `http://127.0.0.1:${metricsPort}`;
 
   try {
-    await Promise.race([
-      Promise.all([
-        // The proxy listener binds only once a configuration has been
-        // applied, so a spec that holds configuration back opts out here.
-        ...((overrides.awaitProxyListener ?? true)
-          ? [waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS)]
-          : []),
-        // The admin health endpoint only exists when the admin listener is
-        // bound; with `admin: false` there is no admin surface, so gate on
-        // the proxy `/livez` and the metrics listener alone. (If both
-        // `admin` and `prometheus` are off, readiness reduces to the proxy
-        // `/livez` — liveness only; a case that needs config-propagation
-        // readiness should keep prometheus on, as the default does.)
-        ...(adminEnabled
-          ? [waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey)]
-          : []),
-        // Gate on the dedicated metrics listener too, so scrapes in the test
-        // never race the listener coming up. Skipped when prometheus is
-        // disabled — nothing binds the metrics port then.
-        ...(prometheusEnabled
-          ? [
-              waitForReady(
-                `${metricsUrl}${overrides.prometheusPath ?? "/metrics"}`,
-                READY_TIMEOUT_MS,
-              ),
-            ]
-          : []),
-      ]),
-      exitedEarly,
-    ]);
+    // A spec that opted out of every gate owns its own waiting: nothing
+    // is listening to probe, so `output()` is the only signal there is.
+    if (overrides.awaitListeners !== false) {
+      await Promise.race([
+        Promise.all([
+          // The proxy listener binds only once a configuration has been
+          // applied, so a spec that holds configuration back opts out here.
+          ...((overrides.awaitProxyListener ?? true)
+            ? [waitForReady(`${proxyUrl}/livez`, READY_TIMEOUT_MS)]
+            : []),
+          // The admin health endpoint only exists when the admin listener is
+          // bound; with `admin: false` there is no admin surface, so gate on
+          // the proxy `/livez` and the metrics listener alone. (If both
+          // `admin` and `prometheus` are off, readiness reduces to the proxy
+          // `/livez` — liveness only; a case that needs config-propagation
+          // readiness should keep prometheus on, as the default does.)
+          ...(adminEnabled
+            ? [waitForReady(`${adminUrl}/admin/v1/health`, READY_TIMEOUT_MS, adminKey)]
+            : []),
+          // Gate on the dedicated metrics listener too, so scrapes in the test
+          // never race the listener coming up. Skipped when prometheus is
+          // disabled — nothing binds the metrics port then.
+          ...(prometheusEnabled
+            ? [
+                waitForReady(
+                  `${metricsUrl}${overrides.prometheusPath ?? "/metrics"}`,
+                  READY_TIMEOUT_MS,
+                ),
+              ]
+            : []),
+        ]),
+        exitedEarly,
+      ]);
+    }
   } catch (err) {
     const detail = exitErr ?? "still running";
     // Keep the head too — a startup error (anyhow's `Error: …` line)

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -278,10 +278,11 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
       "spawnApp: control the admin listener with the `admin` boolean override, not `extra.admin`",
     );
   }
-  if (overrides.awaitListeners === false && overrides.awaitProxyListener === false) {
+  if (overrides.awaitListeners === false && overrides.awaitProxyListener !== undefined) {
     throw new Error(
       "spawnApp: awaitListeners:false already skips every readiness gate — " +
-        "drop the awaitProxyListener override",
+        "drop the awaitProxyListener override, which reads as if `/livez` were " +
+        "still being waited on",
     );
   }
   if (overrides.awaitProxyListener === false) {
@@ -432,7 +433,13 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
   try {
     // A spec that opted out of every gate owns its own waiting: nothing
     // is listening to probe, so `output()` is the only signal there is.
-    if (overrides.awaitListeners !== false) {
+    if (overrides.awaitListeners === false) {
+      // `exitedEarly` is armed either way, and nothing is racing it here.
+      // Left alone, an early non-zero exit would surface as a bare
+      // unhandled rejection under vitest instead of through `waitForExit`
+      // and `output()`, which is where such a spec looks.
+      exitedEarly.catch(() => {});
+    } else {
       await Promise.race([
         Promise.all([
           // The proxy listener binds only once a configuration has been


### PR DESCRIPTION
## The problem

`etcd-client` authenticates once, inside `Client::connect`, and never again. The token it gets there is the only one that connection will ever carry, so once etcd stops accepting it, every later call is refused and the only cure was restarting the gateway. Two ordinary events produce that:

- **The token's lifetime elapses.** Under the default `simple` tokens etcd refreshes the TTL on use, so only an *idle* connection reaches the expiry — precisely the state a gateway with a stable configuration and a quiet admin listener is in almost all the time. It reads fine all day and then cannot read at the moment something changes. Under `jwt` the lifetime is absolute and it happens to everyone. Answered `Unauthenticated`, `etcdserver: invalid auth token`.
- **The auth store's revision changes.** Under `--auth-token jwt` — what a multi-member cluster runs — *any* change to the auth store bumps its revision, and every token issued before it is refused from that instant. One `etcdctl user add` on the cluster and a gateway can no longer read its configuration. Answered `InvalidArgument`, `etcdserver: revision of auth store is old`. Verified against etcd 3.5.18.

What is **not** on that list is an etcd restart. `Authenticate` is a raft entry, so replaying the WAL on startup re-registers the tokens it minted and a connection from before the restart keeps working — verified against 3.5.18, and worth stating because it is the assumption this started from. A restart only invalidates when the token state genuinely does not survive it: a JWT signing key regenerated at startup, or a member brought up on an empty data directory.

## The fix

Recovery is **reactive**, keyed on the answer rather than on a schedule. `LazyEtcdClient::call` runs one etcd call; if etcd refuses it with `Unauthenticated`, it discards that connection, dials a new one — which re-runs `Authenticate` — and retries the call **once**. Nothing runs on a timer, there is no new configuration key, and no client-side mirror of a TTL the gateway cannot observe.

Both clients that can meet a stale token go through it, not just one: the configuration provider's range read and watch create (`EtcdConfigProvider`), and the admin GET surface's reads (`EtcdConfigStore`). An established watch stream is the one exception — a poll cannot dial — and it does not need to be: the stream ends, the supervisor re-enters its cycle, and `load_all` re-authenticates on the way through.

### The safety condition

**A credential etcd has genuinely refused must not be presented over and over**, and it cannot be. This reuses the classification #1135 introduced rather than adding a second one — `classify` gained a third `ConnectError::Unauthenticated` variant beside the existing `Unreachable` / `Rejected`. What routes there:

- `Unauthenticated` — a token etcd does not recognise;
- `InvalidArgument` carrying `etcdserver: revision of auth store is old`;
- `InvalidArgument` carrying `etcdserver: user name is empty`.

And what stays `Rejected`, failing on the first answer with the boot still exiting on it exactly as #1135 made it:

- `InvalidArgument` carrying `etcdserver: authentication failed, invalid user ID or password` — a wrong user or password;
- `PermissionDenied` — a user without the required rights;
- `FailedPrecondition` — credentials sent to a cluster with authentication disabled.

The last two arms of the first list are matched on etcd's message rather than the status code, because etcd gives them the same code as a wrong password. **That is the signal, not a stand-in for one.** etcd's own reference client recovers these errors the same way — it maps a gRPC error back to a typed one through a table keyed on the error string, and its retry interceptor then treats exactly these three as "re-authenticate and retry", while deliberately leaving authentication-failed out. This list is that list, matched the way the reference implementation matches it; the constant carries a note saying so, so nobody later "cleans it up" into a code check.

`user name is empty` is carried for that parity. No reachable scenario was constructed for it here — it goes in because it fails in the safe direction (one extra re-authentication) and because a list that silently drops one of upstream's three arms is the kind of difference nobody finds later.

The retry is additionally bounded at one attempt, so even a token etcd keeps refusing ends the call rather than spinning. And when it does, the report is not the credentials one: a token refused on a connection that authenticated moments earlier is nobody's username and password, so it gets its own `ProviderError::TokenRefused` and its own line, pointing at an auth store changing continuously or a clock that disagrees with etcd's, rather than sending an operator to check a password that is fine.

`request_timeout` now bounds each *attempt* — the dial and the call separately — rather than the pair of them together, so a re-authenticated retry gets the same window the original call had instead of whatever was left of it.

## Making the boot connect observable

With `dial_timeout_ms` unset — the shipped default — an endpoint that accepts TCP and then answers nothing leaves `Client::connect` waiting forever. The gateway is stuck before any listener binds, and it wrote **no log at all**: an operator saw a process with no port and no explanation. It now repeats a line every 10s while the dial is outstanding, the same interval and shape as the first-configuration wait already in `aisix-server`.

**This changes no timeout semantics.** No implicit bound, no default value; unset and `0` still mean unbounded, exactly as #1134 settled. It adds logging only.

## Tests

Each of these fails without its half of the fix (verified by reverting the change and re-running):

- `crates/aisix-etcd/tests/auth_token_recovery.rs` — against a real authenticated etcd issuing short-lived JWTs, which is the one configuration that reaches both halves: a token that expired while idle is replaced without restarting the gateway; a token staled by an `etcdctl user add` on the cluster likewise; and a user etcd refuses at the read is answered once rather than re-authenticated.
- `crates/aisix-admin/tests/etcd_integration.rs` — the same for the admin read path, which is the one that is idle by nature.
- `crates/aisix-etcd/src/client.rs` — against a scripted gRPC server, counting connections as well as calls: each of the three stale-token answers is retried on a *new* connection (that is what re-authenticates; a retry on the same channel would carry the same token), a token that is refused twice stops after one retry, and a refused credential is answered once with no second connection at all. That last one is the safety property and is pinned in both directions — dropping the message match breaks the two new arms, and widening it to all of `InvalidArgument` breaks it. Plus the periodic waiting line, asserted on a real TCP endpoint that accepts and then goes silent.
- `tests/e2e/src/cases/etcd-auth-connect-e2e.test.ts` — a spawned gateway pointed at a silent endpoint with no dial bound reports itself while no listener is up. This needed a `awaitListeners` opt-out in the harness, since the shape being tested is a gateway that binds nothing.

## Baseline

Checked against the upstream project this repo uses as its baseline, at its current head. It has no etcd support at all, so there is no direct equivalent; the nearest thing is its own configuration store, a Postgres database plus Redis.

Its only mid-life credential renewal there is **proactive and expiry-driven**: a background task that mints a new database token shortly before the old one expires, for deployments using a cloud provider's IAM database authentication, and a credential provider that mints a fresh token for each newly established Redis connection. It has **no reactive re-authentication**. An authentication rejection from Postgres is deliberately excluded from the gate that triggers its reconnect-and-retry, so that path does not retry it at all, while a separate 30-second health watchdog reconnects on it forever with the same unchanged credential and nothing ever marks it as permanently refused. A Redis authentication rejection is not recognised as a distinct condition anywhere. And nothing is logged periodically while an initial connection to the store is still outstanding — startup is a bounded three-attempt backoff that either raises or, optionally, comes up with no database at all.

So this PR diverges from that baseline in both halves, deliberately: reactive rather than scheduled, and with the permanently-refused case separated from the transient one so it cannot become an unbounded retry. The scheduled-refresh alternative — which is what both the upstream project and #763 do — was considered and rejected for this repository.

## Credit

The test infrastructure this builds on comes from community PR #763 by @okaybase: the authenticated etcd container in `.github/workflows/ci.yml` with a short `--auth-token-ttl`, and the approach of asserting recovery against a real token expiry rather than a simulated one. That PR's own fix was a scheduled `refresh_token` task on a configurable interval; this takes the reactive route instead, because it keys off what actually happened rather than a predicted schedule — it covers a token store cleared out from under a running gateway, where a scheduled refresh would keep failing until its next tick, and it needs no client-side copy of a server-side TTL. #763's `start_token_refresh_task`, its `auth_token_refresh_secs` config field and its dependency bump are not carried over.
