### PR TITLE
feat(observability): configurable metric labels and raw cache-write usage

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -137,6 +137,21 @@ observability:
   log_level: "info"
   access_log: true
   metrics:
+    # Complete label lists per metric. Omitted metrics retain their defaults.
+    # Restart after changing labels. [] removes all optional business labels;
+    # gauges retain required identity labels. See the variable reference:
+    # https://docs.api7.ai/ai-gateway/dev/reference/metric-labels
+    # Env: AISIX_OBSERVABILITY__METRICS__LABELS='{"aisix_request_ttft_seconds":["provider_key_name","model"]}'
+    # labels:
+    #   aisix_request_ttft_seconds:
+    #     - env_id
+    #     - endpoint
+    #     - model
+    #     - provider
+    #     - status_class
+    #     - streaming
+    #     - provider_key_name
+    labels: {}
     prometheus:
       enabled: true
       path: "/metrics"

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -95,6 +95,21 @@ observability:
   log_level: "info"
   access_log: true
   metrics:
+    # Complete label lists per metric. Omitted metrics retain their defaults.
+    # Restart after changing labels. [] removes all optional business labels;
+    # gauges retain required identity labels. See the variable reference:
+    # https://docs.api7.ai/ai-gateway/dev/reference/metric-labels
+    # Env: AISIX_OBSERVABILITY__METRICS__LABELS='{"aisix_request_ttft_seconds":["provider_key_name","model"]}'
+    # labels:
+    #   aisix_request_ttft_seconds:
+    #     - env_id
+    #     - endpoint
+    #     - model
+    #     - provider
+    #     - status_class
+    #     - streaming
+    #     - provider_key_name
+    labels: {}
     prometheus:
       enabled: true
       path: "/metrics"

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -932,6 +932,13 @@ impl ObservabilityConfig {
 #[serde(deny_unknown_fields, default)]
 pub struct MetricsConfig {
     pub prometheus: PrometheusConfig,
+    /// Complete label selections by metric family name. An omitted family
+    /// keeps its default labels; an empty list selects no business labels.
+    /// Histogram buckets and summary quantiles keep their generated labels.
+    /// Validated at startup; changing a selection requires a restart.
+    /// Environment variables accept the whole map as one JSON object.
+    #[serde(default, deserialize_with = "deserialize_metric_labels")]
+    pub labels: std::collections::BTreeMap<String, Vec<String>>,
     /// Retired; see [`OtlpConfig`]. `Option` for the same reason as
     /// [`ObservabilityConfig::tracing`].
     pub otlp: Option<OtlpConfig>,
@@ -953,6 +960,24 @@ pub struct MetricsConfig {
     /// own Prometheus scrape surface. Validated at boot (fail-fast),
     /// never hot-reloaded.
     pub buckets: HistogramBucketsConfig,
+}
+
+fn deserialize_metric_labels<'de, D>(
+    deserializer: D,
+) -> Result<std::collections::BTreeMap<String, Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Labels {
+        Map(std::collections::BTreeMap<String, Vec<String>>),
+        Json(String),
+    }
+    match Labels::deserialize(deserializer)? {
+        Labels::Map(labels) => Ok(labels),
+        Labels::Json(raw) => serde_json::from_str(&raw).map_err(serde::de::Error::custom),
+    }
 }
 
 /// Per-metric bucket-edge overrides, in seconds. An unset field keeps that
@@ -1804,6 +1829,29 @@ admin:
         assert!(!cfg.proxy.real_ip.recursive);
         assert_eq!(cfg.proxy.real_ip.header, "x-forwarded-for");
         assert!(cfg.proxy.real_ip.parse_trusted().unwrap().is_empty());
+    }
+
+    #[test]
+    fn loads_metric_labels_from_yaml_and_json() {
+        for labels in [
+            "{aisix_request_ttft_seconds: [model, provider_key_name], aisix_requests_total: []}",
+            r#"'{"aisix_request_ttft_seconds":["model","provider_key_name"],"aisix_requests_total":[]}'"#,
+        ] {
+            let file = write_yaml(&format!(
+                "etcd:\n  endpoints: [\"http://127.0.0.1:2379\"]\nproxy:\n  addr: \"127.0.0.1:3000\"\nadmin:\n  admin_keys: [\"test\"]\nobservability:\n  metrics:\n    labels: {labels}\n"
+            ));
+            let cfg = Config::load_from_path(Some(file.path())).unwrap();
+            assert_eq!(
+                cfg.observability.metrics.labels["aisix_request_ttft_seconds"],
+                ["model", "provider_key_name"]
+            );
+            assert!(cfg.observability.metrics.labels["aisix_requests_total"].is_empty());
+            assert!(!cfg
+                .observability
+                .metrics
+                .labels
+                .contains_key("aisix_llm_requests_total"));
+        }
     }
 
     #[test]

