### PR TITLE
perf(config): stop paying whole-configuration costs per watch event

### DIFF
--- a/crates/aisix-core/src/config_status.rs
+++ b/crates/aisix-core/src/config_status.rs
@@ -898,23 +898,57 @@ fn bounded_rejection_error(error: String) -> String {
 /// Hash an etcd entry set: `sha256` over `key '\0' canonical_value '\n'` for
 /// each entry, in ascending key order. See the module docs for the exact
 /// definition. `entries` is `(key, raw_value_bytes)`.
+///
+/// The digest is a published contract — the control plane stores what the
+/// gateway reports and never recomputes it, and the algorithm is documented
+/// in the public Admin API reference — so its output must stay byte-identical
+/// across releases.
 pub fn hash_entries<'a, I>(entries: I) -> String
 where
     I: IntoIterator<Item = (&'a str, &'a [u8])>,
 {
     let mut sorted: Vec<(&str, &[u8])> = entries.into_iter().collect();
     sorted.sort_by(|a, b| a.0.cmp(b.0));
+    hash_records(
+        sorted
+            .into_iter()
+            .map(|(key, value)| hash_record(key, value)),
+    )
+}
+
+/// The exact bytes one entry contributes to [`hash_entries`]:
+/// `key '\0' canonical_value '\n'`.
+///
+/// Split out so a caller that hashes the same entry set repeatedly can
+/// compute this once per entry version and keep it — the JSON parse and
+/// canonical re-serialisation are what make a full-config digest
+/// expensive, and re-running them for every unchanged row on every watch
+/// event is the cost AISIX-Cloud#1542 measured.
+pub fn hash_record(key: &str, value: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(key.len() + value.len() + 2);
+    out.extend_from_slice(key.as_bytes());
+    out.push(0u8);
+    match serde_json::from_slice::<serde_json::Value>(value) {
+        Ok(v) => out.extend_from_slice(canonical_json(&v).as_bytes()),
+        // Not JSON (rejected as non_json): hash the raw bytes so the
+        // observed hash still changes deterministically with the input.
+        Err(_) => out.extend_from_slice(value),
+    }
+    out.push(b'\n');
+    out
+}
+
+/// Digest pre-computed [`hash_record`]s. The caller supplies them in
+/// ascending key order — the ordering [`hash_entries`] establishes by
+/// sorting.
+pub fn hash_records<I, R>(records: I) -> String
+where
+    I: IntoIterator<Item = R>,
+    R: AsRef<[u8]>,
+{
     let mut hasher = Sha256::new();
-    for (key, value) in sorted {
-        hasher.update(key.as_bytes());
-        hasher.update([0u8]);
-        match serde_json::from_slice::<serde_json::Value>(value) {
-            Ok(v) => hasher.update(canonical_json(&v).as_bytes()),
-            // Not JSON (rejected as non_json): hash the raw bytes so the
-            // observed hash still changes deterministically with the input.
-            Err(_) => hasher.update(value),
-        }
-        hasher.update([b'\n']);
+    for record in records {
+        hasher.update(record.as_ref());
     }
     hex(hasher.finalize().as_slice())
 }
@@ -1714,5 +1748,67 @@ mod tests {
             ReloadReason::from_error_kind("unknown_kind"),
             ReloadReason::Validate
         );
+    }
+
+    // The digest is a published contract (see `hash_entries`): cp-api stores
+    // what the gateway reports and never recomputes it, and the algorithm is
+    // rendered into the public Admin API reference. These two constants were
+    // produced by the implementation as it stood before the record cache was
+    // introduced (AISIX-Cloud#1542); they must never change. The fixture
+    // deliberately carries what the canonicalisation actually has to get
+    // right: nested objects whose keys arrive unsorted, an array of objects
+    // (arrays keep their order, the objects inside them do not), a `null`,
+    // a value that is not JSON at all, and keys whose etcd order differs
+    // from their sorted order.
+    const HASH_FIXTURE: &[(&str, &str)] = &[
+        (
+            "/aisix/env/models/b",
+            r#"{"z":1,"a":{"d":[3,1],"c":"x"},"m":null}"#,
+        ),
+        (
+            "/aisix/env/api_keys/a",
+            r#"{"key_hash":"deadbeef","allowed_models":["m2","m1"]}"#,
+        ),
+        ("/aisix/env/guardrails/c", "not json at all"),
+        (
+            "/aisix/env/models/z",
+            r#"{"nested":{"y":{"b":2,"a":1}},"arr":[{"q":1,"p":2}]}"#,
+        ),
+    ];
+    const HASH_FIXTURE_ALL: &str =
+        "19ad332bd0ec12bd419a56786f81ca90b17d9796ac60f46545b9f77642427129";
+    /// The same fixture minus `/aisix/env/models/z` — the shape
+    /// `config_hash` takes when a key is rejected with nothing to serve,
+    /// so the two digests differ.
+    const HASH_FIXTURE_ACCEPTED: &str =
+        "f0b4b0cdc9ae4da988e11b3e64b47e802212859e6ed2d08b64434967a9d41308";
+
+    #[test]
+    fn hash_entries_output_is_pinned() {
+        let all = hash_entries(HASH_FIXTURE.iter().map(|(k, v)| (*k, v.as_bytes())));
+        let accepted = hash_entries(
+            HASH_FIXTURE
+                .iter()
+                .filter(|(k, _)| *k != "/aisix/env/models/z")
+                .map(|(k, v)| (*k, v.as_bytes())),
+        );
+        assert_eq!(all, HASH_FIXTURE_ALL);
+        assert_eq!(accepted, HASH_FIXTURE_ACCEPTED);
+        assert_ne!(all, accepted);
+    }
+
+    #[test]
+    fn hash_records_reproduces_hash_entries() {
+        // Records supplied in ascending key order, the ordering
+        // `hash_entries` establishes by sorting its own input.
+        let mut sorted: Vec<(&str, &str)> = HASH_FIXTURE.to_vec();
+        sorted.sort_by(|a, b| a.0.cmp(b.0));
+        let from_records = hash_records(
+            sorted
+                .iter()
+                .map(|(k, v)| hash_record(k, v.as_bytes()))
+                .collect::<Vec<_>>(),
+        );
+        assert_eq!(from_records, HASH_FIXTURE_ALL);
     }
 }

--- a/crates/aisix-core/src/snapshot.rs
+++ b/crates/aisix-core/src/snapshot.rs
@@ -21,6 +21,16 @@ use dashmap::DashMap;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
+/// Process-wide source of [`ResourceTable::generation`] stamps.
+///
+/// One counter for every table of every snapshot, so a stamp is unique
+/// across kinds and across rebuilds. That is what lets a derived cache
+/// compare two generations for equality and conclude "same rows": a
+/// table rebuilt from scratch (resync, cache restore) takes fresh stamps
+/// rather than replaying the previous snapshot's, so it can never
+/// coincide with the value a cache is holding.
+static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
+
 /// Per-kind table with primary id-index and secondary name-index.
 ///
 /// Both indices point at the same `Arc<ResourceEntry<T>>` so there is no
@@ -35,11 +45,17 @@ pub struct ResourceTable<T: Resource> {
     /// emptiness checks on the hot path go through this counter
     /// instead — one relaxed load, O(1) regardless of shard count.
     count: AtomicUsize,
+    /// Stamp bumped on every mutation of THIS table and carried across
+    /// [`Clone`]. See [`ResourceTable::generation`].
+    generation: AtomicU64,
 }
 
-/// Manual impl: `AtomicUsize` is not `Clone`. The count is re-seeded
+/// Manual impl: the atomics are not `Clone`. The count is re-seeded
 /// from the cloned map's length, which the etcd watch supervisor's
-/// clone-then-mutate update cycle relies on being exact.
+/// clone-then-mutate update cycle relies on being exact. The generation
+/// is COPIED, not re-stamped: a clone holds the same rows, so a cache
+/// keyed on it must not be invalidated by the copy-on-write cycle that
+/// publishes an unrelated table's change.
 impl<T: Resource> Clone for ResourceTable<T> {
     fn clone(&self) -> Self {
         let by_id = self.by_id.clone();
@@ -48,6 +64,7 @@ impl<T: Resource> Clone for ResourceTable<T> {
             by_id,
             by_name: self.by_name.clone(),
             count,
+            generation: AtomicU64::new(self.generation.load(Ordering::Acquire)),
         }
     }
 }
@@ -58,6 +75,10 @@ impl<T: Resource> Default for ResourceTable<T> {
             by_id: DashMap::new(),
             by_name: DashMap::new(),
             count: AtomicUsize::new(0),
+            // Empty and never mutated: an unconfigured kind keeps
+            // generation 0 forever, so two empty tables compare equal
+            // and no consumer rebuilds anything for them.
+            generation: AtomicU64::new(0),
         }
     }
 }
@@ -75,11 +96,46 @@ impl<T: Resource> ResourceTable<T> {
         self.len() == 0
     }
 
