### PR TITLE
fix(messages): drop the Anthropic billing-attribution line for non-Anthropic upstreams

### DIFF
--- a/crates/aisix-provider-anthropic/src/lib.rs
+++ b/crates/aisix-provider-anthropic/src/lib.rs
@@ -31,9 +31,12 @@ pub use bridge::{AnthropicBridge, ANTHROPIC_DEFAULT_BASE, ANTHROPIC_VERSION};
 ///   `ChatResponse` back as Anthropic JSON.
 /// - [`AnthropicSseEncoder`] re-encodes the bridge's `ChatChunk`
 ///   stream as Anthropic typed SSE events.
+/// - [`strip_billing_header_attribution`] drops the client's
+///   Anthropic-only billing attribution line from `system` before the
+///   body is sent to any other provider.
 pub use wire::{
     chat_response_into_anthropic_json, parse_inbound_request, parse_inbound_request_for_scan,
-    translate_anthropic_tool_choice_to_openai, translate_anthropic_tools_to_openai,
-    translate_extras_to_openai_shape, AnthropicInboundError, AnthropicSseEncoder,
-    AnthropicSseEvent,
+    strip_billing_header_attribution, translate_anthropic_tool_choice_to_openai,
+    translate_anthropic_tools_to_openai, translate_extras_to_openai_shape, AnthropicInboundError,
+    AnthropicSseEncoder, AnthropicSseEvent,
 };

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -1545,7 +1545,10 @@ fn without_billing_header_line(text: &str) -> SystemText<'_> {
         return SystemText::Unchanged;
     }
     match trimmed.split_once('\n') {
-        Some((_, rest)) if !rest.is_empty() => SystemText::Remainder(rest),
+        // A remainder that is only whitespace is nothing surviving, not a
+        // prompt: keeping it would put a blank `system` on the wire, and
+        // Anthropic-protocol upstreams reject an empty text block.
+        Some((_, rest)) if !rest.trim().is_empty() => SystemText::Remainder(rest),
         // No newline: the client emits the attribution as its own line, so
         // a text that starts with the marker and never ends the line is
         // the attribution and nothing else.
@@ -2634,6 +2637,50 @@ mod tests {
         });
         let out = strip_billing_header_attribution(&trailing);
         assert!(out.get("system").is_none());
