### PR TITLE
chore(deps): bump fast-uri and qs in the MCP conformance lockfile

### DIFF
--- a/tools/mcp-conformance/package-lock.json
+++ b/tools/mcp-conformance/package-lock.json
@@ -676,9 +676,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
Bumps two transitive npm dependencies in `tools/mcp-conformance/package-lock.json` to clear six open Dependabot security alerts on this repo:

- `fast-uri` 3.1.5 → 3.1.7 (patched floor is 3.1.6) — closes the four high alerts GHSA-f65p-4m7j-42xc, GHSA-jqff-g426-hqxp, GHSA-fph4-wmhf-6fwf, GHSA-5jgf-p345-68v8.
- `qs` 6.15.3 → 6.16.0 (patched floor is 6.16.0) — closes the two moderate alerts GHSA-4mjr-xmp4-gh2g, GHSA-x5fp-wj9c-mxmx.

Both are transitive dependencies of `@modelcontextprotocol/conformance`, the harness's only direct dependency. Each has exactly one entry in the lockfile — no duplicate nested copies — so one bump per package covers every alert. The diff is the two versions plus their `resolved` URLs and integrity hashes, and nothing else; no other package in the graph moved.

`tools/mcp-conformance/package.json` is deliberately untouched. It pins the conformance suite version, and its own description says that bump is made deliberately with the scenario list re-reviewed each time — a separate decision from a security patch.

No runtime exposure. The harness is `"private": true` and exists only to pin the official MCP conformance suite for `scripts/mcp-conformance.sh`. It ships in neither the `aisix` binary nor the image, so neither package is reachable from a request path.

Supersedes the two Dependabot PRs #1116 (fast-uri) and #1125 (qs). Both edit the same lockfile and would conflict with each other, which is why the two bumps land together here.

**Test exception.** No new tests: this is a lockfile-only bump of a CI-only harness, with no source, config or behavior change to cover. The existing `mcp conformance (official suite)` job is the gate that proves the harness still runs on the new versions — it does an `npm ci` against this lockfile and runs the full scenario list. Locally, `npm ci` in `tools/mcp-conformance` resolves cleanly (117 packages, 0 vulnerabilities) and the `conformance` CLI still loads.