+    /// Invalidation key for anything DERIVED from this table's rows.
+    ///
+    /// Monotonic and unique process-wide: it changes whenever this table
+    /// is mutated and is carried unchanged across [`Clone`], so a cache
+    /// that keys on it rebuilds when — and only when — the rows it reads
+    /// actually changed.
+    ///
+    /// **Key derived caches on this, never on
+    /// [`SnapshotHandle::version`].** The snapshot version moves on every
+    /// published write of any kind, so keying on it makes an API-key edit
+    /// invalidate (say) the guardrail index, which is rebuilt
+    /// synchronously on the next request that resolves one. That is the
+    /// shape of AISIX-Cloud#1542. The snapshot version remains the right
+    /// tool for "has ANY configuration changed", such as an install guard
+    /// that must not publish an older build over a newer one.
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    /// Stamped AFTER the mutation lands, and released, so a reader that
+    /// observes a new generation also observes the rows behind it.
+    fn bump_generation(&self) {
+        self.generation.store(
+            NEXT_GENERATION.fetch_add(1, Ordering::Relaxed),
+            Ordering::Release,
+        );
+    }
+
     /// Insert or replace an entry, updating both indices.
     ///
     /// If an entry with the same id already exists, the old name index entry
     /// is removed first (handles rename on update).
     pub fn insert(&self, entry: ResourceEntry<T>) {
+        self.insert_arc(Arc::new(entry));
+    }
+
+    /// [`ResourceTable::insert`] for an entry already behind an `Arc` —
+    /// the copy-on-write path, where the new table shares the previous
+    /// snapshot's rows instead of deep-copying every payload.
+    pub fn insert_arc(&self, entry: Arc<ResourceEntry<T>>) {
         let id = entry.id.clone();
         let name = entry.value.name().to_string();
 
@@ -98,9 +154,10 @@ impl<T: Resource> ResourceTable<T> {
         // one redundant full scan, but can never skip an entry that is
         // already visible in the map.
         self.count.fetch_add(1, Ordering::Relaxed);
-        if self.by_id.insert(id, Arc::new(entry)).is_some() {
+        if self.by_id.insert(id, entry).is_some() {
             self.count.fetch_sub(1, Ordering::Relaxed);
         }
+        self.bump_generation();
     }
 
     /// Remove by id; also removes the matching name index entry.
@@ -109,6 +166,7 @@ impl<T: Resource> ResourceTable<T> {
         self.count.fetch_sub(1, Ordering::Relaxed);
         let name = entry.value.name().to_string();
         self.by_name.remove_if(&name, |_, v| v == id);
+        self.bump_generation();
         Some(entry)
     }
 
@@ -221,6 +279,13 @@ impl<S> SnapshotHandle<S> {
     /// Consumers can compare this to detect snapshot changes without
     /// relying on `Arc` pointer identity (which suffers from the ABA
     /// problem when the allocator reuses addresses).
+    ///
+    /// This answers "has ANY configuration changed", which is almost
+    /// never the question a cache of something DERIVED from the snapshot
+    /// is asking. Key those on [`ResourceTable::generation`] of the
+    /// tables they read instead: one API-key edit moves this counter, and
+    /// a cache keyed on it is then rebuilt on the request path of every
+    /// worker thread for a write it does not read (AISIX-Cloud#1542).
     pub fn version(&self) -> u64 {
         self.version.load(Ordering::Acquire)
     }

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -16,13 +16,13 @@
 //! read path reading a fully-formed `Arc<Snapshot>` the whole time.
 
 use aisix_core::config_status::{
-    hash_entries, AppliedSnapshot, ConfigStatus, IncomingRejection, LoadObservation,
+    hash_record, hash_records, AppliedSnapshot, ConfigStatus, IncomingRejection, LoadObservation,
     PartialCompatResource, SourceKind,
 };
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::AisixSnapshot;
 use chrono::{DateTime, Utc};
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
@@ -166,6 +166,24 @@ pub struct StaleServing {
     pub since_unix_secs: u64,
 }
 
+/// One observed etcd entry plus the bytes it contributes to the config
+/// digests, computed once when the entry is stored.
+#[derive(Debug, Clone)]
+struct StateEntry {
+    entry: RawEntry,
+    /// [`aisix_core::config_status::hash_record`] of `entry`. A pure
+    /// function of `(key, value)`, so it is valid for exactly as long as
+    /// this map holds these bytes.
+    record: Arc<[u8]>,
+}
+
+impl StateEntry {
+    fn new(entry: RawEntry) -> Self {
+        let record: Arc<[u8]> = hash_record(&entry.key, &entry.value).into();
+        Self { entry, record }
+    }
+}
+
 /// One supervisor instance. Consumers call [`Supervisor::run`] once and
 /// drop the returned handle on shutdown.
 pub struct Supervisor<P: ConfigProvider> {
@@ -175,8 +193,15 @@ pub struct Supervisor<P: ConfigProvider> {
 
     // Last-known etcd state, kept in `key → RawEntry` form so deltas
     // (Put/Delete) can update it incrementally and the whole map can
-    // be flushed to disk via `cache.store`.
-    state: Mutex<HashMap<String, RawEntry>>,
+    // be flushed to disk via `cache.store`. Each entry carries its
+    // pre-computed [`hash_record`] so the two full-config digests
+    // `sync_config_status` publishes cost a SHA-256 pass over cached
+    // bytes rather than a JSON parse and canonical re-serialisation of
+    // every row in the configuration on every watch event
+    // (AISIX-Cloud#1542). `BTreeMap`, not `HashMap`, so the records are
+    // already in the ascending-key order the digest is defined over and
+    // no sort runs per call.
+    state: Mutex<BTreeMap<String, StateEntry>>,
     revision: Mutex<i64>,
     cache: SnapshotCache,
 
@@ -256,7 +281,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             provider,
             prefix: prefix.into(),
             handle: SnapshotHandle::new(AisixSnapshot::new()),
-            state: Mutex::new(HashMap::new()),
+            state: Mutex::new(BTreeMap::new()),
             revision: Mutex::new(0),
             cache,
             status: WatchStatus::new(),
@@ -303,9 +328,11 @@ impl<P: ConfigProvider> Supervisor<P> {
             // etcd write lands here, including rejected ones (a resync
             // inserts them wholesale; a rejected live Put mirrors its
             // bytes in too, #871), so source_hash always covers the
-            // observed etcd state.
-            source_hash =
-                hash_entries(state.values().map(|e| (e.key.as_str(), e.value.as_slice())));
+            // observed etcd state. It is a `BTreeMap`, so iterating it
+            // already yields the ascending-key order the digest is
+            // defined over, and each value carries its record from the
+            // one time its bytes were stored.
+            source_hash = hash_records(state.values().map(|e| &e.record));
             let rejected_keys: HashSet<&str> = rejections.iter().map(|r| r.key.as_str()).collect();
             // config_hash covers the bytes each key ACTUALLY serves: the
             // observed etcd bytes for accepted keys, the pinned last-known-
@@ -314,19 +341,16 @@ impl<P: ConfigProvider> Supervisor<P> {
             // map — not the capped rejection buffer — decides which keys
             // substitute, so buffer overflow can never flip a served key's
             // hash contribution to the rejected bytes.
-            config_hash = hash_entries(
-                state
-                    .values()
-                    .filter(|e| {
-                        !rejected_keys.contains(e.key.as_str()) && !stale.contains_key(&e.key)
-                    })
-                    .map(|e| (e.key.as_str(), e.value.as_slice()))
-                    .chain(
-                        stale
-                            .values()
-                            .map(|s| (s.entry.key.as_str(), s.entry.value.as_slice())),
-                    ),
-            );
+            //
+            // With nothing rejected and nothing pinned the filter admits
+            // every key and the chain adds none, so the two digests are
+            // over the identical record sequence — the overwhelmingly
+            // common case, and one full SHA-256 pass to skip.
+            config_hash = if rejected_keys.is_empty() && stale.is_empty() {
+                source_hash.clone()
+            } else {
+                hash_records(served_records(&state, &rejected_keys, &stale))
+            };
             rejected = rejections
                 .iter()
                 .map(|r| self.map_rejection(r, &stale))
@@ -672,17 +696,27 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// mirroring the rejected bytes into `state`, and a resync that
     /// rejects a key either stale-tracks it or drops it from the
     /// snapshot).
-    fn capture_last_good(&self, key_str: &str) {
+    fn capture_last_good(&self, key_str: &str, base: &AisixSnapshot, view: &BatchView) {
         if self.stale_serving.lock().unwrap().contains_key(key_str) {
             return;
         }
         let Ok(parsed) = key::parse(&self.prefix, key_str) else {
             return;
         };
-        if !snapshot_has(&self.handle.load(), parsed.kind, parsed.id) {
+        // The presence probe reads through the batch's own staged
+        // mutations: within one coalesced apply a row put earlier in the
+        // batch is serving as far as this decision is concerned, even
+        // though the snapshot carrying it has not been published yet.
+        if !view.present(base, parsed.kind, parsed.id) {
             return;
         }
-        let Some(good) = self.state.lock().unwrap().get(key_str).cloned() else {
+        let Some(good) = self
+            .state
+            .lock()
+            .unwrap()
+            .get(key_str)
+            .map(|e| e.entry.clone())
+        else {
             return;
         };
         // entry().or_insert_with keeps the original pin (and its `since`)
@@ -700,6 +734,107 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// Apply a single Put event on top of the current snapshot.
     /// Returns `true` if the apply succeeded (schema + parse passed).
     pub fn apply_put(&self, entry: &RawEntry) -> bool {
+        self.apply_events(&[PendingEvent::Put(entry)])[0]
+    }
+
+    /// Apply a Delete event. Returns `true` if anything was actually
+    /// removed (the kind/id was present).
+    pub fn apply_delete(&self, key_str: &str) -> bool {
+        self.apply_events(&[PendingEvent::Delete {
+            key: key_str,
+            revision: None,
+        }])[0]
+    }
+
+    /// Apply a coalesced run of Put/Delete events as ONE copy-on-write
+    /// cycle: one snapshot clone, one publish, one configuration-status
+    /// sync, one cache flush. Returns each event's outcome, in order.
+    ///
+    /// Per-event work — schema validation, rejection bookkeeping,
+    /// last-known-good pinning, the partial-compatibility signal, the
+    /// observed-state map and the revision floor — still runs once per
+    /// event and in order, so a batch decides exactly what the same
+    /// events decided one at a time. What is shared is the work whose
+    /// cost is the size of the WHOLE configuration rather than the size
+    /// of the event: a bulk edit that lands 14 writes a second used to
+    /// pay all of it 14 times a second (AISIX-Cloud#1542).
+    fn apply_events(&self, events: &[PendingEvent<'_>]) -> Vec<bool> {
+        let base = self.handle.load();
+        let mut view = BatchView::default();
+        let mut mutations: Vec<SnapshotMutation> = Vec::new();
+        let mut outcomes = Vec::with_capacity(events.len());
+        // The revision to stamp freshness with, if any event would have
+        // stamped one. `record_apply` keeps the max, so one call with the
+        // batch's max is what N calls would have left behind.
+        let mut apply_stamp: Option<i64> = None;
+        // Whether any event changed something `/status/config` or the
+        // on-disk cache reports. A batch of deletes for keys that were
+        // never there publishes nothing, exactly as each delete would not.
+        let mut changed = false;
+
+        for event in events {
+            let outcome = match event {
+                PendingEvent::Put(entry) => self.stage_put(
+                    entry,
+                    &base,
+                    &mut view,
+                    &mut mutations,
+                    &mut apply_stamp,
+                    &mut changed,
+                ),
+                PendingEvent::Delete { key, revision } => self.stage_delete(
+                    key,
+                    *revision,
+                    &base,
+                    &mut view,
+                    &mut mutations,
+                    &mut apply_stamp,
+                    &mut changed,
+                ),
+            };
+            outcomes.push(outcome);
+        }
+        drop(base);
+
+        if !mutations.is_empty() {
+            // RCU: load → clone → mutate → CAS, retrying the closure if a
+            // concurrent apply raced our CAS. The previous implementation
+            // used a bare load-mutate-store sequence which silently
+            // dropped events under concurrency (see issue #112). The
+            // closure body must be idempotent w.r.t. its input — the
+            // staged mutations are a fixed ordered list replayed onto a
+            // fresh clone each attempt.
+            self.handle.rcu(|current| {
+                let new = clone_snapshot(current);
+                for mutation in &mutations {
+                    mutation.apply_to(&new);
+                }
+                new
+            });
+        }
+        if let Some(revision) = apply_stamp {
+            // /admin/v1/health reads this — record the apply so
+            // `last_apply_age` resets on every event we process.
+            self.status.record_apply(revision);
+        }
+        if changed {
+            self.sync_config_status(false);
+            self.flush_cache();
+        }
+        outcomes
+    }
+
+    /// Stage one Put. See [`Self::apply_events`] for what is per-event
+    /// and what is shared.
+    fn stage_put(
+        &self,
+        entry: &RawEntry,
+        base: &AisixSnapshot,
+        view: &mut BatchView,
+        mutations: &mut Vec<SnapshotMutation>,
+        apply_stamp: &mut Option<i64>,
+        changed: &mut bool,
+    ) -> bool {
         // Build a tiny snapshot out of just the new entry, then merge.
         let (tiny, mut stats) = loader::build_snapshot(&self.prefix, std::slice::from_ref(entry));
         if stats.accepted == 0 {
@@ -708,7 +843,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             // needs the pinned bytes to keep this row alive. Must run
             // BEFORE the state-map update below, which overwrites the
             // serving bytes with the rejected ones.
-            self.capture_last_good(&entry.key);
+            self.capture_last_good(&entry.key, base, view);
             // Mirror the rejected bytes into the observed-state map and
             // the cache like any other observed etcd write: source_hash
             // reflects the observed etcd state immediately, and a
@@ -716,16 +851,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             // rejected-bytes + pinned-value shape a post-resync restart
             // would — keeping the staleness clock continuous instead of
             // resetting it at the next boot.
-            {
-                let mut state = self.state.lock().unwrap();
-                state.insert(entry.key.clone(), entry.clone());
-            }
-            {
-                let mut rev = self.revision.lock().unwrap();
-                if entry.revision > *rev {
-                    *rev = entry.revision;
-                }
-            }
+            self.store_observed(entry);
             // Note: a previously retained partially-compatible entry for
             // this key is deliberately kept — the row's last-good value
             // (loaded with those fields ignored) is still what serves.
@@ -738,29 +864,12 @@ impl<P: ConfigProvider> Supervisor<P> {
             }
             // A rejected watch event still changes the reported state
             // (rejected[] gains this entry; last_reload flips unsuccessful).
-            self.sync_config_status(false);
-            self.flush_cache();
+            *changed = true;
             return false;
         }
 
-        // RCU: load → clone → mutate → CAS, retrying the closure if a
-        // concurrent apply_put / apply_delete / apply_resync raced our
-        // CAS. The previous implementation used a bare load-mutate-
-        // store sequence which silently dropped events under
-        // concurrency (see issue #112). The closure body must be
-        // idempotent w.r.t. its input — `tiny` is captured by reference
-        // and the same delta is applied each retry, which is fine
-        // because the operation is "merge tiny into current".
-        self.handle.rcu(|current| {
-            let new = clone_snapshot(current);
-            // Move any entries from `tiny` into `new`. `merge_snapshot`
-            // must cover every ResourceTable on AisixSnapshot — a
-            // missing kind there means a watch event silently drops on
-            // the floor and the snapshot never sees the new entry, even
-            // though the loader and the proxy both know about it.
-            merge_snapshot(&new, &tiny);
-            new
-        });
+        view.record_put(&self.prefix, &entry.key);
+        mutations.push(SnapshotMutation::Merge(Box::new(tiny)));
         self.remove_rejection_for_key(&entry.key);
         // The key's latest bytes load again — retention ends (#871).
         self.stale_serving.lock().unwrap().remove(&entry.key);
@@ -772,48 +881,45 @@ impl<P: ConfigProvider> Supervisor<P> {
             .drain(..)
             .find(|row| row.key == entry.key);
         self.update_partial_row(&entry.key, partial);
-
-        // Mirror the put into the cache-tracking map and flush.
-        // Track the highest revision we've observed so the cache file
-        // records something monotonic.
-        {
-            let mut state = self.state.lock().unwrap();
-            state.insert(entry.key.clone(), entry.clone());
-        }
-        {
-            let mut rev = self.revision.lock().unwrap();
-            if entry.revision > *rev {
-                *rev = entry.revision;
-            }
-        }
-        // /admin/v1/health reads this — record the apply so `last_apply_age`
-        // resets on every event we successfully process.
-        self.status.record_apply(entry.revision);
-        self.sync_config_status(false);
-        self.flush_cache();
+        // Mirror the put into the cache-tracking map. Track the highest
+        // revision we've observed so the cache file records something
+        // monotonic.
+        self.store_observed(entry);
+        stamp_max(apply_stamp, entry.revision);
+        *changed = true;
         true
     }
 
-    /// Apply a Delete event. Returns `true` if anything was actually
-    /// removed (the kind/id was present).
-    pub fn apply_delete(&self, key_str: &str) -> bool {
+    /// Stage one Delete. `revision` carries the watch header revision the
+    /// cycle loop would otherwise pass to [`Self::set_revision_floor`]
+    /// immediately afterwards; `None` (the standalone
+    /// [`Self::apply_delete`] entry point) leaves the floor alone.
+    #[allow(clippy::too_many_arguments)]
+    fn stage_delete(
+        &self,
+        key_str: &str,
+        revision: Option<i64>,
+        base: &AisixSnapshot,
+        view: &mut BatchView,
+        mutations: &mut Vec<SnapshotMutation>,
+        apply_stamp: &mut Option<i64>,
+        changed: &mut bool,
+    ) -> bool {
         let parsed = match key::parse(&self.prefix, key_str) {
             Ok(k) => k,
             Err(err) => {
                 tracing::warn!(key = %key_str, error = %err, "ignoring delete with bad key");
+                self.raise_revision_floor(revision, apply_stamp, changed);
                 return false;
             }
         };
 
-        // Probe first — if the key isn't present in the current
-        // snapshot we have nothing to do and don't want to take the
-        // RCU CAS path (which would still publish a no-op clone and
-        // race against concurrent applies). The probe + RCU cycle
-        // produces an idempotent "removed" return value: a parallel
-        // delete that wins the race observes the same key already
-        // gone, so this caller returns false (nothing left to remove).
-        let snap = self.handle.load();
-        let present = snapshot_has(&snap, parsed.kind, parsed.id);
+        // Probe first — if the key isn't present we have nothing to
+        // remove and don't want to stage a no-op mutation. The probe
+        // reads through the batch's staged mutations as well as the
+        // published snapshot, so a delete that follows a put of the same
+        // key inside one batch sees the row the put staged.
+        let present = view.present(base, parsed.kind, parsed.id);
         let removed_rejection = self.remove_rejection_for_key(key_str);
         // A deleted key no longer serves, so its partially-compatible
         // signal (if any) goes with it — and so does its last-known-good
@@ -827,86 +933,62 @@ impl<P: ConfigProvider> Supervisor<P> {
         // in source_hash until the next resync and persist the deleted
         // document in the cache file.
         let removed_state = self.state.lock().unwrap().remove(key_str).is_some();
-        drop(snap);
         if !present {
             if removed_rejection || removed_state {
-                let cur_rev = *self.revision.lock().unwrap();
-                self.status.record_apply(cur_rev);
                 // Clearing a rejected key changes the reported state.
-                self.sync_config_status(false);
-                self.flush_cache();
+                // No per-event revision rides a wire delete, so stamp
+                // freshness with the current floor.
+                stamp_max(apply_stamp, *self.revision.lock().unwrap());
+                *changed = true;
             }
+            self.raise_revision_floor(revision, apply_stamp, changed);
             return removed_rejection;
         }
 
-        // RCU: load → clone → remove → CAS, retrying under contention.
-        // The closure body re-checks `removed` from its own clone so
-        // the eventual CAS reflects the latest snapshot's state — if a
-        // sibling apply_delete won the race, the kind.remove on our
-        // clone returns None and we still publish a coherent (no-op)
-        // result.
-        self.handle.rcu(|current| {
-            let new = clone_snapshot(current);
-            match parsed.kind {
-                "models" => {
-                    new.models.remove(parsed.id);
-                }
-                "api_keys" => {
-                    new.apikeys.remove(parsed.id);
-                }
-                "provider_keys" => {
-                    new.provider_keys.remove(parsed.id);
-                }
-                "guardrails" => {
-                    new.guardrails.remove(parsed.id);
-                }
-                "guardrail_attachments" => {
-                    new.guardrail_attachments.remove(parsed.id);
-                }
-                "cache_policies" => {
-                    new.cache_policies.remove(parsed.id);
-                }
-                "observability_exporters" => {
-                    new.observability_exporters.remove(parsed.id);
-                }
-                "rate_limit_policies" => {
-                    new.rate_limit_policies.remove(parsed.id);
-                }
-                "mcp_servers" => {
-                    new.mcp_servers.remove(parsed.id);
-                }
-                "mcp_policies" => {
-                    new.mcp_policies.remove(parsed.id);
-                }
-                "a2a_agents" => {
-                    new.a2a_agents.remove(parsed.id);
-                }
-                "oidc_providers" => {
-                    new.oidc_providers.remove(parsed.id);
-                }
-                "claim_mappings" => {
-                    new.claim_mappings.remove(parsed.id);
-                }
-                "passthrough_routes" => {
-                    new.passthrough_routes.remove(parsed.id);
-                }
-                "mcp_auth_settings" => {
-                    new.mcp_auth_settings.remove(parsed.id);
-                }
-                _ => {}
-            }
-            new
+        view.record_delete(parsed.kind, parsed.id);
+        mutations.push(SnapshotMutation::Remove {
+            kind: parsed.kind.to_string(),
+            id: parsed.id.to_string(),
         });
-        // Stamp /admin/v1/health freshness on a successful delete. We
-        // don't have a per-event revision on the wire delete
-        // (the etcd watch revision is held at the cycle level);
-        // call record_apply with the current revision so age
-        // resets even if the revision number doesn't move.
-        let cur_rev = *self.revision.lock().unwrap();
-        self.status.record_apply(cur_rev);
-        self.sync_config_status(false);
-        self.flush_cache();
+        stamp_max(apply_stamp, *self.revision.lock().unwrap());
+        *changed = true;
+        self.raise_revision_floor(revision, apply_stamp, changed);
         true
+    }
+
+    /// Record an observed etcd write in the state map, with its digest
+    /// record, and advance the revision floor to it.
+    fn store_observed(&self, entry: &RawEntry) {
+        {
+            let mut state = self.state.lock().unwrap();
+            state.insert(entry.key.clone(), StateEntry::new(entry.clone()));
+        }
+        let mut rev = self.revision.lock().unwrap();
+        if entry.revision > *rev {
+            *rev = entry.revision;
+        }
+    }
+
+    /// In-batch form of [`Self::set_revision_floor`]: bump the floor and
+    /// mark the batch as needing a status publish, deferring the single
+    /// `record_apply` / `sync_config_status` to the end of the batch.
+    fn raise_revision_floor(
+        &self,
+        revision: Option<i64>,
+        apply_stamp: &mut Option<i64>,
+        changed: &mut bool,
+    ) {
+        let Some(revision) = revision else {
+            return;
+        };
+        {
+            let mut rev = self.revision.lock().unwrap();
+            if revision > *rev {
+                *rev = revision;
+            }
+        }
+        stamp_max(apply_stamp, revision);
+        *changed = true;
     }
 
     /// Replace the current snapshot with a freshly loaded set (resync).
@@ -933,7 +1015,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             stats
                 .rejections
                 .iter()
-                .filter_map(|r| state.get(&r.key).map(|e| (r.key.clone(), e.clone())))
+                .filter_map(|r| state.get(&r.key).map(|e| (r.key.clone(), e.entry.clone())))
                 .collect()
         };
         let prev_snap = self.handle.load();
@@ -1007,7 +1089,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             let mut state = self.state.lock().unwrap();
             state.clear();
             for e in entries {
-                state.insert(e.key.clone(), e.clone());
+                state.insert(e.key.clone(), StateEntry::new(e.clone()));
             }
         }
         // Resync revision is the max of any entry; if the caller has a
@@ -1047,7 +1129,7 @@ impl<P: ConfigProvider> Supervisor<P> {
     fn flush_cache(&self) {
         let entries: Vec<RawEntry> = {
             let state = self.state.lock().unwrap();
-            state.values().cloned().collect()
+            state.values().map(|e| e.entry.clone()).collect()
         };
         let stale: Vec<StaleServing> = {
             let guard = self.stale_serving.lock().unwrap();
@@ -1186,16 +1268,25 @@ impl<P: ConfigProvider> Supervisor<P> {
             .await
             .map_err(SupervisorError::Provider)?;
 
+        // An event the drain below pulled off the stream but could not
+        // add to its batch (a resync, a stream error, the end of the
+        // stream). Held here so the next loop iteration handles it
+        // exactly as if it had just arrived.
+        let mut pushed_back: Option<Option<Result<WatchEvent, ProviderError>>> = None;
+
         loop {
             if *cancel.borrow() {
                 return Err(SupervisorError::Cancelled);
             }
 
-            let next = tokio::select! {
-                item = stream.next() => item,
-                _ = wait_for_cancel(cancel.clone()) => {
-                    return Err(SupervisorError::Cancelled);
-                }
+            let next = match pushed_back.take() {
+                Some(item) => item,
+                None => tokio::select! {
+                    item = stream.next() => item,
+                    _ = wait_for_cancel(cancel.clone()) => {
+                        return Err(SupervisorError::Cancelled);
+                    }
+                },
             };
 
             match next {
@@ -1208,25 +1299,64 @@ impl<P: ConfigProvider> Supervisor<P> {
                     return Ok(());
                 }
                 Some(Err(err)) => return Err(SupervisorError::Provider(err)),
-                Some(Ok(WatchEvent::Put(raw))) => {
-                    self.apply_put(&raw);
-                }
-                Some(Ok(WatchEvent::Delete { key, revision })) => {
-                    self.apply_delete(&key);
-                    // Advance the applied-revision floor to the delete's
-                    // mod_revision even when the key wasn't present —
-                    // "processed everything up to rev X" must cover
-                    // deletes, otherwise the heartbeat-reported
-                    // applied_revision (#519 B.3) stalls after a CP
-                    // delete until the next put arrives.
-                    self.set_revision_floor(revision);
-                }
                 Some(Ok(WatchEvent::Resync { entries, revision })) => {
                     self.apply_resync(&entries);
-                    // Same rationale: the resync's header revision is the
-                    // "consistent as of" point even when the entry set
-                    // is empty or only contains older mod_revisions.
+                    // The resync's header revision is the "consistent as
+                    // of" point even when the entry set is empty or only
+                    // contains older mod_revisions.
                     self.set_revision_floor(revision);
+                }
+                Some(Ok(first)) => {
+                    // Coalesce: take every Put/Delete that is ALREADY
+                    // waiting on the stream and apply the run as one
+                    // copy-on-write cycle. `now_or_never` never waits, so
+                    // an idle stream still applies each event on its own
+                    // and nothing is delayed to fill a batch. A bulk edit,
+                    // which is where a full-configuration pass per event
+                    // hurts (AISIX-Cloud#1542), arrives faster than the
+                    // apply and coalesces.
+                    let mut batch = vec![first];
+                    while batch.len() < MAX_APPLY_BATCH {
+                        let Some(item) = stream.next().now_or_never() else {
+                            break;
+                        };
+                        match item {
+                            Some(Ok(event @ (WatchEvent::Put(_) | WatchEvent::Delete { .. }))) => {
+                                batch.push(event)
+                            }
+                            other => {
+                                pushed_back = Some(other);
+                                break;
+                            }
+                        }
+                    }
+                    if batch.len() > 1 {
+                        tracing::debug!(
+                            events = batch.len(),
+                            "coalescing watch events into one snapshot publish",
+                        );
+                    }
+                    let staged: Vec<PendingEvent<'_>> = batch
+                        .iter()
+                        .map(|event| match event {
+                            WatchEvent::Put(raw) => PendingEvent::Put(raw),
+                            // Advance the applied-revision floor to the
+                            // delete's mod_revision even when the key
+                            // wasn't present — "processed everything up
+                            // to rev X" must cover deletes, otherwise the
+                            // heartbeat-reported applied_revision (#519
+                            // B.3) stalls after a CP delete until the next
+                            // put arrives.
+                            WatchEvent::Delete { key, revision } => PendingEvent::Delete {
+                                key,
+                                revision: Some(*revision),
+                            },
+                            WatchEvent::Resync { .. } => {
+                                unreachable!("a resync is never added to a coalesced batch")
+                            }
+                        })
+                        .collect();
+                    self.apply_events(&staged);
                 }
             }
         }
@@ -1251,15 +1381,156 @@ async fn wait_for_cancel(mut rx: tokio::sync::watch::Receiver<bool>) {
     }
 }
 
-/// Shallow clone of every [`Arc<ResourceEntry>`] — fast and, importantly,
-/// it doesn't materialise a deep copy of the `T` payload.
-fn clone_snapshot(src: &AisixSnapshot) -> AisixSnapshot {
-    let out = AisixSnapshot::new();
-    merge_snapshot(&out, src);
+/// Largest number of watch events one coalesced apply may cover.
+///
+/// The drain only takes events that are ALREADY queued, so this is not a
+/// latency knob — an idle stream applies each event on its own. It bounds
+/// how long one apply can hold off the publish when the control plane
+/// pushes a bulk edit, so a slow batch cannot make the served snapshot
+/// arbitrarily stale.
+const MAX_APPLY_BATCH: usize = 512;
+
+/// One watch event staged for a coalesced apply.
+enum PendingEvent<'a> {
+    Put(&'a RawEntry),
+    Delete {
+        key: &'a str,
+        /// The watch header revision. `None` leaves the revision floor
+        /// alone, which is what the standalone `apply_delete` entry point
+        /// has always done.
+        revision: Option<i64>,
+    },
+}
+
+/// One staged change to the snapshot, replayed onto a fresh structural
+/// clone inside the RCU closure.
+enum SnapshotMutation {
+    /// Merge an accepted put's single-entry snapshot. Boxed: an
+    /// `AisixSnapshot` is fifteen tables wide and the delete variant is
+    /// two strings.
+    Merge(Box<AisixSnapshot>),
+    Remove {
+        kind: String,
+        id: String,
+    },
+}
+
+impl SnapshotMutation {
+    fn apply_to(&self, dst: &AisixSnapshot) {
+        match self {
+            // `merge_snapshot` must cover every ResourceTable on
+            // AisixSnapshot — a missing kind there means a watch event
+            // silently drops on the floor and the snapshot never sees the
+            // new entry, even though the loader and the proxy both know
+            // about it.
+            Self::Merge(src) => merge_snapshot(dst, src),
+            Self::Remove { kind, id } => remove_from_snapshot(dst, kind, id),
+        }
+    }
+}
+
+/// The staged mutations of a batch, as a presence overlay on the snapshot
+/// the batch started from. Lets the per-event decisions that ask "does
+/// this row serve right now?" see the batch's own earlier events, which
+/// have not been published yet.
+#[derive(Debug, Default)]
+struct BatchView {
+    added: HashSet<(String, String)>,
+    removed: HashSet<(String, String)>,
+}
+
+impl BatchView {
+    fn record_put(&mut self, prefix: &str, key_str: &str) {
+        let Ok(parsed) = key::parse(prefix, key_str) else {
+            return;
+        };
+        let id = (parsed.kind.to_string(), parsed.id.to_string());
+        self.removed.remove(&id);
+        self.added.insert(id);
+    }
+
+    fn record_delete(&mut self, kind: &str, id: &str) {
+        let id = (kind.to_string(), id.to_string());
+        self.added.remove(&id);
+        self.removed.insert(id);
+    }
+
+    fn present(&self, base: &AisixSnapshot, kind: &str, id: &str) -> bool {
+        let probe = (kind.to_string(), id.to_string());
+        if self.removed.contains(&probe) {
+            return false;
+        }
+        if self.added.contains(&probe) {
+            return true;
+        }
+        snapshot_has(base, kind, id)
+    }
+}
+
+/// Keep the larger of `slot` and `revision`.
+fn stamp_max(slot: &mut Option<i64>, revision: i64) {
+    *slot = Some(match *slot {
+        Some(current) if current >= revision => current,
+        _ => revision,
+    });
+}
+
+/// The digest records for the bytes each key ACTUALLY serves, in the
+/// ascending-key order `hash_records` is defined over: the observed etcd
+/// bytes for an accepted key, the pinned last-known-good bytes for a
+/// stale-serving one (#871), and nothing for a key rejected with no last
+/// good. `state` is already sorted, so the pinned records are merged into
+/// the walk rather than sorted with it.
+fn served_records(
+    state: &BTreeMap<String, StateEntry>,
+    rejected_keys: &HashSet<&str>,
+    stale: &HashMap<String, StaleServing>,
+) -> Vec<Arc<[u8]>> {
+    let mut pinned: Vec<(&str, Arc<[u8]>)> = stale
+        .values()
+        .map(|s| {
+            let record: Arc<[u8]> = hash_record(&s.entry.key, &s.entry.value).into();
+            (s.entry.key.as_str(), record)
+        })
+        .collect();
+    pinned.sort_by(|a, b| a.0.cmp(b.0));
+
+    let mut out: Vec<Arc<[u8]>> = Vec::with_capacity(state.len() + pinned.len());
+    let mut next_pinned = 0usize;
+    for (key, entry) in state {
+        // A pinned key etcd no longer reports still serves — emit it in
+        // its own place in the ordering rather than at the end.
+        while next_pinned < pinned.len() && pinned[next_pinned].0 < key.as_str() {
+            out.push(pinned[next_pinned].1.clone());
+            next_pinned += 1;
+        }
+        if next_pinned < pinned.len() && pinned[next_pinned].0 == key.as_str() {
+            out.push(pinned[next_pinned].1.clone());
+            next_pinned += 1;
+            continue;
+        }
+        if rejected_keys.contains(key.as_str()) {
+            continue;
+        }
+        out.push(entry.record.clone());
+    }
+    for (_, record) in &pinned[next_pinned..] {
+        out.push(record.clone());
+    }
     out
 }
 
-/// Insert every entry of `src` into `dst` (replacing same-id entries).
+/// Structural clone: the new snapshot shares every
+/// [`Arc<ResourceEntry>`][aisix_core::ResourceEntry] with `src` and copies
+/// each table's generation, so the copy-on-write cycle behind one watch
+/// event costs a per-row `Arc` bump rather than a deep copy of every
+/// payload in the configuration, and leaves every derived cache valid.
+fn clone_snapshot(src: &AisixSnapshot) -> AisixSnapshot {
+    src.clone()
+}
+
+/// Insert every entry of `src` into `dst` (replacing same-id entries),
+/// sharing the `Arc` rather than copying the payload.
 /// The exhaustive destructuring makes adding a ResourceTable to
 /// [`AisixSnapshot`] a compile error here — a missing kind would mean
 /// entries silently drop on the floor when a watch put merges or a
@@ -1283,49 +1554,103 @@ fn merge_snapshot(dst: &AisixSnapshot, src: &AisixSnapshot) {
         mcp_auth_settings,
     } = src;
     for e in models.entries() {
-        dst.models.insert(clone_entry(&e));
+        dst.models.insert_arc(e);
     }
     for e in apikeys.entries() {
-        dst.apikeys.insert(clone_entry(&e));
+        dst.apikeys.insert_arc(e);
     }
     for e in provider_keys.entries() {
-        dst.provider_keys.insert(clone_entry(&e));
+        dst.provider_keys.insert_arc(e);
     }
     for e in guardrails.entries() {
-        dst.guardrails.insert(clone_entry(&e));
+        dst.guardrails.insert_arc(e);
     }
     for e in guardrail_attachments.entries() {
-        dst.guardrail_attachments.insert(clone_entry(&e));
+        dst.guardrail_attachments.insert_arc(e);
     }
     for e in cache_policies.entries() {
-        dst.cache_policies.insert(clone_entry(&e));
+        dst.cache_policies.insert_arc(e);
     }
     for e in observability_exporters.entries() {
-        dst.observability_exporters.insert(clone_entry(&e));
+        dst.observability_exporters.insert_arc(e);
     }
     for e in rate_limit_policies.entries() {
-        dst.rate_limit_policies.insert(clone_entry(&e));
+        dst.rate_limit_policies.insert_arc(e);
     }
     for e in mcp_servers.entries() {
-        dst.mcp_servers.insert(clone_entry(&e));
+        dst.mcp_servers.insert_arc(e);
     }
     for e in mcp_policies.entries() {
-        dst.mcp_policies.insert(clone_entry(&e));
+        dst.mcp_policies.insert_arc(e);
     }
     for e in a2a_agents.entries() {
-        dst.a2a_agents.insert(clone_entry(&e));
+        dst.a2a_agents.insert_arc(e);
     }
     for e in oidc_providers.entries() {
-        dst.oidc_providers.insert(clone_entry(&e));
+        dst.oidc_providers.insert_arc(e);
     }
     for e in claim_mappings.entries() {
-        dst.claim_mappings.insert(clone_entry(&e));
+        dst.claim_mappings.insert_arc(e);
     }
     for e in passthrough_routes.entries() {
-        dst.passthrough_routes.insert(clone_entry(&e));
+        dst.passthrough_routes.insert_arc(e);
     }
     for e in mcp_auth_settings.entries() {
-        dst.mcp_auth_settings.insert(clone_entry(&e));
+        dst.mcp_auth_settings.insert_arc(e);
+    }
+}
+
+/// Remove `(kind, id)` from `snap`. An unknown kind is a no-op —
+/// [`snapshot_has`] already read it as absent, so nothing staged a
+/// removal for it.
+fn remove_from_snapshot(snap: &AisixSnapshot, kind: &str, id: &str) {
+    match kind {
+        "models" => {
+            snap.models.remove(id);
+        }
+        "api_keys" => {
+            snap.apikeys.remove(id);
+        }
+        "provider_keys" => {
+            snap.provider_keys.remove(id);
+        }
+        "guardrails" => {
+            snap.guardrails.remove(id);
+        }
+        "guardrail_attachments" => {
+            snap.guardrail_attachments.remove(id);
+        }
+        "cache_policies" => {
+            snap.cache_policies.remove(id);
+        }
+        "observability_exporters" => {
+            snap.observability_exporters.remove(id);
+        }
+        "rate_limit_policies" => {
+            snap.rate_limit_policies.remove(id);
+        }
+        "mcp_servers" => {
+            snap.mcp_servers.remove(id);
+        }
+        "mcp_policies" => {
+            snap.mcp_policies.remove(id);
+        }
+        "a2a_agents" => {
+            snap.a2a_agents.remove(id);
+        }
+        "oidc_providers" => {
+            snap.oidc_providers.remove(id);
+        }
+        "claim_mappings" => {
+            snap.claim_mappings.remove(id);
+        }
+        "passthrough_routes" => {
+            snap.passthrough_routes.remove(id);
+        }
+        "mcp_auth_settings" => {
+            snap.mcp_auth_settings.remove(id);
+        }
+        _ => {}
     }
 }
 
@@ -1411,14 +1736,6 @@ fn resource_counts(snap: &AisixSnapshot) -> BTreeMap<String, usize> {
     counts
 }
 
-fn clone_entry<T: Clone>(src: &Arc<aisix_core::ResourceEntry<T>>) -> aisix_core::ResourceEntry<T> {
-    aisix_core::ResourceEntry {
-        id: src.id.clone(),
-        value: src.value.clone(),
-        revision: src.revision,
-    }
-}
-
 /// Total time the supervisor will wait across its full 1→60s backoff
 /// ladder before saturating. Exposed as a constant for tests and docs.
 pub const BACKOFF_SATURATE_AFTER: Duration = Duration::from_secs(63);
@@ -1483,6 +1800,262 @@ mod tests {
             value: v.to_vec(),
             revision: rev,
         }
+    }
+
+    const VALID_APIKEY: &[u8] = br#"{
+        "key_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "allowed_models": ["my-gpt4"]
+    }"#;
+
+    const VALID_GUARDRAIL: &[u8] = br#"{
+        "name": "kw",
+        "kind": "keyword",
+        "patterns": [{"kind": "literal", "value": "AKIA"}]
+    }"#;
+
+    /// The two config digests must stay byte-identical to what the
+    /// unchanged `hash_entries` produces over the same served set: cp-api
+    /// stores `config_hash` verbatim and never recomputes it, and the
+    /// algorithm is documented in the public Admin API reference. The
+    /// fixture drives the three shapes the cached-record path has to get
+    /// right at once — an accepted row, a row rejected with nothing to
+    /// serve, and a row serving its pinned last known good while etcd
+    /// holds bytes that do not load.
+    #[tokio::test]
+    async fn config_digests_match_the_reference_algorithm() {
+        let provider = Arc::new(FakeProvider::new(vec![], 0));
+        let sup = Supervisor::new(provider, "/aisix");
+        sup.load_once().await.unwrap();
+
+        assert!(sup.apply_put(&entry("/aisix/models/m-1", VALID_MODEL, 2)));
+        assert!(sup.apply_put(&entry("/aisix/api_keys/k-1", VALID_APIKEY, 3)));
+        assert!(sup.apply_put(&entry("/aisix/guardrails/g-1", VALID_GUARDRAIL, 4)));
+        // Rejected with no previous good value: serves nothing.
+        assert!(!sup.apply_put(&entry("/aisix/models/m-2", b"{\"display_name\": 7}", 5)));
+        // Rejected over a row that WAS serving: keeps serving the pin.
+        // Deliberately a key that sorts in the MIDDLE of the served set —
+        // the pinned record has to take the key's own place in the
+        // ordering, and a digest over the right bytes in the wrong order
+        // is a different digest.
+        assert!(!sup.apply_put(&entry("/aisix/guardrails/g-1", b"not json at all", 6)));
+
+        let view = sup.config_status().view();
+        let state: Vec<(String, Vec<u8>)> = sup
+            .state
+            .lock()
+            .unwrap()
+            .values()
+            .map(|e| (e.entry.key.clone(), e.entry.value.clone()))
+            .collect();
+        let stale = sup.stale_serving.lock().unwrap().clone();
+        assert_eq!(
+            stale.len(),
+            1,
+            "the pinned row is what makes the two differ"
+        );
+        let rejected: HashSet<String> = sup
+            .rejections
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|r| r.key.clone())
+            .collect();
+        assert_eq!(rejected.len(), 2);
+
+        let expected_source = aisix_core::config_status::hash_entries(
+            state.iter().map(|(k, v)| (k.as_str(), v.as_slice())),
+        );
+        let expected_config = aisix_core::config_status::hash_entries(
+            state
+                .iter()
+                .filter(|(k, _)| !rejected.contains(k) && !stale.contains_key(k))
+                .map(|(k, v)| (k.as_str(), v.as_slice()))
+                .chain(
+                    stale
+                        .values()
+                        .map(|s| (s.entry.key.as_str(), s.entry.value.as_slice())),
+                ),
+        );
+        assert_eq!(
+            view.source.source_hash.as_deref(),
+            Some(expected_source.as_str())
+        );
+        assert_eq!(view.applied.as_ref().unwrap().config_hash, expected_config);
+        assert_ne!(expected_source, expected_config);
+
+        // The STALE map, not the capped rejection buffer, decides which
+        // keys substitute their pinned bytes. Drop the pinned key's
+        // rejection — what a buffer overflow does — and the served bytes
+        // must not flip to the ones that do not load.
+        assert!(sup.remove_rejection_for_key("/aisix/guardrails/g-1"));
+        sup.sync_config_status(false);
+        let expected_overflow = aisix_core::config_status::hash_entries(
+            state
+                .iter()
+                .filter(|(k, _)| k != "/aisix/models/m-2" && !stale.contains_key(k))
+                .map(|(k, v)| (k.as_str(), v.as_slice()))
+                .chain(
+                    stale
+                        .values()
+                        .map(|s| (s.entry.key.as_str(), s.entry.value.as_slice())),
+                ),
+        );
+        assert_eq!(expected_overflow, expected_config);
+        assert_eq!(
+            sup.config_status()
+                .view()
+                .applied
+                .as_ref()
+                .unwrap()
+                .config_hash,
+            expected_overflow,
+        );
+    }
+
+    /// A watch event must not deep-copy the configuration. The published
+    /// snapshot shares every row it did not change with its predecessor —
+    /// which is also what makes a derived cache able to tell an unchanged
+    /// row from a rewritten one by `Arc` identity.
+    #[tokio::test]
+    async fn a_put_shares_every_untouched_row_with_the_previous_snapshot() {
+        let provider = Arc::new(FakeProvider::new(vec![], 0));
+        let sup = Supervisor::new(provider, "/aisix");
+        sup.load_once().await.unwrap();
+        assert!(sup.apply_put(&entry("/aisix/models/m-1", VALID_MODEL, 2)));
+        assert!(sup.apply_put(&entry("/aisix/guardrails/g-1", VALID_GUARDRAIL, 3)));
+
+        let before = sup.handle().load();
+        let model_before = before.models.get_by_id("m-1").unwrap();
+        let guardrail_before = before.guardrails.get_by_id("g-1").unwrap();
+
+        assert!(sup.apply_put(&entry("/aisix/api_keys/k-1", VALID_APIKEY, 4)));
+
+        let after = sup.handle().load();
+        assert!(
+            !Arc::ptr_eq(&before, &after),
+            "a new snapshot was published"
+        );
+        assert!(Arc::ptr_eq(
+            &model_before,
+            &after.models.get_by_id("m-1").unwrap()
+        ));
+        assert!(Arc::ptr_eq(
+            &guardrail_before,
+            &after.guardrails.get_by_id("g-1").unwrap()
+        ));
+    }
+
+    /// A write bumps the generation of the table it touched and of no
+    /// other, across the copy-on-write publish. This is the invalidation
+    /// key every derived cache reads (AISIX-Cloud#1542).
+    #[tokio::test]
+    async fn only_the_written_table_changes_generation() {
+        let provider = Arc::new(FakeProvider::new(vec![], 0));
+        let sup = Supervisor::new(provider, "/aisix");
+        sup.load_once().await.unwrap();
+        assert!(sup.apply_put(&entry("/aisix/guardrails/g-1", VALID_GUARDRAIL, 2)));
+
+        let before = sup.handle().load();
+        let (g0, m0) = (before.guardrails.generation(), before.models.generation());
+
+        assert!(sup.apply_put(&entry("/aisix/api_keys/k-1", VALID_APIKEY, 3)));
+        let after = sup.handle().load();
+        assert!(after.apikeys.generation() > before.apikeys.generation());
+        assert_eq!(after.guardrails.generation(), g0);
+        assert_eq!(after.models.generation(), m0);
+        assert!(
+            sup.handle().version() > 0,
+            "the global version still moves on every publish"
+        );
+
+        assert!(sup.apply_put(&entry("/aisix/models/m-1", VALID_MODEL, 4)));
+        let latest = sup.handle().load();
+        assert!(latest.models.generation() > m0);
+        assert_eq!(latest.guardrails.generation(), g0);
+
+        // A delete moves it too.
+        assert!(sup.apply_delete("/aisix/guardrails/g-1"));
+        assert!(sup.handle().load().guardrails.generation() > g0);
+    }
+
+    /// A run of watch events that is already queued is applied as ONE
+    /// copy-on-write cycle: one publish, one status sync, one cache
+    /// flush. Per-event decisions still run per event and in order.
+    #[tokio::test]
+    async fn a_queued_run_of_events_publishes_once() {
+        let events: Vec<Result<WatchEvent, ProviderError>> = (1..=6)
+            .map(|i| {
+                Ok(WatchEvent::Put(entry(
+                    &format!("/aisix/models/m-{i}"),
+                    VALID_MODEL,
+                    i,
+                )))
+            })
+            .collect();
+        let provider = Arc::new(FakeProvider::new(vec![], 0).with_events(events));
+        let sup = Arc::new(Supervisor::new(provider, "/aisix"));
+        let version_before = sup.handle().version();
+        let reloads_before = sup.config_status().metrics().reloads_total;
+
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        // One cycle: load_all, then drain the whole prepared stream.
+        let _ = sup.cycle(&rx).await;
+
+        let snap = sup.handle().load();
+        assert_eq!(snap.models.len(), 6);
+        // The initial resync publishes once; the six puts publish once
+        // between them. Before the coalescing they published six times.
+        assert_eq!(
+            sup.handle().version() - version_before,
+            2,
+            "the queued run should be one publish on top of the resync",
+        );
+        // Every model row shares one generation stamp — they were merged
+        // into a single table mutation cycle, not six.
+        assert_eq!(
+            sup.config_status().metrics().reloads_total - reloads_before,
+            1,
+            "only the resync counts as a reload",
+        );
+    }
+
+    /// Coalescing must not change what the individual events decided.
+    #[tokio::test]
+    async fn a_batch_decides_exactly_what_the_events_decide_alone() {
+        let events: Vec<Result<WatchEvent, ProviderError>> = vec![
+            Ok(WatchEvent::Put(entry("/aisix/models/m-1", VALID_MODEL, 2))),
+            Ok(WatchEvent::Put(entry(
+                "/aisix/api_keys/k-1",
+                VALID_APIKEY,
+                3,
+            ))),
+            // Rejected AFTER the accepted put of the same key: the row is
+            // serving as far as this decision goes, even though the
+            // snapshot carrying it has not been published yet, so its
+            // bytes are pinned as the last known good.
+            Ok(WatchEvent::Put(entry(
+                "/aisix/models/m-1",
+                b"not json at all",
+                4,
+            ))),
+            Ok(WatchEvent::Delete {
+                key: "/aisix/api_keys/k-1".into(),
+                revision: 5,
+            }),
+        ];
+        let provider = Arc::new(FakeProvider::new(vec![], 0).with_events(events));
+        let sup = Arc::new(Supervisor::new(provider, "/aisix"));
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        let _ = sup.cycle(&rx).await;
+
+        let snap = sup.handle().load();
+        assert_eq!(snap.models.len(), 1, "the pinned last known good serves");
+        assert_eq!(snap.apikeys.len(), 0, "the delete landed");
+        let stale = sup.stale_serving.lock().unwrap();
+        assert!(
+            stale.contains_key("/aisix/models/m-1"),
+            "the earlier put in the same batch counted as serving",
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -767,10 +767,11 @@ impl<P: ConfigProvider> Supervisor<P> {
         // stamped one. `record_apply` keeps the max, so one call with the
         // batch's max is what N calls would have left behind.
         let mut apply_stamp: Option<i64> = None;
-        // Whether any event changed something `/status/config` or the
-        // on-disk cache reports. A batch of deletes for keys that were
-        // never there publishes nothing, exactly as each delete would not.
-        let mut changed = false;
+        // What the batch has to publish. Split, because the two are not
+        // the same set of events: a delete's revision-floor bump moves
+        // what `/status/config` reports without changing a byte of the
+        // observed state the cache file holds, and used to write nothing.
+        let mut dirty = Dirty::default();
 
         for event in events {
             let outcome = match event {
@@ -780,7 +781,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                     &mut view,
                     &mut mutations,
                     &mut apply_stamp,
-                    &mut changed,
+                    &mut dirty,
                 ),
                 PendingEvent::Delete { key, revision } => self.stage_delete(
                     key,
@@ -789,7 +790,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                     &mut view,
                     &mut mutations,
                     &mut apply_stamp,
-                    &mut changed,
+                    &mut dirty,
                 ),
             };
             outcomes.push(outcome);
@@ -817,8 +818,10 @@ impl<P: ConfigProvider> Supervisor<P> {
             // `last_apply_age` resets on every event we process.
             self.status.record_apply(revision);
         }
-        if changed {
+        if dirty.status {
             self.sync_config_status(false);
+        }
+        if dirty.cache {
             self.flush_cache();
         }
         outcomes
@@ -833,7 +836,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         view: &mut BatchView,
         mutations: &mut Vec<SnapshotMutation>,
         apply_stamp: &mut Option<i64>,
-        changed: &mut bool,
+        dirty: &mut Dirty,
     ) -> bool {
         // Build a tiny snapshot out of just the new entry, then merge.
         let (tiny, mut stats) = loader::build_snapshot(&self.prefix, std::slice::from_ref(entry));
@@ -863,13 +866,27 @@ impl<P: ConfigProvider> Supervisor<P> {
                 self.push_rejection(r);
             }
             // A rejected watch event still changes the reported state
-            // (rejected[] gains this entry; last_reload flips unsuccessful).
-            *changed = true;
+            // (rejected[] gains this entry; last_reload flips unsuccessful),
+            // and its bytes are now part of the observed state on disk.
+            dirty.status = true;
+            dirty.cache = true;
             return false;
         }
 
         view.record_put(&self.prefix, &entry.key);
-        mutations.push(SnapshotMutation::Merge(Box::new(tiny)));
+        // Fold a run of puts into ONE staged snapshot rather than keeping a
+        // `Box<AisixSnapshot>` per event alive until the commit: the loader
+        // hands back a full fifteen-table snapshot for the single row it
+        // parsed, and every one of those tables eagerly allocates a DashMap
+        // shard array sized by the core count — hundreds of kilobytes per
+        // event on a large host, for one row. Merging is order-preserving:
+        // a later insert of the same id replaces the earlier one, which is
+        // what applying the two puts in sequence does. A delete breaks the
+        // run, so the ordering across kinds is kept too.
+        match mutations.last_mut() {
+            Some(SnapshotMutation::Merge(accumulated)) => merge_snapshot(accumulated, &tiny),
+            _ => mutations.push(SnapshotMutation::Merge(Box::new(tiny))),
+        }
         self.remove_rejection_for_key(&entry.key);
         // The key's latest bytes load again — retention ends (#871).
         self.stale_serving.lock().unwrap().remove(&entry.key);
@@ -886,7 +903,8 @@ impl<P: ConfigProvider> Supervisor<P> {
         // monotonic.
         self.store_observed(entry);
         stamp_max(apply_stamp, entry.revision);
-        *changed = true;
+        dirty.status = true;
+        dirty.cache = true;
         true
     }
 
@@ -903,13 +921,13 @@ impl<P: ConfigProvider> Supervisor<P> {
         view: &mut BatchView,
         mutations: &mut Vec<SnapshotMutation>,
         apply_stamp: &mut Option<i64>,
-        changed: &mut bool,
+        dirty: &mut Dirty,
     ) -> bool {
         let parsed = match key::parse(&self.prefix, key_str) {
             Ok(k) => k,
             Err(err) => {
                 tracing::warn!(key = %key_str, error = %err, "ignoring delete with bad key");
-                self.raise_revision_floor(revision, apply_stamp, changed);
+                self.raise_revision_floor(revision, apply_stamp, dirty);
                 return false;
             }
         };
@@ -939,9 +957,10 @@ impl<P: ConfigProvider> Supervisor<P> {
                 // No per-event revision rides a wire delete, so stamp
                 // freshness with the current floor.
                 stamp_max(apply_stamp, *self.revision.lock().unwrap());
-                *changed = true;
+                dirty.status = true;
+                dirty.cache = true;
             }
-            self.raise_revision_floor(revision, apply_stamp, changed);
+            self.raise_revision_floor(revision, apply_stamp, dirty);
             return removed_rejection;
         }
 
@@ -951,8 +970,9 @@ impl<P: ConfigProvider> Supervisor<P> {
             id: parsed.id.to_string(),
         });
         stamp_max(apply_stamp, *self.revision.lock().unwrap());
-        *changed = true;
-        self.raise_revision_floor(revision, apply_stamp, changed);
+        dirty.status = true;
+        dirty.cache = true;
+        self.raise_revision_floor(revision, apply_stamp, dirty);
         true
     }
 
@@ -972,11 +992,14 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// In-batch form of [`Self::set_revision_floor`]: bump the floor and
     /// mark the batch as needing a status publish, deferring the single
     /// `record_apply` / `sync_config_status` to the end of the batch.
+    ///
+    /// Status only — the floor is not part of the observed entry set, and
+    /// `set_revision_floor` never wrote the cache file either.
     fn raise_revision_floor(
         &self,
         revision: Option<i64>,
         apply_stamp: &mut Option<i64>,
-        changed: &mut bool,
+        dirty: &mut Dirty,
     ) {
         let Some(revision) = revision else {
             return;
@@ -988,7 +1011,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             }
         }
         stamp_max(apply_stamp, revision);
-        *changed = true;
+        dirty.status = true;
     }
 
     /// Replace the current snapshot with a freshly loaded set (resync).
@@ -1306,7 +1329,10 @@ impl<P: ConfigProvider> Supervisor<P> {
                     // contains older mod_revisions.
                     self.set_revision_floor(revision);
                 }
-                Some(Ok(first)) => {
+                // Explicit over the two batchable variants rather than a
+                // catch-all: a new `WatchEvent` must fail to compile here
+                // instead of falling into a batch that cannot carry it.
+                Some(Ok(first @ (WatchEvent::Put(_) | WatchEvent::Delete { .. }))) => {
                     // Coalesce: take every Put/Delete that is ALREADY
                     // waiting on the stream and apply the run as one
                     // copy-on-write cycle. `now_or_never` never waits, so
@@ -1351,6 +1377,9 @@ impl<P: ConfigProvider> Supervisor<P> {
                                 key,
                                 revision: Some(*revision),
                             },
+                            // Unreachable by the arm above and the drain's
+                            // own filter, both of which are exhaustive over
+                            // `WatchEvent`.
                             WatchEvent::Resync { .. } => {
                                 unreachable!("a resync is never added to a coalesced batch")
                             }
@@ -1465,6 +1494,16 @@ impl BatchView {
         }
         snapshot_has(base, kind, id)
     }
+}
+
+/// What one coalesced apply still owes when its events are staged.
+#[derive(Debug, Default)]
+struct Dirty {
+    /// `/status/config` and the `aisix_config_*` series.
+    status: bool,
+    /// The on-disk snapshot cache, whose content is the observed entry
+    /// set — so a bump of the revision floor alone does not dirty it.
+    cache: bool,
 }
 
 /// Keep the larger of `slot` and `revision`.
@@ -1600,55 +1639,75 @@ fn merge_snapshot(dst: &AisixSnapshot, src: &AisixSnapshot) {
     }
 }
 
-/// Remove `(kind, id)` from `snap`. An unknown kind is a no-op —
-/// [`snapshot_has`] already read it as absent, so nothing staged a
-/// removal for it.
+/// Remove `(kind, id)` from `snap`.
+///
+/// Exhaustively destructured for the same drift-guard reason as
+/// [`merge_snapshot`] and [`snapshot_has`]: a kind added to the snapshot
+/// but missed here would be found present by `snapshot_has`, stage a
+/// removal, and then silently no-op — the row would never be deletable.
 fn remove_from_snapshot(snap: &AisixSnapshot, kind: &str, id: &str) {
+    let AisixSnapshot {
+        models,
+        apikeys,
+        provider_keys,
+        guardrails,
+        guardrail_attachments,
+        cache_policies,
+        observability_exporters,
+        rate_limit_policies,
+        mcp_servers,
+        mcp_policies,
+        a2a_agents,
+        oidc_providers,
+        claim_mappings,
+        passthrough_routes,
+        mcp_auth_settings,
+    } = snap;
     match kind {
         "models" => {
-            snap.models.remove(id);
+            models.remove(id);
         }
         "api_keys" => {
-            snap.apikeys.remove(id);
+            apikeys.remove(id);
         }
         "provider_keys" => {
-            snap.provider_keys.remove(id);
+            provider_keys.remove(id);
         }
         "guardrails" => {
-            snap.guardrails.remove(id);
+            guardrails.remove(id);
         }
         "guardrail_attachments" => {
-            snap.guardrail_attachments.remove(id);
+            guardrail_attachments.remove(id);
         }
         "cache_policies" => {
-            snap.cache_policies.remove(id);
+            cache_policies.remove(id);
         }
         "observability_exporters" => {
-            snap.observability_exporters.remove(id);
+            observability_exporters.remove(id);
         }
         "rate_limit_policies" => {
-            snap.rate_limit_policies.remove(id);
+            rate_limit_policies.remove(id);
         }
         "mcp_servers" => {
-            snap.mcp_servers.remove(id);
+            mcp_servers.remove(id);
         }
         "mcp_policies" => {
-            snap.mcp_policies.remove(id);
+            mcp_policies.remove(id);
         }
         "a2a_agents" => {
-            snap.a2a_agents.remove(id);
+            a2a_agents.remove(id);
         }
         "oidc_providers" => {
-            snap.oidc_providers.remove(id);
+            oidc_providers.remove(id);
         }
         "claim_mappings" => {
-            snap.claim_mappings.remove(id);
+            claim_mappings.remove(id);
         }
         "passthrough_routes" => {
-            snap.passthrough_routes.remove(id);
+            passthrough_routes.remove(id);
         }
         "mcp_auth_settings" => {
-            snap.mcp_auth_settings.remove(id);
+            mcp_auth_settings.remove(id);
         }
         _ => {}
     }
@@ -2010,8 +2069,6 @@ mod tests {
             2,
             "the queued run should be one publish on top of the resync",
         );
-        // Every model row shares one generation stamp — they were merged
-        // into a single table mutation cycle, not six.
         assert_eq!(
             sup.config_status().metrics().reloads_total - reloads_before,
             1,
@@ -2019,9 +2076,85 @@ mod tests {
         );
     }
 
-    /// Coalescing must not change what the individual events decided.
+    /// A put after a delete of the same id must not be folded into the
+    /// staged snapshot that preceded the delete — the delete would then
+    /// remove the row the later put re-added, and it would be gone.
     #[tokio::test]
-    async fn a_batch_decides_exactly_what_the_events_decide_alone() {
+    async fn a_delete_breaks_the_run_of_puts_it_sits_between() {
+        let events: Vec<Result<WatchEvent, ProviderError>> = vec![
+            Ok(WatchEvent::Put(entry("/aisix/models/m-1", VALID_MODEL, 2))),
+            Ok(WatchEvent::Put(entry(
+                "/aisix/api_keys/k-1",
+                VALID_APIKEY,
+                3,
+            ))),
+            Ok(WatchEvent::Delete {
+                key: "/aisix/models/m-1".into(),
+                revision: 4,
+            }),
+            Ok(WatchEvent::Put(entry("/aisix/models/m-1", VALID_MODEL, 5))),
+            Ok(WatchEvent::Put(entry(
+                "/aisix/guardrails/g-1",
+                VALID_GUARDRAIL,
+                6,
+            ))),
+        ];
+        let provider = Arc::new(FakeProvider::new(vec![], 0).with_events(events));
+        let sup = Arc::new(Supervisor::new(provider, "/aisix"));
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        let _ = sup.cycle(&rx).await;
+
+        let snap = sup.handle().load();
+        assert_eq!(snap.models.len(), 1, "the put after the delete survived");
+        assert_eq!(snap.apikeys.len(), 1);
+        assert_eq!(snap.guardrails.len(), 1);
+    }
+
+    /// A delete for a key the gateway never held changes what
+    /// `/status/config` reports (the revision floor moved) and nothing
+    /// about the observed entry set — so it must not rewrite the on-disk
+    /// snapshot cache, which is what it did before the two were split.
+    #[tokio::test]
+    async fn a_delete_of_an_unknown_key_publishes_status_without_writing_the_cache() {
+        let provider = Arc::new(FakeProvider::new(vec![], 0));
+        let sup = Supervisor::new(provider, "/aisix");
+        sup.load_once().await.unwrap();
+        sup.await_pending_cache_writes().await;
+
+        assert!(
+            !sup.apply_events(&[PendingEvent::Delete {
+                key: "/aisix/models/never-existed",
+                revision: Some(99),
+            }])[0]
+        );
+
+        assert!(
+            sup.pending_writes.lock().unwrap().is_empty(),
+            "a cache write was spawned for a key that changed no state",
+        );
+        // Status WAS published: the revision floor the delete carried is
+        // what `/status/config` and the heartbeat now report.
+        let view = sup.config_status().view();
+        assert_eq!(view.source.observed_revision, Some(99));
+        assert_eq!(view.applied.unwrap().applied_revision, Some(99));
+
+        // A delete that DOES change state still writes.
+        assert!(sup.apply_put(&entry("/aisix/models/m-1", VALID_MODEL, 100)));
+        sup.await_pending_cache_writes().await;
+        assert!(
+            sup.apply_events(&[PendingEvent::Delete {
+                key: "/aisix/models/m-1",
+                revision: Some(101),
+            }])[0]
+        );
+        assert!(!sup.pending_writes.lock().unwrap().is_empty());
+    }
+
+    /// A decision that asks "does this row serve right now?" must see the
+    /// batch's own earlier events, which have not been published yet —
+    /// otherwise coalescing silently changes what the same events decide.
+    #[tokio::test]
+    async fn a_rejected_put_pins_the_accepted_put_before_it_in_the_same_batch() {
         let events: Vec<Result<WatchEvent, ProviderError>> = vec![
             Ok(WatchEvent::Put(entry("/aisix/models/m-1", VALID_MODEL, 2))),
             Ok(WatchEvent::Put(entry(

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -81,13 +81,20 @@ pub fn build_chain_from_snapshot(
     bedrock_endpoint_url: Option<&str>,
     embedder: &GuardrailEmbedderSlot,
 ) -> GuardrailChain {
-    build_chain_from_snapshot_reported(table, bedrock_endpoint_url, embedder).0
+    build_chain_from_snapshot_reported(
+        table,
+        bedrock_endpoint_url,
+        embedder,
+        &mut GuardrailInstances::default(),
+    )
+    .0
 }
 
 fn build_chain_from_snapshot_reported(
     table: &ResourceTable<DomainGuardrail>,
     bedrock_endpoint_url: Option<&str>,
     embedder: &GuardrailEmbedderSlot,
+    instances: &mut GuardrailInstances,
 ) -> (GuardrailChain, Vec<GuardrailBuildRejection>) {
     let mut chain: Vec<(String, Arc<dyn Guardrail>)> = Vec::new();
     // `applied` mirrors `chain` 1:1 — the `{kind, hook}` of each member that
@@ -103,7 +110,12 @@ fn build_chain_from_snapshot_reported(
         if !row.enabled {
             continue;
         }
-        match build_one(row, bedrock_endpoint_url, embedder) {
+        match instances.instance(
+            entry,
+            bedrock_endpoint_url,
+            embedder,
+            &mut BuildReuse::default(),
+        ) {
             Ok(Some(g)) => {
                 chain.push((row.name.clone(), g));
                 applied.push(applied_for(row));
@@ -113,18 +125,7 @@ fn build_chain_from_snapshot_reported(
                 // keyword list). Skip silently — operators see this
                 // shape when they're staging a rule.
             }
-            Err(err) => {
-                tracing::warn!(
-                    name = %row.name,
-                    id = %entry.id,
-                    error = %err,
-                    "skipping guardrail with invalid config",
-                );
-                rejected.push(GuardrailBuildRejection {
-                    id: entry.id.clone(),
-                    reason: err.status_reason(),
-                });
-            }
+            Err(rejection) => rejected.push(rejection),
         }
     }
 
@@ -185,6 +186,88 @@ fn applied_for(row: &DomainGuardrail) -> AppliedGuardrail {
     AppliedGuardrail {
         kind: row.config.kind_str().to_owned(),
         hook: row.hook_point.as_str().to_owned(),
+    }
+}
+
+/// Runtime guardrail instances kept across index/chain rebuilds.
+///
+/// One instance per guardrail ROW, shared by every attachment that
+/// references it and reused by the next build unless the row itself
+/// changed. Constructing a network-backed guardrail builds a
+/// `reqwest::Client`, and every one of those reloads the operating
+/// system's CA store; doing that once per attachment on every rebuild is
+/// what a rebuild actually costs (AISIX-Cloud#1542).
+///
+/// Row identity is the `Arc` the snapshot holds, not the etcd revision:
+/// the copy-on-write publish shares row `Arc`s with the previous
+/// snapshot, so an unchanged row is literally the same allocation, and
+/// that holds for the declarative resources file too, where revisions
+/// carry no meaning. The memo keeps its own `Arc` on each row it
+/// remembers, so an address can never be recycled underneath it.
+#[derive(Default)]
+struct GuardrailInstances {
+    by_id: std::collections::HashMap<String, MemoSlot>,
+}
+
+struct MemoSlot {
+    row: Arc<aisix_core::resource::ResourceEntry<DomainGuardrail>>,
+    outcome: Result<Option<Arc<dyn Guardrail>>, GuardrailBuildRejection>,
+}
+
+/// How much of a build was construction and how much was reuse. Logged so
+/// an operator (and the e2e suite) can see that an unrelated
+/// configuration write did not reconstruct anything.
+#[derive(Debug, Default, Clone, Copy)]
+struct BuildReuse {
+    constructed: usize,
+    reused: usize,
+}
+
+impl GuardrailInstances {
+    fn instance(
+        &mut self,
+        entry: &Arc<aisix_core::resource::ResourceEntry<DomainGuardrail>>,
+        bedrock_endpoint_url: Option<&str>,
+        embedder: &GuardrailEmbedderSlot,
+        reuse: &mut BuildReuse,
+    ) -> Result<Option<Arc<dyn Guardrail>>, GuardrailBuildRejection> {
+        if let Some(slot) = self.by_id.get(&entry.id) {
+            if Arc::ptr_eq(&slot.row, entry) {
+                reuse.reused += 1;
+                return slot.outcome.clone();
+            }
+        }
+        reuse.constructed += 1;
+        let outcome = match build_one(&entry.value, bedrock_endpoint_url, embedder) {
+            Ok(built) => Ok(built),
+            Err(err) => {
+                tracing::warn!(
+                    guardrail_id = %entry.id,
+                    name = %entry.value.name,
+                    error = %err,
+                    "skipping guardrail with invalid config",
+                );
+                Err(GuardrailBuildRejection {
+                    id: entry.id.clone(),
+                    reason: err.status_reason(),
+                })
+            }
+        };
+        self.by_id.insert(
+            entry.id.clone(),
+            MemoSlot {
+                row: Arc::clone(entry),
+                outcome: outcome.clone(),
+            },
+        );
+        outcome
+    }
+
+    /// Forget rows the snapshot no longer carries, so create/delete churn
+    /// cannot grow the memo without bound.
+    fn retain_present(&mut self, guardrails: &ResourceTable<DomainGuardrail>) {
+        self.by_id
+            .retain(|id, _| guardrails.get_by_id(id).is_some());
     }
 }
 
@@ -942,8 +1025,12 @@ pub struct LiveGuardrailChain {
 }
 
 struct Cache {
-    last_version: u64,
+    /// The `guardrails` table generation the cached chain was built
+    /// from — NOT the snapshot version, which moves on every published
+    /// write of any kind. See [`ResourceTable::generation`].
+    last_generation: u64,
     chain: Arc<GuardrailChain>,
+    instances: GuardrailInstances,
 }
 
 impl LiveGuardrailChain {
@@ -964,15 +1051,17 @@ impl LiveGuardrailChain {
         embedder: GuardrailEmbedderSlot,
         config_status: Option<ConfigStatus>,
     ) -> Arc<Self> {
-        // Read version before load so that a concurrent store() between
-        // the two reads causes current() to see a version bump and rebuild,
-        // rather than caching stale data under the new version.
-        let last_version = snapshot.version();
+        // The generation is read from the snapshot that is built from, so
+        // the two can never disagree — unlike a version read beside the
+        // load, which has to be ordered by hand.
         let snap = snapshot.load();
+        let last_generation = snap.guardrails.generation();
+        let mut instances = GuardrailInstances::default();
         let (chain, rejected) = build_chain_from_snapshot_reported(
             &snap.guardrails,
             bedrock_endpoint_url.as_deref(),
             &embedder,
+            &mut instances,
         );
         publish_build_rejections(config_status.as_ref(), rejected);
         Arc::new(Self {
@@ -981,28 +1070,33 @@ impl LiveGuardrailChain {
             embedder,
             config_status,
             cache: Mutex::new(Cache {
-                last_version,
+                last_generation,
                 chain: Arc::new(chain),
+                instances,
             }),
         })
     }
 
     fn current(&self) -> Arc<GuardrailChain> {
-        let cur_version = self.snapshot.version();
         let mut cache = self
             .cache
             .lock()
             .expect("LiveGuardrailChain mutex poisoned");
-        if cache.last_version != cur_version {
-            let snap = self.snapshot.load();
+        // Loaded under the lock, so the chain installed is always the one
+        // built from the newest snapshot any caller has seen and an older
+        // build can never replace a newer one.
+        let snap = self.snapshot.load();
+        let generation = snap.guardrails.generation();
+        if cache.last_generation != generation {
             let (chain, rejected) = build_chain_from_snapshot_reported(
                 &snap.guardrails,
                 self.bedrock_endpoint_url.as_deref(),
                 &self.embedder,
+                &mut cache.instances,
             );
             publish_build_rejections(self.config_status.as_ref(), rejected);
             cache.chain = Arc::new(chain);
-            cache.last_version = cur_version;
+            cache.last_generation = generation;
         }
         Arc::clone(&cache.chain)
     }
@@ -1111,7 +1205,14 @@ pub fn build_index_from_snapshot(
     bedrock_endpoint_url: Option<&str>,
     embedder: &GuardrailEmbedderSlot,
 ) -> GuardrailIndex {
-    build_index_from_snapshot_reported(guardrails, attachments, bedrock_endpoint_url, embedder).0
+    build_index_from_snapshot_reported(
+        guardrails,
+        attachments,
+        bedrock_endpoint_url,
+        embedder,
+        &mut GuardrailInstances::default(),
+    )
+    .0
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1128,9 +1229,11 @@ fn build_index_from_snapshot_reported(
     attachments: &ResourceTable<GuardrailAttachment>,
     bedrock_endpoint_url: Option<&str>,
     embedder: &GuardrailEmbedderSlot,
-) -> (GuardrailIndex, Vec<GuardrailBuildRejection>) {
+    instances: &mut GuardrailInstances,
+) -> (GuardrailIndex, Vec<GuardrailBuildRejection>, BuildReuse) {
     let mut entries = Vec::new();
     let mut rejected = BTreeMap::<String, GuardrailBuildRejection>::new();
+    let mut reuse = BuildReuse::default();
 
     // Deterministic attachment order: `GuardrailIndex::new` sorts by
     // (priority desc, scope-specificity desc) with a STABLE sort, so
@@ -1165,24 +1268,18 @@ fn build_index_from_snapshot_reported(
             continue;
         }
 
-        let runtime_guardrail = match build_one(row, bedrock_endpoint_url, embedder) {
-            Ok(Some(g)) => g,
-            Ok(None) => continue, // inert (e.g. empty keyword list)
-            Err(err) => {
-                tracing::warn!(
-                    guardrail_id = %gid,
-                    error = %err,
-                    "skipping guardrail with invalid config in index build",
-                );
-                rejected
-                    .entry(gid.clone())
-                    .or_insert_with(|| GuardrailBuildRejection {
-                        id: gid.clone(),
-                        reason: err.status_reason(),
-                    });
-                continue;
-            }
-        };
+        // One instance per ROW, shared by all its attachments: `build_one`
+        // reads only the row, and everything the attachment contributes
+        // (scope, priority) lands on the index entry below.
+        let runtime_guardrail =
+            match instances.instance(&guardrail_arc, bedrock_endpoint_url, embedder, &mut reuse) {
+                Ok(Some(g)) => g,
+                Ok(None) => continue, // inert (e.g. empty keyword list)
+                Err(rejection) => {
+                    rejected.entry(gid.clone()).or_insert(rejection);
+                    continue;
+                }
+            };
 
         let scope_kind = match attachment.scope_type {
             GuardrailScopeType::Env => ScopeKind::Env,
@@ -1204,9 +1301,11 @@ fn build_index_from_snapshot_reported(
         ));
     }
 
+    instances.retain_present(guardrails);
     (
         GuardrailIndex::from_entries(entries),
         rejected.into_values().collect(),
+        reuse,
     )
 }
 
@@ -1507,11 +1606,32 @@ pub struct LiveGuardrailIndex {
     /// `/status/config` and the managed heartbeat.
     config_status: Option<ConfigStatus>,
     cache: Mutex<IndexCache>,
+    /// Index builds this instance has run. The observable behind the
+    /// invalidation and single-flight contracts — "an unrelated
+    /// configuration write did not rebuild anything" has no other
+    /// externally visible form.
+    rebuilds: std::sync::atomic::AtomicU64,
 }
 
 struct IndexCache {
-    last_version: u64,
+    /// The `(guardrails, guardrail_attachments)` table generations the
+    /// cached index was built from. Keying on these instead of the
+    /// snapshot version is the whole point: the version moves on every
+    /// published write of ANY kind, so an API-key edit used to invalidate
+    /// the index and make the next request on each worker thread rebuild
+    /// every enabled attachment synchronously (AISIX-Cloud#1542).
+    last_key: (u64, u64),
     index: Arc<GuardrailIndex>,
+    instances: GuardrailInstances,
+}
+
+/// The invalidation key for [`IndexCache`]: the generations of exactly
+/// the two tables [`build_index_from_snapshot_reported`] reads.
+fn index_key(snap: &AisixSnapshot) -> (u64, u64) {
+    (
+        snap.guardrails.generation(),
+        snap.guardrail_attachments.generation(),
+    )
 }
 
 impl LiveGuardrailIndex {
@@ -1548,14 +1668,15 @@ impl LiveGuardrailIndex {
         embedder: GuardrailEmbedderSlot,
         config_status: Option<ConfigStatus>,
     ) -> Arc<Self> {
-        // Read version before load — same ordering discipline as LiveGuardrailChain.
-        let last_version = snapshot.version();
         let snap = snapshot.load();
-        let (index, rejected) = build_index_from_snapshot_reported(
+        let last_key = index_key(&snap);
+        let mut instances = GuardrailInstances::default();
+        let (index, rejected, _) = build_index_from_snapshot_reported(
             &snap.guardrails,
             &snap.guardrail_attachments,
             bedrock_endpoint_url.as_deref(),
             &embedder,
+            &mut instances,
         );
         publish_build_rejections(config_status.as_ref(), rejected);
         Arc::new(Self {
@@ -1565,66 +1686,79 @@ impl LiveGuardrailIndex {
             metrics_sink,
             config_status,
             cache: Mutex::new(IndexCache {
-                last_version,
+                last_key,
                 index: Arc::new(index),
+                instances,
             }),
+            rebuilds: std::sync::atomic::AtomicU64::new(1),
         })
     }
 
-    fn current(&self) -> Arc<GuardrailIndex> {
-        loop {
-            let build_version = self.snapshot.version();
-
-            // Fast path: return cached index without building.
-            {
-                let cache = self
-                    .cache
-                    .lock()
-                    .expect("LiveGuardrailIndex mutex poisoned");
-                if cache.last_version >= build_version {
-                    return Arc::clone(&cache.index);
-                }
-            }
-
-            // Build outside the lock. A snapshot swap during this work makes
-            // the result obsolete; try_install_index rejects it and the loop
-            // retries from the newer version.
-            let snap = self.snapshot.load();
-            if self.snapshot.version() != build_version {
-                continue;
-            }
-            let (new_index, rejected) = build_index_from_snapshot_reported(
-                &snap.guardrails,
-                &snap.guardrail_attachments,
-                self.bedrock_endpoint_url.as_deref(),
-                &self.embedder,
-            );
-            if let Some(index) = self.try_install_index(build_version, new_index, rejected) {
-                return index;
-            }
-        }
+    /// Index builds run so far, the first (in the constructor) included.
+    #[cfg(test)]
+    fn rebuilds(&self) -> u64 {
+        self.rebuilds.load(std::sync::atomic::Ordering::Relaxed)
     }
 
-    /// Install a completed build only when it is still the newest snapshot.
-    /// Publishing status while holding the same cache lock makes cache and
-    /// rejection state advance in one monotonic version order.
-    fn try_install_index(
-        &self,
-        build_version: u64,
-        new_index: GuardrailIndex,
-        rejected: Vec<GuardrailBuildRejection>,
-    ) -> Option<Arc<GuardrailIndex>> {
+    /// The index for the current snapshot, rebuilding it only when the
+    /// guardrail or attachment tables actually changed.
+    ///
+    /// Bounded: one build per call at most, and no retry loop. The build
+    /// runs under the cache lock, which single-flights it — concurrent
+    /// callers on every worker thread used to each run their own — and
+    /// makes the install trivially monotonic, because the snapshot a
+    /// build reads is loaded while holding that same lock and `load`
+    /// never goes backwards. The previous shape read the version outside
+    /// the lock, discarded any build whose snapshot moved underneath it,
+    /// and started over with no bound on the number of attempts; a bulk
+    /// configuration edit kept that loop going while the worker's
+    /// current-thread runtime could not schedule anything else, `/livez`
+    /// included (AISIX-Cloud#1542).
+    fn current(&self) -> Arc<GuardrailIndex> {
+        let key = index_key(&self.snapshot.load());
+        {
+            let cache = self
+                .cache
+                .lock()
+                .expect("LiveGuardrailIndex mutex poisoned");
+            if cache.last_key == key {
+                return Arc::clone(&cache.index);
+            }
+        }
+
         let mut cache = self
             .cache
             .lock()
             .expect("LiveGuardrailIndex mutex poisoned");
-        if cache.last_version >= build_version || self.snapshot.version() != build_version {
-            return None;
+        let snap = self.snapshot.load();
+        let key = index_key(&snap);
+        if cache.last_key == key {
+            return Arc::clone(&cache.index);
         }
+        let cache = &mut *cache;
+        let (new_index, rejected, reuse) = build_index_from_snapshot_reported(
+            &snap.guardrails,
+            &snap.guardrail_attachments,
+            self.bedrock_endpoint_url.as_deref(),
+            &self.embedder,
+            &mut cache.instances,
+        );
+        tracing::info!(
+            guardrails = snap.guardrails.len(),
+            attachments = snap.guardrail_attachments.len(),
+            entries = new_index.len(),
+            constructed = reuse.constructed,
+            reused = reuse.reused,
+            "guardrail index rebuilt",
+        );
         cache.index = Arc::new(new_index);
-        cache.last_version = build_version;
+        cache.last_key = key;
+        self.rebuilds
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // Published under the same lock so the cache and the reported
+        // rejection state advance together.
         publish_build_rejections(self.config_status.as_ref(), rejected);
-        Some(Arc::clone(&cache.index))
+        Arc::clone(&cache.index)
     }
 
     /// Resolve the guardrail chain applicable to `ctx`.
@@ -3676,7 +3810,14 @@ mod tests {
     }
 
     #[test]
-    fn older_index_build_cannot_restore_a_superseded_rejection() {
+    fn concurrent_resolves_run_one_build_and_publish_the_newest_snapshot() {
+        // Every worker thread resolves through the same index. Before
+        // AISIX-Cloud#1542 each of them ran its own build on the first
+        // request after any snapshot change, and a build whose snapshot
+        // moved underneath it was thrown away and restarted with no
+        // bound — which is also how an obsolete rejection could be
+        // republished over a newer one. The build now runs under the
+        // cache lock, from a snapshot loaded while holding it.
         let broken = AisixSnapshot::new();
         broken.guardrails.insert(entry(
             "broken",
@@ -3688,7 +3829,6 @@ mod tests {
             parse_attachment(r#"{"guardrail_id":"g-1","scope_type":"env","priority":0}"#),
         ));
         let handle = SnapshotHandle::new(broken);
-        let old_version = handle.version();
         let status = ConfigStatus::new(aisix_core::SourceKind::Etcd);
         status.record_load(aisix_core::LoadObservation {
             source_hash: "old".into(),
@@ -3713,6 +3853,7 @@ mod tests {
             Some(status.clone()),
         );
         assert_eq!(status.view().rejected.len(), 1);
+        assert_eq!(live.rebuilds(), 1);
 
         let fixed = AisixSnapshot::new();
         fixed.guardrails.insert(entry(
@@ -3727,7 +3868,6 @@ mod tests {
             parse_attachment(r#"{"guardrail_id":"g-1","scope_type":"env","priority":0}"#),
         ));
         handle.store(fixed);
-        let new_version = handle.version();
         status.record_load(aisix_core::LoadObservation {
             source_hash: "new".into(),
             observed_revision: Some(2),
@@ -3744,41 +3884,149 @@ mod tests {
             wholly_rejected: false,
         });
 
-        // Hold the old result until the newer build has installed, then let
-        // it race the cache/status publication in the previously-buggy order.
-        let (release_old, wait_old) = std::sync::mpsc::channel();
-        let old_live = Arc::clone(&live);
-        let old = std::thread::spawn(move || {
-            wait_old.recv().unwrap();
-            old_live.try_install_index(
-                old_version,
-                GuardrailIndex::from_entries(Vec::new()),
-                vec![GuardrailBuildRejection {
-                    id: "g-1".into(),
-                    reason: "obsolete rejection".into(),
-                }],
-            )
-        });
+        let start = Arc::new(std::sync::Barrier::new(8));
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let live = Arc::clone(&live);
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    live.current().len()
+                })
+            })
+            .collect();
+        for t in threads {
+            assert_eq!(t.join().unwrap(), 1);
+        }
 
-        let snap = handle.load();
-        let (new_index, new_rejected) = build_index_from_snapshot_reported(
-            &snap.guardrails,
-            &snap.guardrail_attachments,
-            None,
-            &GuardrailEmbedderSlot::none(),
-        );
-        assert!(live
-            .try_install_index(new_version, new_index, new_rejected)
-            .is_some());
-        release_old.send(()).unwrap();
-        assert!(old.join().unwrap().is_none());
-
+        // Eight callers, one build.
+        assert_eq!(live.rebuilds(), 2);
         let view = status.view();
         assert!(
             view.rejected.is_empty(),
             "obsolete result restored: {view:?}"
         );
         assert_eq!(view.applied.unwrap().config_hash, "new");
+    }
+
+    #[test]
+    fn a_write_to_an_unrelated_table_does_not_rebuild_the_index() {
+        // The bug AISIX-Cloud#1542 reported: one API key edit bumped the
+        // single global snapshot version, so the next request on every
+        // worker thread rebuilt every enabled attachment's runtime
+        // instance — one `reqwest::Client` each, each reloading the
+        // system CA store.
+        let snap = AisixSnapshot::new();
+        snap.guardrails.insert(entry(
+            "kw",
+            "g-1",
+            parse(
+                r#"{"name":"kw","kind":"keyword","patterns":[{"kind":"literal","value":"AKIA"}]}"#,
+            ),
+        ));
+        snap.guardrail_attachments.insert(attachment_entry(
+            "a-1",
+            parse_attachment(r#"{"guardrail_id":"g-1","scope_type":"env","priority":0}"#),
+        ));
+        let handle = SnapshotHandle::new(snap);
+        let live = LiveGuardrailIndex::new(handle.clone(), None);
+        let first = live.current();
+        assert_eq!(live.rebuilds(), 1);
+
+        // A published write to a table the index does not read. The
+        // structural clone shares the guardrail rows, so their table's
+        // generation rides along unchanged.
+        for _ in 0..5 {
+            let next = handle.load().as_ref().clone();
+            next.apikeys
+                .insert(aisix_core::resource::ResourceEntry::new(
+                    "k-1",
+                    serde_json::from_str::<aisix_core::models::ApiKey>(
+                        r#"{"key_hash":"abc","allowed_models":["m"]}"#,
+                    )
+                    .unwrap(),
+                    1,
+                ));
+            handle.store(next);
+        }
+
+        assert!(handle.version() > 0);
+        assert!(Arc::ptr_eq(&first, &live.current()));
+        assert_eq!(live.rebuilds(), 1);
+    }
+
+    #[test]
+    fn an_attachment_write_rebuilds_the_index_but_reuses_unchanged_instances() {
+        let snap = AisixSnapshot::new();
+        for i in 1..=3 {
+            snap.guardrails.insert(entry(
+                &format!("kw-{i}"),
+                &format!("g-{i}"),
+                parse(&format!(
+                    r#"{{"name":"kw-{i}","kind":"keyword","patterns":[{{"kind":"literal","value":"AKIA{i}"}}]}}"#
+                )),
+            ));
+            snap.guardrail_attachments.insert(attachment_entry(
+                &format!("a-{i}"),
+                parse_attachment(&format!(
+                    r#"{{"guardrail_id":"g-{i}","scope_type":"env","priority":0}}"#
+                )),
+            ));
+        }
+        let handle = SnapshotHandle::new(snap);
+        let live = LiveGuardrailIndex::new(handle.clone(), None);
+        let before = live.current();
+        assert_eq!(before.len(), 3);
+        let members_before = before.instances();
+
+        // A fourth attachment onto an existing guardrail: the index has
+        // to change, the three instances behind it must not.
+        let next = handle.load().as_ref().clone();
+        next.guardrail_attachments.insert(attachment_entry(
+            "a-4",
+            parse_attachment(r#"{"guardrail_id":"g-1","scope_type":"env","priority":1}"#),
+        ));
+        handle.store(next);
+
+        let after = live.current();
+        assert_eq!(after.len(), 4);
+        assert_eq!(live.rebuilds(), 2);
+        let members_after = after.instances();
+        for member in &members_before {
+            assert!(
+                members_after.iter().any(|m| Arc::ptr_eq(m, member)),
+                "an unchanged guardrail row was reconstructed",
+            );
+        }
+
+        // Now change one row's content: that one — and only that one —
+        // is reconstructed.
+        let next = handle.load().as_ref().clone();
+        next.guardrails.insert(entry(
+            "kw-2",
+            "g-2",
+            parse(r#"{"name":"kw-2","kind":"keyword","patterns":[{"kind":"literal","value":"SECRET"}]}"#),
+        ));
+        handle.store(next);
+
+        let changed = live.current();
+        let changed_members = changed.instances();
+        let g2_before = before
+            .instance_for("g-2")
+            .expect("g-2 in the pre-change index")
+            .clone();
+        assert!(
+            !changed_members.iter().any(|m| Arc::ptr_eq(m, &g2_before)),
+            "the changed guardrail row kept its old instance",
+        );
+        let g1_before = before
+            .instance_for("g-1")
+            .expect("g-1 in the pre-change index")
+            .clone();
+        assert!(
+            changed_members.iter().any(|m| Arc::ptr_eq(m, &g1_before)),
+            "an unchanged guardrail row was reconstructed",
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -129,6 +129,7 @@ fn build_chain_from_snapshot_reported(
         }
     }
 
+    instances.retain_present(table);
     (GuardrailChain::new_with_applied(chain, applied), rejected)
 }
 
@@ -1000,17 +1001,16 @@ impl Guardrail for MonitorGuardrail {
     }
 }
 
-/// Adapter that wraps a snapshot handle and rebuilds the runtime
-/// chain whenever the snapshot pointer changes. The chat handler
-/// holds an `Arc<dyn Guardrail>` pointing at this; it never sees
-/// the rebuild.
+/// Adapter that wraps a snapshot handle and rebuilds the runtime chain
+/// whenever the `guardrails` table changes. The chat handler holds an
+/// `Arc<dyn Guardrail>` pointing at this; it never sees the rebuild.
 ///
-/// Cheap path (cache hit): one atomic load + one pointer compare,
-/// then a clone of an `Arc<GuardrailChain>`. Rebuild path (cache
-/// miss): runs through the entries table and recompiles regexes.
-/// Compilation only happens on the first call after each snapshot
-/// store from the etcd supervisor — typical run is one or zero
-/// rebuilds per minute even on a chatty configuration.
+/// Cheap path (cache hit): one snapshot load + one generation compare,
+/// then a clone of an `Arc<GuardrailChain>`. Rebuild path (cache miss):
+/// runs through the entries table, reusing the runtime instance of every
+/// row whose content did not change. Keyed on
+/// [`ResourceTable::generation`] and NOT on the snapshot version, so a
+/// write to any other resource kind rebuilds nothing (AISIX-Cloud#1542).
 ///
 /// `bedrock_endpoint_url` is captured at construct time and reused
 /// on every rebuild; this is a deployment-wide setting (sourced
@@ -1547,10 +1547,12 @@ fn presence_timestamps(
 ///     so nothing rebuilds, so nothing is said.
 ///
 /// Riding the build also put the emit on the request path, where
-/// `LiveGuardrailIndex::current()` builds outside the lock and every request
-/// arriving during one rebuild runs its own — which is how the original
+/// `LiveGuardrailIndex::current()` built outside the lock and every request
+/// arriving during one rebuild ran its own — which is how the original
 /// "seen in two consecutive builds" rule managed to see two builds inside a
-/// single snapshot version.
+/// single snapshot version. That build is single-flighted now
+/// (AISIX-Cloud#1542), but the timer is what makes the two cases above
+/// reportable at all, so it stays.
 pub fn sweep_unattached_guardrails(
     guardrails: &ResourceTable<DomainGuardrail>,
     attachments: &ResourceTable<GuardrailAttachment>,
@@ -1585,14 +1587,17 @@ pub fn sweep_unattached_guardrails(
 // LiveGuardrailIndex — lazy-rebuild adapter over a snapshot handle
 // ---------------------------------------------------------------------------
 
-/// Wraps a snapshot handle and rebuilds the runtime index whenever the
-/// snapshot pointer changes. The proxy chat handler calls `resolve(ctx)`
-/// on each request to get the applicable `GuardrailChain`.
+/// Wraps a snapshot handle and rebuilds the runtime index when — and only
+/// when — the `guardrails` or `guardrail_attachments` table changes. The
+/// endpoint handlers call `resolve(ctx)` on each request to get the
+/// applicable `GuardrailChain`.
 ///
-/// Rebuild semantics are identical to `LiveGuardrailChain`: one atomic
-/// load + one version compare on the hot path; a full index build (linear
-/// in the number of attachment rows) only on the first call after each
-/// snapshot swap.
+/// Hot path: one snapshot load, one generation-pair compare, one `Arc`
+/// clone. A rebuild walks the attachment rows and constructs a runtime
+/// instance only for guardrail rows whose content changed, single-flighted
+/// across every worker thread. Keying on the tables the build reads,
+/// rather than on the snapshot version, is what keeps an unrelated
+/// configuration write off the request path (AISIX-Cloud#1542).
 pub struct LiveGuardrailIndex {
     snapshot: SnapshotHandle<AisixSnapshot>,
     bedrock_endpoint_url: Option<String>,

--- a/crates/aisix-guardrails/src/index.rs
+++ b/crates/aisix-guardrails/src/index.rs
@@ -235,6 +235,28 @@ impl GuardrailIndex {
     pub(crate) fn from_entries(entries: Vec<IndexEntry>) -> Self {
         Self::new(entries)
     }
+
+    /// The runtime instance behind the first entry for `guardrail_id`.
+    /// Instance identity is what proves a row was, or was not,
+    /// reconstructed across an index rebuild.
+    #[cfg(test)]
+    pub(crate) fn instance_for(&self, guardrail_id: &str) -> Option<&Arc<dyn Guardrail>> {
+        self.entries
+            .iter()
+            .find(|e| e.guardrail_id == guardrail_id)
+            .map(|e| &e.guardrail)
+    }
+
+    /// One entry per attachment, so a guardrail with several attachments
+    /// appears several times — deliberately: sharing ONE instance across
+    /// them is the property under test.
+    #[cfg(test)]
+    pub(crate) fn instances(&self) -> Vec<Arc<dyn Guardrail>> {
+        self.entries
+            .iter()
+            .map(|e| Arc::clone(&e.guardrail))
+            .collect()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -365,6 +365,7 @@ impl McpGateway {
         snapshot: &AisixSnapshot,
         client_headers: Option<&http::HeaderMap>,
     ) -> Self {
+        crate::openapi::sweep_tool_cache(&snapshot.mcp_servers);
         let upstreams = snapshot
             .mcp_servers
             .entries()
@@ -408,6 +409,7 @@ impl McpGateway {
         server: &str,
         client_headers: Option<&http::HeaderMap>,
     ) -> Option<Self> {
+        crate::openapi::sweep_tool_cache(&snapshot.mcp_servers);
         let entry = snapshot.mcp_servers.get_by_name(server)?;
         if !entry.value.enabled {
             return None;

--- a/crates/aisix-mcp/src/openapi.rs
+++ b/crates/aisix-mcp/src/openapi.rs
@@ -19,10 +19,11 @@
 //! runtime): the control plane validates and materializes it at write time, so
 //! the tool set only changes when the resource does.
 
-use std::collections::HashSet;
-use std::sync::{Arc, OnceLock};
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
+use aisix_core::snapshot::ResourceTable;
 use aisix_core::{McpAuthType, McpServer, ResourceEntry};
 use async_trait::async_trait;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
@@ -149,11 +150,36 @@ impl OpenApiBridge {
         &self.entry.value
     }
 
-    fn tools(&self) -> Result<Vec<GeneratedTool>, McpError> {
+    /// This server's tool set, generated once per row version.
+    ///
+    /// The aggregating `/mcp` endpoint builds a bridge per enabled server
+    /// per request, and both `tools/list` and `tools/call` ask for the
+    /// tools — so without this every call walked every registered
+    /// server's whole OpenAPI document, resolving `$ref`s and building a
+    /// JSON Schema per operation (AISIX-Cloud#1542).
+    fn tools(&self) -> Result<Arc<Vec<GeneratedTool>>, McpError> {
         let spec = self.server().spec.as_ref().ok_or_else(|| {
             McpError::Request("openapi server has no spec configured".to_string())
         })?;
-        generate_tools(spec)
+        let mut cache = tool_cache();
+        if let Some(cached) = cache.by_id.get(&self.entry.id) {
+            // Row identity is the snapshot's `Arc`: a copy-on-write
+            // publish shares rows it did not change, so the same
+            // allocation means the same spec. The cache keeps its own
+            // `Arc`, so the address cannot be recycled underneath it.
+            if Arc::ptr_eq(&cached.row, &self.entry) {
+                return Ok(Arc::clone(&cached.tools));
+            }
+        }
+        let tools = Arc::new(generate_tools(spec)?);
+        cache.by_id.insert(
+            self.entry.id.clone(),
+            CachedTools {
+                row: Arc::clone(&self.entry),
+                tools: Arc::clone(&tools),
+            },
+        );
+        Ok(tools)
     }
 
     /// Inject the gateway-held credential for this server. For `oauth2` this
@@ -294,16 +320,54 @@ fn tool_error(text: String) -> McpToolResult {
     }
 }
 
+/// Tool sets generated from `type: openapi` rows, keyed by the row's
+/// etcd id and shared across every per-request bridge in the process.
+static TOOL_CACHE: OnceLock<Mutex<ToolCache>> = OnceLock::new();
+
+#[derive(Default)]
+struct ToolCache {
+    /// The `mcp_servers` table generation the map was last swept against.
+    swept: Option<u64>,
+    by_id: HashMap<String, CachedTools>,
+}
+
+struct CachedTools {
+    row: Arc<ResourceEntry<McpServer>>,
+    tools: Arc<Vec<GeneratedTool>>,
+}
+
+fn tool_cache() -> std::sync::MutexGuard<'static, ToolCache> {
+    TOOL_CACHE
+        .get_or_init(|| Mutex::new(ToolCache::default()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Forget cached tool sets for servers the snapshot no longer carries.
+///
+/// Called where a snapshot is in hand — the bridge itself only ever sees
+/// its own row. Cheap when nothing changed: a create/delete moves the
+/// `mcp_servers` generation and nothing else does.
+pub(crate) fn sweep_tool_cache(servers: &ResourceTable<McpServer>) {
+    let generation = servers.generation();
+    let mut cache = tool_cache();
+    if cache.swept == Some(generation) {
+        return;
+    }
+    cache.by_id.retain(|id, _| servers.get_by_id(id).is_some());
+    cache.swept = Some(generation);
+}
+
 #[async_trait]
 impl McpBridge for OpenApiBridge {
     async fn list_tools(&self) -> Result<Vec<McpTool>, McpError> {
         Ok(self
             .tools()?
-            .into_iter()
+            .iter()
             .map(|t| McpTool {
-                name: t.name,
-                description: Some(t.description),
-                input_schema: t.input_schema,
+                name: t.name.clone(),
+                description: Some(t.description.clone()),
+                input_schema: t.input_schema.clone(),
             })
             .collect())
     }
@@ -842,6 +906,60 @@ mod tests {
             .iter()
             .find(|t| t.name == name)
             .unwrap_or_else(|| panic!("tool {name} not generated"))
+    }
+
+    fn openapi_server(id: &str, path: &str) -> Arc<ResourceEntry<McpServer>> {
+        let server: McpServer = serde_json::from_value(json!({
+            "name": format!("srv-{id}"),
+            "type": "openapi",
+            "url": "http://127.0.0.1:1/",
+            "spec": {
+                "openapi": "3.0.0",
+                "paths": { path: { "get": { "operationId": "listItems" } } }
+            }
+        }))
+        .expect("test mcp_server");
+        Arc::new(ResourceEntry::new(id, server, 1))
+    }
+
+    fn server_table(entries: &[Arc<ResourceEntry<McpServer>>]) -> ResourceTable<McpServer> {
+        let table = ResourceTable::new();
+        for e in entries {
+            table.insert_arc(Arc::clone(e));
+        }
+        table
+    }
+
+    /// The aggregating `/mcp` endpoint builds a bridge per enabled server
+    /// per REQUEST, and both `tools/list` and `tools/call` ask for the
+    /// tool set — so regenerating it from the spec each time made one
+    /// call cost a walk of every registered document (AISIX-Cloud#1542).
+    #[test]
+    fn tool_generation_is_cached_per_row_and_evicted_with_it() {
+        let row = openapi_server("cache-row-1", "/items");
+        let table = server_table(&[Arc::clone(&row)]);
+        sweep_tool_cache(&table);
+
+        // Two bridges, as two requests would build them.
+        let first = OpenApiBridge::new(Arc::clone(&row)).tools().unwrap();
+        let second = OpenApiBridge::new(Arc::clone(&row)).tools().unwrap();
+        assert!(Arc::ptr_eq(&first, &second), "the tool set was regenerated");
+        assert_eq!(first[0].name, "listitems");
+
+        // A rewritten row is a different `Arc`: regenerate.
+        let rewritten = openapi_server("cache-row-1", "/things");
+        let after_write = OpenApiBridge::new(Arc::clone(&rewritten)).tools().unwrap();
+        assert!(!Arc::ptr_eq(&first, &after_write));
+        assert_eq!(after_write[0].path, "/things");
+
+        // Deleting the row evicts it, so the map cannot grow under
+        // create/delete churn.
+        sweep_tool_cache(&server_table(&[]));
+        let after_delete = OpenApiBridge::new(Arc::clone(&rewritten)).tools().unwrap();
+        assert!(
+            !Arc::ptr_eq(&after_write, &after_delete),
+            "the deleted row was still cached",
+        );
     }
 
     #[test]

--- a/crates/aisix-mcp/src/openapi.rs
+++ b/crates/aisix-mcp/src/openapi.rs
@@ -161,6 +161,12 @@ impl OpenApiBridge {
         let spec = self.server().spec.as_ref().ok_or_else(|| {
             McpError::Request("openapi server has no spec configured".to_string())
         })?;
+        // Generation runs under the lock. It is one lock for every
+        // registered server, so the first concurrent burst after a spec
+        // changes serialises on it — still strictly less total work than
+        // regenerating per request, which is what happened before, and a
+        // generate-outside-then-double-check dance would trade that for
+        // duplicate generations under the same race.
         let mut cache = tool_cache();
         if let Some(cached) = cache.by_id.get(&self.entry.id) {
             // Row identity is the snapshot's `Arc`: a copy-on-write
@@ -934,6 +940,11 @@ mod tests {
     /// per REQUEST, and both `tools/list` and `tools/call` ask for the
     /// tool set — so regenerating it from the spec each time made one
     /// call cost a walk of every registered document (AISIX-Cloud#1542).
+    // Uses ids of its own: `TOOL_CACHE` is process-wide, and
+    // `sweep_tool_cache` with a table that does not carry a row evicts it.
+    // A second test in THIS crate's lib-test binary that reaches the cache
+    // (anything going through `McpGateway::from_snapshot*`) would have to
+    // coordinate with this one; today there is none.
     #[test]
     fn tool_generation_is_cached_per_row_and_evicted_with_it() {
         let row = openapi_server("cache-row-1", "/items");

--- a/crates/aisix-mcp/src/openapi.rs
+++ b/crates/aisix-mcp/src/openapi.rs
@@ -161,23 +161,22 @@ impl OpenApiBridge {
         let spec = self.server().spec.as_ref().ok_or_else(|| {
             McpError::Request("openapi server has no spec configured".to_string())
         })?;
-        // Generation runs under the lock. It is one lock for every
-        // registered server, so the first concurrent burst after a spec
-        // changes serialises on it — still strictly less total work than
-        // regenerating per request, which is what happened before, and a
-        // generate-outside-then-double-check dance would trade that for
-        // duplicate generations under the same race.
-        let mut cache = tool_cache();
-        if let Some(cached) = cache.by_id.get(&self.entry.id) {
-            // Row identity is the snapshot's `Arc`: a copy-on-write
-            // publish shares rows it did not change, so the same
-            // allocation means the same spec. The cache keeps its own
-            // `Arc`, so the address cannot be recycled underneath it.
-            if Arc::ptr_eq(&cached.row, &self.entry) {
-                return Ok(Arc::clone(&cached.tools));
-            }
+        // Row identity is the snapshot's `Arc`: a copy-on-write publish
+        // shares rows it did not change, so the same allocation means the
+        // same spec. The cache keeps its own `Arc`, so the address cannot
+        // be recycled underneath it.
+        if let Some(hit) = lookup_tools(&self.entry) {
+            return Ok(hit);
         }
+        // Generated with the lock RELEASED. One lock serves every
+        // registered server, so holding it across the spec walk would
+        // make one server's miss block every other server's hit — and a
+        // write that replaces one row makes the aggregating endpoint's
+        // concurrent requests all miss at once. The cost is that a race
+        // may generate the same tool set twice; the second insert simply
+        // replaces the first, and both are equal.
         let tools = Arc::new(generate_tools(spec)?);
+        let mut cache = tool_cache();
         cache.by_id.insert(
             self.entry.id.clone(),
             CachedTools {
@@ -340,6 +339,14 @@ struct ToolCache {
 struct CachedTools {
     row: Arc<ResourceEntry<McpServer>>,
     tools: Arc<Vec<GeneratedTool>>,
+}
+
+/// The cached tool set for `entry`, if this exact row version has one.
+/// Holds the lock only long enough to read it.
+fn lookup_tools(entry: &Arc<ResourceEntry<McpServer>>) -> Option<Arc<Vec<GeneratedTool>>> {
+    let cache = tool_cache();
+    let cached = cache.by_id.get(&entry.id)?;
+    Arc::ptr_eq(&cached.row, entry).then(|| Arc::clone(&cached.tools))
 }
 
 fn tool_cache() -> std::sync::MutexGuard<'static, ToolCache> {

--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -433,16 +433,29 @@ impl Entry {
 /// byte-identical behavior. Only when none holds do the trackers take the
 /// cheap read-first paths — writes whose consumers provably don't exist.
 ///
-/// The predicate set is recomputed at most once per snapshot version
-/// (packed with the version into one atomic so the pair can never be
-/// observed torn). A racing store between the version read and the table
-/// walk can cache bits against a stale version; the next call detects the
-/// mismatch and recomputes, so the value converges immediately.
+/// Two tiers, both packed with their key into one atomic so a pair can
+/// never be observed torn. The hot tier is keyed on the snapshot version:
+/// one relaxed load answers "nothing has changed at all". When that
+/// misses, the `models` table generation answers "nothing THIS reads has
+/// changed" — a write to any other resource kind then costs one snapshot
+/// load and restamps the hot tier rather than rescanning every model.
+/// Before AISIX-Cloud#1542 the version was the only key, so every API-key
+/// edit rescanned the whole model table on the next request.
+///
+/// A racing store between a key read and the table walk can cache bits
+/// against a stale key; the next call detects the mismatch and
+/// recomputes, so the value converges immediately.
 #[derive(Debug)]
 pub struct BookkeepingFlags {
     snapshot: SnapshotHandle<AisixSnapshot>,
     /// `(snapshot version << 3) | predicate bits`, or [`UNCOMPUTED`].
     packed: AtomicU64,
+    /// `(models table generation << 3) | predicate bits`, or
+    /// [`UNCOMPUTED`].
+    packed_by_generation: AtomicU64,
+    /// Walks of the model table. The observable behind "an unrelated
+    /// configuration write does not rescan every model".
+    scans: AtomicU64,
 }
 
 const FLAG_LEAST_BUSY: u64 = 1;
@@ -456,6 +469,8 @@ impl BookkeepingFlags {
         Arc::new(Self {
             snapshot,
             packed: AtomicU64::new(UNCOMPUTED),
+            packed_by_generation: AtomicU64::new(UNCOMPUTED),
+            scans: AtomicU64::new(0),
         })
     }
 
@@ -465,6 +480,12 @@ impl BookkeepingFlags {
         self.bits() != 0
     }
 
+    /// Model-table walks run so far.
+    #[cfg(test)]
+    fn scans(&self) -> u64 {
+        self.scans.load(Ordering::Relaxed)
+    }
+
     fn bits(&self) -> u64 {
         let ver = self.snapshot.version();
         let packed = self.packed.load(Ordering::Relaxed);
@@ -472,6 +493,17 @@ impl BookkeepingFlags {
             return packed & FLAG_BITS;
         }
         let snap = self.snapshot.load();
+        let generation = snap.models.generation();
+        let by_generation = self.packed_by_generation.load(Ordering::Relaxed);
+        if by_generation != UNCOMPUTED && by_generation >> 3 == generation {
+            // Some other table moved. The predicates read `models` only,
+            // so the answer stands — restamp it under the new version so
+            // the next call takes the one-load path again.
+            let bits = by_generation & FLAG_BITS;
+            self.packed.store((ver << 3) | bits, Ordering::Relaxed);
+            return bits;
+        }
+        self.scans.fetch_add(1, Ordering::Relaxed);
         let mut bits = 0;
         for entry in snap.models.entries() {
             let m = &entry.value;
@@ -486,6 +518,8 @@ impl BookkeepingFlags {
                 bits |= FLAG_HEALTH_CHECKS;
             }
         }
+        self.packed_by_generation
+            .store((generation << 3) | bits, Ordering::Relaxed);
         self.packed.store((ver << 3) | bits, Ordering::Relaxed);
         bits
     }
@@ -1011,6 +1045,42 @@ mod tests {
     use super::*;
     use axum::body::to_bytes;
     use std::thread;
+
+    fn an_api_key() -> aisix_core::ApiKey {
+        serde_json::from_str(r#"{"key_hash":"abc","allowed_models":["vg"]}"#).expect("test key")
+    }
+
+    #[test]
+    fn a_write_to_an_unrelated_table_does_not_rescan_the_models() {
+        // The predicates read `models` and nothing else, but they used to
+        // be keyed on the snapshot version, which moves on every
+        // published write of any kind — so a bulk API-key edit rescanned
+        // the whole model table on the next request (AISIX-Cloud#1542).
+        let handle =
+            SnapshotHandle::new(snapshot_with(Some(model_json(Some("least_busy"), false))));
+        let flags = BookkeepingFlags::new(handle.clone());
+        assert!(flags.any_active());
+        assert_eq!(flags.scans(), 1);
+
+        for i in 0..5 {
+            let next = handle.load().as_ref().clone();
+            next.apikeys.insert(aisix_core::ResourceEntry::new(
+                format!("k-{i}"),
+                an_api_key(),
+                1,
+            ));
+            handle.store(next);
+            assert!(flags.any_active(), "the answer must not change");
+        }
+        assert_eq!(flags.scans(), 1, "the model table was walked again");
+
+        // A write that DOES touch models rescans.
+        let next = handle.load().as_ref().clone();
+        next.models.remove("m-1");
+        handle.store(next);
+        assert!(!flags.any_active());
+        assert_eq!(flags.scans(), 2);
+    }
 
     #[test]
     fn new_model_is_healthy() {

--- a/tests/e2e/src/cases/guardrail-index-invalidation-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-index-invalidation-e2e.test.ts
@@ -1,0 +1,254 @@
+import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  pickFreePort,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E for what invalidates the runtime guardrail index (AISIX-Cloud#1542).
+//
+// The index is rebuilt lazily, on the first request that resolves a
+// guardrail after the configuration changed, on the worker thread serving
+// that request — and building it constructs one runtime instance per
+// enabled attachment, each with its own HTTP client. So "what counts as a
+// change" is a latency question, not a bookkeeping one: while the index
+// keyed on the single global snapshot version, one API-key edit made every
+// worker reconstruct every attachment before it could answer anything,
+// liveness probes included.
+//
+// The three things a spec has to hold apart here:
+//   - a write to a resource the index does not read must not rebuild it;
+//   - a write to an attachment must, and exactly once;
+//   - and after either, the guardrails in force must still be the
+//     configured ones — a cache that never invalidates would also pass a
+//     test that only counted rebuilds.
+//
+// Rebuilds are observed through the gateway's own `guardrail index
+// rebuilt` log line rather than a metric, which is why the app runs at
+// `info`.
+
+const CALLER = "sk-guardrail-index-invalidation";
+const hash = (s: string) => createHash("sha256").update(s).digest("hex");
+
+const BLOCK_MARKER = "guardrailindexblockmarker";
+const SCREENED_MODEL = "gi-screened";
+const UNSCREENED_MODEL = "gi-unscreened";
+const LATE_MODEL = "gi-late";
+// Enough attachments that a rebuild is a real cost rather than a rounding
+// error, without making the seed slow.
+const EXTRA_SCOPES = 6;
+
+const REBUILT = /guardrail index rebuilt/;
+
+interface GuardMock {
+  baseUrl: string;
+  calls: number;
+  close(): Promise<void>;
+}
+
+// A minimal Lakera Guard `/v2/guard` mock: flags BLOCK_MARKER as a
+// prompt attack, passes everything else. Its only job here is to be a
+// network-backed guardrail whose enforcement is unambiguous.
+async function startGuardMock(): Promise<GuardMock> {
+  const state = { calls: 0 };
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      state.calls += 1;
+      let flagged = false;
+      try {
+        const body = JSON.parse(raw);
+        const messages: Array<{ content?: string }> = Array.isArray(body.messages)
+          ? body.messages
+          : [];
+        flagged = messages.some((m) => (m.content ?? "").includes(BLOCK_MARKER));
+      } catch {
+        // leave defaults
+      }
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          flagged,
+          payload: [],
+          breakdown: flagged
+            ? [{ detector_type: "prompt_attack", detected: true }]
+            : [],
+        }),
+      );
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    get calls() {
+      return state.calls;
+    },
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe("guardrail index invalidation", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let guard: GuardMock | undefined;
+  let seed: SeedClient | undefined;
+  let proxy: ProxyClient | undefined;
+  let etcdReachable = false;
+  let guardrailID = "";
+  let lateModelID = "";
+
+  function rebuilds(): number {
+    return app!
+      .output()
+      .split("\n")
+      .filter((l) => REBUILT.test(l)).length;
+  }
+
+  async function chat(model: string, content: string): Promise<number> {
+    return (await proxy!.chat({ model, messages: [{ role: "user", content }] }))
+      .status;
+  }
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    guard = await startGuardMock();
+    // `info`: the rebuild line this spec counts is emitted there.
+    app = await spawnApp({ logLevel: "info" });
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "gi-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    const model = (display_name: string) => ({
+      display_name,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: pk.id,
+    });
+    const screened = await seed.createModel(model(SCREENED_MODEL));
+    await seed.createModel(model(UNSCREENED_MODEL));
+    const late = await seed.createModel(model(LATE_MODEL));
+    lateModelID = late.id;
+
+    const guardrail = await seed.createGuardrail(
+      {
+        name: "gi-lakera",
+        kind: "lakera",
+        hook_point: "input",
+        api_key: "test-key",
+        endpoint: guard.baseUrl,
+      },
+      { attach: false },
+    );
+    guardrailID = guardrail.id;
+    await seed.attachGuardrailToModel(guardrailID, screened.id);
+    // Several more attachments onto scopes this spec never calls, so the
+    // index carries a realistic number of entries for one guardrail.
+    for (let i = 0; i < EXTRA_SCOPES; i += 1) {
+      const extra = await seed.createModel(model(`gi-extra-${i}`));
+      await seed.attachGuardrailToModel(guardrailID, extra.id);
+    }
+
+    await seed.createApiKey({
+      key_hash: hash(CALLER),
+      allowed_models: [
+        SCREENED_MODEL,
+        UNSCREENED_MODEL,
+        LATE_MODEL,
+        ...Array.from({ length: EXTRA_SCOPES }, (_, i) => `gi-extra-${i}`),
+      ],
+    });
+    proxy = new ProxyClient(app.proxyUrl, CALLER);
+    await waitConfigPropagation(
+      async () => (await proxy!.listModels()).status === 200,
+    );
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await guard?.close();
+  });
+
+  test("an unrelated write does not rebuild the index; an attachment write does, once", async (ctx) => {
+    if (!etcdReachable) ctx.skip();
+
+    // Warm: the first request that resolves a guardrail builds the index,
+    // and the guardrail must actually be in force before anything below
+    // means anything.
+    expect(await chat(SCREENED_MODEL, BLOCK_MARKER)).toBe(422);
+    const callsAfterWarm = guard!.calls;
+    expect(callsAfterWarm).toBeGreaterThan(0);
+    const afterWarm = rebuilds();
+    expect(afterWarm).toBeGreaterThan(0);
+
+    // Thirty writes to a resource kind the index does not read — the
+    // shape of the bulk API-key edit in the report. Each one publishes a
+    // new snapshot and moves the global version.
+    const unrelated = await seed!.createApiKey({
+      key_hash: hash("sk-guardrail-index-unrelated"),
+      allowed_models: [SCREENED_MODEL],
+    });
+    for (let i = 0; i < 30; i += 1) {
+      await seed!.update("api_keys", unrelated.id, {
+        key_hash: hash("sk-guardrail-index-unrelated"),
+        allowed_models: [SCREENED_MODEL, `filler-${i}`],
+      });
+    }
+    // A positive gate that the writes landed: the last one is visible to
+    // the gateway's own authentication.
+    const unrelatedCaller = new ProxyClient(
+      app!.proxyUrl,
+      "sk-guardrail-index-unrelated",
+    );
+    await waitConfigPropagation(
+      async () => (await unrelatedCaller.listModels()).status === 200,
+    );
+
+    // Requests after those writes still screen, and still on the index
+    // built before them.
+    expect(await chat(SCREENED_MODEL, BLOCK_MARKER)).toBe(422);
+    expect(await chat(SCREENED_MODEL, "hello")).toBe(200);
+    expect(rebuilds()).toBe(afterWarm);
+    expect(guard!.calls).toBeGreaterThan(callsAfterWarm);
+
+    // A model with no attachment is not screened at all, before or after.
+    const beforeUnscreened = guard!.calls;
+    expect(await chat(UNSCREENED_MODEL, BLOCK_MARKER)).toBe(200);
+    expect(guard!.calls).toBe(beforeUnscreened);
+
+    // Now attach the guardrail to a model that had none. This one MUST
+    // rebuild — and the new scope must actually be enforced, which is
+    // what separates a correct cache key from one that never invalidates.
+    const attachment = await seed!.attachGuardrailToModel(guardrailID, lateModelID);
+    await waitConfigPropagation(
+      async () => (await chat(LATE_MODEL, BLOCK_MARKER)) === 422,
+    );
+    expect(rebuilds()).toBe(afterWarm + 1);
+
+    // And removing it stops the enforcement.
+    await seed!.delete("guardrail_attachments", attachment.id);
+    await waitConfigPropagation(
+      async () => (await chat(LATE_MODEL, BLOCK_MARKER)) === 200,
+    );
+    expect(rebuilds()).toBe(afterWarm + 2);
+    // The scope that was configured all along is untouched by either.
+    expect(await chat(SCREENED_MODEL, BLOCK_MARKER)).toBe(422);
+  });
+});

--- a/tests/e2e/src/cases/guardrail-index-invalidation-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-index-invalidation-e2e.test.ts
@@ -87,7 +87,10 @@ async function startGuardMock(): Promise<GuardMock> {
     });
   });
   const port = await pickFreePort();
-  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
   return {
     baseUrl: `http://127.0.0.1:${port}`,
     get calls() {
@@ -117,6 +120,24 @@ describe("guardrail index invalidation", () => {
   async function chat(model: string, content: string): Promise<number> {
     return (await proxy!.chat({ model, messages: [{ role: "user", content }] }))
       .status;
+  }
+
+  // Gate on a caller key seeded AFTER the write under test: etcd delivers
+  // in revision order, so that key authenticating implies the write ahead
+  // of it is in the snapshot. Gating on the enforcement itself would turn
+  // a broken invalidation into a 30s timeout instead of an assertion, and
+  // `listModels` resolves no guardrail, so the gate cannot consume the
+  // rebuild the next assertion counts.
+  async function propagated(tag: string): Promise<void> {
+    const plaintext = `sk-guardrail-index-gate-${tag}`;
+    await seed!.createApiKey({
+      key_hash: hash(plaintext),
+      allowed_models: [SCREENED_MODEL],
+    });
+    const gate = new ProxyClient(app!.proxyUrl, plaintext);
+    await waitConfigPropagation(
+      async () => (await gate.listModels()).status === 200,
+    );
   }
 
   beforeAll(async () => {
@@ -237,16 +258,14 @@ describe("guardrail index invalidation", () => {
     // rebuild — and the new scope must actually be enforced, which is
     // what separates a correct cache key from one that never invalidates.
     const attachment = await seed!.attachGuardrailToModel(guardrailID, lateModelID);
-    await waitConfigPropagation(
-      async () => (await chat(LATE_MODEL, BLOCK_MARKER)) === 422,
-    );
+    await propagated("attached");
+    expect(await chat(LATE_MODEL, BLOCK_MARKER)).toBe(422);
     expect(rebuilds()).toBe(afterWarm + 1);
 
     // And removing it stops the enforcement.
     await seed!.delete("guardrail_attachments", attachment.id);
-    await waitConfigPropagation(
-      async () => (await chat(LATE_MODEL, BLOCK_MARKER)) === 200,
-    );
+    await propagated("detached");
+    expect(await chat(LATE_MODEL, BLOCK_MARKER)).toBe(200);
     expect(rebuilds()).toBe(afterWarm + 2);
     // The scope that was configured all along is untouched by either.
     expect(await chat(SCREENED_MODEL, BLOCK_MARKER)).toBe(422);

--- a/tests/e2e/src/harness/seed.ts
+++ b/tests/e2e/src/harness/seed.ts
@@ -89,6 +89,20 @@ export class SeedClient {
     });
   }
 
+  /** Model-scope attachment: the guardrail applies to one model's traffic. */
+  async attachGuardrailToModel(
+    guardrailID: string,
+    modelID: string,
+    priority = 100,
+  ): Promise<{ id: string; value: Record<string, unknown> }> {
+    return this.put("guardrail_attachments", {
+      guardrail_id: guardrailID,
+      scope_type: "model",
+      scope_id: modelID,
+      priority,
+    });
+  }
+
   async createCachePolicy(
     policy: Record<string, unknown>,
   ): Promise<{ id: string; value: Record<string, unknown> }> {


### PR DESCRIPTION
## The problem

A bulk configuration edit made the gateway starve its own request path. In the reported incident three gateways failed liveness probes and were restarted while ~1500 API-key `allowed_models` edits landed at ~14 writes/second.

Every accepted etcd write did three things whose cost is the size of the whole configuration rather than the size of the write:

- deep-copied the entire snapshot (every row's payload, not just the `Arc`),
- recomputed `source_hash` and `config_hash` — a JSON parse and canonical re-serialisation of every stored document, twice, per event,
- bumped the single global snapshot version, which was the invalidation key of every derived cache.

The third is what reached the request path. The next request on **each** worker thread then rebuilt the whole guardrail index synchronously: one runtime instance per enabled attachment, one `reqwest::Client` each, every one of them reloading the operating system's CA store — and if the snapshot moved during the build, the result was discarded and the build restarted, with no bound on the attempts. Proxy workers are current-thread runtimes, so `/livez` on that worker waited behind all of it.

Locally, on one CPU with a single guardrail and 16 enabled attachments, 39 of 43 liveness probes timed out during a 40-second update window and the diagnostic probe exceeded 10s; with the attachments disabled and everything else identical the same window peaked at ~7ms.

## What changed

**Derived caches key on the tables they read, not on the global version.** `ResourceTable` carries a generation stamp, bumped when that table is mutated and carried unchanged across the copy-on-write clone. The guardrail index keys on the `guardrails` and `guardrail_attachments` generations; the bookkeeping-flags cache (`least_busy` / `least_latency` / background health-check predicates, which rescanned every model) re-keys on `models` the same way. The snapshot version keeps its job of answering "has anything changed at all".

**One guardrail instance per row, not per attachment.** `build_one` reads only the guardrail row — scope and priority already land on the index entry — so the instance is shared across a row's attachments and reused across rebuilds unless that row itself changed. A row's identity is the snapshot's `Arc`, which the structural clone preserves, so this holds for the declarative resources file too, where revisions carry no meaning.

**One index build per call, single-flighted.** The build runs under the cache lock, from a snapshot loaded while holding it, which both stops every worker from running its own and makes the install trivially monotonic. The retry loop is gone.

**The snapshot clone is structural.** The new snapshot shares every row `Arc` with its predecessor instead of deep-copying payloads — which the function's own doc comment already claimed it did.

**Digest records are computed once per entry version.** Each observed entry carries its `key '\0' canonical_json '\n'` bytes, computed when the bytes are stored; both digests are a SHA-256 pass over cached records in the key order the state map already holds them in.

**Queued watch events are applied as one copy-on-write cycle** — one snapshot clone, one publish, one status sync, one cache flush. Only events already waiting on the stream are taken, so nothing is delayed to fill a batch and an idle stream behaves exactly as before. Per-event validation, rejection bookkeeping, last-known-good pinning and logging still run per event and in order, and the decisions that ask "does this row serve right now?" read through the batch's own staged mutations.

**MCP OpenAPI tool sets are cached per row.** The aggregating `/mcp` endpoint builds a bridge per enabled server per request, and both `tools/list` and `tools/call` ask for the tools, so every call re-walked every registered document, resolving `$ref`s and building a JSON Schema per operation. Cached per `mcp_server` row, evicted when the row leaves the snapshot.

## Behavior and compatibility

- **No configuration, wire shape, or reported value changes.** `config_hash` and `source_hash` stay byte-identical: the control plane stores what the gateway reports and never recomputes it, and the algorithm is documented in the public Admin API reference.
- The guardrails in force for a request are unchanged, as are the rejected-row reporting and the enabled-but-unattached notice.
- New log line at `info`: `guardrail index rebuilt`, with the row counts and how many instances were constructed vs reused. The e2e observes rebuilds through it rather than through a new metric.

## Tests

Unit and integration coverage for each half, each mutation-checked — the fix was reverted piece by piece and every test below was confirmed to go red:

- the digest output, pinned twice: against hex constants produced by the implementation as it stood before this change, and against the unchanged reference implementation over a supervisor state carrying an accepted row, a row rejected with nothing to serve, and a row serving its pinned last known good in the middle of the key ordering (a digest over the right bytes in the wrong order is a different digest);
- the structural clone, by `Arc` identity of untouched rows across a publish;
- only the written table's generation moving, on both put and delete;
- a queued run of events producing one publish and one status sync;
- a batch deciding what the same events decide alone, including a rejected put that follows an accepted put of the same key within one batch;
- an unrelated write leaving the index object identical and rebuilding nothing, an attachment write rebuilding once while unchanged rows keep their instances, and a changed row losing its own;
- eight concurrent resolves running one build;
- an unrelated write not rescanning the model table;
- the MCP tool cache hitting, missing on a rewritten row, and evicting a deleted one.

DP standalone e2e (`guardrail-index-invalidation-e2e.test.ts`, real binary + etcd + mock upstream + mock guardrail endpoint): a network-backed guardrail attached to several model scopes; 30 writes to an unrelated API key rebuild nothing while the guardrail keeps screening; a new attachment rebuilds exactly once **and** is enforced; deleting it stops the enforcement, and the scope configured all along is untouched by either.

Fixes api7/AISIX-Cloud#1542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved caching for configurations, guardrails, health checks, and OpenAPI tools.
  - Reduced unnecessary rebuilds, rescans, and tool regeneration when unrelated resources change.
  - Batched configuration updates for more efficient processing.

- **Reliability**
  - Improved consistency during concurrent updates, deletions, shutdown, and cache invalidation.
  - Preserved stable configuration digest results and accurate guardrail behavior as attachments change.

- **Testing**
  - Expanded coverage for caching, batching, digest consistency, guardrail updates, concurrent processing, and tool regeneration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->