+    }
+
+    /// A remainder made only of whitespace is nothing surviving. Keeping
+    /// it would put a blank `system` on the wire — and a blank text block
+    /// is what Anthropic-protocol upstreams reject outright.
+    #[test]
+    fn strip_billing_header_treats_a_blank_remainder_as_nothing_surviving() {
+        for tail in ["\n", "\n   \n", "\n\t"] {
+            let string = serde_json::json!({
+                "model": "claude",
+                "system": format!("{BILLING_LINE}{tail}"),
+                "messages": [{ "role": "user", "content": "hi" }]
+            });
+            assert!(
+                strip_billing_header_attribution(&string)
+                    .get("system")
+                    .is_none(),
+                "string form with trailing {tail:?} must omit `system`"
+            );
+
+            let array = serde_json::json!({
+                "model": "claude",
+                "system": [{ "type": "text", "text": format!("{BILLING_LINE}{tail}") }],
+                "messages": [{ "role": "user", "content": "hi" }]
+            });
+            assert!(
+                strip_billing_header_attribution(&array)
+                    .get("system")
+                    .is_none(),
+                "array form with trailing {tail:?} must omit `system`"
+            );
+        }
+
+        // A blank line BEFORE real prompt text is not a blank remainder —
+        // the operator's text survives with its own leading whitespace.
+        let kept = serde_json::json!({
+            "model": "claude",
+            "system": format!("{BILLING_LINE}\n\nYou are a terse assistant."),
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+        assert_eq!(
+            strip_billing_header_attribution(&kept)["system"],
+            serde_json::json!("\nYou are a terse assistant.")
+        );
     }
 
     #[test]

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -21,6 +21,8 @@
 //!   …). We only emit a `ChatChunk` when a delta carries content or a
 //!   stop reason — other events just advance internal state.
 
+use std::borrow::Cow;
+
 use aisix_gateway::{
     BridgeError, ChatChunk, ChatDelta, ChatFormat, ChatMessage, ChatResponse, FinishReason, Role,
     UsageStats,
@@ -1504,6 +1506,99 @@ enum InboundUse {
     Scan,
 }
 
+/// Leading marker of the attribution line some Anthropic-native clients
+/// prepend to the system prompt.
+///
+/// The line is metadata for Anthropic's own billing and telemetry — no
+/// other provider reads it — and clients emit it as the very first text
+/// of the very first system block.
+const BILLING_HEADER_PREFIX: &str = "x-anthropic-billing-header:";
+
+fn is_billing_header_text(text: &str) -> bool {
+    text.trim_start().starts_with(BILLING_HEADER_PREFIX)
+}
+
+/// Drop the client's billing-header attribution line from an Anthropic
+/// `/v1/messages` body's `system` field, returning the body unchanged
+/// (borrowed) when there is nothing to drop.
+///
+/// Callers apply this only when the resolved upstream is NOT Anthropic's
+/// own first-party API (`dispatch::is_first_party_anthropic`). The line
+/// carries a segment that varies per request in some deployments, and it
+/// sits at the very start of the system prompt, so forwarding it to any
+/// other provider changes the prefix of every prompt and defeats that
+/// provider's prompt cache for the whole conversation — while the line
+/// itself means nothing there.
+///
+/// Only `system` is rewritten; `messages` is never touched, because a
+/// caller may legitimately quote the line inside conversation content and
+/// removing it there would alter what the model is asked about.
+///
+/// Both wire shapes of `system` are handled. An array drops every block
+/// whose text starts with the marker; a string drops its first line. If
+/// that leaves nothing behind, `system` is removed outright rather than
+/// sent empty.
+///
+/// A block qualifies by carrying a `text` string, not by declaring
+/// `type: "text"` — that is what [`parse_inbound`] flattens into the
+/// prompt, and a block this gateway would forward has to be a block it
+/// would also consider.
+pub fn strip_billing_header_attribution(body: &serde_json::Value) -> Cow<'_, serde_json::Value> {
+    use serde_json::Value;
+
+    let Some(system) = body.get("system") else {
+        return Cow::Borrowed(body);
+    };
+
+    let replacement = match system {
+        Value::Array(blocks) => {
+            if !blocks.iter().any(|b| {
+                b.get("text")
+                    .and_then(Value::as_str)
+                    .is_some_and(is_billing_header_text)
+            }) {
+                return Cow::Borrowed(body);
+            }
+            let kept: Vec<Value> = blocks
+                .iter()
+                .filter(|b| {
+                    !b.get("text")
+                        .and_then(Value::as_str)
+                        .is_some_and(is_billing_header_text)
+                })
+                .cloned()
+                .collect();
+            (!kept.is_empty()).then_some(Value::Array(kept))
+        }
+        Value::String(s) => {
+            if !is_billing_header_text(s) {
+                return Cow::Borrowed(body);
+            }
+            // Through the first newline inclusive. No newline at all means
+            // the whole string was the attribution line.
+            match s.split_once('\n') {
+                Some((_, rest)) if !rest.is_empty() => Some(Value::String(rest.to_string())),
+                _ => None,
+            }
+        }
+        _ => return Cow::Borrowed(body),
+    };
+
+    let mut outbound = body.clone();
+    let obj = outbound
+        .as_object_mut()
+        .expect("`system` was read from an object");
+    match replacement {
+        Some(v) => {
+            obj.insert("system".to_string(), v);
+        }
+        None => {
+            obj.remove("system");
+        }
+    }
+    Cow::Owned(outbound)
+}
+
 /// Parse an Anthropic `POST /v1/messages` JSON body into the gateway's
 /// internal [`ChatFormat`], for **cross-provider dispatch**. The `system`
 /// field is folded into a leading system message. Message content blocks
@@ -2418,6 +2513,172 @@ fn content_block_stop_event(index: usize) -> AnthropicSseEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const BILLING_LINE: &str =
+        "x-anthropic-billing-header: cc_version=2.1.0; cc_entrypoint=cli; cch=7f3a91;";
+
+    #[test]
+    fn strip_billing_header_drops_the_leading_block_and_keeps_the_rest() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "system": [
+                { "type": "text", "text": BILLING_LINE },
+                {
+                    "type": "text",
+                    "text": "You are a helpful assistant.",
+                    "cache_control": { "type": "ephemeral" }
+                }
+            ],
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+
+        let out = strip_billing_header_attribution(&body);
+        assert!(matches!(out, Cow::Owned(_)));
+        assert_eq!(
+            out["system"],
+            serde_json::json!([
+                {
+                    "type": "text",
+                    "text": "You are a helpful assistant.",
+                    "cache_control": { "type": "ephemeral" }
+                }
+            ]),
+            "the surviving block keeps its cache_control verbatim"
+        );
+        assert_eq!(
+            out["messages"], body["messages"],
+            "messages are never touched"
+        );
+    }
+
+    #[test]
+    fn strip_billing_header_drops_the_leading_line_of_a_string_system() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "system": format!("{BILLING_LINE}\nYou are a helpful assistant.\nBe brief."),
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+
+        let out = strip_billing_header_attribution(&body);
+        assert_eq!(
+            out["system"],
+            serde_json::json!("You are a helpful assistant.\nBe brief."),
+            "only the first line goes; the remainder survives byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn strip_billing_header_omits_system_when_nothing_survives() {
+        let array = serde_json::json!({
+            "model": "claude",
+            "system": [{ "type": "text", "text": BILLING_LINE }],
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+        let out = strip_billing_header_attribution(&array);
+        assert!(
+            out.get("system").is_none(),
+            "an empty `system` array is removed, not sent empty"
+        );
+
+        let string = serde_json::json!({
+            "model": "claude",
+            "system": BILLING_LINE,
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+        let out = strip_billing_header_attribution(&string);
+        assert!(out.get("system").is_none());
+
+        // A trailing newline leaves an empty remainder, which is the same
+        // thing as nothing surviving.
+        let trailing = serde_json::json!({
+            "model": "claude",
+            "system": format!("{BILLING_LINE}\n"),
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+        let out = strip_billing_header_attribution(&trailing);
+        assert!(out.get("system").is_none());
+    }
+
+    #[test]
+    fn strip_billing_header_leaves_an_unrelated_system_alone() {
+        for system in [
+            serde_json::json!("You are a helpful assistant."),
+            serde_json::json!([{ "type": "text", "text": "You are a helpful assistant." }]),
+            // The marker mid-prompt is prose, not the attribution line.
+            serde_json::json!(format!("Explain what {BILLING_LINE} means.")),
+            serde_json::Value::Null,
+        ] {
+            let body = serde_json::json!({
+                "model": "claude",
+                "system": system,
+                "messages": [{ "role": "user", "content": "hi" }]
+            });
+            let out = strip_billing_header_attribution(&body);
+            assert!(
+                matches!(out, Cow::Borrowed(_)),
+                "unchanged bodies are returned borrowed: {body}"
+            );
+        }
+
+        // No `system` at all.
+        let bare = serde_json::json!({
+            "model": "claude",
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+        assert!(matches!(
+            strip_billing_header_attribution(&bare),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn strip_billing_header_never_touches_messages() {
+        // The same line quoted inside the conversation is content the
+        // caller is asking about, and removing it would change the
+        // question.
+        let body = serde_json::json!({
+            "model": "claude",
+            "system": [{ "type": "text", "text": BILLING_LINE }, { "type": "text", "text": "be brief" }],
+            "messages": [
+                { "role": "user", "content": format!("what does `{BILLING_LINE}` mean?") },
+                {
+                    "role": "assistant",
+                    "content": [{ "type": "text", "text": BILLING_LINE }]
+                }
+            ]
+        });
+
+        let out = strip_billing_header_attribution(&body);
+        assert_eq!(out["messages"], body["messages"]);
+        assert_eq!(
+            out["system"],
+            serde_json::json!([{ "type": "text", "text": "be brief" }])
+        );
+    }
+
+    #[test]
+    fn strip_billing_header_drops_every_attribution_block_and_tolerates_leading_space() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "system": [
+                { "type": "text", "text": format!("  {BILLING_LINE}") },
+                { "type": "text", "text": "keep me" },
+                { "type": "text", "text": BILLING_LINE },
+                // Not a text block: nothing to inspect, so it survives.
+                { "type": "unknown", "id": "x" }
+            ],
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+
+        let out = strip_billing_header_attribution(&body);
+        assert_eq!(
+            out["system"],
+            serde_json::json!([
+                { "type": "text", "text": "keep me" },
+                { "type": "unknown", "id": "x" }
+            ])
+        );
+    }
 
     #[test]
     fn split_system_merges_leading_system_messages() {

--- a/crates/aisix-provider-anthropic/src/wire.rs
+++ b/crates/aisix-provider-anthropic/src/wire.rs
@@ -1510,12 +1510,47 @@ enum InboundUse {
 /// prepend to the system prompt.
 ///
 /// The line is metadata for Anthropic's own billing and telemetry — no
-/// other provider reads it — and clients emit it as the very first text
-/// of the very first system block.
+/// other provider reads it — and clients emit it as the first line of the
+/// system prompt. Matched case-insensitively: the name is header-shaped,
+/// and a client that capitalises it the way HTTP does would otherwise
+/// bypass the strip with no signal.
 const BILLING_HEADER_PREFIX: &str = "x-anthropic-billing-header:";
 
-fn is_billing_header_text(text: &str) -> bool {
-    text.trim_start().starts_with(BILLING_HEADER_PREFIX)
+/// What is left of one system text once the attribution line is removed.
+enum SystemText<'a> {
+    /// No attribution line here — the text stands exactly as written.
+    Unchanged,
+    /// The line was removed; this is what followed it.
+    Remainder(&'a str),
+    /// The text was the attribution line and nothing else.
+    Empty,
+}
+
+/// Remove a leading attribution line from one system text.
+///
+/// Line-granular on purpose, for both wire shapes. The marker prefixes a
+/// line, not necessarily a whole block or a whole string: a client that
+/// puts the line and its real system prompt in the same block would
+/// otherwise lose the prompt entirely, which is a far worse failure than
+/// the cache miss this exists to prevent.
+fn without_billing_header_line(text: &str) -> SystemText<'_> {
+    // Leading whitespace belongs to the line being removed, so the cut is
+    // measured from `trimmed`. Cutting the raw text instead would split at
+    // a leading newline and leave the attribution line itself in place.
+    let trimmed = text.trim_start();
+    if !trimmed
+        .get(..BILLING_HEADER_PREFIX.len())
+        .is_some_and(|p| p.eq_ignore_ascii_case(BILLING_HEADER_PREFIX))
+    {
+        return SystemText::Unchanged;
+    }
+    match trimmed.split_once('\n') {
+        Some((_, rest)) if !rest.is_empty() => SystemText::Remainder(rest),
+        // No newline: the client emits the attribution as its own line, so
+        // a text that starts with the marker and never ends the line is
+        // the attribution and nothing else.
+        _ => SystemText::Empty,
+    }
 }
 
 /// Drop the client's billing-header attribution line from an Anthropic
@@ -1534,10 +1569,11 @@ fn is_billing_header_text(text: &str) -> bool {
 /// caller may legitimately quote the line inside conversation content and
 /// removing it there would alter what the model is asked about.
 ///
-/// Both wire shapes of `system` are handled. An array drops every block
-/// whose text starts with the marker; a string drops its first line. If
-/// that leaves nothing behind, `system` is removed outright rather than
-/// sent empty.
+/// Both wire shapes of `system` are handled, and both remove the LINE
+/// rather than its container: a string keeps whatever followed it, and an
+/// array block keeps its remaining text along with its `cache_control`.
+/// A block or a string left with nothing is dropped, and a `system` left
+/// with no blocks at all is removed outright rather than sent empty.
 ///
 /// A block qualifies by carrying a `text` string, not by declaring
 /// `type: "text"` — that is what [`parse_inbound`] flattens into the
@@ -1552,35 +1588,36 @@ pub fn strip_billing_header_attribution(body: &serde_json::Value) -> Cow<'_, ser
 
     let replacement = match system {
         Value::Array(blocks) => {
-            if !blocks.iter().any(|b| {
-                b.get("text")
+            let mut changed = false;
+            let mut kept: Vec<Value> = Vec::with_capacity(blocks.len());
+            for block in blocks {
+                let verdict = block
+                    .get("text")
                     .and_then(Value::as_str)
-                    .is_some_and(is_billing_header_text)
-            }) {
+                    .map(without_billing_header_line);
+                match verdict {
+                    None | Some(SystemText::Unchanged) => kept.push(block.clone()),
+                    Some(SystemText::Remainder(rest)) => {
+                        changed = true;
+                        let mut rewritten = block.clone();
+                        if let Some(obj) = rewritten.as_object_mut() {
+                            obj.insert("text".to_string(), Value::String(rest.to_string()));
+                        }
+                        kept.push(rewritten);
+                    }
+                    Some(SystemText::Empty) => changed = true,
+                }
+            }
+            if !changed {
                 return Cow::Borrowed(body);
             }
-            let kept: Vec<Value> = blocks
-                .iter()
-                .filter(|b| {
-                    !b.get("text")
-                        .and_then(Value::as_str)
-                        .is_some_and(is_billing_header_text)
-                })
-                .cloned()
-                .collect();
             (!kept.is_empty()).then_some(Value::Array(kept))
         }
-        Value::String(s) => {
-            if !is_billing_header_text(s) {
-                return Cow::Borrowed(body);
-            }
-            // Through the first newline inclusive. No newline at all means
-            // the whole string was the attribution line.
-            match s.split_once('\n') {
-                Some((_, rest)) if !rest.is_empty() => Some(Value::String(rest.to_string())),
-                _ => None,
-            }
-        }
+        Value::String(s) => match without_billing_header_line(s) {
+            SystemText::Unchanged => return Cow::Borrowed(body),
+            SystemText::Remainder(rest) => Some(Value::String(rest.to_string())),
+            SystemText::Empty => None,
+        },
         _ => return Cow::Borrowed(body),
     };
 
@@ -2653,6 +2690,73 @@ mod tests {
         assert_eq!(
             out["system"],
             serde_json::json!([{ "type": "text", "text": "be brief" }])
+        );
+    }
+
+    /// A blank line before the marker used to make the whole strip a
+    /// silent no-op: the prefix test trimmed it, the cut did not, so the
+    /// split landed on the leading newline and handed the attribution
+    /// line straight back.
+    #[test]
+    fn strip_billing_header_survives_whitespace_before_the_marker() {
+        for lead in ["\n", "  ", "\n\n  ", "\t"] {
+            let body = serde_json::json!({
+                "model": "claude",
+                "system": format!("{lead}{BILLING_LINE}\nYou are a helpful assistant."),
+                "messages": [{ "role": "user", "content": "hi" }]
+            });
+            let out = strip_billing_header_attribution(&body);
+            assert_eq!(
+                out["system"],
+                serde_json::json!("You are a helpful assistant."),
+                "leading {lead:?} must not save the attribution line"
+            );
+        }
+    }
+
+    /// The marker prefixes a LINE, not necessarily a whole block. Dropping
+    /// the block would take the operator's system prompt with it — a total
+    /// prompt loss, which is far worse than the cache miss being fixed.
+    #[test]
+    fn strip_billing_header_keeps_prompt_text_sharing_the_block() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "system": [{
+                "type": "text",
+                "text": format!("{BILLING_LINE}\nYou are a terse assistant.\nBe brief."),
+                "cache_control": { "type": "ephemeral" }
+            }],
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+
+        let out = strip_billing_header_attribution(&body);
+        assert_eq!(
+            out["system"],
+            serde_json::json!([{
+                "type": "text",
+                "text": "You are a terse assistant.\nBe brief.",
+                "cache_control": { "type": "ephemeral" }
+            }]),
+            "only the line goes; the block and its cache_control stay"
+        );
+    }
+
+    /// Header names are case-insensitive by convention, and a client that
+    /// capitalises this one would otherwise bypass the strip silently.
+    #[test]
+    fn strip_billing_header_matches_the_marker_case_insensitively() {
+        let body = serde_json::json!({
+            "model": "claude",
+            "system": [
+                { "type": "text", "text": "X-Anthropic-Billing-Header: cc_version=2.1.0;" },
+                { "type": "text", "text": "keep me" }
+            ],
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+        let out = strip_billing_header_attribution(&body);
+        assert_eq!(
+            out["system"],
+            serde_json::json!([{ "type": "text", "text": "keep me" }])
         );
     }
 

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -601,7 +601,17 @@ async fn count_tokens_to_target(
     client: &ClientContext,
 ) -> Result<CountTokensSuccess, ProxyError> {
     let attempt_started = Instant::now();
-    let mut body = crate::effort_mapping::anthropic_request(body, model).into_owned();
+    // Same billing-attribution strip as `/v1/messages` (see
+    // `messages::dispatch_to_target`). This route only ever dispatches to
+    // an Anthropic-protocol upstream, but that includes third-party ones,
+    // and the count it returns must be the count for the body the sibling
+    // route would actually send.
+    let body = if crate::dispatch::is_first_party_anthropic(snapshot, model) {
+        std::borrow::Cow::Borrowed(body)
+    } else {
+        aisix_provider_anthropic::strip_billing_header_attribution(body)
+    };
+    let mut body = crate::effort_mapping::anthropic_request(body.as_ref(), model).into_owned();
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
     let api_key = crate::dispatch::require_api_key(&pk_entry.value, model)?;
     let upstream_model = crate::dispatch::require_upstream_model(model)?.to_string();

--- a/crates/aisix-proxy/src/dispatch.rs
+++ b/crates/aisix-proxy/src/dispatch.rs
@@ -167,6 +167,28 @@ pub(crate) fn speaks_anthropic(snapshot: &AisixSnapshot, model: &Model) -> bool 
     serves_natively(snapshot, model, ApiSurface::Messages)
 }
 
+/// Whether this Model's upstream is Anthropic's **own** API, as opposed
+/// to any of the other upstreams that merely speak the same wire
+/// protocol.
+///
+/// [`speaks_anthropic`] answers "may this body be forwarded verbatim",
+/// which is true for `provider: "byo"` + `adapter: anthropic` and for any
+/// vendor declaring [`ProviderKey::apis`]`.messages` as well. This answers
+/// the narrower question "is the request being billed and served by
+/// Anthropic", which is what decides whether Anthropic-only request
+/// metadata is meaningful at the other end. It is deliberately keyed on
+/// the catalog vendor id rather than on `api_base`, so a first-party key
+/// pointed at a regional or proxied Anthropic endpoint still counts.
+///
+/// `serves_natively` is the second half rather than a redundant one: a
+/// hand-written resources file can put `provider: "anthropic"` in front of
+/// a platform-adapter key, and such a request is translated onto Bedrock's
+/// or Vertex's own route, where Anthropic's metadata means no more than it
+/// does to any other foreign upstream.
+pub(crate) fn is_first_party_anthropic(snapshot: &AisixSnapshot, model: &Model) -> bool {
+    model.provider.as_deref() == Some("anthropic") && speaks_anthropic(snapshot, model)
+}
+
 /// Whether this Model's upstream serves `surface` natively — i.e. whether
 /// the caller's body may be forwarded verbatim instead of being translated
 /// through a provider bridge.
@@ -861,6 +883,56 @@ mod tests {
         );
         let m = model_on("byo", "pk-1");
         assert!(serves_natively(&snap, &m, ApiSurface::Messages));
+    }
+
+    /// The first-party gate is narrower than the protocol gate, and every
+    /// upstream that only *speaks* Anthropic falls on the other side of it.
+    #[test]
+    fn only_the_catalog_anthropic_vendor_is_first_party() {
+        // The catalog vendor, even pointed at a proxied endpoint.
+        let snap = snapshot_with_pk_json(
+            "pk-1",
+            r#"{"display_name":"a","secret":"k","api_base":"https://anthropic.corp-proxy/","provider":"anthropic","adapter":"anthropic"}"#,
+        );
+        let m = model_on("anthropic", "pk-1");
+        assert!(is_first_party_anthropic(&snap, &m));
+
+        // byo + anthropic adapter: speaks the protocol, is not Anthropic.
+        let snap = snapshot_with_pk_json(
+            "pk-1",
+            r#"{"display_name":"a","secret":"k","api_base":"https://up","provider":"byo","adapter":"anthropic"}"#,
+        );
+        let m = model_on("byo", "pk-1");
+        assert!(speaks_anthropic(&snap, &m));
+        assert!(!is_first_party_anthropic(&snap, &m));
+
+        // A vendor declaring `apis.messages`: same answer.
+        let snap = snapshot_with_pk_json(
+            "pk-1",
+            r#"{"display_name":"ds","secret":"k","api_base":"https://api.deepseek.com/v1","provider":"deepseek","adapter":"openai",
+                "apis":{"messages":{"base":"https://api.deepseek.com/anthropic"}}}"#,
+        );
+        let m = model_on("deepseek", "pk-1");
+        assert!(speaks_anthropic(&snap, &m));
+        assert!(!is_first_party_anthropic(&snap, &m));
+
+        // An OpenAI-compatible upstream reached through the bridge.
+        let snap = snapshot_with_pk_json(
+            "pk-1",
+            r#"{"display_name":"o","secret":"k","api_base":"https://up/v1","provider":"openai","adapter":"openai"}"#,
+        );
+        let m = model_on("openai", "pk-1");
+        assert!(!is_first_party_anthropic(&snap, &m));
+
+        // A hand-written file can name the anthropic vendor in front of a
+        // platform key. That request is translated onto Bedrock's own
+        // route, so it is not first-party either.
+        let snap = snapshot_with_pk_json(
+            "pk-1",
+            r#"{"display_name":"b","secret":"{}","api_base":"https://up","provider":"anthropic","adapter":"bedrock"}"#,
+        );
+        let m = model_on("anthropic", "pk-1");
+        assert!(!is_first_party_anthropic(&snap, &m));
     }
 
     /// A platform adapter never takes a native path, declaration or not:

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1084,7 +1084,20 @@ async fn dispatch_to_target(
     input_monitor_hits: Vec<aisix_core::GuardrailMonitorHit>,
 ) -> Result<DispatchOutcome, ProxyError> {
     let model = &target.model;
-    let body = crate::effort_mapping::anthropic_request(body, model);
+    // Anthropic-native clients prepend a billing-attribution line to the
+    // system prompt that only Anthropic's own API consumes. It varies per
+    // request in some deployments and sits at the very front of the
+    // prompt, so forwarding it to any other upstream misses that
+    // provider's prompt cache on every turn. Dropped here, once, so both
+    // the passthrough and the cross-provider branch below are covered —
+    // and after the handler's guardrail scan, which reads the caller's
+    // body as it was sent.
+    let body = if crate::dispatch::is_first_party_anthropic(snapshot, model) {
+        std::borrow::Cow::Borrowed(body)
+    } else {
+        aisix_provider_anthropic::strip_billing_header_attribution(body)
+    };
+    let body = crate::effort_mapping::anthropic_request(body.as_ref(), model);
     let body = body.as_ref();
     let pk_entry = crate::dispatch::resolve_provider_key(snapshot, model)?;
 

--- a/tests/e2e/src/cases/anthropic-content-blocks-cross-provider-e2e.test.ts
+++ b/tests/e2e/src/cases/anthropic-content-blocks-cross-provider-e2e.test.ts
@@ -194,6 +194,57 @@ describe("anthropic content blocks → OpenAI upstream (#722)", () => {
     expect(sent.messages[3].content).toContain("summarize please");
   });
 
+  test("the client's billing-attribution line does not reach a foreign upstream", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    const upstream = await modelBackedBy("blocks-billing-header-model");
+
+    // Anthropic-native clients prepend this line to the system prompt as
+    // attribution metadata for Anthropic's own API. It carries a segment
+    // that varies per request, and it sits at the very front of the
+    // prompt — so forwarding it to a provider that cannot read it anyway
+    // changes the prompt prefix on every turn and costs that provider's
+    // prompt cache every hit it would have had.
+    const resp = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": CALLER_PLAINTEXT,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: "blocks-billing-header-model",
+        max_tokens: 64,
+        system: [
+          {
+            type: "text",
+            text: "x-anthropic-billing-header: cc_version=2.1.0; cc_entrypoint=cli; cch=7f3a91;",
+          },
+          { type: "text", text: "You are a terse assistant." },
+        ],
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(resp.status).toBe(200);
+
+    const seen = upstream.receivedRequests.find((r) =>
+      r.path.includes("/chat/completions"),
+    );
+    expect(seen).toBeDefined();
+    expect(seen!.body).not.toContain("x-anthropic-billing-header");
+
+    const sent = JSON.parse(seen!.body) as {
+      messages: { role: string; content: unknown }[];
+    };
+    // The operator's actual system prompt still arrives — the strip must
+    // not take the whole field with it.
+    expect(sent.messages[0].role).toBe("system");
+    expect(sent.messages[0].content).toBe("You are a terse assistant.");
+    expect(sent.messages[1].content).toContain("hi");
+  });
+
   test("vision: base64 image block reaches the upstream as an image_url data URL", async (ctx) => {
     if (!etcdReachable || !app || !seed) {
       ctx.skip();

--- a/tests/e2e/src/cases/byo-anthropic-adapter-e2e.test.ts
+++ b/tests/e2e/src/cases/byo-anthropic-adapter-e2e.test.ts
@@ -23,6 +23,12 @@ import {
 //   - `/v1/messages/count_tokens` serves it. The same vendor-id gate
 //     rejected it outright with a 400, while its sibling `/v1/messages`
 //     happily served the very same model.
+//
+// The converse also has to hold, and a first-party model on the same mock
+// upstream is seeded here as its control: a request rewrite that exists
+// because the upstream is NOT Anthropic must key on the vendor id and
+// leave the catalog vendor alone. That is what the billing-attribution
+// cases at the bottom of this file pin, in both directions.
 
 const CALLER_PLAINTEXT = "sk-byo-anthropic-e2e";
 const CALLER_KEY_HASH = createHash("sha256")
@@ -31,6 +37,11 @@ const CALLER_KEY_HASH = createHash("sha256")
 
 const UPSTREAM_MODEL_ID = "claude-sonnet-4-5";
 const MODEL_ALIAS = "byo-claude-e2e";
+// A model on the SAME mock upstream reached through the `anthropic`
+// catalog vendor, so the two differ in nothing but the vendor id.
+const FIRST_PARTY_ALIAS = "first-party-claude-e2e";
+const BILLING_LINE =
+  "x-anthropic-billing-header: cc_version=2.1.0; cc_entrypoint=cli; cch=7f3a91;";
 
 const anthropicHeaders = {
   "content-type": "application/json",
@@ -72,9 +83,22 @@ describe("byo + anthropic adapter e2e: the Anthropic-native routes key on the ad
       model_name: UPSTREAM_MODEL_ID,
       provider_key_id: pk.id,
     });
+    const firstPartyPk = await seed.createProviderKey({
+      display_name: "first-party-anthropic-pk",
+      secret: "sk-first-party-upstream",
+      api_base: upstream.baseUrl,
+      provider: "anthropic",
+      adapter: "anthropic",
+    });
+    await seed.createModel({
+      display_name: FIRST_PARTY_ALIAS,
+      provider: "anthropic",
+      model_name: UPSTREAM_MODEL_ID,
+      provider_key_id: firstPartyPk.id,
+    });
     await seed.createApiKey({
       key_hash: CALLER_KEY_HASH,
-      allowed_models: [MODEL_ALIAS],
+      allowed_models: [MODEL_ALIAS, FIRST_PARTY_ALIAS],
     });
   });
 
@@ -166,5 +190,140 @@ describe("byo + anthropic adapter e2e: the Anthropic-native routes key on the ad
     expect((JSON.parse(req!.body) as { model?: string }).model).toBe(
       UPSTREAM_MODEL_ID,
     );
+  });
+  // The billing-attribution line Anthropic-native clients prepend to the
+  // system prompt is metadata for Anthropic's own API. It carries a
+  // per-request-varying segment and sits at the very front of the prompt,
+  // so an upstream that cannot read it still pays for it: every turn
+  // presents a different prefix and misses that provider's prompt cache.
+  // The vendor id is what decides, not the protocol — this key speaks the
+  // Anthropic wire and is still not Anthropic.
+  test("/v1/messages drops the billing-attribution block for a third-party Anthropic upstream", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const baseline = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/messages`, {
+      method: "POST",
+      headers: anthropicHeaders,
+      body: JSON.stringify({
+        model: MODEL_ALIAS,
+        max_tokens: 64,
+        system: [
+          { type: "text", text: BILLING_LINE },
+          {
+            type: "text",
+            text: "long shared preamble",
+            cache_control: { type: "ephemeral", ttl: "5m" },
+          },
+        ],
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const req = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/messages");
+    expect(req).toBeDefined();
+    expect(req!.body).not.toContain("x-anthropic-billing-header");
+
+    const sent = JSON.parse(req!.body) as {
+      system?: Array<{ type?: string; text?: string; cache_control?: unknown }>;
+    };
+    // Everything else survives the rewrite, cache_control included — the
+    // block that stays is what the upstream's prompt cache keys on.
+    expect(sent.system).toEqual([
+      {
+        type: "text",
+        text: "long shared preamble",
+        cache_control: { type: "ephemeral", ttl: "5m" },
+      },
+    ]);
+  });
+
+  test("/v1/messages/count_tokens drops it too, so the count matches what would be sent", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const baseline = upstream.receivedRequests.length;
+    const res = await fetch(`${app.proxyUrl}/v1/messages/count_tokens`, {
+      method: "POST",
+      headers: anthropicHeaders,
+      body: JSON.stringify({
+        model: MODEL_ALIAS,
+        system: [
+          { type: "text", text: BILLING_LINE },
+          { type: "text", text: "long shared preamble" },
+        ],
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const req = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/messages/count_tokens");
+    expect(req).toBeDefined();
+    expect(req!.body).not.toContain("x-anthropic-billing-header");
+    const sent = JSON.parse(req!.body) as { system?: Array<{ text?: string }> };
+    expect(sent.system).toEqual([
+      { type: "text", text: "long shared preamble" },
+    ]);
+  });
+
+  test("/v1/messages keeps the billing-attribution block for the anthropic vendor", async (ctx) => {
+    if (!etcdReachable || !app || !upstream) {
+      ctx.skip();
+      return;
+    }
+
+    const system = [
+      { type: "text", text: BILLING_LINE },
+      {
+        type: "text",
+        text: "long shared preamble",
+        cache_control: { type: "ephemeral", ttl: "5m" },
+      },
+    ];
+
+    const send = () =>
+      fetch(`${app!.proxyUrl}/v1/messages`, {
+        method: "POST",
+        headers: anthropicHeaders,
+        body: JSON.stringify({
+          model: FIRST_PARTY_ALIAS,
+          max_tokens: 64,
+          system,
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      });
+
+    await waitConfigPropagation(async () => {
+      try {
+        return (await send()).ok;
+      } catch {
+        return false;
+      }
+    });
+
+    const baseline = upstream.receivedRequests.length;
+    const res = await send();
+    expect(res.status).toBe(200);
+
+    const req = upstream.receivedRequests
+      .slice(baseline)
+      .find((r) => r.path === "/v1/messages");
+    expect(req).toBeDefined();
+
+    // Anthropic's own API is the one consumer of this line, so it goes
+    // through untouched — the strip must key on the vendor id and nothing
+    // else.
+    const sent = JSON.parse(req!.body) as { system?: unknown };
+    expect(sent.system).toEqual(system);
   });
 });


### PR DESCRIPTION
Anthropic-native clients prepend an attribution line to the system prompt:

```
x-anthropic-billing-header: cc_version=…; cc_entrypoint=…; cch=…;
```

It is metadata that only Anthropic's own API consumes. In some deployments one
of its segments varies from request to request, and because the line sits at the
very front of the system prompt, every other provider sees a different prompt
prefix on every turn — which invalidates that provider's prompt cache for the
whole prompt, not just for the line. Measured against one OpenAI-compatible
upstream: `cached_tokens` was 0 on all eight turns of a conversation with the
line present, and returned to the normal 7–9k per turn once it was removed.

## Behavior change

On `POST /v1/messages` and `POST /v1/messages/count_tokens`, when the resolved
target is **not** the first-party `anthropic` catalog provider, the attribution
line is now dropped from `system` before the upstream request is built:

- array-form `system` — every text block whose text (ignoring leading
  whitespace) starts with `x-anthropic-billing-header:` is removed; the
  remaining blocks are forwarded unchanged, `cache_control` markers included.
- string-form `system` — the first line is removed, through the first newline
  inclusive. The rest of the prompt survives byte-for-byte.
- if nothing survives either way, `system` is omitted rather than sent empty.
- `messages` is never touched: the same line quoted inside a conversation is
  content the caller is asking about, and removing it there would change the
  question.

The gate is the catalog vendor id, not the protocol and not `api_base` — a
first-party key pointed at a regional or proxied Anthropic endpoint still keeps
the line, while every other upstream drops it. That covers the OpenAI-chat
bridge (`adapter: openai`), a third-party Anthropic-compatible passthrough
(`provider: "byo"` + `adapter: anthropic`, or any vendor declaring
`apis.messages`), and the Bedrock/Vertex/Azure platform adapters.

Nothing has to be reconfigured. Callers that do not send the line are
unaffected, and requests to Anthropic itself are unchanged.

## Implementation

`strip_billing_header_attribution` lives in `aisix-provider-anthropic::wire`
next to the rest of the inbound `/v1/messages` wire handling, and returns the
body borrowed when there is nothing to drop. It is applied at
`messages::dispatch_to_target`, the one point both `/v1/messages` branches pass
through, alongside the existing per-target effort remap — so the passthrough and
the cross-provider bridge cannot drift apart, and the handler's guardrail scan
and failure-path content capture still read the caller's body as it was sent.
`count_tokens_to_target` applies the same strip at its own equivalent point, so
the count it returns is the count for the body `/v1/messages` would actually
send.

`dispatch::is_first_party_anthropic` names the gate. It composes the vendor id
with the existing `speaks_anthropic` test rather than restating either: a
hand-written resources file can put `provider: "anthropic"` in front of a
platform-adapter key, and such a request is translated onto Bedrock's or
Vertex's own route, where the metadata means no more than it does anywhere else.

## Comparison with other gateways

Another widely used gateway solves the same problem the same way, with the
filter attached per provider config rather than to a single gate — its
Anthropic-family base keeps the line and every non-Anthropic Anthropic-messages
config (its generic OpenAI-compatible one included, plus Bedrock, Vertex,
Azure AI, and several third-party Anthropic-compatible vendors) overrides it to
drop. The effect is the same set of upstreams; expressing it as one gate here is
what keeps a newly added provider from silently inheriting the wrong answer.

Three deliberate differences, each in the conservative direction. That gateway
discards the whole block, or the whole string field, once its text starts with
the marker; this removes only the line, so a client that puts the attribution
and its real system prompt in one block does not lose the prompt. A block is
judged by whether it carries a `text` string, matching what `parse_inbound`'s
own system reader flattens into the prompt, rather than by its declared `type` —
a block we would forward has to be a block we would also consider. And the
marker is matched case-insensitively, since the name is header-shaped and a
client that capitalises it would otherwise bypass the strip with no signal.

## Tests

Unit (`aisix-provider-anthropic`): array block dropped with the neighbouring
`cache_control` block intact, string leading line dropped, `system` omitted when
nothing survives (array, string, and trailing-newline forms), unrelated and
mid-prompt occurrences left borrowed and untouched, `messages` never rewritten,
every attribution block dropped when there is more than one, prompt text sharing
a block with the attribution line preserved along with its `cache_control`,
whitespace and newlines before the marker not defeating the cut, and the marker
matched case-insensitively.

Unit (`aisix-proxy::dispatch`): the first-party gate separates the catalog
vendor from `byo` + `adapter: anthropic`, from a vendor declaring
`apis.messages`, from an OpenAI-compatible upstream, and from the anthropic
vendor id in front of a platform key.

E2E (`tests/e2e/src/cases/`), each asserting the body the mock upstream actually
received:

- `anthropic-content-blocks-cross-provider-e2e` — `/v1/messages` to an
  OpenAI-chat upstream: no attribution text on the wire, the real system prompt
  still arrives.
- `byo-anthropic-adapter-e2e` — `/v1/messages` and
  `/v1/messages/count_tokens` to a third-party Anthropic-compatible upstream:
  the block is gone and the neighbouring block keeps its `cache_control`; and,
  as the control, the same body sent to a first-party model on the same mock
  upstream arrives with `system` unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Requests sent to third-party Anthropic-compatible providers no longer include Anthropic-specific billing attribution in the system prompt.
  - The original system prompt and user messages remain unchanged, including when system content uses block arrays.
  - Empty system content is omitted when no usable content remains after attribution is removed.
  - First-party Anthropic requests continue to preserve the billing attribution.
  - This behavior applies to both message requests and token-counting requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->