--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -316,6 +316,9 @@ pub struct UsageStats {
     /// OpenAI prompt-cache hit count. Subset of `prompt_tokens`.
     #[serde(default)]
     pub cached_prompt_tokens: u32,
+    /// Raw OpenAI cache-write count; it is not additive to prompt tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_write_tokens: Option<u32>,
     /// OpenAI o1/o3 reasoning tokens. Subset of `completion_tokens`.
     #[serde(default)]
     pub reasoning_tokens: u32,
@@ -399,6 +402,7 @@ impl UsageStats {
             cached_prompt_tokens: self
                 .cached_prompt_tokens
                 .saturating_add(other.cached_prompt_tokens),
+            cache_write_tokens: add_opt(self.cache_write_tokens, other.cache_write_tokens),
             reasoning_tokens: self.reasoning_tokens.saturating_add(other.reasoning_tokens),
             cache_creation_tokens: self
                 .cache_creation_tokens
@@ -502,8 +506,8 @@ impl UsageStats {
             .saturating_add(self.cached_prompt_tokens)
     }
 
-    /// Anthropic `usage.cache_creation_input_tokens`. No OpenAI-shape
-    /// upstream reports a cache write, so there is nothing to fold in.
+    /// Anthropic `usage.cache_creation_input_tokens`. OpenAI cache writes
+    /// keep their own raw field; they do not use this additive accounting.
     pub fn anthropic_cache_creation_input_tokens(&self) -> u32 {
         self.cache_creation_tokens
     }
@@ -917,10 +921,8 @@ mod tests {
         for u in [anthropic_shape(), openai_shape()] {
             assert_eq!(u.anthropic_cache_read_input_tokens(), R);
         }
-        // The cache WRITE does not: OpenAI accounting has no such
-        // bucket, so an OpenAI upstream's non-hit input is all plain
-        // input. Fabricating a write to make the two shapes look alike
-        // would invent a number the upstream never sent.
+        // OpenAI's raw write count is not Anthropic's additive creation
+        // count. Non-hit OpenAI input remains plain Anthropic input.
         let ant = anthropic_shape();
         assert_eq!(ant.anthropic_input_tokens(), N);
         assert_eq!(ant.anthropic_cache_creation_input_tokens(), W);
@@ -1018,9 +1020,9 @@ mod tests {
         assert_eq!(mixed.openai_total_tokens(), 2 * (N + W + R + O));
 
         // The Anthropic side sums to the same 2 × 140 of input, but
-        // splits it differently, and correctly so: OpenAI accounting has
-        // no cache-WRITE bucket, so that member's non-hit input is all
-        // plain input. Only the Anthropic member contributes a write.
+        // splits it differently: that OpenAI member's non-hit input is
+        // all plain input. Only the Anthropic member contributes an
+        // additive cache-creation count.
         assert_eq!(mixed.anthropic_input_tokens(), N + (W + N));
         assert_eq!(mixed.anthropic_cache_read_input_tokens(), 2 * R);
         assert_eq!(mixed.anthropic_cache_creation_input_tokens(), W);
@@ -1039,6 +1041,7 @@ mod tests {
             completion_tokens: 5,
             total_tokens: 15,
             cached_prompt_tokens: 2,
+            cache_write_tokens: Some(3),
             reasoning_tokens: 3,
             cache_creation_tokens: 1,
             cache_read_tokens: 4,
@@ -1050,6 +1053,7 @@ mod tests {
             completion_tokens: 7,
             total_tokens: 27,
             cached_prompt_tokens: 1,
+            cache_write_tokens: Some(5),
             reasoning_tokens: 0,
             cache_creation_tokens: 0,
             cache_read_tokens: 6,
@@ -1061,6 +1065,7 @@ mod tests {
         assert_eq!(sum.completion_tokens, 12);
         assert_eq!(sum.total_tokens, 42);
         assert_eq!(sum.cached_prompt_tokens, 3);
+        assert_eq!(sum.cache_write_tokens, Some(8));
         assert_eq!(sum.reasoning_tokens, 3);
         assert_eq!(sum.cache_creation_tokens, 1);
         assert_eq!(sum.cache_read_tokens, 10);

--- a/crates/aisix-obs/examples/dump_metric_catalog.rs
+++ b/crates/aisix-obs/examples/dump_metric_catalog.rs
@@ -1,0 +1,10 @@
+fn main() {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "variables": aisix_obs::metric_labels::METRIC_VARIABLES,
+            "metrics": aisix_obs::metric_labels::METRIC_DEFINITIONS,
+        }))
+        .expect("metric catalog serializes")
+    );
+}

--- a/crates/aisix-obs/src/lib.rs
+++ b/crates/aisix-obs/src/lib.rs
@@ -14,6 +14,7 @@
 #![deny(rust_2018_idioms)]
 
 pub mod access_log;
+pub mod metric_labels;
 pub mod metrics;
 pub mod otlp_http_sink;
 pub mod sink;

--- a/crates/aisix-obs/src/metric_labels.rs
+++ b/crates/aisix-obs/src/metric_labels.rs
@@ -1,0 +1,685 @@
+//! Metric label selections are applied when a series is registered, before
+//! counters or distributions accumulate. Filtering scrape text would lose
+//! observations when several original series project onto the same labels.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex,
+};
+
+use metrics::{
+    Counter, CounterFn, Gauge, Histogram, Key, KeyName, Label, Metadata, Recorder, SharedString,
+    Unit,
+};
+use metrics_exporter_prometheus::PrometheusRecorder;
+use serde::Serialize;
+
+use crate::metrics::*;
+
+#[derive(Debug, Serialize)]
+pub struct MetricVariable {
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
+macro_rules! variable {
+    ($name:literal, $description:literal) => {
+        MetricVariable {
+            name: $name,
+            description: $description,
+        }
+    };
+}
+
+pub static METRIC_VARIABLES: &[MetricVariable] = &[
+    variable!("env_id", "The gateway's AISIX Cloud environment ID; unknown when not connected to AISIX Cloud. Available on every metric."),
+    variable!("endpoint", "The matched route template, without caller-supplied path parameters."),
+    variable!("inbound_protocol", "The protocol used by the caller, derived from the matched endpoint."),
+    variable!("upstream_protocol", "The wire protocol of the selected provider credential; unknown before upstream selection or for non-LLM traffic."),
+    variable!("provider", "The provider kind attributed to this observation; ensemble when no single provider owns the result."),
+    variable!("model", "The configured gateway model identity attributed to the observation. Wildcard requests use the configured model pattern. See the metric reference for its request or attempt scope."),
+    variable!("upstream_model", "The upstream model identity, bounded to the configured model pattern for wildcard models."),
+    variable!("provider_key_id", "The identifier of the selected provider credential. This is an identifier, never its secret."),
+    variable!("provider_key_name", "The display name of that same provider credential. Renaming a credential starts a new series when this variable is selected."),
+    variable!("api_key_id", "The identifier of the authenticating gateway API key, never its plaintext value."),
+    variable!("team_id", "The team associated with the authenticating API key."),
+    variable!("user_id", "The member associated with the authenticating API key."),
+    variable!("user_name", "The member display name carried by the API key's configuration snapshot."),
+    variable!("stream", "Whether the request asked for streaming, encoded as true or false. Used by the detailed request metrics."),
+    variable!("streaming", "Whether the observed request is streaming, encoded as true or false. Used by the request latency histograms."),
+    variable!("is_fallback", "Whether request attribution identifies a fallback attempt, encoded as true or false."),
+    variable!("status", "The HTTP status code on request and usage-event metrics; the HTTP status class on A2A request metrics."),
+    variable!("status_class", "The HTTP status class: 2xx, 3xx, 4xx, 5xx, or other."),
+    variable!("status_code", "The HTTP status class on usage-event metrics: 2xx, 3xx, 4xx, 5xx, or other. The status variable retains the exact code."),
+    variable!("outcome", "The outcome defined by the metric, such as the request result, cache decision, or request-body-limit result."),
+    variable!("client_type", "The classified client name from built-in or configured client_type_rules; never the raw User-Agent."),
+    variable!("token_type", "The token count category: input, output, or total. Total already includes the input and output categories."),
+    variable!("fallback_model", "The configured fallback model attributed to a routing fallback."),
+    variable!("scope", "The scope of the rate-limit decision."),
+    variable!("layer", "The layer of the rate-limit decision."),
+    variable!("policy_id", "The rate-limit policy identifier, or the metric's missing-policy value."),
+    variable!("reason", "The bounded reason code defined by the emitting authentication, guardrail, configuration, or exporter metric."),
+    variable!("method", "The authentication method used for the credential decision."),
+    variable!("result", "The authentication or guardrail execution result, as defined by the metric."),
+    variable!("guardrail", "The configured guardrail name."),
+    variable!("kind", "The guardrail kind on guardrail metrics, or the resource kind on configuration metrics."),
+    variable!("phase", "The guardrail execution phase."),
+    variable!("error_type", "The bounded guardrail failure category, or none when no error occurred."),
+    variable!("handler", "The usage event's handler family, such as chat, messages, embeddings, or mcp."),
+    variable!("policy", "The configured cache policy name."),
+    variable!("cause", "The bounded semantic-cache embedding failure cause."),
+    variable!("op", "The semantic-cache storage operation."),
+    variable!("operation", "The Redis operation or A2A operation, as defined by the metric."),
+    variable!("exporter", "The configured observability exporter name."),
+    variable!("agent", "The registered A2A agent name."),
+    variable!("state", "The A2A task state reported by the upstream agent."),
+    variable!("hash", "The hash of the applied gateway resource configuration."),
+];
+
+#[derive(Debug, Serialize)]
+pub struct MetricDefinition {
+    pub name: &'static str,
+    pub default_labels: &'static [&'static str],
+    pub extra_labels: &'static [&'static str],
+    pub required_labels: &'static [&'static str],
+}
+
+impl MetricDefinition {
+    pub fn supports(&self, label: &str) -> bool {
+        label == "env_id"
+            || self.default_labels.contains(&label)
+            || self.extra_labels.contains(&label)
+    }
+}
+
+const REQUEST: &[&str] = &[
+    "endpoint",
+    "inbound_protocol",
+    "upstream_protocol",
+    "provider",
+    "model",
+    "upstream_model",
+    "provider_key_id",
+    "provider_key_name",
+    "api_key_id",
+    "team_id",
+    "user_id",
+    "user_name",
+    "stream",
+    "is_fallback",
+    "status",
+    "outcome",
+];
+const REQUEST_DURATION: &[&str] = &[
+    "endpoint",
+    "inbound_protocol",
+    "upstream_protocol",
+    "provider",
+    "model",
+    "upstream_model",
+    "provider_key_id",
+    "provider_key_name",
+    "api_key_id",
+    "team_id",
+    "user_id",
+    "user_name",
+    "stream",
+    "status",
+    "outcome",
+];
+const USAGE: &[&str] = &[
+    "endpoint",
+    "inbound_protocol",
+    "upstream_protocol",
+    "provider",
+    "model",
+    "upstream_model",
+    "provider_key_id",
+    "provider_key_name",
+    "api_key_id",
+    "team_id",
+    "user_id",
+    "user_name",
+];
+const LATENCY: &[&str] = &[
+    "env_id",
+    "endpoint",
+    "model",
+    "provider",
+    "status_class",
+    "streaming",
+];
+const DEPLOYMENT: &[&str] = &["provider", "model", "upstream_model", "provider_key_id"];
+const BUDGET: &[&str] = &["api_key_id", "team_id", "user_id", "user_name"];
+
+macro_rules! metric {
+    ($name:ident, $defaults:expr) => {
+        MetricDefinition {
+            name: $name,
+            default_labels: $defaults,
+            extra_labels: &[],
+            required_labels: &[],
+        }
+    };
+    ($name:ident, $defaults:expr, extra = $extra:expr) => {
+        MetricDefinition {
+            name: $name,
+            default_labels: $defaults,
+            extra_labels: $extra,
+            required_labels: &[],
+        }
+    };
+    ($name:ident, $defaults:expr, required = $required:expr) => {
+        MetricDefinition {
+            name: $name,
+            default_labels: $defaults,
+            extra_labels: &[],
+            required_labels: $required,
+        }
+    };
+}
+
+pub static METRIC_DEFINITIONS: &[MetricDefinition] = &[
+    metric!(
+        M_REQUESTS_TOTAL,
+        &["provider", "model", "status", "outcome"]
+    ),
+    metric!(M_REQUEST_DURATION, &["provider", "model", "status"]),
+    metric!(M_RATELIMIT_REJECTIONS, &["scope", "layer", "policy_id"]),
+    metric!(M_TOKENS_CONSUMED, &["provider", "model"]),
+    metric!(M_LLM_SPEND_MICRO_USD_TOTAL, USAGE),
+    metric!(M_LLM_INPUT_TOKENS_TOTAL, USAGE),
+    metric!(M_LLM_OUTPUT_TOKENS_TOTAL, USAGE),
+    metric!(M_LLM_TOTAL_TOKENS_TOTAL, USAGE),
+    metric!(M_LLM_CACHED_INPUT_TOKENS_TOTAL, USAGE),
+    metric!(M_LLM_CACHE_READ_INPUT_TOKENS_TOTAL, USAGE),
+    metric!(M_LLM_CACHE_CREATION_INPUT_TOKENS_TOTAL, USAGE),
+    metric!(M_LLM_REQUESTS_TOTAL, REQUEST),
+    metric!(
+        M_LLM_REQUEST_DURATION,
+        REQUEST_DURATION,
+        extra = &["is_fallback"]
+    ),
+    metric!(M_LLM_TTFT, USAGE),
+    metric!(
+        M_LLM_TOKENS_BY_CLIENT_TOTAL,
+        &["client_type", "model", "token_type"]
+    ),
+    metric!(
+        M_PROXY_IN_FLIGHT,
+        &["endpoint", "inbound_protocol"],
+        required = &["endpoint"]
+    ),
+    metric!(M_PROXY_REQUESTS_TOTAL, REQUEST),
+    metric!(M_PROXY_FAILED_REQUESTS_TOTAL, REQUEST),
+    metric!(
+        M_PROXY_REQUEST_DURATION,
+        REQUEST_DURATION,
+        extra = &["is_fallback"]
+    ),
+    metric!(
+        M_PROXY_CLIENT_CANCELLED_TOTAL,
+        &["endpoint", "model", "provider_key_id", "provider_key_name"]
+    ),
+    metric!(
+        M_PROXY_BODY_LIMIT_REJECTIONS_TOTAL,
+        &["endpoint", "inbound_protocol", "outcome"]
+    ),
+    metric!(M_DEPLOYMENT_REQUESTS_TOTAL, DEPLOYMENT),
+    metric!(M_DEPLOYMENT_SUCCESS_TOTAL, DEPLOYMENT),
+    metric!(M_DEPLOYMENT_FAILURE_TOTAL, DEPLOYMENT),
+    metric!(M_DEPLOYMENT_STATE, DEPLOYMENT, required = DEPLOYMENT),
+    metric!(M_DEPLOYMENT_COOLED_DOWN_TOTAL, DEPLOYMENT),
+    metric!(
+        M_ROUTING_SUCCESSFUL_FALLBACKS_TOTAL,
+        &["model", "fallback_model"]
+    ),
+    metric!(
+        M_ROUTING_FAILED_FALLBACKS_TOTAL,
+        &["model", "fallback_model"]
+    ),
+    metric!(
+        M_RATELIMIT_REMAINING_REQUESTS,
+        &["api_key_id", "model"],
+        required = &["api_key_id", "model"]
+    ),
+    metric!(
+        M_RATELIMIT_REMAINING_TOKENS,
+        &["api_key_id", "model"],
+        required = &["api_key_id", "model"]
+    ),
+    metric!(M_BUDGET_LIMIT_USD, BUDGET, required = BUDGET),
+    metric!(M_BUDGET_SPENT_USD, BUDGET, required = BUDGET),
+    metric!(M_BUDGET_REMAINING_USD, BUDGET, required = BUDGET),
+    metric!(M_BUDGET_RESET_SECONDS, BUDGET, required = BUDGET),
+    metric!(M_BUDGET_DETAILS_PRESENT, BUDGET, required = BUDGET),
+    metric!(M_REDIS_FAILURES_TOTAL, &["operation"]),
+    metric!(
+        M_USAGE_EVENT_DROPS_TOTAL,
+        &[
+            "reason",
+            "model",
+            "provider_key_id",
+            "provider_key_name",
+            "user_id",
+            "user_name",
+            "upstream_protocol"
+        ]
+    ),
+    metric!(M_GUARDRAIL_BLOCKS_TOTAL, &[]),
+    metric!(M_GUARDRAIL_BYPASSES_TOTAL, &["reason"]),
+    metric!(M_AUTH_DECISIONS_TOTAL, &["method", "result", "reason"]),
+    metric!(
+        M_GUARDRAIL_LATENCY_SECONDS,
+        &[
+            "env_id",
+            "guardrail",
+            "kind",
+            "phase",
+            "result",
+            "error_type"
+        ]
+    ),
+    metric!(
+        M_USAGE_EVENT_EMITS_TOTAL,
+        &[
+            "handler",
+            "status_code",
+            "status",
+            "inbound_protocol",
+            "upstream_protocol",
+            "model",
+            "provider_key_id",
+            "provider_key_name",
+            "user_id",
+            "user_name"
+        ]
+    ),
+    metric!(M_CACHE_REQUESTS_TOTAL, &["policy", "outcome"]),
+    metric!(M_CACHE_SEMANTIC_EMBED_SECONDS, &["policy"]),
+    metric!(M_CACHE_SEMANTIC_EMBED_FAILURES_TOTAL, &["policy", "cause"]),
+    metric!(M_CACHE_SEMANTIC_STORE_FAILURES_TOTAL, &["policy", "op"]),
+    metric!(M_OTLP_FANOUT_DROPS_TOTAL, &["exporter", "reason"]),
+    metric!(M_OTLP_FANOUT_FAILURES_TOTAL, &["exporter"]),
+    metric!(M_REQUEST_E2E_LATENCY_SECONDS, LATENCY, extra = USAGE),
+    metric!(M_REQUEST_TTFT_SECONDS, LATENCY, extra = USAGE),
+    metric!(M_A2A_REQUESTS_TOTAL, &["agent", "operation", "status"]),
+    metric!(M_A2A_TTFB_SECONDS, &["agent", "operation"]),
+    metric!(M_A2A_STREAM_EVENTS_TOTAL, &["agent", "operation"]),
+    metric!(M_A2A_TASK_STATE_TOTAL, &["agent", "state"]),
+    metric!(M_CONFIG_LAST_RELOAD_SUCCESSFUL, &[]),
+    metric!(M_CONFIG_LAST_RELOAD_SUCCESS_TIMESTAMP, &[]),
+    metric!(M_CONFIG_RELOADS_TOTAL, &[]),
+    metric!(M_CONFIG_RELOAD_FAILURES_TOTAL, &["reason"]),
+    metric!(M_CONFIG_REJECTED_RESOURCES, &["kind"], required = &["kind"]),
+    metric!(
+        M_CONFIG_PARTIALLY_COMPATIBLE_RESOURCES,
+        &["kind"],
+        required = &["kind"]
+    ),
+    metric!(
+        M_CONFIG_STALE_SERVED_RESOURCES,
+        &["kind"],
+        required = &["kind"]
+    ),
+    metric!(M_CONFIG_OBSERVED_REVISION, &[]),
+    metric!(M_CONFIG_APPLIED_REVISION, &[]),
+    metric!(M_CONFIG_HASH_INFO, &["hash"], required = &["hash"]),
+    metric!(M_CONFIG_SOURCE_CONNECTED, &[]),
+];
+
+#[derive(Debug)]
+pub struct LabelSelection {
+    labels: HashMap<String, Vec<String>>,
+}
+
+impl LabelSelection {
+    pub fn compile(config: &BTreeMap<String, Vec<String>>) -> Result<Self, String> {
+        for (name, labels) in config {
+            let definition = METRIC_DEFINITIONS
+                .iter()
+                .find(|metric| metric.name == name)
+                .ok_or_else(|| {
+                    format!("observability.metrics.labels: unknown metric family {name:?}")
+                })?;
+            let mut seen = HashSet::new();
+            for label in labels {
+                if !definition.supports(label) {
+                    return Err(format!(
+                        "observability.metrics.labels.{name}: unsupported variable {label:?}"
+                    ));
+                }
+                if !seen.insert(label) {
+                    return Err(format!(
+                        "observability.metrics.labels.{name}: duplicate variable {label:?}"
+                    ));
+                }
+            }
+            for required in definition.required_labels {
+                if !labels.iter().any(|label| label == required) {
+                    return Err(format!("observability.metrics.labels.{name}: must retain identity label {required:?}"));
+                }
+            }
+        }
+        let mut labels: HashMap<String, Vec<String>> = METRIC_DEFINITIONS
+            .iter()
+            .map(|metric| {
+                (
+                    metric.name.to_owned(),
+                    metric
+                        .default_labels
+                        .iter()
+                        .map(|label| (*label).to_owned())
+                        .collect(),
+                )
+            })
+            .collect();
+        labels.extend(config.clone());
+        Ok(Self { labels })
+    }
+
+    fn project(&self, key: &Key, env_id: &str) -> Key {
+        let Some(selected) = self.labels.get(key.name()) else {
+            return key.clone();
+        };
+        if key.labels().len() == selected.len()
+            && key
+                .labels()
+                .all(|label| selected.iter().any(|name| name == label.key()))
+        {
+            return key.clone();
+        }
+        let labels = selected
+            .iter()
+            .map(|name| {
+                let value = if name == "env_id" {
+                    env_id
+                } else {
+                    key.labels()
+                        .find(|label| label.key() == name)
+                        .map_or("unknown", Label::value)
+                };
+                Label::new(name.to_owned(), value.to_owned())
+            })
+            .collect::<Vec<_>>();
+        Key::from_parts(key.name().to_owned(), labels)
+    }
+}
+
+pub(crate) struct LabelRecorder {
+    inner: PrometheusRecorder,
+    selection: LabelSelection,
+    env_id: String,
+    counters: Mutex<HashMap<Key, Counter>>,
+}
+
+impl LabelRecorder {
+    pub fn new(inner: PrometheusRecorder, selection: LabelSelection, env_id: &str) -> Self {
+        Self {
+            inner,
+            selection,
+            env_id: if env_id.is_empty() { "unknown" } else { env_id }.to_owned(),
+            counters: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+struct ProjectedCounter {
+    target: Counter,
+    last: AtomicU64,
+}
+
+impl CounterFn for ProjectedCounter {
+    fn increment(&self, value: u64) {
+        self.last.fetch_add(value, Ordering::Relaxed);
+        self.target.increment(value);
+    }
+
+    fn absolute(&self, value: u64) {
+        // Each original counter owns its own absolute value. Taking the
+        // maximum on the merged handle would lose the other sources.
+        let previous = self.last.fetch_max(value, Ordering::Relaxed);
+        if value > previous {
+            self.target.increment(value - previous);
+        }
+    }
+}
+
+impl Recorder for LabelRecorder {
+    fn describe_counter(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.inner.describe_counter(key, unit, description);
+    }
+
+    fn describe_gauge(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.inner.describe_gauge(key, unit, description);
+    }
+
+    fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.inner.describe_histogram(key, unit, description);
+    }
+
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
+        let projected = self.selection.project(key, &self.env_id);
+        // Only ConfigStatus counters supply absolute source values. Keep
+        // those sources separate; increment-only traffic counters can share
+        // the projected handle without retaining the removed label values.
+        if !matches!(
+            key.name(),
+            M_CONFIG_RELOADS_TOTAL | M_CONFIG_RELOAD_FAILURES_TOTAL
+        ) || key
+            .labels()
+            .all(|label| projected.labels().any(|selected| selected == label))
+        {
+            return self.inner.register_counter(&projected, metadata);
+        }
+        self.counters
+            .lock()
+            .expect("projected counters")
+            .entry(key.clone())
+            .or_insert_with(|| {
+                Counter::from_arc(Arc::new(ProjectedCounter {
+                    target: self.inner.register_counter(&projected, metadata),
+                    last: AtomicU64::new(0),
+                }))
+            })
+            .clone()
+    }
+
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
+        self.inner
+            .register_gauge(&self.selection.project(key, &self.env_id), metadata)
+    }
+
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
+        self.inner
+            .register_histogram(&self.selection.project(key, &self.env_id), metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn selection(name: &str, labels: &[&str]) -> BTreeMap<String, Vec<String>> {
+        BTreeMap::from([(
+            name.to_owned(),
+            labels.iter().map(|label| (*label).to_owned()).collect(),
+        )])
+    }
+
+    fn sample<'a>(out: &'a str, name: &str) -> Vec<&'a str> {
+        out.lines()
+            .filter(|line| {
+                line.starts_with(name)
+                    && matches!(line.as_bytes().get(name.len()), Some(b'{' | b' '))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn selected_counter_labels_merge_observations_and_keep_unconfigured_defaults() {
+        let metrics = Metrics::new_with_labels(
+            "test-env",
+            &HistogramBuckets::default(),
+            &selection(M_PROXY_REQUESTS_TOTAL, &["provider", "env_id"]),
+        )
+        .unwrap();
+        for name in ["key-a", "key-b", "key-a"] {
+            metrics.record_proxy_request(
+                RequestLabels {
+                    provider: "openai",
+                    provider_key_name: name,
+                    ..Default::default()
+                },
+                Duration::from_millis(100),
+            );
+        }
+        let out = metrics.render();
+        let selected = sample(&out, M_PROXY_REQUESTS_TOTAL);
+        assert_eq!(selected.len(), 1, "{out}");
+        assert!(selected[0].contains("provider=\"openai\""));
+        assert!(selected[0].contains("env_id=\"test-env\""));
+        assert!(!selected[0].contains("provider_key_name"));
+        assert!(selected[0].ends_with(" 3"));
+        let defaults = sample(&out, "aisix_proxy_request_duration_seconds_count");
+        assert_eq!(
+            defaults.len(),
+            2,
+            "unconfigured family preserves the key split: {out}"
+        );
+    }
+
+    #[test]
+    fn selected_histogram_labels_partition_buckets_sum_and_count() {
+        let metrics = Metrics::new_with_labels(
+            "env",
+            &HistogramBuckets::default(),
+            &selection(M_REQUEST_TTFT_SECONDS, &["provider_key_name"]),
+        )
+        .unwrap();
+        for (name, ms) in [("primary", 100), ("backup", 200), ("primary", 300)] {
+            metrics.record_request_ttft(
+                LatencyLabels {
+                    streaming: true,
+                    details: UsageLabels {
+                        provider_key_name: name,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Duration::from_millis(ms),
+            );
+        }
+        let out = metrics.render();
+        for suffix in ["_bucket", "_sum", "_count"] {
+            let name = format!("{M_REQUEST_TTFT_SECONDS}{suffix}");
+            let rows = sample(&out, &name);
+            assert!(!rows.is_empty());
+            assert!(rows.iter().all(|line| line.contains("provider_key_name=")));
+            assert!(rows.iter().all(|line| !line.contains("endpoint=")));
+        }
+        let counts = sample(&out, "aisix_request_ttft_seconds_count");
+        assert_eq!(counts.len(), 2);
+        assert!(counts
+            .iter()
+            .any(|line| line.contains("\"primary\"") && line.ends_with(" 2")));
+        assert!(counts
+            .iter()
+            .any(|line| line.contains("\"backup\"") && line.ends_with(" 1")));
+        let sums = sample(&out, "aisix_request_ttft_seconds_sum");
+        assert!(
+            sums.iter()
+                .any(|line| line.contains("\"primary\"") && line.ends_with(" 0.4")),
+            "{out}"
+        );
+        assert!(
+            out.lines()
+                .any(|line| line.contains("provider_key_name=\"primary\"")
+                    && line.contains("le=\"0.1\"")
+                    && line.ends_with(" 1")),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn removing_all_labels_merges_absolute_counters_without_losing_sources() {
+        let inner = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = inner.handle();
+        let recorder = LabelRecorder::new(
+            inner,
+            LabelSelection::compile(&selection(M_CONFIG_RELOAD_FAILURES_TOTAL, &[])).unwrap(),
+            "env",
+        );
+        metrics::with_local_recorder(&recorder, || {
+            metrics::counter!(M_CONFIG_RELOAD_FAILURES_TOTAL, "reason" => "parse").absolute(3);
+            metrics::counter!(M_CONFIG_RELOAD_FAILURES_TOTAL, "reason" => "io").absolute(5);
+            metrics::counter!(M_CONFIG_RELOAD_FAILURES_TOTAL, "reason" => "parse").absolute(4);
+            metrics::counter!(M_CONFIG_RELOAD_FAILURES_TOTAL, "reason" => "io").absolute(5);
+        });
+        let out = handle.render();
+        assert_eq!(
+            sample(&out, M_CONFIG_RELOAD_FAILURES_TOTAL),
+            vec!["aisix_config_reload_failures_total 9"]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_families_variables_and_duplicate_selections() {
+        for (name, labels) in [
+            ("typo", vec![]),
+            (
+                "aisix_request_ttft_seconds_bucket",
+                vec!["provider_key_name"],
+            ),
+            (M_REQUEST_TTFT_SECONDS, vec!["request_id"]),
+            (M_REQUEST_TTFT_SECONDS, vec!["le"]),
+            (
+                M_REQUEST_TTFT_SECONDS,
+                vec!["provider_key_name", "provider_key_name"],
+            ),
+            (M_PROXY_IN_FLIGHT, vec!["provider_key_name"]),
+            (M_PROXY_IN_FLIGHT, vec![]),
+            (
+                M_DEPLOYMENT_STATE,
+                vec!["provider", "model", "upstream_model"],
+            ),
+        ] {
+            assert!(
+                LabelSelection::compile(&selection(name, &labels)).is_err(),
+                "{name}: {labels:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn catalog_covers_each_metric_constant_and_documents_every_variable() {
+        let source = include_str!("metrics.rs");
+        let names = regex::Regex::new(r#"pub const M_\w+: &str =\s*\"([^\"]+)\""#).unwrap();
+        let actual: HashSet<_> = names
+            .captures_iter(source)
+            .map(|cap| cap[1].to_owned())
+            .collect();
+        let registered: HashSet<_> = METRIC_DEFINITIONS
+            .iter()
+            .map(|metric| metric.name.to_owned())
+            .collect();
+        assert_eq!(actual, registered);
+        assert_eq!(registered.len(), METRIC_DEFINITIONS.len());
+        let variables: HashSet<_> = METRIC_VARIABLES
+            .iter()
+            .map(|variable| variable.name)
+            .collect();
+        assert_eq!(variables.len(), METRIC_VARIABLES.len());
+        for metric in METRIC_DEFINITIONS {
+            for label in metric.default_labels.iter().chain(metric.extra_labels) {
+                assert!(
+                    variables.contains(label),
+                    "{} uses undocumented {label}",
+                    metric.name
+                );
+            }
+        }
+    }
+}

--- a/crates/aisix-obs/src/metric_labels.rs
+++ b/crates/aisix-obs/src/metric_labels.rs
@@ -415,6 +415,10 @@ pub(crate) struct LabelRecorder {
 }
 
 impl LabelRecorder {
+    pub(crate) fn selected_labels(&self, metric: &str) -> &[String] {
+        self.selection.labels.get(metric).map_or(&[], Vec::as_slice)
+    }
+
     pub fn new(inner: PrometheusRecorder, selection: LabelSelection, env_id: &str) -> Self {
         Self {
             inner,

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -2551,20 +2551,27 @@ impl Metrics {
             metric,
             elapsed.as_secs_f64(),
             |k| {
-                k.label(labels.endpoint);
-                k.label(model);
-                k.label(provider);
-                k.label(status_bucket(labels.status));
-                k.label_bool(labels.streaming);
-                k.label(labels.details.inbound_protocol);
-                k.label(labels.details.upstream_protocol);
-                k.label(labels.details.upstream_model);
-                k.label(labels.details.provider_key_id);
-                k.label(labels.details.provider_key_name);
-                k.label(labels.details.api_key_id);
-                k.label(labels.details.team_id);
-                k.label(labels.details.user_id);
-                k.label(labels.details.user_name);
+                for name in self.inner.recorder.selected_labels(metric) {
+                    let value = match name.as_str() {
+                        "env_id" => continue,
+                        "endpoint" => labels.endpoint,
+                        "model" => model,
+                        "provider" => provider,
+                        "status_class" => status_bucket(labels.status),
+                        "streaming" => bool_str(labels.streaming),
+                        "inbound_protocol" => labels.details.inbound_protocol,
+                        "upstream_protocol" => labels.details.upstream_protocol,
+                        "upstream_model" => labels.details.upstream_model,
+                        "provider_key_id" => labels.details.provider_key_id,
+                        "provider_key_name" => labels.details.provider_key_name,
+                        "api_key_id" => labels.details.api_key_id,
+                        "team_id" => labels.details.team_id,
+                        "user_id" => labels.details.user_id,
+                        "user_name" => labels.details.user_name,
+                        _ => "unknown",
+                    };
+                    k.label(value);
+                }
             },
             || {
                 metrics::histogram!(
@@ -3947,6 +3954,66 @@ mod tests {
         // scrape does not gain a zero-valued series per request.
         assert!(!rendered.contains(M_LLM_CACHED_INPUT_TOKENS_TOTAL));
         assert!(!rendered.contains(M_LLM_INPUT_TOKENS_TOTAL));
+    }
+
+    #[test]
+    fn latency_cache_uses_only_selected_labels() {
+        let before = WORKER_CACHE.with(|cell| cell.borrow().histograms.len());
+        let defaults = Metrics::new(false);
+        for index in 0..100 {
+            let caller = format!("caller-{index}");
+            let labels = LatencyLabels {
+                details: UsageLabels {
+                    user_name: &caller,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            defaults.record_request_e2e_latency(labels, Duration::from_millis(1));
+            defaults.record_request_ttft(labels, Duration::from_millis(1));
+        }
+        assert_eq!(
+            WORKER_CACHE.with(|cell| cell.borrow().histograms.len()),
+            before + 2
+        );
+
+        let selected = Metrics::new_with_labels(
+            "test",
+            &HistogramBuckets::default(),
+            &[(
+                M_REQUEST_TTFT_SECONDS.to_string(),
+                vec!["user_name".to_string()],
+            )]
+            .into(),
+        )
+        .unwrap();
+        for user_name in ["alice", "bob"] {
+            for model in ["one", "two"] {
+                selected.record_request_ttft(
+                    LatencyLabels {
+                        model,
+                        details: UsageLabels {
+                            user_name,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    Duration::from_millis(1),
+                );
+            }
+        }
+        assert_eq!(
+            WORKER_CACHE.with(|cell| cell.borrow().histograms.len()),
+            before + 4
+        );
+        let rendered = selected.render();
+        for user_name in ["alice", "bob"] {
+            assert!(rendered
+                .lines()
+                .any(|line| line.starts_with("aisix_request_ttft_seconds_count{")
+                    && line.contains(&format!("user_name=\"{user_name}\""))
+                    && line.ends_with(" 2")));
+        }
     }
 
     #[test]

--- a/crates/aisix-obs/src/metrics.rs
+++ b/crates/aisix-obs/src/metrics.rs
@@ -28,9 +28,8 @@
 //! `metrics-exporter-prometheus`'s text renderer; no global recorder is
 //! installed, so tests can spin up isolated instances per case.
 
-use metrics_exporter_prometheus::{
-    Matcher, PrometheusBuilder, PrometheusHandle, PrometheusRecorder,
-};
+use crate::metric_labels::{LabelRecorder, LabelSelection};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use std::collections::HashMap;
 use std::hash::Hasher;
 use std::sync::Arc;
@@ -577,7 +576,7 @@ pub struct Metrics {
 }
 
 struct MetricsInner {
-    recorder: PrometheusRecorder,
+    recorder: LabelRecorder,
     handle: PrometheusHandle,
     /// Per-(endpoint, protocol) in-flight counts. A linear scan over a
     /// bounded slot list (route templates × protocols): the steady-state
@@ -931,6 +930,16 @@ impl Metrics {
     /// Like [`Metrics::new_with_env_id`], with operator-supplied histogram
     /// bucket edges (`observability.metrics.buckets`, AISIX-Cloud#1226).
     pub fn new_with_buckets(env_id: &str, buckets: &HistogramBuckets) -> Self {
+        Self::new_with_labels(env_id, buckets, &Default::default())
+            .expect("default metric labels are valid")
+    }
+
+    pub fn new_with_labels(
+        env_id: &str,
+        buckets: &HistogramBuckets,
+        labels: &std::collections::BTreeMap<String, Vec<String>>,
+    ) -> Result<Self, String> {
+        let selection = LabelSelection::compile(labels)?;
         // Buckets ONLY for the SLO histograms and the guardrail latency
         // histogram: with `metrics-exporter-prometheus`, a distribution
         // without configured buckets renders as a summary — which is what
@@ -958,8 +967,9 @@ impl Metrics {
             .expect("bucket lists are validated non-empty")
             .build_recorder();
         let handle = recorder.handle();
+        let recorder = LabelRecorder::new(recorder, selection, env_id);
         static NEXT_INSTANCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-        Self {
+        Ok(Self {
             inner: Arc::new(MetricsInner {
                 recorder,
                 handle,
@@ -976,7 +986,7 @@ impl Metrics {
                 config_labels: Mutex::new(ConfigLabelState::default()),
                 retirable: Mutex::new(HashMap::new()),
             }),
-        }
+        })
     }
 
     /// Remember one label set of a retirable gauge family.
@@ -2546,6 +2556,15 @@ impl Metrics {
                 k.label(provider);
                 k.label(status_bucket(labels.status));
                 k.label_bool(labels.streaming);
+                k.label(labels.details.inbound_protocol);
+                k.label(labels.details.upstream_protocol);
+                k.label(labels.details.upstream_model);
+                k.label(labels.details.provider_key_id);
+                k.label(labels.details.provider_key_name);
+                k.label(labels.details.api_key_id);
+                k.label(labels.details.team_id);
+                k.label(labels.details.user_id);
+                k.label(labels.details.user_name);
             },
             || {
                 metrics::histogram!(
@@ -2556,6 +2575,15 @@ impl Metrics {
                     "provider" => provider.to_string(),
                     "status_class" => status_bucket(labels.status),
                     "streaming" => bool_str(labels.streaming),
+                    "inbound_protocol" => labels.details.inbound_protocol.to_string(),
+                    "upstream_protocol" => labels.details.upstream_protocol.to_string(),
+                    "upstream_model" => labels.details.upstream_model.to_string(),
+                    "provider_key_id" => labels.details.provider_key_id.to_string(),
+                    "provider_key_name" => labels.details.provider_key_name.to_string(),
+                    "api_key_id" => labels.details.api_key_id.to_string(),
+                    "team_id" => labels.details.team_id.to_string(),
+                    "user_id" => labels.details.user_id.to_string(),
+                    "user_name" => labels.details.user_name.to_string(),
                 )
             },
         );
@@ -2614,7 +2642,7 @@ pub struct A2aCallOutcome {
     pub task_state: &'static str,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct LatencyLabels<'a> {
     /// Route template, e.g. `/v1/chat/completions`. Bounded set.
     pub endpoint: &'a str,
@@ -2625,6 +2653,9 @@ pub struct LatencyLabels<'a> {
     /// Raw HTTP status; bucketed to `2xx`/`4xx`/… at record time.
     pub status: u16,
     pub streaming: bool,
+    /// Attribution available for optional labels; the default histogram
+    /// selection retains only its historical dimensions.
+    pub details: UsageLabels<'a>,
 }
 
 /// Missing dimensions default to `"unknown"`, never an empty label value.
@@ -2944,6 +2975,7 @@ impl RequestLabels<'_> {
             "user_id" => self.user_id.to_string(),
             "user_name" => self.user_name.to_string(),
             "stream" => bool_str(self.stream),
+            "is_fallback" => bool_str(self.is_fallback),
             "status" => self.status.to_string(),
             "outcome" => self.outcome.as_str().to_string(),
         )
@@ -4961,6 +4993,7 @@ mod tests {
             provider: "p",
             status: 200,
             streaming: false,
+            details: Default::default(),
         };
         let variants = [
             LatencyLabels {
@@ -5843,6 +5876,7 @@ mod tests {
             provider: "openai",
             status: 200,
             streaming: false,
+            details: Default::default(),
         };
         m.record_request_e2e_latency(labels, Duration::from_millis(1500));
         m.record_request_ttft(
@@ -5903,6 +5937,7 @@ mod tests {
                 provider: "anthropic",
                 status: 502,
                 streaming: false,
+                details: Default::default(),
             },
             Duration::from_millis(1500),
         );
@@ -5936,6 +5971,7 @@ mod tests {
             provider: "openai",
             status: 200,
             streaming: true,
+            details: Default::default(),
         };
         m.record_request_ttft(labels, Duration::ZERO);
         assert!(
@@ -5982,6 +6018,7 @@ mod tests {
             provider: "openai",
             status: 200,
             streaming: true,
+            details: Default::default(),
         };
         m.record_request_e2e_latency(labels, Duration::from_millis(1500));
         m.record_request_ttft(labels, Duration::from_millis(1500));
@@ -6015,6 +6052,7 @@ mod tests {
                 provider: "anthropic",
                 status: 200,
                 streaming: true,
+                details: Default::default(),
             },
             Duration::from_millis(1500),
         );
@@ -6051,6 +6089,7 @@ mod tests {
             provider: "openai",
             status: 200,
             streaming: true,
+            details: Default::default(),
         };
         m.record_request_e2e_latency(labels, Duration::from_millis(1500));
         m.record_request_ttft(labels, Duration::from_millis(1500));

--- a/crates/aisix-obs/src/usage.rs
+++ b/crates/aisix-obs/src/usage.rs
@@ -119,6 +119,9 @@ pub struct UsageEvent {
     /// the absent-or-zero case identically.
     #[serde(default, skip_serializing_if = "is_zero_u32")]
     pub cached_prompt_tokens: u32,
+    /// Raw OpenAI cache-write count; it is not additive to prompt tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_write_tokens: Option<u32>,
 
     /// OpenAI o1/o3 reasoning tokens. Subset of `completion_tokens`.
     #[serde(default, skip_serializing_if = "is_zero_u32")]

--- a/crates/aisix-provider-openai/src/wire.rs
+++ b/crates/aisix-provider-openai/src/wire.rs
@@ -247,6 +247,8 @@ pub struct OpenAiPromptDetails {
     /// Tokens served from the prompt cache (50% of prompt rate).
     #[serde(default)]
     pub cached_tokens: u32,
+    #[serde(default)]
+    pub cache_write_tokens: Option<u32>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -364,6 +366,10 @@ fn into_usage(u: OpenAiUsage) -> UsageStats {
             .filter(|&n| n > 0)
             .or(u.prompt_cache_hit_tokens)
             .unwrap_or(0),
+        cache_write_tokens: u
+            .prompt_tokens_details
+            .as_ref()
+            .and_then(|d| d.cache_write_tokens),
         reasoning_tokens: u
             .completion_tokens_details
             .as_ref()
@@ -592,6 +598,33 @@ pub(crate) fn embed_response_into(raw: OpenAiEmbedResponse) -> EmbeddingResponse
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cache_write_preserves_raw_values_and_presence() {
+        for value in [Some(37), Some(0), None] {
+            let mut details = serde_json::json!({"cached_tokens": 19});
+            if let Some(value) = value {
+                details["cache_write_tokens"] = value.into();
+            }
+            let wire: OpenAiUsage = serde_json::from_value(serde_json::json!({
+                "prompt_tokens": 101,
+                "completion_tokens": 11,
+                "total_tokens": 112,
+                "prompt_tokens_details": details,
+            }))
+            .unwrap();
+            let usage = into_usage(wire);
+            assert_eq!(usage.cache_write_tokens, value);
+            assert_eq!(usage.prompt_tokens, 101);
+            assert_eq!(usage.total_tokens, 112);
+            assert_eq!(usage.cache_creation_tokens, 0);
+            let serialized = serde_json::to_value(&usage).unwrap();
+            assert_eq!(
+                serialized.get("cache_write_tokens"),
+                value.map(serde_json::Value::from).as_ref()
+            );
+        }
+    }
 
     #[test]
     fn non_streaming_response_parses_into_chat_response() {

--- a/crates/aisix-proxy/src/a2a.rs
+++ b/crates/aisix-proxy/src/a2a.rs
@@ -929,14 +929,17 @@ fn emit_a2a_usage(
     // the unary, quota-rejected and failed-to-open paths are in the sample
     // too — a streaming-only series would report `/a2a` as having no failures
     // at all.
-    state.metrics.record_request_e2e_latency(
-        aisix_obs::LatencyLabels {
-            endpoint: "/a2a",
-            model: A2A_MODEL_LABEL,
+    crate::request_metrics::record_e2e_latency(
+        state,
+        "/a2a",
+        crate::request_metrics::Caller::new(auth),
+        crate::request_metrics::Upstream {
             provider: "a2a",
-            status: status_code,
-            streaming: is_streaming_operation(call.operation),
+            model: A2A_MODEL_LABEL,
+            stream: is_streaming_operation(call.operation),
+            ..Default::default()
         },
+        status_code,
         latency,
     );
     // The `aisix_a2a_*` family rides on the same chokepoint as the usage

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -3802,6 +3802,7 @@ async fn dispatch_ensemble(
         let client_model_for_telem = req.model.clone();
         let bounded_model_for_telem =
             crate::usage_attr::metric_model_label(snapshot, &req.model).into_owned();
+        let metric_caller = crate::request_metrics::Caller::from_api_key_id(snapshot, api_key_id);
         let api_key_id_for_telem = api_key_id.to_string();
         let applied_guardrails_for_telem = applied_guardrails.to_vec();
         // See the single-upstream streaming path.
@@ -3997,9 +3998,7 @@ async fn dispatch_ensemble(
                 // so record the client-visible panel+judge aggregate against
                 // the ensemble alias rather than dropping the request from
                 // those series entirely.
-                let owned_caller =
-                    crate::request_metrics::Caller::from_api_key_id(&snap, &api_key_id_for_telem);
-                let caller = owned_caller.as_caller();
+                let caller = metric_caller.as_caller();
                 let ensemble_pk =
                     crate::usage_attr::ResolvedPk::resolve(&snap, crate::request_metrics::UNKNOWN);
                 crate::request_metrics::record_usage(

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -258,6 +258,7 @@ pub async fn chat_completions(
                     success.completion_tokens.unwrap_or(0) as u32,
                     UsageExtras {
                         cached_prompt_tokens: success.cached_prompt_tokens,
+                        cache_write_tokens: success.cache_write_tokens,
                         reasoning_tokens: success.reasoning_tokens,
                         cache_creation_tokens: success.cache_creation_tokens,
                         cache_read_tokens: success.cache_read_tokens,
@@ -437,14 +438,16 @@ pub async fn chat_completions(
                 status,
                 elapsed,
             );
-            state.metrics.record_request_e2e_latency(
-                LatencyLabels {
-                    endpoint: "/v1/chat/completions",
-                    model: metric_model.as_ref(),
-                    provider: last_target.provider(),
-                    status,
-                    streaming: req.is_streaming(),
-                },
+            crate::request_metrics::record_e2e_latency(
+                &state,
+                "/v1/chat/completions",
+                crate::request_metrics::Caller::new(&auth),
+                last_target.upstream(
+                    metric_model.as_ref(),
+                    req.is_streaming(),
+                    routing.fallback_count() > 0,
+                ),
+                status,
                 elapsed,
             );
             emit_access_log(
@@ -564,6 +567,7 @@ pub async fn chat_completions(
                         c.completion_tokens,
                         UsageExtras {
                             cached_prompt_tokens: c.cached_prompt_tokens,
+                            cache_write_tokens: c.cache_write_tokens,
                             reasoning_tokens: c.reasoning_tokens,
                             cache_creation_tokens: c.cache_creation_tokens,
                             cache_read_tokens: c.cache_read_tokens,
@@ -684,6 +688,7 @@ struct Success {
     /// for providers that don't expose them; cp-api falls back to the
     /// standard prompt / completion rate when these are 0.
     cached_prompt_tokens: u32,
+    cache_write_tokens: Option<u32>,
     reasoning_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
@@ -1247,6 +1252,7 @@ struct UpstreamCharge {
     /// carried no usage block.
     usage_estimated: bool,
     cached_prompt_tokens: u32,
+    cache_write_tokens: Option<u32>,
     reasoning_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
@@ -2119,6 +2125,7 @@ async fn dispatch(
                     comp.completion_tokens,
                     UsageExtras {
                         cached_prompt_tokens: comp.cached_prompt_tokens,
+                        cache_write_tokens: comp.cache_write_tokens,
                         reasoning_tokens: comp.reasoning_tokens,
                         cache_creation_tokens: comp.cache_creation_tokens,
                         cache_read_tokens: comp.cache_read_tokens,
@@ -2230,6 +2237,20 @@ async fn dispatch(
                         provider: &provider_for_metrics,
                         status: 200,
                         streaming: true,
+                        details: UsageLabels {
+                            endpoint: "/v1/chat/completions",
+                            inbound_protocol: "openai",
+                            upstream_protocol: pk.labels().protocol(),
+                            provider: &provider_for_metrics,
+                            model: &bounded_model_for_metrics,
+                            upstream_model: &bounded_upstream_for_metrics,
+                            provider_key_id: pk.labels().id(),
+                            provider_key_name: pk.labels().name(),
+                            api_key_id: &api_key_id_for_telem,
+                            team_id: team_id_for_metrics.as_deref().unwrap_or("unknown"),
+                            user_id: user_id_for_metrics.as_deref().unwrap_or("unknown"),
+                            user_name: user_name_for_metrics.as_deref().unwrap_or("unknown"),
+                        },
                     },
                     started.elapsed(),
                 );
@@ -2240,6 +2261,20 @@ async fn dispatch(
                         provider: &provider_for_metrics,
                         status: 200,
                         streaming: true,
+                        details: UsageLabels {
+                            endpoint: "/v1/chat/completions",
+                            inbound_protocol: "openai",
+                            upstream_protocol: pk.labels().protocol(),
+                            provider: &provider_for_metrics,
+                            model: &bounded_model_for_metrics,
+                            upstream_model: &bounded_upstream_for_metrics,
+                            provider_key_id: pk.labels().id(),
+                            provider_key_name: pk.labels().name(),
+                            api_key_id: &api_key_id_for_telem,
+                            team_id: team_id_for_metrics.as_deref().unwrap_or("unknown"),
+                            user_id: user_id_for_metrics.as_deref().unwrap_or("unknown"),
+                            user_name: user_name_for_metrics.as_deref().unwrap_or("unknown"),
+                        },
                     },
                     Duration::from_millis(u64::from(comp.upstream_ttft_ms)),
                 );
@@ -2287,6 +2322,7 @@ async fn dispatch(
             total_tokens: None,
             cost_usd: 0.0,
             cached_prompt_tokens: 0,
+            cache_write_tokens: None,
             reasoning_tokens: 0,
             cache_creation_tokens: 0,
             cache_read_tokens: 0,
@@ -2558,6 +2594,7 @@ async fn dispatch(
                 // "of which N were cache hits" stat reflects the
                 // original event accurately.
                 let cached_prompt_tokens = cached.usage.cached_prompt_tokens;
+                let cache_write_tokens = cached.usage.cache_write_tokens;
                 let reasoning_tokens = cached.usage.reasoning_tokens;
                 let cache_creation_tokens = cached.usage.cache_creation_tokens;
                 let cache_read_tokens = cached.usage.cache_read_tokens;
@@ -2665,6 +2702,7 @@ async fn dispatch(
                     total_tokens: Some(total),
                     usage_estimated,
                     cached_prompt_tokens,
+                    cache_write_tokens,
                     reasoning_tokens,
                     cache_creation_tokens,
                     cache_read_tokens,
@@ -3079,6 +3117,7 @@ async fn dispatch(
     // the upstream gets moved into render_response below — we need them
     // on the Success struct for telemetry.
     let cached_prompt_tokens = upstream.usage.cached_prompt_tokens;
+    let cache_write_tokens = upstream.usage.cache_write_tokens;
     let reasoning_tokens = upstream.usage.reasoning_tokens;
     let cache_creation_tokens = upstream.usage.cache_creation_tokens;
     let cache_read_tokens = upstream.usage.cache_read_tokens;
@@ -3136,6 +3175,7 @@ async fn dispatch(
                 completion_tokens: completion_tokens_u32,
                 usage_estimated,
                 cached_prompt_tokens,
+                cache_write_tokens,
                 reasoning_tokens,
                 cache_creation_tokens,
                 cache_read_tokens,
@@ -3298,6 +3338,7 @@ async fn dispatch(
         total_tokens: Some(total),
         usage_estimated,
         cached_prompt_tokens,
+        cache_write_tokens,
         reasoning_tokens,
         cache_creation_tokens,
         cache_read_tokens,
@@ -3465,6 +3506,7 @@ async fn dispatch_ensemble(
             effective.usage.completion_tokens,
             UsageExtras {
                 cached_prompt_tokens: effective.usage.cached_prompt_tokens,
+                cache_write_tokens: effective.usage.cache_write_tokens,
                 reasoning_tokens: effective.usage.reasoning_tokens,
                 cache_creation_tokens: effective.usage.cache_creation_tokens,
                 cache_read_tokens: effective.usage.cache_read_tokens,
@@ -3865,6 +3907,7 @@ async fn dispatch_ensemble(
                         member.usage.completion_tokens,
                         UsageExtras {
                             cached_prompt_tokens: member.usage.cached_prompt_tokens,
+                            cache_write_tokens: member.usage.cache_write_tokens,
                             reasoning_tokens: member.usage.reasoning_tokens,
                             cache_creation_tokens: member.usage.cache_creation_tokens,
                             cache_read_tokens: member.usage.cache_read_tokens,
@@ -3902,6 +3945,7 @@ async fn dispatch_ensemble(
                     comp.completion_tokens,
                     UsageExtras {
                         cached_prompt_tokens: comp.cached_prompt_tokens,
+                        cache_write_tokens: comp.cache_write_tokens,
                         reasoning_tokens: comp.reasoning_tokens,
                         cache_creation_tokens: comp.cache_creation_tokens,
                         cache_read_tokens: comp.cache_read_tokens,
@@ -3995,6 +4039,20 @@ async fn dispatch_ensemble(
                         provider: "ensemble",
                         status: 200,
                         streaming: true,
+                        details: UsageLabels {
+                            endpoint: "/v1/chat/completions",
+                            inbound_protocol: "openai",
+                            upstream_protocol: ensemble_pk.labels().protocol(),
+                            provider: "ensemble",
+                            model: &bounded_model_for_telem,
+                            upstream_model: crate::request_metrics::UNKNOWN,
+                            provider_key_id: ensemble_pk.labels().id(),
+                            provider_key_name: ensemble_pk.labels().name(),
+                            api_key_id: caller.api_key_id,
+                            team_id: caller.team_id,
+                            user_id: caller.user_id,
+                            user_name: caller.user_name,
+                        },
                     },
                     started.elapsed(),
                 );
@@ -4005,6 +4063,20 @@ async fn dispatch_ensemble(
                         provider: "ensemble",
                         status: 200,
                         streaming: true,
+                        details: UsageLabels {
+                            endpoint: "/v1/chat/completions",
+                            inbound_protocol: "openai",
+                            upstream_protocol: ensemble_pk.labels().protocol(),
+                            provider: "ensemble",
+                            model: &bounded_model_for_telem,
+                            upstream_model: crate::request_metrics::UNKNOWN,
+                            provider_key_id: ensemble_pk.labels().id(),
+                            provider_key_name: ensemble_pk.labels().name(),
+                            api_key_id: caller.api_key_id,
+                            team_id: caller.team_id,
+                            user_id: caller.user_id,
+                            user_name: caller.user_name,
+                        },
                     },
                     Duration::from_millis(u64::from(comp.upstream_ttft_ms)),
                 );
@@ -4049,6 +4121,7 @@ async fn dispatch_ensemble(
             usage_estimated: false,
             cost_usd: 0.0,
             cached_prompt_tokens: 0,
+            cache_write_tokens: None,
             reasoning_tokens: 0,
             cache_creation_tokens: 0,
             cache_read_tokens: 0,
@@ -4184,6 +4257,7 @@ async fn dispatch_ensemble(
             effective_judge.usage.completion_tokens,
             UsageExtras {
                 cached_prompt_tokens: effective_judge.usage.cached_prompt_tokens,
+                cache_write_tokens: effective_judge.usage.cache_write_tokens,
                 reasoning_tokens: effective_judge.usage.reasoning_tokens,
                 cache_creation_tokens: effective_judge.usage.cache_creation_tokens,
                 cache_read_tokens: effective_judge.usage.cache_read_tokens,
@@ -4333,6 +4407,7 @@ async fn dispatch_ensemble(
         total_tokens: Some(u64::from(metric_usage.total_tokens)),
         usage_estimated: false,
         cached_prompt_tokens: metric_usage.cached_prompt_tokens,
+        cache_write_tokens: metric_usage.cache_write_tokens,
         reasoning_tokens: metric_usage.reasoning_tokens,
         cache_creation_tokens: metric_usage.cache_creation_tokens,
         cache_read_tokens: metric_usage.cache_read_tokens,
@@ -4390,7 +4465,6 @@ fn record_success(
     s: &Success,
     elapsed: Duration,
 ) {
-    let metrics = &state.metrics;
     let caller = crate::request_metrics::Caller::new(auth);
     crate::request_metrics::record(
         state,
@@ -4411,15 +4485,19 @@ fn record_success(
     // `elapsed` for a stream is time-to-response-start; the stream's
     // on_complete records the full duration instead.
     if !stream {
-        let bounded_model = crate::usage_attr::metric_model_label(&state.snapshot.load(), model);
-        metrics.record_request_e2e_latency(
-            LatencyLabels {
-                endpoint: "/v1/chat/completions",
-                model: bounded_model.as_ref(),
+        crate::request_metrics::record_e2e_latency(
+            state,
+            "/v1/chat/completions",
+            caller,
+            crate::request_metrics::Upstream {
                 provider,
-                status,
-                streaming: false,
+                model,
+                upstream_model: &s.upstream_model,
+                pk: pk.labels(),
+                stream: false,
+                ..Default::default()
             },
+            status,
             elapsed,
         );
     }
@@ -4535,6 +4613,7 @@ fn emit_usage_event(
         prompt_tokens,
         completion_tokens,
         cached_prompt_tokens: extras.cached_prompt_tokens,
+        cache_write_tokens: extras.cache_write_tokens,
         reasoning_tokens: extras.reasoning_tokens,
         cache_creation_tokens: extras.cache_creation_tokens,
         cache_read_tokens: extras.cache_read_tokens,
@@ -4664,6 +4743,7 @@ pub(crate) fn sanitize_tag(s: String) -> String {
 #[derive(Default)]
 struct UsageExtras {
     cached_prompt_tokens: u32,
+    cache_write_tokens: Option<u32>,
     reasoning_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
@@ -4918,6 +4998,7 @@ struct StreamCompletion {
     /// cumulative-tokens accounting can overflow u32 over a long key.
     total_tokens: u64,
     cached_prompt_tokens: u32,
+    cache_write_tokens: Option<u32>,
     reasoning_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
@@ -5374,6 +5455,7 @@ where
                         if t > comp.total_tokens {
                             comp.total_tokens = t;
                         }
+                        comp.cache_write_tokens = comp.cache_write_tokens.max(u.cache_write_tokens);
                         if u.cached_prompt_tokens > comp.cached_prompt_tokens {
                             comp.cached_prompt_tokens = u.cached_prompt_tokens;
                         }

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -101,6 +101,7 @@ struct CompletionUsage {
     /// on `/v1/chat/completions`; 0 when the upstream omits it, never
     /// inferred.
     cached_prompt_tokens: u32,
+    cache_write_tokens: Option<u32>,
     /// True when any counter was filled by the local estimator because
     /// the upstream reported no usage (AISIX-Cloud#1074).
     usage_estimated: bool,
@@ -210,6 +211,7 @@ pub async fn completions(
                     prompt_tokens: 0,
                     completion_tokens: 0,
                     cached_prompt_tokens: 0,
+                    cache_write_tokens: None,
                     usage_estimated: false,
                 });
                 emit_usage_event(
@@ -495,6 +497,7 @@ async fn dispatch(
                     prompt_tokens: 0,
                     completion_tokens: 0,
                     cached_prompt_tokens: 0,
+                    cache_write_tokens: None,
                     usage_estimated: false,
                 });
                 let est_model = model.upstream_model().unwrap_or("unknown");
@@ -706,10 +709,15 @@ fn extract_completion_usage(body: &Value) -> Option<CompletionUsage> {
         .and_then(|d| d.get("cached_tokens"))
         .and_then(|v| v.as_u64())
         .unwrap_or(0) as u32;
+    let cache_write_tokens = usage
+        .pointer("/prompt_tokens_details/cache_write_tokens")
+        .and_then(Value::as_u64)
+        .map(|n| n.min(u32::MAX as u64) as u32);
     Some(CompletionUsage {
         prompt_tokens,
         completion_tokens,
         cached_prompt_tokens,
+        cache_write_tokens,
         usage_estimated: false,
     })
 }
@@ -803,6 +811,8 @@ fn emit_usage_event(
         requested_model: requested_model.to_string(),
         prompt_tokens: usage.prompt_tokens,
         completion_tokens: usage.completion_tokens,
+        cached_prompt_tokens: usage.cached_prompt_tokens,
+        cache_write_tokens: usage.cache_write_tokens,
         usage_estimated: usage.usage_estimated,
         // Single-attempt endpoint: the attempt spans the whole request, so
         // the upstream figure and what the caller waited for coincide.

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -295,6 +295,7 @@ pub async fn messages(
                     &api_key_id,
                     &provider_label,
                     &model_name,
+                    &model_name,
                     &upstream_model,
                     auth.key().team_id.as_deref(),
                     auth.key().user_id.as_deref(),
@@ -441,6 +442,7 @@ pub async fn messages(
                     &api_key_id,
                     "unknown",
                     &model_name,
+                    &model_name,
                     "unknown",
                     auth.key().team_id.as_deref(),
                     auth.key().user_id.as_deref(),
@@ -537,6 +539,7 @@ fn emit_failed_attempts_anthropic(
             &rec.target_model_id,
             api_key_id,
             provider,
+            model,
             model,
             upstream_model,
             team_id,
@@ -1581,7 +1584,8 @@ async fn anthropic_passthrough_dispatch(
                     &api_key_id_c,
                     &provider_c,
                     &model_name_c,
-                    &upstream_model_c,
+                    &metric_model,
+                    &metric_upstream_model,
                     team_id_c.as_deref(),
                     user_id_c.as_deref(),
                     user_name_c.as_deref(),
@@ -2282,7 +2286,8 @@ async fn cross_provider_dispatch(
                     &api_key_id_for_telem,
                     &provider_for_telem,
                     &model_for_telem,
-                    &upstream_model_for_telem,
+                    &metric_model,
+                    &metric_upstream_model,
                     team_id_for_telem.as_deref(),
                     user_id_for_telem.as_deref(),
                     user_name_for_telem.as_deref(),
@@ -3056,6 +3061,7 @@ fn emit_anthropic_usage_event(
     api_key_id: &str,
     provider: &str,
     model: &str,
+    metric_model: &str,
     upstream_model: &str,
     team_id: Option<&str>,
     user_id: Option<&str>,
@@ -3192,7 +3198,7 @@ fn emit_anthropic_usage_event(
         },
         crate::request_metrics::Upstream {
             provider,
-            model,
+            model: metric_model,
             upstream_model,
             pk: pk.labels(),
             ..Default::default()
@@ -3210,8 +3216,11 @@ fn emit_anthropic_usage_event(
     );
     if metrics.upstream_ttft_ms > 0 {
         let snap_for_labels = state.snapshot.load();
-        let (bounded_model, bounded_upstream) =
-            crate::usage_attr::metric_model_label_pair(&snap_for_labels, model, upstream_model);
+        let (bounded_model, bounded_upstream) = crate::usage_attr::metric_model_label_pair(
+            &snap_for_labels,
+            metric_model,
+            upstream_model,
+        );
         state.metrics.record_request_ttft(
             LatencyLabels {
                 endpoint: "/v1/messages",

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -216,16 +216,19 @@ pub async fn messages(
             // SLO e2e histogram (AISIX-Cloud#1011): non-streaming only —
             // a stream records its full duration at completion instead.
             if !stream_requested {
-                let bounded_model =
-                    crate::usage_attr::metric_model_label(&state.snapshot.load(), &model_name);
-                state.metrics.record_request_e2e_latency(
-                    LatencyLabels {
-                        endpoint: "/v1/messages",
-                        model: bounded_model.as_ref(),
+                crate::request_metrics::record_e2e_latency(
+                    &state,
+                    "/v1/messages",
+                    crate::request_metrics::Caller::new(&auth),
+                    crate::request_metrics::Upstream {
                         provider: &provider_label,
-                        status,
-                        streaming: false,
+                        model: &model_name,
+                        upstream_model: &upstream_model,
+                        pk: pk.labels(),
+                        stream: false,
+                        ..Default::default()
                     },
+                    status,
                     elapsed,
                 );
             }
@@ -350,14 +353,16 @@ pub async fn messages(
                 status,
                 elapsed,
             );
-            state.metrics.record_request_e2e_latency(
-                LatencyLabels {
-                    endpoint: "/v1/messages",
-                    model: metric_model.as_ref(),
-                    provider: last_target.provider(),
-                    status,
-                    streaming: stream_requested,
-                },
+            crate::request_metrics::record_e2e_latency(
+                &state,
+                "/v1/messages",
+                crate::request_metrics::Caller::new(&auth),
+                last_target.upstream(
+                    metric_model.as_ref(),
+                    stream_requested,
+                    routing.fallback_count() > 0,
+                ),
+                status,
                 elapsed,
             );
             // AISIX-Cloud#1428: a guardrail refusal IS this failure, so the
@@ -1432,10 +1437,6 @@ async fn anthropic_passthrough_dispatch(
         let api_key_id_c = api_key_id.to_string();
         let provider_c = provider_label.clone();
         let model_name_c = model_name.to_string();
-        // Bounded twin for the latency-histogram label (emit-chokepoint
-        // rule) — usage events keep the raw requested string.
-        let bounded_model_c =
-            crate::usage_attr::metric_model_label(&state.snapshot.load(), model_name).into_owned();
         let provider_key_id_c = pk_id.to_string();
         let upstream_model_c = upstream_model.clone();
         let team_id_c = team_id.clone();
@@ -1535,6 +1536,7 @@ async fn anthropic_passthrough_dispatch(
                     // Anthropic upstream: the cache hit arrives as
                     // `cache_read_input_tokens`, never the OpenAI-shape subset.
                     cached_prompt_tokens: 0,
+                    cache_write_tokens: None,
                     cache_creation_tokens: usage.cache_creation_tokens,
                     cache_read_tokens: usage.cache_read_tokens,
                     usage_estimated: usage.usage_estimated,
@@ -1544,21 +1546,27 @@ async fn anthropic_passthrough_dispatch(
                     upstream_ttft_ms: usage.upstream_ttft_ms,
                     downstream_latency_ms: usage.downstream_latency_ms,
                 };
-                state_c.metrics.record_request_e2e_latency(
-                    LatencyLabels {
-                        endpoint: "/v1/messages",
-                        model: &bounded_model_c,
+                let snap_c = state_c.snapshot.load();
+                let pk_c = crate::usage_attr::ResolvedPk::resolve(&snap_c, &provider_key_id_c);
+                crate::request_metrics::record_e2e_latency(
+                    &state_c,
+                    "/v1/messages",
+                    crate::request_metrics::Caller::from_api_key_id(&snap_c, &api_key_id_c)
+                        .as_caller(),
+                    crate::request_metrics::Upstream {
                         provider: &provider_c,
-                        status: 200,
-                        streaming: true,
+                        model: &model_name_c,
+                        upstream_model: &upstream_model_c,
+                        pk: pk_c.labels(),
+                        stream: true,
+                        ..Default::default()
                     },
+                    200,
                     started.elapsed(),
                 );
                 // A stream can outlive several config generations, so the
                 // end-of-stream emit reads a FRESH snapshot rather than the
                 // one the request started on (#941).
-                let snap_c = state_c.snapshot.load();
-                let pk_c = crate::usage_attr::ResolvedPk::resolve(&snap_c, &provider_key_id_c);
                 emit_anthropic_usage_event(
                     &state_c,
                     &snap_c,
@@ -1928,6 +1936,7 @@ fn anthropic_metrics_from_response_json(body: &Value) -> AnthropicUsageMetrics {
         usage_estimated: false,
         // Anthropic upstream: see the streaming sibling — no OpenAI-shape subset.
         cached_prompt_tokens: 0,
+        cache_write_tokens: None,
         prompt_tokens: usage
             .and_then(|u| u.get("input_tokens"))
             .and_then(Value::as_u64)
@@ -2133,8 +2142,6 @@ async fn cross_provider_dispatch(
         let api_key_id_for_telem = api_key_id.to_string();
         let provider_for_telem = provider_label.clone();
         let model_for_telem = model_name.to_string();
-        let bounded_model_for_telem =
-            crate::usage_attr::metric_model_label(&state.snapshot.load(), model_name).into_owned();
         let provider_key_id_for_telem = provider_key_id.to_string();
         let upstream_model_for_telem = upstream_model.clone();
         let team_id_for_telem = team_id;
@@ -2223,6 +2230,7 @@ async fn cross_provider_dispatch(
                     prompt_tokens: comp.prompt_tokens,
                     completion_tokens: comp.completion_tokens,
                     cached_prompt_tokens: comp.cached_prompt_tokens,
+                    cache_write_tokens: comp.cache_write_tokens,
                     cache_creation_tokens: comp.cache_creation_tokens,
                     cache_read_tokens: comp.cache_read_tokens,
                     usage_estimated: comp.usage_estimated,
@@ -2232,20 +2240,29 @@ async fn cross_provider_dispatch(
                     upstream_ttft_ms: comp.upstream_ttft_ms,
                     downstream_latency_ms: comp.downstream_latency_ms,
                 };
-                state_for_telem.metrics.record_request_e2e_latency(
-                    LatencyLabels {
-                        endpoint: "/v1/messages",
-                        model: &bounded_model_for_telem,
-                        provider: &provider_for_telem,
-                        status: 200,
-                        streaming: true,
-                    },
-                    started_for_telem.elapsed(),
-                );
-                // Fresh snapshot at stream end — see the passthrough path.
                 let snap_telem = state_for_telem.snapshot.load();
                 let pk_telem =
                     crate::usage_attr::ResolvedPk::resolve(&snap_telem, &provider_key_id_for_telem);
+                crate::request_metrics::record_e2e_latency(
+                    &state_for_telem,
+                    "/v1/messages",
+                    crate::request_metrics::Caller::from_api_key_id(
+                        &snap_telem,
+                        &api_key_id_for_telem,
+                    )
+                    .as_caller(),
+                    crate::request_metrics::Upstream {
+                        provider: &provider_for_telem,
+                        model: &model_for_telem,
+                        upstream_model: &upstream_model_for_telem,
+                        pk: pk_telem.labels(),
+                        stream: true,
+                        ..Default::default()
+                    },
+                    200,
+                    started_for_telem.elapsed(),
+                );
+                // Fresh snapshot at stream end — see the passthrough path.
                 emit_anthropic_usage_event(
                     &state_for_telem,
                     &snap_telem,
@@ -2400,6 +2417,7 @@ async fn cross_provider_dispatch(
         prompt_tokens: resp.usage.prompt_tokens,
         completion_tokens: resp.usage.completion_tokens,
         cached_prompt_tokens: resp.usage.cached_prompt_tokens,
+        cache_write_tokens: resp.usage.cache_write_tokens,
         cache_creation_tokens: resp.usage.cache_creation_tokens,
         cache_read_tokens: resp.usage.cache_read_tokens,
         usage_estimated: false,
@@ -2552,6 +2570,7 @@ fn build_anthropic_sse_stream(
                     if let Some(u) = chunk.usage.as_ref() {
                         comp.prompt_tokens = comp.prompt_tokens.max(u.prompt_tokens);
                         comp.completion_tokens = comp.completion_tokens.max(u.completion_tokens);
+                        comp.cache_write_tokens = comp.cache_write_tokens.max(u.cache_write_tokens);
                         comp.cached_prompt_tokens =
                             comp.cached_prompt_tokens.max(u.cached_prompt_tokens);
                         comp.cache_creation_tokens =
@@ -2820,6 +2839,7 @@ struct AnthropicStreamCompletion {
     completion_tokens: u32,
     /// See [`AnthropicUsageMetrics::cached_prompt_tokens`].
     cached_prompt_tokens: u32,
+    cache_write_tokens: Option<u32>,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
     /// True when the Drop guard filled any token counter from the local
@@ -2983,6 +3003,7 @@ struct AnthropicUsageMetrics {
     /// double-count it, unlike the two Anthropic-shape counters below,
     /// which sit ON TOP of `prompt_tokens`.
     cached_prompt_tokens: u32,
+    cache_write_tokens: Option<u32>,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
     /// True when any token counter was filled by the local estimator
@@ -3081,6 +3102,7 @@ fn emit_anthropic_usage_event(
         prompt_tokens: metrics.prompt_tokens,
         completion_tokens: metrics.completion_tokens,
         cached_prompt_tokens: metrics.cached_prompt_tokens,
+        cache_write_tokens: metrics.cache_write_tokens,
         cache_creation_tokens: metrics.cache_creation_tokens,
         cache_read_tokens: metrics.cache_read_tokens,
         usage_estimated: metrics.usage_estimated,
@@ -3189,6 +3211,20 @@ fn emit_anthropic_usage_event(
                 provider,
                 status: status_code,
                 streaming: true,
+                details: UsageLabels {
+                    endpoint: "/v1/messages",
+                    inbound_protocol: "anthropic",
+                    upstream_protocol,
+                    provider,
+                    model: bounded_model.as_ref(),
+                    upstream_model: bounded_upstream.as_ref(),
+                    provider_key_id: pk.labels().id(),
+                    provider_key_name: pk.labels().name(),
+                    api_key_id,
+                    team_id: team_id.unwrap_or("unknown"),
+                    user_id: user_id.unwrap_or("unknown"),
+                    user_name: user_name.unwrap_or("unknown"),
+                },
             },
             Duration::from_millis(u64::from(metrics.upstream_ttft_ms)),
         );

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1441,6 +1441,7 @@ async fn anthropic_passthrough_dispatch(
         let upstream_model_c = upstream_model.clone();
         let (metric_model, metric_upstream_model) =
             crate::usage_attr::metric_model_label_pair(snapshot, model_name, &upstream_model_c);
+        let metric_caller = crate::request_metrics::Caller::from_api_key_id(snapshot, api_key_id);
         let metric_model = metric_model.into_owned();
         let metric_upstream_model = metric_upstream_model.into_owned();
         let team_id_c = team_id.clone();
@@ -1555,8 +1556,7 @@ async fn anthropic_passthrough_dispatch(
                 crate::request_metrics::record_e2e_latency(
                     &state_c,
                     "/v1/messages",
-                    crate::request_metrics::Caller::from_api_key_id(&snap_c, &api_key_id_c)
-                        .as_caller(),
+                    metric_caller.as_caller(),
                     crate::request_metrics::Upstream {
                         provider: &provider_c,
                         model: &metric_model,
@@ -2153,6 +2153,7 @@ async fn cross_provider_dispatch(
             model_name,
             &upstream_model_for_telem,
         );
+        let metric_caller = crate::request_metrics::Caller::from_api_key_id(snapshot, api_key_id);
         let metric_model = metric_model.into_owned();
         let metric_upstream_model = metric_upstream_model.into_owned();
         let team_id_for_telem = team_id;
@@ -2257,11 +2258,7 @@ async fn cross_provider_dispatch(
                 crate::request_metrics::record_e2e_latency(
                     &state_for_telem,
                     "/v1/messages",
-                    crate::request_metrics::Caller::from_api_key_id(
-                        &snap_telem,
-                        &api_key_id_for_telem,
-                    )
-                    .as_caller(),
+                    metric_caller.as_caller(),
                     crate::request_metrics::Upstream {
                         provider: &provider_for_telem,
                         model: &metric_model,

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -1439,6 +1439,10 @@ async fn anthropic_passthrough_dispatch(
         let model_name_c = model_name.to_string();
         let provider_key_id_c = pk_id.to_string();
         let upstream_model_c = upstream_model.clone();
+        let (metric_model, metric_upstream_model) =
+            crate::usage_attr::metric_model_label_pair(snapshot, model_name, &upstream_model_c);
+        let metric_model = metric_model.into_owned();
+        let metric_upstream_model = metric_upstream_model.into_owned();
         let team_id_c = team_id.clone();
         let user_id_c = user_id.clone();
         let user_name_c = user_name.clone();
@@ -1555,8 +1559,8 @@ async fn anthropic_passthrough_dispatch(
                         .as_caller(),
                     crate::request_metrics::Upstream {
                         provider: &provider_c,
-                        model: &model_name_c,
-                        upstream_model: &upstream_model_c,
+                        model: &metric_model,
+                        upstream_model: &metric_upstream_model,
                         pk: pk_c.labels(),
                         stream: true,
                         ..Default::default()
@@ -2144,6 +2148,13 @@ async fn cross_provider_dispatch(
         let model_for_telem = model_name.to_string();
         let provider_key_id_for_telem = provider_key_id.to_string();
         let upstream_model_for_telem = upstream_model.clone();
+        let (metric_model, metric_upstream_model) = crate::usage_attr::metric_model_label_pair(
+            snapshot,
+            model_name,
+            &upstream_model_for_telem,
+        );
+        let metric_model = metric_model.into_owned();
+        let metric_upstream_model = metric_upstream_model.into_owned();
         let team_id_for_telem = team_id;
         let user_id_for_telem = user_id;
         let user_name_for_telem = user_name;
@@ -2253,8 +2264,8 @@ async fn cross_provider_dispatch(
                     .as_caller(),
                     crate::request_metrics::Upstream {
                         provider: &provider_for_telem,
-                        model: &model_for_telem,
-                        upstream_model: &upstream_model_for_telem,
+                        model: &metric_model,
+                        upstream_model: &metric_upstream_model,
                         pk: pk_telem.labels(),
                         stream: true,
                         ..Default::default()

--- a/crates/aisix-proxy/src/passthrough_route.rs
+++ b/crates/aisix-proxy/src/passthrough_route.rs
@@ -1396,6 +1396,7 @@ struct PassthroughUsage {
     prompt_tokens: u32,
     completion_tokens: u32,
     cached_prompt_tokens: u32,
+    cache_write_tokens: Option<u32>,
     reasoning_tokens: u32,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
@@ -1414,6 +1415,7 @@ impl PassthroughUsage {
         self.prompt_tokens = self.prompt_tokens.max(other.prompt_tokens);
         self.completion_tokens = self.completion_tokens.max(other.completion_tokens);
         self.cached_prompt_tokens = self.cached_prompt_tokens.max(other.cached_prompt_tokens);
+        self.cache_write_tokens = self.cache_write_tokens.max(other.cache_write_tokens);
         self.reasoning_tokens = self.reasoning_tokens.max(other.reasoning_tokens);
         self.cache_creation_tokens = self.cache_creation_tokens.max(other.cache_creation_tokens);
         self.cache_read_tokens = self.cache_read_tokens.max(other.cache_read_tokens);
@@ -1462,6 +1464,8 @@ fn usage_of(usage: &serde_json::Value) -> Option<PassthroughUsage> {
         .filter(|&n| n > 0)
         .or_else(|| nested("input_tokens_details", "cached_tokens").filter(|&n| n > 0))
         .or_else(|| flat(&["prompt_cache_hit_tokens", "cached_tokens"]));
+    let cache_write = nested("prompt_tokens_details", "cache_write_tokens")
+        .or_else(|| nested("input_tokens_details", "cache_write_tokens"));
     let reasoning = nested("completion_tokens_details", "reasoning_tokens")
         .filter(|&n| n > 0)
         .or_else(|| nested("output_tokens_details", "reasoning_tokens").filter(|&n| n > 0))
@@ -1475,6 +1479,7 @@ fn usage_of(usage: &serde_json::Value) -> Option<PassthroughUsage> {
         prompt,
         completion,
         cached_prompt,
+        cache_write,
         reasoning,
         cache_creation,
         cache_read,
@@ -1486,6 +1491,7 @@ fn usage_of(usage: &serde_json::Value) -> Option<PassthroughUsage> {
         prompt_tokens: prompt.unwrap_or(0),
         completion_tokens: completion.unwrap_or(0),
         cached_prompt_tokens: cached_prompt.unwrap_or(0),
+        cache_write_tokens: cache_write,
         reasoning_tokens: reasoning.unwrap_or(0),
         cache_creation_tokens: cache_creation.unwrap_or(0),
         cache_read_tokens: cache_read.unwrap_or(0),
@@ -2258,6 +2264,7 @@ impl RouteTelemetry {
             prompt_tokens: usage.prompt_tokens,
             completion_tokens: usage.completion_tokens,
             cached_prompt_tokens: usage.cached_prompt_tokens,
+            cache_write_tokens: usage.cache_write_tokens,
             reasoning_tokens: usage.reasoning_tokens,
             cache_creation_tokens: usage.cache_creation_tokens,
             cache_read_tokens: usage.cache_read_tokens,

--- a/crates/aisix-proxy/src/render.rs
+++ b/crates/aisix-proxy/src/render.rs
@@ -104,14 +104,10 @@ pub struct Usage {
 pub struct PromptTokensDetails {
     /// Prompt tokens served from the provider's prompt cache.
     pub cached_tokens: u32,
-    /// Prompt tokens the provider WROTE into its cache this turn.
-    ///
-    /// Not an OpenAI field — OpenAI has no cache-write concept — but
-    /// without it an Anthropic/Bedrock cache write is an unexplained
-    /// increase in `prompt_tokens` that the caller cannot price, and
-    /// Anthropic bills a write above the plain input rate. Emitted only
-    /// when the upstream reported one, so an OpenAI upstream's usage is
-    /// byte-identical to before. LiteLLM surfaces the same counter here.
+    /// Raw OpenAI cache-write counter, kept separate from additive cache creation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_write_tokens: Option<u32>,
+    /// Cache creation reported by an Anthropic-shape upstream.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_creation_tokens: Option<u32>,
 }
@@ -153,13 +149,14 @@ impl Usage {
             prompt_tokens: u.openai_prompt_tokens(),
             completion_tokens: u.completion_tokens,
             total_tokens: u.openai_total_tokens(),
-            prompt_tokens_details: (cached_tokens > 0 || cache_creation_tokens > 0).then_some(
-                PromptTokensDetails {
-                    cached_tokens,
-                    cache_creation_tokens: (cache_creation_tokens > 0)
-                        .then_some(cache_creation_tokens),
-                },
-            ),
+            prompt_tokens_details: (cached_tokens > 0
+                || cache_creation_tokens > 0
+                || u.cache_write_tokens.is_some())
+            .then_some(PromptTokensDetails {
+                cached_tokens,
+                cache_write_tokens: u.cache_write_tokens,
+                cache_creation_tokens: (cache_creation_tokens > 0).then_some(cache_creation_tokens),
+            }),
             completion_tokens_details: (u.reasoning_tokens > 0).then_some(
                 CompletionTokensDetails {
                     reasoning_tokens: u.reasoning_tokens,

--- a/crates/aisix-proxy/src/request_metrics.rs
+++ b/crates/aisix-proxy/src/request_metrics.rs
@@ -413,6 +413,8 @@ pub(crate) fn record(
     }
 }
 
+/// Stream callbacks must capture bounded model labels from their dispatch
+/// snapshot: the model row may be gone by the time the stream ends.
 pub(crate) fn record_e2e_latency(
     state: &ProxyState,
     endpoint: &'static str,

--- a/crates/aisix-proxy/src/request_metrics.rs
+++ b/crates/aisix-proxy/src/request_metrics.rs
@@ -413,6 +413,43 @@ pub(crate) fn record(
     }
 }
 
+pub(crate) fn record_e2e_latency(
+    state: &ProxyState,
+    endpoint: &'static str,
+    caller: Caller<'_>,
+    upstream: Upstream<'_>,
+    status: u16,
+    elapsed: Duration,
+) {
+    let snap = state.snapshot.load();
+    let (model, upstream_model) =
+        crate::usage_attr::metric_model_label_pair(&snap, upstream.model, upstream.upstream_model);
+    state.metrics.record_request_e2e_latency(
+        aisix_obs::LatencyLabels {
+            endpoint,
+            model: model.as_ref(),
+            provider: upstream.provider,
+            status,
+            streaming: upstream.stream,
+            details: UsageLabels {
+                endpoint,
+                inbound_protocol: crate::inbound_protocol_for_endpoint(endpoint),
+                upstream_protocol: upstream.pk.protocol(),
+                provider: upstream.provider,
+                model: model.as_ref(),
+                upstream_model: upstream_model.as_ref(),
+                provider_key_id: upstream.pk.id(),
+                provider_key_name: upstream.pk.name(),
+                api_key_id: caller.api_key_id,
+                team_id: caller.team_id,
+                user_id: caller.user_id,
+                user_name: caller.user_name,
+            },
+        },
+        elapsed,
+    );
+}
+
 /// What one request consumed. Every counter below no-ops on an all-zero
 /// value, so the zero-token paths — a failed attempt, a 501, `/v1/files` —
 /// cost nothing and create no series.

--- a/crates/aisix-proxy/src/request_metrics.rs
+++ b/crates/aisix-proxy/src/request_metrics.rs
@@ -85,24 +85,14 @@ impl<'a> Caller<'a> {
         }
     }
 
-    /// Recover the caller from an api-key id alone.
-    ///
-    /// The streaming emits run from a detached task or a Drop guard that was
-    /// handed an `api_key_id: &str` rather than the key itself, and threading
-    /// the team / user / name triple down every dispatch signature to reach
-    /// them would be a lot of plumbing for three labels. The id resolves back
-    /// to the same row the auth extractor matched, so the labels come out
-    /// identical to [`Caller::new`]; an id that no longer resolves (the key
-    /// was deleted mid-stream) degrades to `unknown` rather than dropping the
-    /// sample.
-    pub(crate) fn from_api_key_id(
-        snap: &aisix_core::AisixSnapshot,
-        api_key_id: &'a str,
-    ) -> Owned<'a> {
+    /// Recover an owned caller from the request's dispatch snapshot.
+    /// Capture this before starting a stream so key deletion or reassignment
+    /// cannot change the caller attributed to the completed request.
+    pub(crate) fn from_api_key_id(snap: &aisix_core::AisixSnapshot, api_key_id: &str) -> Owned {
         let entry = snap.apikeys.get_by_id(api_key_id);
         let key = entry.as_ref().map(|e| &e.value);
         Owned {
-            api_key_id,
+            api_key_id: api_key_id.to_owned(),
             team_id: key.and_then(|k| k.team_id.clone()),
             user_id: key.and_then(|k| k.user_id.clone()),
             user_name: key.and_then(|k| k.user_name.clone()),
@@ -125,17 +115,17 @@ impl<'a> Caller<'a> {
 
 /// Owning form of [`Caller`], for the snapshot lookup whose strings cannot
 /// outlive the guard. Call [`Owned::as_caller`] at the emit.
-pub(crate) struct Owned<'a> {
-    api_key_id: &'a str,
+pub(crate) struct Owned {
+    api_key_id: String,
     team_id: Option<String>,
     user_id: Option<String>,
     user_name: Option<String>,
 }
 
-impl<'a> Owned<'a> {
-    pub(crate) fn as_caller(&'a self) -> Caller<'a> {
+impl Owned {
+    pub(crate) fn as_caller(&self) -> Caller<'_> {
         Caller {
-            api_key_id: self.api_key_id,
+            api_key_id: &self.api_key_id,
             team_id: self.team_id.as_deref().unwrap_or(UNKNOWN),
             user_id: self.user_id.as_deref().unwrap_or(UNKNOWN),
             user_name: self.user_name.as_deref().unwrap_or(UNKNOWN),

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -359,7 +359,8 @@ pub async fn responses(
                         &request_id,
                         &success.model_id,
                         &model_name,
-                        &api_key_id,
+                        &model_name,
+                        crate::request_metrics::Caller::new(&auth),
                         &success.provider,
                         &success.upstream_model,
                         status,
@@ -1730,7 +1731,6 @@ async fn responses_to_target(
         let request_id_c = request_id.to_string();
         let model_id_c = model_id.to_string();
         let requested_model_c = requested_model.to_string();
-        let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
         let provider_c = provider_label.clone();
         let upstream_model_c = upstream_model.clone();
@@ -1862,9 +1862,10 @@ async fn responses_to_target(
                     &request_id_c,
                     &model_id_c,
                     &requested_model_c,
-                    &api_key_id_c,
+                    &metric_model,
+                    metric_caller.as_caller(),
                     &provider_c,
-                    &upstream_model_c,
+                    &metric_upstream_model,
                     // A stream the consumer abandoned mid-flight is reported
                     // as 499, matching LiteLLM. The upstream work still
                     // happened, so the event is emitted either way — only
@@ -2260,7 +2261,6 @@ async fn responses_cross_provider_to_target(
         let request_id_c = request_id.to_string();
         let model_id_c = model_id.to_string();
         let requested_model_c = requested_model.to_string();
-        let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
         let provider_c = provider_label.clone();
         let upstream_model_c = model.upstream_model().unwrap_or("unknown").to_string();
@@ -2385,9 +2385,10 @@ async fn responses_cross_provider_to_target(
                     &request_id_c,
                     &model_id_c,
                     &requested_model_c,
-                    &api_key_id_c,
+                    &metric_model,
+                    metric_caller.as_caller(),
                     &provider_c,
-                    &upstream_model_c,
+                    &metric_upstream_model,
                     status,
                     // Attempt-scoped — see the sibling verbatim path.
                     attempt_started.elapsed(),
@@ -3349,7 +3350,8 @@ fn emit_usage_event(
     request_id: &str,
     model_id: &str,
     requested_model: &str,
-    api_key_id: &str,
+    metric_model: &str,
+    caller: crate::request_metrics::Caller<'_>,
     // Metric labels the UsageEvent has no field for (AISIX-Cloud#1234
     // follow-up): the wire struct is the CP contract, so they ride
     // alongside rather than in it.
@@ -3383,7 +3385,7 @@ fn emit_usage_event(
         request_id: request_id.to_string(),
         occurred_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         model_id: model_id.to_string(),
-        api_key_id: api_key_id.to_string(),
+        api_key_id: caller.api_key_id.to_string(),
         requested_model: requested_model.to_string(),
         prompt_tokens: usage.prompt_tokens,
         completion_tokens: usage.completion_tokens,
@@ -3456,15 +3458,13 @@ fn emit_usage_event(
         usage.cache_creation_tokens,
         usage.cache_read_tokens,
     );
-    let owned_caller = crate::request_metrics::Caller::from_api_key_id(snap, api_key_id);
-    let caller = owned_caller.as_caller();
     crate::request_metrics::record_usage(
         state,
         "/v1/responses",
         caller,
         crate::request_metrics::Upstream {
             provider,
-            model: requested_model,
+            model: metric_model,
             upstream_model,
             pk: pk.labels(),
             ..Default::default()
@@ -3482,7 +3482,7 @@ fn emit_usage_event(
     );
     if usage.upstream_ttft_ms > 0 {
         let (bounded_model, bounded_upstream) =
-            crate::usage_attr::metric_model_label_pair(snap, requested_model, upstream_model);
+            crate::usage_attr::metric_model_label_pair(snap, metric_model, upstream_model);
         let ttft = Duration::from_millis(u64::from(usage.upstream_ttft_ms));
         state.metrics.record_request_ttft(
             LatencyLabels {

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -145,6 +145,7 @@ struct ResponseUsage {
     /// OpenAI prompt-cache hit count, subset of `prompt_tokens`,
     /// surfaced via `usage.input_tokens_details.cached_tokens`.
     cached_prompt_tokens: u32,
+    cache_write_tokens: Option<u32>,
     /// Anthropic `cache_creation_input_tokens` (cache write). Always 0 on
     /// the verbatim OpenAI path; carried for the cross-provider bridge
     /// path (#825) so an Anthropic-backed /v1/responses call bills cache
@@ -319,16 +320,19 @@ pub async fn responses(
                 // SLO e2e histogram (AISIX-Cloud#1011): recorded even when
                 // the upstream response carried no parseable usage block —
                 // latency observation must not depend on token accounting.
-                let bounded_model =
-                    crate::usage_attr::metric_model_label(&state.snapshot.load(), &model_name);
-                state.metrics.record_request_e2e_latency(
-                    LatencyLabels {
-                        endpoint: "/v1/responses",
-                        model: bounded_model.as_ref(),
+                crate::request_metrics::record_e2e_latency(
+                    &state,
+                    "/v1/responses",
+                    crate::request_metrics::Caller::new(&auth),
+                    crate::request_metrics::Upstream {
                         provider: &success.provider,
-                        status,
-                        streaming: stream_requested,
+                        model: &model_name,
+                        upstream_model: &success.upstream_model,
+                        pk: pk.labels(),
+                        stream: false,
+                        ..Default::default()
                     },
+                    status,
                     elapsed,
                 );
                 if let Some(mut usage) = success.usage {
@@ -411,14 +415,16 @@ pub async fn responses(
                 status,
                 elapsed,
             );
-            state.metrics.record_request_e2e_latency(
-                LatencyLabels {
-                    endpoint: "/v1/responses",
-                    model: metric_model.as_ref(),
-                    provider: last_target.provider(),
-                    status,
-                    streaming: stream_requested,
-                },
+            crate::request_metrics::record_e2e_latency(
+                &state,
+                "/v1/responses",
+                crate::request_metrics::Caller::new(&auth),
+                last_target.upstream(
+                    metric_model.as_ref(),
+                    stream_requested,
+                    routing.fallback_count() > 0,
+                ),
+                status,
                 elapsed,
             );
             // AISIX-Cloud#1428: a guardrail refusal IS this failure, so the
@@ -1724,9 +1730,6 @@ async fn responses_to_target(
         let request_id_c = request_id.to_string();
         let model_id_c = model_id.to_string();
         let requested_model_c = requested_model.to_string();
-        let bounded_model_c =
-            crate::usage_attr::metric_model_label(&state.snapshot.load(), requested_model)
-                .into_owned();
         let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
         let provider_c = provider_label.clone();
@@ -1817,14 +1820,22 @@ async fn responses_to_target(
                     _ => None,
                 };
                 // SLO e2e histogram: full stream duration (verbatim path).
-                state_c.metrics.record_request_e2e_latency(
-                    LatencyLabels {
-                        endpoint: "/v1/responses",
-                        model: &bounded_model_c,
+                let snap_c = state_c.snapshot.load();
+                let pk_c = ResolvedPk::resolve(&snap_c, &provider_key_id_c);
+                crate::request_metrics::record_e2e_latency(
+                    &state_c,
+                    "/v1/responses",
+                    crate::request_metrics::Caller::from_api_key_id(&snap_c, &api_key_id_c)
+                        .as_caller(),
+                    crate::request_metrics::Upstream {
                         provider: &provider_c,
-                        status: 200,
-                        streaming: true,
+                        model: &requested_model_c,
+                        upstream_model: &upstream_model_c,
+                        pk: pk_c.labels(),
+                        stream: true,
+                        ..Default::default()
                     },
+                    200,
                     started.elapsed(),
                 );
                 // Live-forward path: no output masking possible (a masking
@@ -1837,8 +1848,6 @@ async fn responses_to_target(
                 // A stream can outlive several config generations, so the
                 // end-of-stream emit reads a FRESH snapshot rather than the
                 // one the request started on (#941).
-                let snap_c = state_c.snapshot.load();
-                let pk_c = ResolvedPk::resolve(&snap_c, &provider_key_id_c);
                 emit_usage_event(
                     &state_c,
                     &snap_c,
@@ -2244,9 +2253,6 @@ async fn responses_cross_provider_to_target(
         let request_id_c = request_id.to_string();
         let model_id_c = model_id.to_string();
         let requested_model_c = requested_model.to_string();
-        let bounded_model_c =
-            crate::usage_attr::metric_model_label(&state.snapshot.load(), requested_model)
-                .into_owned();
         let api_key_id_c = api_key_id.to_string();
         let provider_key_id_c = provider_key_id.clone();
         let provider_c = provider_label.clone();
@@ -2312,6 +2318,7 @@ async fn responses_cross_provider_to_target(
                     completion_tokens: comp.completion_tokens,
                     reasoning_tokens: comp.reasoning_tokens,
                     cached_prompt_tokens: comp.cached_prompt_tokens,
+                    cache_write_tokens: comp.cache_write_tokens,
                     cache_creation_tokens: comp.cache_creation_tokens,
                     cache_read_tokens: comp.cache_read_tokens,
                     usage_estimated: comp.usage_estimated,
@@ -2336,21 +2343,27 @@ async fn responses_cross_provider_to_target(
                 };
                 // SLO e2e histogram: full stream duration (bridge path).
                 // Blocked streams keep this guard's 422 status.
-                state_c.metrics.record_request_e2e_latency(
-                    LatencyLabels {
-                        endpoint: "/v1/responses",
-                        model: &bounded_model_c,
+                let snap_c = state_c.snapshot.load();
+                let pk_c = ResolvedPk::resolve(&snap_c, &provider_key_id_c);
+                crate::request_metrics::record_e2e_latency(
+                    &state_c,
+                    "/v1/responses",
+                    crate::request_metrics::Caller::from_api_key_id(&snap_c, &api_key_id_c)
+                        .as_caller(),
+                    crate::request_metrics::Upstream {
                         provider: &provider_c,
-                        status,
-                        streaming: true,
+                        model: &requested_model_c,
+                        upstream_model: &upstream_model_c,
+                        pk: pk_c.labels(),
+                        stream: true,
+                        ..Default::default()
                     },
+                    status,
                     started.elapsed(),
                 );
                 // A stream can outlive several config generations, so the
                 // end-of-stream emit reads a FRESH snapshot rather than the
                 // one the request started on (#941).
-                let snap_c = state_c.snapshot.load();
-                let pk_c = ResolvedPk::resolve(&snap_c, &provider_key_id_c);
                 emit_usage_event(
                     &state_c,
                     &snap_c,
@@ -2439,6 +2452,7 @@ async fn responses_cross_provider_to_target(
             completion_tokens: resp.usage.completion_tokens,
             reasoning_tokens: resp.usage.reasoning_tokens,
             cached_prompt_tokens: resp.usage.cached_prompt_tokens,
+            cache_write_tokens: resp.usage.cache_write_tokens,
             cache_creation_tokens: resp.usage.cache_creation_tokens,
             cache_read_tokens: resp.usage.cache_read_tokens,
             usage_estimated: false,
@@ -2613,6 +2627,10 @@ fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
         .and_then(|d| d.get("cached_tokens"))
         .and_then(|v| v.as_u64())
         .unwrap_or(0) as u32;
+    let cache_write_tokens = usage
+        .pointer("/input_tokens_details/cache_write_tokens")
+        .and_then(Value::as_u64)
+        .map(|n| n.min(u32::MAX as u64) as u32);
     Some(ResponseUsage {
         // Parsed from a fully buffered response body, so by definition the
         // response was delivered in full.
@@ -2622,6 +2640,7 @@ fn extract_response_usage(body: &Value) -> Option<ResponseUsage> {
         usage_estimated: false,
         reasoning_tokens,
         cached_prompt_tokens,
+        cache_write_tokens,
         // OpenAI verbatim path: no Anthropic-style cache counters.
         cache_creation_tokens: 0,
         cache_read_tokens: 0,
@@ -3355,6 +3374,7 @@ fn emit_usage_event(
         prompt_tokens: usage.prompt_tokens,
         completion_tokens: usage.completion_tokens,
         cached_prompt_tokens: usage.cached_prompt_tokens,
+        cache_write_tokens: usage.cache_write_tokens,
         reasoning_tokens: usage.reasoning_tokens,
         // Anthropic cache counters (#825 cross-provider path); 0 on the
         // verbatim OpenAI path.
@@ -3457,6 +3477,20 @@ fn emit_usage_event(
                 provider,
                 status: status_code,
                 streaming: true,
+                details: UsageLabels {
+                    endpoint: "/v1/responses",
+                    inbound_protocol: "openai",
+                    upstream_protocol: pk.labels().protocol(),
+                    provider,
+                    model: bounded_model.as_ref(),
+                    upstream_model: bounded_upstream.as_ref(),
+                    provider_key_id: pk.labels().id(),
+                    provider_key_name: pk.labels().name(),
+                    api_key_id: caller.api_key_id,
+                    team_id: caller.team_id,
+                    user_id: caller.user_id,
+                    user_name: caller.user_name,
+                },
             },
             ttft,
         );

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -329,7 +329,7 @@ pub async fn responses(
                         model: &model_name,
                         upstream_model: &success.upstream_model,
                         pk: pk.labels(),
-                        stream: false,
+                        stream: stream_requested,
                         ..Default::default()
                     },
                     status,
@@ -1734,6 +1734,13 @@ async fn responses_to_target(
         let provider_key_id_c = provider_key_id.clone();
         let provider_c = provider_label.clone();
         let upstream_model_c = upstream_model.clone();
+        let (metric_model, metric_upstream_model) = crate::usage_attr::metric_model_label_pair(
+            snapshot,
+            requested_model,
+            &upstream_model_c,
+        );
+        let metric_model = metric_model.into_owned();
+        let metric_upstream_model = metric_upstream_model.into_owned();
         let client_c = client_ctx.clone();
         // #688: carry the reservation into the end-of-stream guard — keys drive
         // post-stream TPM/TPD accounting, the hold keeps the concurrency slot(s)
@@ -1829,8 +1836,8 @@ async fn responses_to_target(
                         .as_caller(),
                     crate::request_metrics::Upstream {
                         provider: &provider_c,
-                        model: &requested_model_c,
-                        upstream_model: &upstream_model_c,
+                        model: &metric_model,
+                        upstream_model: &metric_upstream_model,
                         pk: pk_c.labels(),
                         stream: true,
                         ..Default::default()
@@ -2257,6 +2264,13 @@ async fn responses_cross_provider_to_target(
         let provider_key_id_c = provider_key_id.clone();
         let provider_c = provider_label.clone();
         let upstream_model_c = model.upstream_model().unwrap_or("unknown").to_string();
+        let (metric_model, metric_upstream_model) = crate::usage_attr::metric_model_label_pair(
+            snapshot,
+            requested_model,
+            &upstream_model_c,
+        );
+        let metric_model = metric_model.into_owned();
+        let metric_upstream_model = metric_upstream_model.into_owned();
         let client_c = client_ctx.clone();
         let attempt_c = attempt.clone();
         // #688: carry the reservation into the end-of-stream guard — keys drive
@@ -2352,8 +2366,8 @@ async fn responses_cross_provider_to_target(
                         .as_caller(),
                     crate::request_metrics::Upstream {
                         provider: &provider_c,
-                        model: &requested_model_c,
-                        upstream_model: &upstream_model_c,
+                        model: &metric_model,
+                        upstream_model: &metric_upstream_model,
                         pk: pk_c.labels(),
                         stream: true,
                         ..Default::default()

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -1739,6 +1739,7 @@ async fn responses_to_target(
             requested_model,
             &upstream_model_c,
         );
+        let metric_caller = crate::request_metrics::Caller::from_api_key_id(snapshot, api_key_id);
         let metric_model = metric_model.into_owned();
         let metric_upstream_model = metric_upstream_model.into_owned();
         let client_c = client_ctx.clone();
@@ -1832,8 +1833,7 @@ async fn responses_to_target(
                 crate::request_metrics::record_e2e_latency(
                     &state_c,
                     "/v1/responses",
-                    crate::request_metrics::Caller::from_api_key_id(&snap_c, &api_key_id_c)
-                        .as_caller(),
+                    metric_caller.as_caller(),
                     crate::request_metrics::Upstream {
                         provider: &provider_c,
                         model: &metric_model,
@@ -2269,6 +2269,7 @@ async fn responses_cross_provider_to_target(
             requested_model,
             &upstream_model_c,
         );
+        let metric_caller = crate::request_metrics::Caller::from_api_key_id(snapshot, api_key_id);
         let metric_model = metric_model.into_owned();
         let metric_upstream_model = metric_upstream_model.into_owned();
         let client_c = client_ctx.clone();
@@ -2362,8 +2363,7 @@ async fn responses_cross_provider_to_target(
                 crate::request_metrics::record_e2e_latency(
                     &state_c,
                     "/v1/responses",
-                    crate::request_metrics::Caller::from_api_key_id(&snap_c, &api_key_id_c)
-                        .as_caller(),
+                    metric_caller.as_caller(),
                     crate::request_metrics::Upstream {
                         provider: &provider_c,
                         model: &metric_model,

--- a/crates/aisix-proxy/src/responses_bridge.rs
+++ b/crates/aisix-proxy/src/responses_bridge.rs
@@ -342,9 +342,11 @@ fn build_output_items(text: Option<&str>, tool_calls: Option<&Vec<Value>>) -> Ve
 /// `cached_tokens > input_tokens` (AISIX-Cloud#1447).
 fn responses_usage_json(u: &UsageStats) -> Value {
     let mut input_details = json!({"cached_tokens": u.openai_cached_tokens()});
-    // A cache WRITE is billed input with no OpenAI field of its own, so
-    // name it beside the hit rather than leave it as an unexplained part
-    // of `input_tokens`. Present only when the upstream reported one.
+    if let Some(cache_write) = u.cache_write_tokens {
+        input_details["cache_write_tokens"] = cache_write.into();
+    }
+    // Preserve the additive Anthropic counter separately from OpenAI's
+    // raw cache_write_tokens value. Their accounting is different.
     let cache_creation = u.anthropic_cache_creation_input_tokens();
     if cache_creation > 0 {
         input_details["cache_creation_tokens"] = cache_creation.into();
@@ -444,6 +446,7 @@ pub struct ResponsesSseEncoder {
     total_tokens: u32,
     reasoning_tokens: u32,
     cached_prompt_tokens: u32,
+    cache_write_tokens: Option<u32>,
     cache_creation_tokens: u32,
     cache_read_tokens: u32,
 }
@@ -475,6 +478,7 @@ impl ResponsesSseEncoder {
             total_tokens: 0,
             reasoning_tokens: 0,
             cached_prompt_tokens: 0,
+            cache_write_tokens: None,
             cache_creation_tokens: 0,
             cache_read_tokens: 0,
         }
@@ -509,6 +513,7 @@ impl ResponsesSseEncoder {
             self.total_tokens = self.total_tokens.max(u.total_tokens);
             self.reasoning_tokens = self.reasoning_tokens.max(u.reasoning_tokens);
             self.cached_prompt_tokens = self.cached_prompt_tokens.max(u.cached_prompt_tokens);
+            self.cache_write_tokens = self.cache_write_tokens.max(u.cache_write_tokens);
             self.cache_creation_tokens = self.cache_creation_tokens.max(u.cache_creation_tokens);
             self.cache_read_tokens = self.cache_read_tokens.max(u.cache_read_tokens);
         }
@@ -522,6 +527,7 @@ impl ResponsesSseEncoder {
             completion_tokens: self.completion_tokens,
             total_tokens: self.total_tokens,
             cached_prompt_tokens: self.cached_prompt_tokens,
+            cache_write_tokens: self.cache_write_tokens,
             reasoning_tokens: self.reasoning_tokens,
             cache_creation_tokens: self.cache_creation_tokens,
             cache_read_tokens: self.cache_read_tokens,
@@ -913,6 +919,7 @@ pub struct ResponsesStreamCompletion {
     pub completion_tokens: u32,
     pub reasoning_tokens: u32,
     pub cached_prompt_tokens: u32,
+    pub cache_write_tokens: Option<u32>,
     pub cache_creation_tokens: u32,
     pub cache_read_tokens: u32,
     pub finish_reason: String,
@@ -1126,6 +1133,7 @@ pub fn build_responses_bridge_stream(
                             comp.completion_tokens = comp.completion_tokens.max(u.completion_tokens);
                             comp.reasoning_tokens = comp.reasoning_tokens.max(u.reasoning_tokens);
                             comp.cached_prompt_tokens = comp.cached_prompt_tokens.max(u.cached_prompt_tokens);
+                            comp.cache_write_tokens = comp.cache_write_tokens.max(u.cache_write_tokens);
                             comp.cache_creation_tokens = comp.cache_creation_tokens.max(u.cache_creation_tokens);
                             comp.cache_read_tokens = comp.cache_read_tokens.max(u.cache_read_tokens);
                         }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -857,10 +857,14 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     let histogram_buckets =
         aisix_obs::HistogramBuckets::from_config(&cfg.observability.metrics.buckets)
             .map_err(|e| anyhow::anyhow!(e))?;
-    let metrics = Arc::new(Metrics::new_with_buckets(
-        &cfg.etcd.env_id,
-        &histogram_buckets,
-    ));
+    let metrics = Arc::new(
+        Metrics::new_with_labels(
+            &cfg.etcd.env_id,
+            &histogram_buckets,
+            &cfg.observability.metrics.labels,
+        )
+        .map_err(|e| anyhow::anyhow!(e))?,
+    );
     // Built before the stores below because each Redis-backed store takes
     // the handle: their failures are fail-open by design, so the counter
     // is the only place the degradation shows (#1060).

--- a/tests/e2e/src/cases/metric-label-selection-e2e.test.ts
+++ b/tests/e2e/src/cases/metric-label-selection-e2e.test.ts
@@ -1,0 +1,139 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient, ProxyClient, SeedClient, spawnApp, startOpenAiUpstream,
+  waitConfigPropagation, type OpenAiUpstream, type SpawnedApp,
+} from "../harness/index.js";
+import { metricDelta, scrapeMetrics, sumMetric } from "../harness/metrics.js";
+
+const KEY = "sk-metric-label-selection";
+const TTFT = "aisix_request_ttft_seconds";
+const E2E = "aisix_request_e2e_latency_seconds";
+const contexts = [
+  { endpoint: "chat/completions", provider: "openai", wire: "chat" },
+  { endpoint: "messages", provider: "deepseek", wire: "chat" },
+  { endpoint: "responses", provider: "deepseek", wire: "chat" },
+  { endpoint: "messages", provider: "anthropic", wire: "anthropic" },
+  { endpoint: "responses", provider: "openai", wire: "responses" },
+];
+const usage = { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 };
+const streams: Record<string, unknown[]> = {
+  chat: [
+    { id: "labels", model: "upstream", choices: [{ index: 0, delta: { content: "ok" }, finish_reason: null }] },
+    { id: "labels", model: "upstream", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage },
+  ],
+  responses: [
+    { type: "response.created", response: { id: "resp-labels", model: "upstream", status: "in_progress" } },
+    { type: "response.completed", response: { id: "resp-labels", model: "upstream", status: "completed", output: [], usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } } },
+  ],
+  anthropic: [
+    { type: "message_start", message: { id: "msg-labels", model: "upstream", type: "message", role: "assistant", content: [], usage: { input_tokens: 10, output_tokens: 0 } } },
+    { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
+    { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } },
+    { type: "message_stop" },
+  ],
+};
+
+describe("metric label configuration is applied to real request observations", () => {
+  let app: SpawnedApp | undefined;
+  const upstreams: OpenAiUpstream[] = [];
+  const scenarios: Array<{ endpoint: string; model: string; name: string }> = [];
+  let reachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    reachable = await etcd.ping();
+    if (!reachable) return;
+    app = await spawnApp({ extraEnv: {
+      AISIX_OBSERVABILITY__METRICS__LABELS: JSON.stringify({
+        [TTFT]: ["provider_key_name", "upstream_model", "api_key_id"],
+        [E2E]: ["endpoint", "provider_key_name"],
+        aisix_proxy_requests_total: ["endpoint"],
+        aisix_requests_total: [],
+      }),
+    } });
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    for (const [index, context] of contexts.entries()) {
+      const upstream = await startOpenAiUpstream({
+        streamEvents: [...streams[context.wire].map((v) => JSON.stringify(v)), "[DONE]"],
+        firstEventDelayMs: 20,
+      });
+      upstreams.push(upstream);
+      for (const suffix of ["a", "b"]) {
+        const name = `credential-${index}-${suffix}`;
+        const pk = await seed.createProviderKey({
+          display_name: name, provider: context.provider,
+          adapter: context.wire === "anthropic" ? "anthropic" : "openai",
+          secret: "test", api_base: `${upstream.baseUrl}/v1`,
+        });
+        const model = `labels-${index}-${suffix}`;
+        await seed.createModel({
+          display_name: model, model_name: "upstream", provider: context.provider, provider_key_id: pk.id,
+        });
+        scenarios.push({ endpoint: context.endpoint, model, name });
+      }
+    }
+    await seed.createApiKey({ key_hash: createHash("sha256").update(KEY).digest("hex"), allowed_models: scenarios.map((s) => s.model) });
+    const client = new ProxyClient(app.proxyUrl, KEY);
+    await waitConfigPropagation(async () => (await client.listModels()).status === 200);
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  test("unsupported label configuration fails startup", async (ctx) => {
+    if (!reachable) return ctx.skip();
+    await expect(spawnApp({ extraEnv: {
+      AISIX_OBSERVABILITY__METRICS__LABELS: JSON.stringify({ [TTFT]: ["request_id"] }),
+    } })).rejects.toThrow(/unsupported variable.*request_id/);
+  });
+
+  test("credentials partition all histogram components while removed counter labels aggregate", async (ctx) => {
+    if (!reachable) return ctx.skip();
+    const before = await scrapeMetrics(app!.metricsUrl);
+    for (const scenario of scenarios) {
+      for (let repeat = 0; repeat < 2; repeat++) {
+        const response = await fetch(`${app!.proxyUrl}/v1/${scenario.endpoint}`, {
+          method: "POST", headers: { authorization: `Bearer ${KEY}`, "content-type": "application/json" },
+          body: JSON.stringify({ model: scenario.model, stream: true, max_tokens: 100,
+            ...(scenario.endpoint === "responses" ? { input: "hello" } : { messages: [{ role: "user", content: "hello" }] }),
+          }),
+        });
+        const body = await response.text();
+        expect(response.status, `${scenario.model}: ${body}`).toBe(200);
+      }
+    }
+    await expect.poll(async () => sumMetric(await scrapeMetrics(app!.metricsUrl), `${TTFT}_count`), { timeout: 5000 }).toBe(scenarios.length * 2);
+    const after = await scrapeMetrics(app!.metricsUrl);
+    expect(metricDelta(before, after, "aisix_requests_total")).toBe(scenarios.length * 2);
+    expect(after.filter((s) => s.name === "aisix_requests_total")).toHaveLength(1);
+    for (const sample of after.filter((s) => s.name === "aisix_requests_total")) expect(sample.labels).toEqual({});
+    for (const scenario of scenarios) {
+      for (const family of [TTFT, E2E]) {
+        const samples = after.filter((s) => s.name.startsWith(`${family}_`) && s.labels.provider_key_name === scenario.name);
+        expect(samples.length, scenario.name).toBeGreaterThan(2);
+        expect(sumMetric(samples, `${family}_count`)).toBe(2);
+        expect(sumMetric(samples, `${family}_bucket`, { le: "+Inf" })).toBe(2);
+        expect(sumMetric(samples, `${family}_sum`)).toBeGreaterThan(0);
+        for (const sample of samples) {
+          const labels = Object.keys(sample.labels).filter((key) => key !== "le").sort();
+          expect(labels).toEqual((family === TTFT ? ["provider_key_name", "upstream_model", "api_key_id"] : ["endpoint", "provider_key_name"]).sort());
+          if (family === TTFT) {
+            expect(sample.labels.upstream_model).toBe("upstream");
+            expect(sample.labels.api_key_id).not.toBe("unknown");
+          }
+        }
+      }
+    }
+    for (const endpoint of new Set(scenarios.map((s) => `/v1/${s.endpoint}`))) {
+      expect(metricDelta(before, after, "aisix_proxy_requests_total", { endpoint }))
+        .toBe(scenarios.filter((s) => `/v1/${s.endpoint}` === endpoint).length * 2);
+    }
+    for (const sample of after.filter((s) => s.name === "aisix_proxy_requests_total")) expect(Object.keys(sample.labels)).toEqual(["endpoint"]);
+    const defaults = after.find((s) => s.name === "aisix_llm_requests_total")!;
+    expect(defaults.labels).toHaveProperty("model");
+    expect(defaults.labels).toHaveProperty("provider_key_id");
+  });
+});

--- a/tests/e2e/src/cases/openai-cache-write-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/openai-cache-write-usage-e2e.test.ts
@@ -70,7 +70,10 @@ describe("OpenAI cache-write usage survives every supported entry point", () => 
       res.end();
     });
     const port = await pickFreePort();
-    await new Promise<void>((resolve) => server!.listen(port, "127.0.0.1", resolve));
+    await new Promise<void>((resolve, reject) => {
+      server!.once("error", reject);
+      server!.listen(port, "127.0.0.1", resolve);
+    });
     app = await spawnApp({ extraEnv: { DD_CRED_WRITE_API_KEY: "test" } });
     const seed = new SeedClient(etcd, app.etcdPrefix);
     await seed.createObservabilityExporter({

--- a/tests/e2e/src/cases/openai-cache-write-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/openai-cache-write-usage-e2e.test.ts
@@ -9,7 +9,7 @@ import {
 
 const KEY = "sk-cache-write-usage-test";
 const surfaces = ["chat/completions", "messages", "responses", "completions", "responses-bridge"];
-const cases = surfaces.flatMap((surface) => [false, true].flatMap((stream) =>
+const cases = surfaces.flatMap((surface) => (surface === "completions" ? [false] : [false, true]).flatMap((stream) =>
   [37, 0, undefined].map((write) => ({
     surface, stream, write,
     model: `write-${surface.replaceAll("/", "-")}-${stream}-${write ?? "absent"}`,
@@ -75,7 +75,7 @@ describe("OpenAI cache-write usage survives every supported entry point", () => 
     const seed = new SeedClient(etcd, app.etcdPrefix);
     await seed.createObservabilityExporter({
       name: "cache-write", kind: "datadog", enabled: true,
-      site: `127.0.0.1:${port}`, credential_ref: "write", content_mode: "metadata_only",
+      site: `127.0.0.1:${port}`, credential_ref: "write", service: "cache-write-test", content_mode: "metadata_only",
     });
     for (const provider of ["openai", "deepseek"]) {
       const pk = await seed.createProviderKey({
@@ -135,8 +135,8 @@ describe("OpenAI cache-write usage survives every supported entry point", () => 
     for (const scenario of cases) {
       const event = logs.find((l) => l["aisix.requested_model"] === scenario.model)!;
       expect(event["aisix.cache_write_tokens"], scenario.model).toBe(scenario.write);
-      expect(event["aisix.prompt_tokens"], scenario.model).toBe(101);
-      expect(event["aisix.completion_tokens"], scenario.model).toBe(11);
+      expect(event["gen_ai.usage.input_tokens"], scenario.model).toBe(101);
+      expect(event["gen_ai.usage.output_tokens"], scenario.model).toBe(11);
       expect(event["aisix.cached_prompt_tokens"], scenario.model).toBe(19);
       expect(event["aisix.cache_creation_tokens"], scenario.model).toBeUndefined();
     }

--- a/tests/e2e/src/cases/openai-cache-write-usage-e2e.test.ts
+++ b/tests/e2e/src/cases/openai-cache-write-usage-e2e.test.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { gunzipSync } from "node:zlib";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient, ProxyClient, SeedClient, pickFreePort, spawnApp,
+  waitConfigPropagation, type SpawnedApp,
+} from "../harness/index.js";
+
+const KEY = "sk-cache-write-usage-test";
+const surfaces = ["chat/completions", "messages", "responses", "completions", "responses-bridge"];
+const cases = surfaces.flatMap((surface) => [false, true].flatMap((stream) =>
+  [37, 0, undefined].map((write) => ({
+    surface, stream, write,
+    model: `write-${surface.replaceAll("/", "-")}-${stream}-${write ?? "absent"}`,
+  })),
+));
+
+describe("OpenAI cache-write usage survives every supported entry point", () => {
+  let app: SpawnedApp | undefined;
+  let server: Server | undefined;
+  let reachable = false;
+  const logs: Record<string, unknown>[] = [];
+  let intakeError: unknown;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    reachable = await etcd.ping();
+    if (!reachable) return;
+    server = createServer(async (req, res) => {
+      const parts: Buffer[] = [];
+      for await (const part of req) parts.push(Buffer.from(part));
+      const bytes = Buffer.concat(parts);
+      if (req.url === "/api/v2/logs") {
+        try { logs.push(...JSON.parse(gunzipSync(bytes).toString())); }
+        catch (error) { intakeError = error; }
+        res.writeHead(202).end();
+        return;
+      }
+      const request = JSON.parse(bytes.toString());
+      const write = request.model.endsWith("absent") ? undefined
+        : request.model.endsWith("-37") ? 37 : 0;
+      const details = { cached_tokens: 19, ...(write === undefined ? {} : { cache_write_tokens: write }) };
+      const responses = req.url === "/v1/responses";
+      const usage = responses
+        ? { input_tokens: 101, output_tokens: 11, total_tokens: 112, input_tokens_details: details }
+        : { prompt_tokens: 101, completion_tokens: 11, total_tokens: 112, prompt_tokens_details: details };
+      const response = responses ? {
+        id: "resp-write", object: "response", model: request.model, status: "completed",
+        output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] }], usage,
+      } : {
+        id: "chatcmpl-write", object: "chat.completion", created: 1, model: request.model,
+        choices: [{ index: 0, text: "ok", message: { role: "assistant", content: "ok" }, finish_reason: "stop" }], usage,
+      };
+      if (!request.stream) {
+        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify(response));
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      const events = responses ? [
+        { type: "response.created", response: { ...response, status: "in_progress", usage: null } },
+        { type: "response.completed", response },
+      ] : [
+        { ...response, usage: undefined, choices: [{ index: 0, text: "ok", delta: { content: "ok" }, finish_reason: null }] },
+        { ...response, usage: undefined, choices: [{ index: 0, text: "", delta: {}, finish_reason: "stop" }] },
+        { ...response, choices: [], usage },
+      ];
+      for (const event of events) res.write(`data: ${JSON.stringify(event)}\n\n`);
+      if (!responses) res.write("data: [DONE]\n\n");
+      res.end();
+    });
+    const port = await pickFreePort();
+    await new Promise<void>((resolve) => server!.listen(port, "127.0.0.1", resolve));
+    app = await spawnApp({ extraEnv: { DD_CRED_WRITE_API_KEY: "test" } });
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    await seed.createObservabilityExporter({
+      name: "cache-write", kind: "datadog", enabled: true,
+      site: `127.0.0.1:${port}`, credential_ref: "write", content_mode: "metadata_only",
+    });
+    for (const provider of ["openai", "deepseek"]) {
+      const pk = await seed.createProviderKey({
+        display_name: `cache-write-${provider}`, provider, adapter: "openai",
+        secret: "test", api_base: `http://127.0.0.1:${port}/v1`,
+      });
+      for (const scenario of cases.filter((c) => (c.surface === "responses-bridge") === (provider === "deepseek"))) {
+        await seed.createModel({
+          display_name: scenario.model, model_name: scenario.model, provider, provider_key_id: pk.id,
+        });
+      }
+    }
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update(KEY).digest("hex"),
+      allowed_models: cases.map((c) => c.model),
+    });
+    const client = new ProxyClient(app.proxyUrl, KEY);
+    await waitConfigPropagation(async () => (await client.listModels()).status === 200);
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await new Promise<void>((resolve, reject) => {
+      if (!server) return resolve();
+      server.close((error) => error ? reject(error) : resolve());
+    });
+  });
+
+  test("logs retain a raw value, explicit zero, and absence without changing token accounting", async (ctx) => {
+    if (!reachable) return ctx.skip();
+    for (const scenario of cases) {
+      const endpoint = scenario.surface === "responses-bridge" ? "responses" : scenario.surface;
+      const response = await fetch(`${app!.proxyUrl}/v1/${endpoint}`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${KEY}`, "content-type": "application/json" },
+        body: JSON.stringify({
+          model: scenario.model, stream: scenario.stream, max_tokens: 100,
+          ...(endpoint === "responses" ? { input: "hello" }
+            : endpoint === "completions" ? { prompt: "hello" }
+            : { messages: [{ role: "user", content: "hello" }] }),
+          ...(endpoint === "chat/completions" && scenario.stream ? { stream_options: { include_usage: true } } : {}),
+        }),
+      });
+      const body = await response.text();
+      expect(response.status, `${scenario.model}: ${body}`).toBe(200);
+      if (!scenario.stream && endpoint !== "messages") {
+        const usage = JSON.parse(body).usage;
+        const details = endpoint === "responses" ? usage.input_tokens_details : usage.prompt_tokens_details;
+        expect(details.cache_write_tokens, scenario.model).toBe(scenario.write);
+        expect(usage.total_tokens, scenario.model).toBe(112);
+      }
+    }
+    await expect.poll(() => {
+      if (intakeError) throw intakeError;
+      return cases.every((c) => logs.some((l) => l["aisix.requested_model"] === c.model));
+    }, { timeout: 15_000 }).toBe(true);
+    for (const scenario of cases) {
+      const event = logs.find((l) => l["aisix.requested_model"] === scenario.model)!;
+      expect(event["aisix.cache_write_tokens"], scenario.model).toBe(scenario.write);
+      expect(event["aisix.prompt_tokens"], scenario.model).toBe(101);
+      expect(event["aisix.completion_tokens"], scenario.model).toBe(11);
+      expect(event["aisix.cached_prompt_tokens"], scenario.model).toBe(19);
+      expect(event["aisix.cache_creation_tokens"], scenario.model).toBeUndefined();
+    }
+  });
+});

--- a/tests/e2e/src/cases/passthrough-usage-dimensions-e2e.test.ts
+++ b/tests/e2e/src/cases/passthrough-usage-dimensions-e2e.test.ts
@@ -182,7 +182,7 @@ describe("passthrough-route usage event: token dimensions and the caller's wait"
           prompt_tokens: 900,
           completion_tokens: 25,
           total_tokens: 925,
-          prompt_tokens_details: { cached_tokens: 768 },
+          prompt_tokens_details: { cached_tokens: 768, cache_write_tokens: 113 },
           completion_tokens_details: { reasoning_tokens: 17 },
         },
       },
@@ -342,6 +342,7 @@ describe("passthrough-route usage event: token dimensions and the caller's wait"
     expect(chat["gen_ai.usage.input_tokens"]).toBe(900);
     expect(chat["gen_ai.usage.output_tokens"]).toBe(25);
     expect(chat["aisix.cached_prompt_tokens"]).toBe(768);
+    expect(chat["aisix.cache_write_tokens"]).toBe(113);
     expect(chat["aisix.reasoning_tokens"]).toBe(17);
     expect(chat["aisix.requested_model"]).toBe("gpt-4o-mini");
   });

--- a/tests/e2e/src/cases/request-latency-label-lifetime-e2e.test.ts
+++ b/tests/e2e/src/cases/request-latency-label-lifetime-e2e.test.ts
@@ -10,6 +10,7 @@ import { scrapeMetrics, sumMetric } from "../harness/metrics.js";
 const KEY = "sk-latency-lifetime";
 const E2E = "aisix_request_e2e_latency_seconds";
 const contexts = [
+  { endpoint: "chat/completions", provider: "openai", adapter: "openai" },
   { endpoint: "messages", provider: "anthropic", adapter: "anthropic" },
   { endpoint: "messages", provider: "deepseek", adapter: "openai" },
   { endpoint: "responses", provider: "openai", adapter: "openai" },
@@ -34,7 +35,7 @@ describe("request latency labels survive buffering and configuration reloads", (
   async function setup() {
     const app = await spawnApp({ extraEnv: {
       AISIX_OBSERVABILITY__METRICS__LABELS: JSON.stringify({
-        [E2E]: ["endpoint", "model", "upstream_model", "status_class", "streaming"],
+        [E2E]: ["endpoint", "model", "upstream_model", "status_class", "streaming", "api_key_id", "team_id", "user_id", "user_name"],
       }),
     } });
     apps.push(app);
@@ -42,12 +43,13 @@ describe("request latency labels survive buffering and configuration reloads", (
   }
 
   async function authorize(app: SpawnedApp, seed: SeedClient, models: string[]) {
-    await seed.createApiKey({
+    const apiKey = await seed.createApiKey({
+      team_id: "original-team", user_id: "original-user", user_name: "Original User",
       key_hash: createHash("sha256").update(KEY).digest("hex"), allowed_models: models,
     });
     const client = new ProxyClient(app.proxyUrl, KEY);
     await waitConfigPropagation(async () => (await client.listModels()).status === 200);
-    return client;
+    return { client, apiKey };
   }
 
   function request(app: SpawnedApp, endpoint: string, model: string) {
@@ -92,7 +94,7 @@ describe("request latency labels survive buffering and configuration reloads", (
     }
   });
 
-  test("deleting wildcard rows during native and bridged streams retains bounded labels", async (ctx) => {
+  test("deleting models and API keys during native and bridged streams retains request labels", async (ctx) => {
     if (!reachable) return ctx.skip();
     const { app, seed } = await setup();
     const pending: Array<{ res: ServerResponse; terminal: unknown[] }> = [];
@@ -116,7 +118,10 @@ describe("request latency labels survive buffering and configuration reloads", (
     });
     servers.push(server);
     const port = await pickFreePort();
-    await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(port, "127.0.0.1", resolve);
+    });
     const models = [];
     for (const [index, context] of contexts.entries()) {
       const pk = await seed.createProviderKey({ display_name: `lifetime-${index}`,
@@ -128,7 +133,7 @@ describe("request latency labels survive buffering and configuration reloads", (
       });
       models.push(model);
     }
-    const client = await authorize(app, seed, contexts.map((_, index) => `lifetime-${index}/*`));
+    const { client, apiKey } = await authorize(app, seed, contexts.map((_, index) => `lifetime-${index}/*`));
     const requests = contexts.map((context, index) => request(app, context.endpoint, `lifetime-${index}/caller-name-${index}`));
     await expect.poll(() => pending.length).toBe(contexts.length);
     // Wait for client headers too: each request has entered its relay before the reload.
@@ -138,6 +143,8 @@ describe("request latency labels survive buffering and configuration reloads", (
       const response = await client.listModels();
       return response.status === 200 && (response.body as { data: unknown[] }).data.length === 0;
     });
+    await seed.delete("api_keys", apiKey.id);
+    await waitConfigPropagation(async () => (await client.listModels()).status === 401);
     for (const { res, terminal } of pending) {
       for (const event of terminal) res.write(`data: ${JSON.stringify(event)}\n\n`);
       res.end("data: [DONE]\n\n");
@@ -150,6 +157,7 @@ describe("request latency labels survive buffering and configuration reloads", (
     for (const [index, context] of contexts.entries()) {
       expect(sumMetric(samples, `${E2E}_count`, {
         endpoint: `/v1/${context.endpoint}`, model: `lifetime-${index}/*`, upstream_model: "*", streaming: "true",
+        api_key_id: apiKey.id, team_id: "original-team", user_id: "original-user", user_name: "Original User",
       })).toBe(1);
     }
     expect(samples.filter((s) => s.name.startsWith(`${E2E}_`)).every((s) =>

--- a/tests/e2e/src/cases/request-latency-label-lifetime-e2e.test.ts
+++ b/tests/e2e/src/cases/request-latency-label-lifetime-e2e.test.ts
@@ -1,0 +1,159 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient, ProxyClient, SeedClient, pickFreePort, spawnApp, startOpenAiUpstream,
+  waitConfigPropagation, type OpenAiUpstream, type SpawnedApp,
+} from "../harness/index.js";
+import { scrapeMetrics, sumMetric } from "../harness/metrics.js";
+
+const KEY = "sk-latency-lifetime";
+const E2E = "aisix_request_e2e_latency_seconds";
+const contexts = [
+  { endpoint: "messages", provider: "anthropic", adapter: "anthropic" },
+  { endpoint: "messages", provider: "deepseek", adapter: "openai" },
+  { endpoint: "responses", provider: "openai", adapter: "openai" },
+  { endpoint: "responses", provider: "deepseek", adapter: "openai" },
+];
+
+describe("request latency labels survive buffering and configuration reloads", () => {
+  let reachable = false;
+  const apps: SpawnedApp[] = [];
+  const upstreams: OpenAiUpstream[] = [];
+  const servers: Server[] = [];
+  beforeAll(async () => { reachable = await new EtcdClient().ping(); });
+  afterAll(async () => {
+    await Promise.all(apps.map((app) => app.exit()));
+    await Promise.all(upstreams.map((upstream) => upstream.close()));
+    await Promise.all(servers.map((server) => new Promise<void>((resolve, reject) => {
+      server.closeAllConnections();
+      server.close((error) => error ? reject(error) : resolve());
+    })));
+  });
+
+  async function setup() {
+    const app = await spawnApp({ extraEnv: {
+      AISIX_OBSERVABILITY__METRICS__LABELS: JSON.stringify({
+        [E2E]: ["endpoint", "model", "upstream_model", "status_class", "streaming"],
+      }),
+    } });
+    apps.push(app);
+    return { app, seed: new SeedClient(new EtcdClient(), app.etcdPrefix) };
+  }
+
+  async function authorize(app: SpawnedApp, seed: SeedClient, models: string[]) {
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update(KEY).digest("hex"), allowed_models: models,
+    });
+    const client = new ProxyClient(app.proxyUrl, KEY);
+    await waitConfigPropagation(async () => (await client.listModels()).status === 200);
+    return client;
+  }
+
+  function request(app: SpawnedApp, endpoint: string, model: string) {
+    return fetch(`${app.proxyUrl}/v1/${endpoint}`, {
+      method: "POST", headers: { authorization: `Bearer ${KEY}`, "content-type": "application/json" },
+      body: JSON.stringify({ model, stream: true, max_tokens: 100,
+        ...(endpoint === "responses" ? { input: "hello" } : { messages: [{ role: "user", content: "hello" }] }),
+      }),
+    });
+  }
+
+  test("buffered Responses keep streaming=true for both allowed and blocked output", async (ctx) => {
+    if (!reachable) return ctx.skip();
+    const { app, seed } = await setup();
+    await seed.createGuardrail({ name: "block-secret", kind: "keyword", enabled: true,
+      hook_point: "output", enforcement_mode: "block", patterns: [{ kind: "literal", value: "SECRET" }],
+    });
+    for (const [model, text] of [["buffer-allowed", "hello"], ["buffer-blocked", "SECRET"]]) {
+      const response = { id: "resp-buffer", model, status: "completed",
+        output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text }] }],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      };
+      const upstream = await startOpenAiUpstream({ streamEvents: [
+        JSON.stringify({ type: "response.created", response: { ...response, status: "in_progress", output: [] } }),
+        JSON.stringify({ type: "response.output_text.delta", delta: text }),
+        JSON.stringify({ type: "response.completed", response }),
+      ] });
+      upstreams.push(upstream);
+      const pk = await seed.createProviderKey({ display_name: model, provider: "openai",
+        adapter: "openai", secret: "test", api_base: `${upstream.baseUrl}/v1`,
+      });
+      await seed.createModel({ display_name: model, model_name: model, provider: "openai", provider_key_id: pk.id });
+    }
+    await authorize(app, seed, ["buffer-allowed", "buffer-blocked"]);
+    for (const [model, status] of [["buffer-allowed", 200], ["buffer-blocked", 422]] as const) {
+      const response = await request(app, "responses", model);
+      const body = await response.text();
+      expect(response.status, body).toBe(status);
+      const samples = await scrapeMetrics(app.metricsUrl);
+      expect(sumMetric(samples, `${E2E}_count`, { model, streaming: "true" })).toBe(1);
+      expect(sumMetric(samples, `${E2E}_count`, { model, streaming: "false" })).toBe(0);
+    }
+  });
+
+  test("deleting wildcard rows during native and bridged streams retains bounded labels", async (ctx) => {
+    if (!reachable) return ctx.skip();
+    const { app, seed } = await setup();
+    const pending: Array<{ res: ServerResponse; terminal: unknown[] }> = [];
+    const server = createServer(async (req, res) => {
+      for await (const _ of req) { /* consume the request before streaming */ }
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      if (req.url === "/v1/messages") {
+        res.write(`data: ${JSON.stringify({ type: "message_start", message: { id: "msg-lifetime", model: "upstream", type: "message", role: "assistant", content: [], usage: { input_tokens: 10, output_tokens: 0 } } })}\n\n`);
+        pending.push({ res, terminal: [
+          { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
+          { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } },
+          { type: "message_stop" },
+        ] });
+      } else if (req.url === "/v1/responses") {
+        res.write(`data: ${JSON.stringify({ type: "response.created", response: { id: "resp-lifetime", model: "upstream", status: "in_progress", output: [] } })}\n\n`);
+        pending.push({ res, terminal: [{ type: "response.completed", response: { id: "resp-lifetime", model: "upstream", status: "completed", output: [], usage: { input_tokens: 10, output_tokens: 5 } } }] });
+      } else {
+        res.write(`data: ${JSON.stringify({ id: "chat-lifetime", model: "upstream", choices: [{ index: 0, delta: { content: "ok" }, finish_reason: null }] })}\n\n`);
+        pending.push({ res, terminal: [{ id: "chat-lifetime", model: "upstream", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }] });
+      }
+    });
+    servers.push(server);
+    const port = await pickFreePort();
+    await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+    const models = [];
+    for (const [index, context] of contexts.entries()) {
+      const pk = await seed.createProviderKey({ display_name: `lifetime-${index}`,
+        provider: context.provider, adapter: context.adapter,
+        secret: "test", api_base: `http://127.0.0.1:${port}/v1`,
+      });
+      const model = await seed.createModel({ display_name: `lifetime-${index}/*`, model_name: "*",
+        provider: context.provider, provider_key_id: pk.id,
+      });
+      models.push(model);
+    }
+    const client = await authorize(app, seed, contexts.map((_, index) => `lifetime-${index}/*`));
+    const requests = contexts.map((context, index) => request(app, context.endpoint, `lifetime-${index}/caller-name-${index}`));
+    await expect.poll(() => pending.length).toBe(contexts.length);
+    // Wait for client headers too: each request has entered its relay before the reload.
+    const responses = await Promise.all(requests);
+    for (const model of models) await seed.delete("models", model.id);
+    await waitConfigPropagation(async () => {
+      const response = await client.listModels();
+      return response.status === 200 && (response.body as { data: unknown[] }).data.length === 0;
+    });
+    for (const { res, terminal } of pending) {
+      for (const event of terminal) res.write(`data: ${JSON.stringify(event)}\n\n`);
+      res.end("data: [DONE]\n\n");
+    }
+    for (const response of responses) {
+      expect(response.status, await response.text()).toBe(200);
+    }
+    await expect.poll(async () => sumMetric(await scrapeMetrics(app.metricsUrl), `${E2E}_count`)).toBe(contexts.length);
+    const samples = await scrapeMetrics(app.metricsUrl);
+    for (const [index, context] of contexts.entries()) {
+      expect(sumMetric(samples, `${E2E}_count`, {
+        endpoint: `/v1/${context.endpoint}`, model: `lifetime-${index}/*`, upstream_model: "*", streaming: "true",
+      })).toBe(1);
+    }
+    expect(samples.filter((s) => s.name.startsWith(`${E2E}_`)).every((s) =>
+      !s.labels.model.includes("caller-name") && !s.labels.upstream_model.includes("caller-name"),
+    )).toBe(true);
+  });
+});

--- a/tests/e2e/src/cases/request-latency-label-lifetime-e2e.test.ts
+++ b/tests/e2e/src/cases/request-latency-label-lifetime-e2e.test.ts
@@ -9,12 +9,14 @@ import { scrapeMetrics, sumMetric } from "../harness/metrics.js";
 
 const KEY = "sk-latency-lifetime";
 const E2E = "aisix_request_e2e_latency_seconds";
+const TTFT = "aisix_request_ttft_seconds";
 const contexts = [
   { endpoint: "chat/completions", provider: "openai", adapter: "openai" },
   { endpoint: "messages", provider: "anthropic", adapter: "anthropic" },
   { endpoint: "messages", provider: "deepseek", adapter: "openai" },
   { endpoint: "responses", provider: "openai", adapter: "openai" },
   { endpoint: "responses", provider: "deepseek", adapter: "openai" },
+  { endpoint: "chat/completions", provider: "ensemble", adapter: "openai" },
 ];
 
 describe("request latency labels survive buffering and configuration reloads", () => {
@@ -35,7 +37,9 @@ describe("request latency labels survive buffering and configuration reloads", (
   async function setup() {
     const app = await spawnApp({ extraEnv: {
       AISIX_OBSERVABILITY__METRICS__LABELS: JSON.stringify({
-        [E2E]: ["endpoint", "model", "upstream_model", "status_class", "streaming", "api_key_id", "team_id", "user_id", "user_name"],
+        ...Object.fromEntries([E2E, TTFT].map((metric) => [metric,
+          ["endpoint", "model", "upstream_model", "status_class", "streaming", "api_key_id", "team_id", "user_id", "user_name"],
+        ])),
       }),
     } });
     apps.push(app);
@@ -99,7 +103,19 @@ describe("request latency labels survive buffering and configuration reloads", (
     const { app, seed } = await setup();
     const pending: Array<{ res: ServerResponse; terminal: unknown[] }> = [];
     const server = createServer(async (req, res) => {
-      for await (const _ of req) { /* consume the request before streaming */ }
+      let raw = "";
+      for await (const chunk of req) raw += chunk.toString();
+      const input = JSON.parse(raw);
+      if (!input.stream) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ id: "panel", model: "upstream",
+          choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        }));
+        return;
+      }
+      // Ensure the gateway measures a non-zero upstream TTFT.
+      await new Promise((resolve) => setTimeout(resolve, 20));
       res.writeHead(200, { "content-type": "text/event-stream" });
       if (req.url === "/v1/messages") {
         res.write(`data: ${JSON.stringify({ type: "message_start", message: { id: "msg-lifetime", model: "upstream", type: "message", role: "assistant", content: [], usage: { input_tokens: 10, output_tokens: 0 } } })}\n\n`);
@@ -123,18 +139,30 @@ describe("request latency labels survive buffering and configuration reloads", (
       server.listen(port, "127.0.0.1", resolve);
     });
     const models = [];
+    const allowed: string[] = [];
+    const requested: string[] = [];
     for (const [index, context] of contexts.entries()) {
+      const ensemble = context.provider === "ensemble";
+      const provider = ensemble ? "openai" : context.provider;
       const pk = await seed.createProviderKey({ display_name: `lifetime-${index}`,
-        provider: context.provider, adapter: context.adapter,
+        provider, adapter: context.adapter,
         secret: "test", api_base: `http://127.0.0.1:${port}/v1`,
       });
-      const model = await seed.createModel({ display_name: `lifetime-${index}/*`, model_name: "*",
-        provider: context.provider, provider_key_id: pk.id,
+      const displayName = ensemble ? "lifetime-member" : `lifetime-${index}/*`;
+      const model = await seed.createModel({ display_name: displayName, model_name: "*",
+        provider, provider_key_id: pk.id,
       });
       models.push(model);
+      if (ensemble) {
+        models.push(await seed.createModel({ display_name: "lifetime-ensemble", ensemble: {
+          panel: [{ model: displayName }], judge: { model: displayName }, min_responses: 1,
+        } }));
+      }
+      allowed.push(ensemble ? "lifetime-ensemble" : displayName);
+      requested.push(ensemble ? "lifetime-ensemble" : `lifetime-${index}/caller-name-${index}`);
     }
-    const { client, apiKey } = await authorize(app, seed, contexts.map((_, index) => `lifetime-${index}/*`));
-    const requests = contexts.map((context, index) => request(app, context.endpoint, `lifetime-${index}/caller-name-${index}`));
+    const { client, apiKey } = await authorize(app, seed, allowed);
+    const requests = contexts.map((context, index) => request(app, context.endpoint, requested[index]));
     await expect.poll(() => pending.length).toBe(contexts.length);
     // Wait for client headers too: each request has entered its relay before the reload.
     const responses = await Promise.all(requests);
@@ -155,10 +183,13 @@ describe("request latency labels survive buffering and configuration reloads", (
     await expect.poll(async () => sumMetric(await scrapeMetrics(app.metricsUrl), `${E2E}_count`)).toBe(contexts.length);
     const samples = await scrapeMetrics(app.metricsUrl);
     for (const [index, context] of contexts.entries()) {
-      expect(sumMetric(samples, `${E2E}_count`, {
-        endpoint: `/v1/${context.endpoint}`, model: `lifetime-${index}/*`, upstream_model: "*", streaming: "true",
-        api_key_id: apiKey.id, team_id: "original-team", user_id: "original-user", user_name: "Original User",
-      })).toBe(1);
+      for (const metric of [E2E, TTFT]) {
+        expect(sumMetric(samples, `${metric}_count`, {
+          endpoint: `/v1/${context.endpoint}`, model: allowed[index],
+          upstream_model: context.provider === "ensemble" ? "unknown" : "*", streaming: "true",
+          api_key_id: apiKey.id, team_id: "original-team", user_id: "original-user", user_name: "Original User",
+        }), `${metric} ${context.endpoint} ${context.provider}`).toBe(1);
+      }
     }
     expect(samples.filter((s) => s.name.startsWith(`${E2E}_`)).every((s) =>
       !s.labels.model.includes("caller-name") && !s.labels.upstream_model.includes("caller-name"),

--- a/tests/e2e/src/harness/metrics.ts
+++ b/tests/e2e/src/harness/metrics.ts
@@ -25,7 +25,7 @@ export async function scrapeMetrics(
   }
   const out: MetricSample[] = [];
   for (const line of (await res.text()).split("\n")) {
-    const m = /^([a-z_]+)(\{(.*)\})? ([0-9.e+-]+)$/.exec(line.trim());
+    const m = /^([a-z_][a-z0-9_]*)(\{(.*)\})? ([0-9.e+-]+)$/.exec(line.trim());
     if (!m) continue;
     const labels: Record<string, string> = {};
     for (const pair of m[3]?.match(/[a-z_]+="[^"]*"/g) ?? []) {


### PR DESCRIPTION
OpenAI cache writes were lost from usage events, and request latency metrics could not be grouped by provider credential. This change preserves the upstream's optional `cache_write_tokens` value and lets operators select the complete label list for each metric family.

`observability.metrics.labels` accepts YAML or a JSON map through `AISIX_OBSERVABILITY__METRICS__LABELS`. Unconfigured metrics keep their existing defaults. Selected labels apply before observations accumulate, so removing counter or histogram labels aggregates their observations. Required gauge identity labels remain mandatory. Unknown metrics, unsupported variables, and duplicate labels fail startup; changes require a restart. TTFT and request latency support credential and caller attribution across native and bridged request paths.

Cache-write values, including explicit zero, survive native OpenAI, protocol bridges, legacy non-streaming Completions, and recognized passthrough usage. An omitted value remains absent. This raw count stays separate from Anthropic's additive `cache_creation_tokens` and does not change token totals or billing. The field follows the [OpenAI usage contract](https://github.com/openai/openai-python/blob/main/src/openai/types/completion_usage.py) and [Responses usage contract](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_usage.py).

Coverage includes a real gateway and etcd with mock upstreams and a Datadog intake, checking 27 cache-write scenarios, histogram partitioning, counter aggregation, unchanged defaults, and invalid startup configuration. Regression cases also preserve streaming attribution through output-guardrail buffering and original caller and bounded model labels when API keys and wildcard models are deleted during native, bridged, or ensemble streams, for both TTFT and end-to-end latency. Latency handle-cache tests verify that only selected labels partition entries. The control-plane integration and bilingual documentation ship in paired PRs.

Paired control plane: https://github.com/api7/AISIX-Cloud/pull/1536. Documentation: https://github.com/api7/docs/pull/2335 and https://github.com/api7/docs.apiseven.com/pull/600.

Fixes api7/AISIX-Cloud#1486
Fixes api7/AISIX-Cloud#1488
