### PR TITLE
fix(redis): bound every command so an unreachable Redis degrades instead of hanging

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -258,8 +258,13 @@ cache:
   #   # A Redis that stops answering without closing the socket (host down,
   #   # network partition, stopped container) would otherwise block the
   #   # request for minutes instead of degrading it. After a failure,
-  #   # commands short-circuit for a few seconds so the outage costs this
-  #   # budget once rather than once per request. Must be >= 1.
+  #   # commands short-circuit for about five seconds and then ONE request
+  #   # probes, so an outage costs this budget roughly once per five
+  #   # seconds rather than once per request. Must be >= 1.
+  #   #
+  #   # In sentinel mode, discovering the master is not one round trip —
+  #   # the client walks the sentinels one at a time — so that step gets
+  #   # this budget once per configured sentinel, plus one for the master.
   #   # timeout_secs: 5
 
 # Rate-limit counter backend (api7/AISIX-Cloud#798).
@@ -286,6 +291,9 @@ ratelimit:
   #   # counting. Same field and same meaning as cache.redis above; without
   #   # it an unreachable Redis blocks every rate-limited request for
   #   # minutes instead of degrading it. Must be >= 1.
+  #   #
+  #   # The cache and the limiter cool off independently, so a request that
+  #   # uses both can pay one budget for each while a shared Redis is down.
   #   # timeout_secs: 5
   # Seconds before an unreleased concurrency slot (crashed replica /
   # hung upstream) is reclaimed. Redis backend only.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -252,6 +252,15 @@ cache:
   #   # roots for the master it discovers, so ca_file does not apply there
   #   # (it is logged at startup). Use SSL_CERT_FILE or the system trust
   #   # store for that one case; `verify` does apply.
+  #   #
+  #   # Seconds one Redis round trip, or one connection attempt, may take
+  #   # before it is abandoned and the request proceeds without the cache.
+  #   # A Redis that stops answering without closing the socket (host down,
+  #   # network partition, stopped container) would otherwise block the
+  #   # request for minutes instead of degrading it. After a failure,
+  #   # commands short-circuit for a few seconds so the outage costs this
+  #   # budget once rather than once per request. Must be >= 1.
+  #   # timeout_secs: 5
 
 # Rate-limit counter backend (api7/AISIX-Cloud#798).
 #
@@ -272,6 +281,12 @@ ratelimit:
   #   # sentinels: ["redis://10.0.0.1:26379"]   # mode: sentinel
   #   # master_name: "mymaster"                  # mode: sentinel
   #   # tls: { ca_file: "/etc/aisix/tls/redis-ca.pem" }   # for rediss://
+  #   # Seconds one Redis round trip, or one connection attempt, may take
+  #   # before it is abandoned and the limiter falls back to per-replica
+  #   # counting. Same field and same meaning as cache.redis above; without
+  #   # it an unreachable Redis blocks every rate-limited request for
+  #   # minutes instead of degrading it. Must be >= 1.
+  #   # timeout_secs: 5
   # Seconds before an unreleased concurrency slot (crashed replica /
   # hung upstream) is reclaimed. Redis backend only.
   # concurrency_ttl_secs: 300

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -28,6 +28,13 @@
 # (api7/AISIX-Cloud#798):
 #   AISIX_RATELIMIT__BACKEND=redis
 #   AISIX_RATELIMIT__REDIS__URL=redis://<host>:6379
+#   AISIX_RATELIMIT__REDIS__TIMEOUT_SECS=5   # optional; this is the default
+#
+# `timeout_secs` bounds one Redis round trip and one connection attempt.
+# The limiter fails open to per-replica counting when Redis errors, but an
+# unreachable Redis produces no error at all until something times out, so
+# without the bound a rate-limited request waits on TCP retransmission for
+# minutes. Lower it for a Redis on the same node; it must be >= 1.
 #
 # Subsequent boots re-use the mTLS bundle written under
 # `managed.mtls_dir`.

--- a/crates/aisix-cache/src/semantic_redis.rs
+++ b/crates/aisix-cache/src/semantic_redis.rs
@@ -135,9 +135,21 @@ impl RedisSemanticCache {
             .query_async::<()>(&mut conn)
             .await
             .map_err(|e| {
-                CacheError::Backend(format!(
-                    "vector search unsupported (requires Redis 8+ or the search module): {e}"
-                ))
+                // An I/O error — a command timeout, a dropped connection,
+                // the connection layer's cool-off — says nothing about
+                // whether the server has the search module. The probe runs
+                // once per process and its verdict is permanent, so a
+                // wrong attribution here is what the operator reads for
+                // the life of the pod.
+                if e.is_io_error() {
+                    CacheError::Backend(format!(
+                        "vector-search probe did not complete (cache.redis unreachable or                          too slow; this does not mean the server lacks vector search): {e}"
+                    ))
+                } else {
+                    CacheError::Backend(format!(
+                        "vector search unsupported (requires Redis 8+ or the search module): {e}"
+                    ))
+                }
             })
     }
 

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -1160,7 +1160,7 @@ pub enum RedisMode {
 ///
 /// To keep secrets out of the config file, supply `password` via the
 /// matching env var instead, e.g. `AISIX_RATELIMIT__REDIS__PASSWORD`.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct RedisConnConfig {
     pub mode: RedisMode,
@@ -1187,6 +1187,42 @@ pub struct RedisConnConfig {
     /// Only consulted for `rediss://` URLs; a plaintext `redis://`
     /// connection never negotiates TLS regardless of what is set here.
     pub tls: OutboundTlsConfig,
+    /// Seconds a single Redis round trip, and a single connection
+    /// attempt, may take before it is abandoned. Default
+    /// [`DEFAULT_REDIS_TIMEOUT_SECS`].
+    ///
+    /// Every consumer of this connection fails **open** on a Redis error
+    /// (the rate limiter falls back to per-replica counters, the caches
+    /// to a miss), but that only helps if the error actually arrives.
+    /// A peer that stops answering without closing the socket — host
+    /// down, network partition, a stopped container — leaves the command
+    /// blocked on TCP retransmission for minutes, so without a bound the
+    /// request hangs instead of degrading.
+    ///
+    /// Must be at least 1; there is deliberately no "unbounded" setting.
+    pub timeout_secs: u64,
+}
+
+/// Default bound on one Redis round trip / connection attempt.
+/// Generous enough that a healthy in-cluster Redis never trips it, short
+/// enough that an unreachable one degrades a request instead of hanging it.
+pub const DEFAULT_REDIS_TIMEOUT_SECS: u64 = 5;
+
+impl Default for RedisConnConfig {
+    fn default() -> Self {
+        Self {
+            mode: RedisMode::default(),
+            url: None,
+            nodes: Vec::new(),
+            sentinels: Vec::new(),
+            master_name: None,
+            username: None,
+            password: None,
+            database: None,
+            tls: OutboundTlsConfig::default(),
+            timeout_secs: DEFAULT_REDIS_TIMEOUT_SECS,
+        }
+    }
 }
 
 impl RedisConnConfig {
@@ -1219,6 +1255,12 @@ impl RedisConnConfig {
                     ));
                 }
             }
+        }
+        if self.timeout_secs == 0 {
+            return Err(format!(
+                "{ctx}.timeout_secs must be at least 1 second (an unbounded Redis \
+                 command blocks the request instead of failing open)"
+            ));
         }
         match (&self.tls.client_cert_file, &self.tls.client_key_file) {
             (Some(_), None) => {
@@ -2864,6 +2906,36 @@ ratelimit:
         let redis = cfg.ratelimit.redis.unwrap();
         assert_eq!(redis.mode, RedisMode::Single);
         assert_eq!(redis.url.as_deref(), Some("redis://127.0.0.1:6379"));
+    }
+
+    /// The bound exists because every consumer of the Redis connection
+    /// fails open on an *error*, and a peer that stops answering without
+    /// closing the socket never produces one — the request hangs instead
+    /// of degrading. So it has to be on by default, not opt-in.
+    #[test]
+    fn redis_timeout_defaults_to_five_seconds() {
+        let f = redis_backend_yaml("    url: \"redis://127.0.0.1:6379\"");
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.ratelimit.redis.unwrap().timeout_secs, 5);
+        assert_eq!(RedisConnConfig::default().timeout_secs, 5);
+    }
+
+    #[test]
+    fn redis_timeout_is_configurable_per_block() {
+        let f = redis_backend_yaml("    url: \"redis://127.0.0.1:6379\"\n    timeout_secs: 2");
+        let cfg = Config::load_from_path(Some(f.path())).unwrap();
+        assert_eq!(cfg.ratelimit.redis.unwrap().timeout_secs, 2);
+    }
+
+    /// `0` would mean "wait forever", which is the defect this field was
+    /// added to remove — so it is rejected rather than silently accepted.
+    #[test]
+    fn redis_timeout_of_zero_is_rejected() {
+        let f = redis_backend_yaml("    url: \"redis://127.0.0.1:6379\"\n    timeout_secs: 0");
+        let err = Config::load_from_path(Some(f.path()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ratelimit.redis.timeout_secs"), "{err}");
     }
 
     #[test]

--- a/crates/aisix-ratelimit/tests/redis_integration.rs
+++ b/crates/aisix-ratelimit/tests/redis_integration.rs
@@ -529,18 +529,21 @@ async fn env_namespace_isolates_model_alias_bucket() {
         .expect_err("same env shares the counter");
 }
 
-/// A TCP relay in front of Redis that a test can cut. Until then every
-/// byte is forwarded both ways; afterwards the relay answers each client
-/// request with a Redis error instead of forwarding it.
+/// A TCP relay in front of Redis that a test can break, in either of the
+/// two shapes a real outage takes.
 ///
-/// An error reply rather than a dropped socket on purpose: the client's
-/// connection manager answers a dropped socket by reconnecting with its
-/// own multi-minute backoff, so a test that closes the connection spends
-/// that backoff before the operation it is measuring ever returns. Both
-/// shapes reach `RedisStore` as the same `Err`.
+/// - [`cut`](RedisCutoff::cut) — the relay answers each request with a
+///   Redis error instead of forwarding it. Redis is *reachable* and
+///   refusing, which is the cheap failure: the client learns immediately.
+/// - [`blackhole`](RedisCutoff::blackhole) — the socket stays open and
+///   nothing is ever forwarded or answered, which is what a stopped
+///   container, a downed host or a partitioned network looks like from
+///   the client end. Nothing arrives, nothing is refused, and without a
+///   command budget the caller waits on TCP retransmission for minutes.
 struct RedisCutoff {
     port: u16,
     cut: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    hole: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl RedisCutoff {
@@ -553,7 +556,9 @@ impl RedisCutoff {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let cut = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let hole = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let flag = cut.clone();
+        let hole_flag = hole.clone();
         tokio::spawn(async move {
             loop {
                 let Ok((mut client, _)) = listener.accept().await else {
@@ -563,6 +568,7 @@ impl RedisCutoff {
                     continue;
                 };
                 let flag = flag.clone();
+                let hole_flag = hole_flag.clone();
                 tokio::spawn(async move {
                     let mut from_client = [0u8; 8192];
                     let mut from_server = [0u8; 8192];
@@ -573,7 +579,10 @@ impl RedisCutoff {
                                 if n == 0 {
                                     return;
                                 }
-                                if flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                if hole_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                    // Swallowed: no forward, no reply, no
+                                    // close. The peer has simply gone quiet.
+                                } else if flag.load(std::sync::atomic::Ordering::Relaxed) {
                                     if client
                                         .write_all(b"-ERR simulated redis outage\r\n")
                                         .await
@@ -587,6 +596,9 @@ impl RedisCutoff {
                             }
                             n = server.read(&mut from_server) => {
                                 let Ok(n) = n else { return };
+                                if hole_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                                    continue;
+                                }
                                 if n == 0 || client.write_all(&from_server[..n]).await.is_err() {
                                     return;
                                 }
@@ -596,7 +608,7 @@ impl RedisCutoff {
                 });
             }
         });
-        Self { port, cut }
+        Self { port, cut, hole }
     }
 
     fn url(&self) -> String {
@@ -605,6 +617,10 @@ impl RedisCutoff {
 
     fn cut(&self) {
         self.cut.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn blackhole(&self) {
+        self.hole.store(true, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -669,5 +685,70 @@ async fn a_redis_outage_counts_every_failed_operation() {
     assert!(
         counter_value(&metrics.render(), "ratelimit_acquire") > first,
         "each failed operation counts, not only the one that logged",
+    );
+}
+
+/// A Redis that stops answering without closing the socket must degrade
+/// the request, not hold it.
+///
+/// The store has always failed open on `Err`, but with no command budget
+/// the `Err` never arrived: the command sat on TCP retransmission and the
+/// caller — a live proxy request — hung with it. Reported against 1.2.0-rc.1
+/// and reproduced identically on v1.1.0, where a `docker stop` of Redis
+/// left every rate-limited request unanswered past three minutes.
+///
+/// Two properties, because each fails without the other: the first
+/// command must return inside the budget, and the ones behind it must not
+/// each pay that budget again for as long as the outage lasts.
+#[tokio::test]
+async fn a_silent_redis_fails_open_within_the_command_budget() {
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: RATELIMIT_TEST_REDIS_URL not set");
+        return;
+    };
+    let relay = RedisCutoff::start(&url).await;
+    let cfg = RedisConnConfig {
+        timeout_secs: 2,
+        ..single(&relay.url())
+    };
+    let store = RedisStore::connect(&cfg)
+        .await
+        .expect("redis connect through the relay");
+    let key = unique_key("blackhole");
+    let limits = RateLimit {
+        rpm: Some(10),
+        ..rl()
+    };
+
+    store
+        .acquire(&key, &limits, "m-1")
+        .await
+        .expect("allowed while Redis answers");
+
+    relay.blackhole();
+
+    let started = std::time::Instant::now();
+    store
+        .acquire(&key, &limits, "m-2")
+        .await
+        .expect("fail-open still admits");
+    let first = started.elapsed();
+    assert!(
+        first < Duration::from_secs(6),
+        "the first silent command must give up on its budget, took {first:?}",
+    );
+
+    // Behind it the breaker is open, so this one costs nothing at all —
+    // otherwise every request for the length of the outage carries the
+    // full budget as added latency.
+    let started = std::time::Instant::now();
+    store
+        .acquire(&key, &limits, "m-3")
+        .await
+        .expect("fail-open still admits");
+    let second = started.elapsed();
+    assert!(
+        second < Duration::from_millis(500),
+        "the command behind a failure must short-circuit, took {second:?}",
     );
 }

--- a/crates/aisix-ratelimit/tests/redis_integration.rs
+++ b/crates/aisix-ratelimit/tests/redis_integration.rs
@@ -596,10 +596,16 @@ impl RedisCutoff {
                             }
                             n = server.read(&mut from_server) => {
                                 let Ok(n) = n else { return };
+                                // EOF first: a closed upstream read stays
+                                // ready forever, so `continue`-ing on it
+                                // would spin the relay task.
+                                if n == 0 {
+                                    return;
+                                }
                                 if hole_flag.load(std::sync::atomic::Ordering::Relaxed) {
                                     continue;
                                 }
-                                if n == 0 || client.write_all(&from_server[..n]).await.is_err() {
+                                if client.write_all(&from_server[..n]).await.is_err() {
                                     return;
                                 }
                             }
@@ -707,8 +713,12 @@ async fn a_silent_redis_fails_open_within_the_command_budget() {
         return;
     };
     let relay = RedisCutoff::start(&url).await;
+    // Below the 5s default on purpose: a bound of 6s would pass whether or
+    // not the per-block field reached the connection, so it would not be a
+    // check at all.
+    const BUDGET_SECS: u64 = 2;
     let cfg = RedisConnConfig {
-        timeout_secs: 2,
+        timeout_secs: BUDGET_SECS,
         ..single(&relay.url())
     };
     let store = RedisStore::connect(&cfg)
@@ -734,8 +744,14 @@ async fn a_silent_redis_fails_open_within_the_command_budget() {
         .expect("fail-open still admits");
     let first = started.elapsed();
     assert!(
-        first < Duration::from_secs(6),
-        "the first silent command must give up on its budget, took {first:?}",
+        first >= Duration::from_secs(BUDGET_SECS),
+        "the budget is what makes it give up; a faster return means the \
+         blackhole was not reached, took {first:?}",
+    );
+    assert!(
+        first < Duration::from_millis(BUDGET_SECS * 1000 + 1_500),
+        "the first silent command must give up on its own budget, not the \
+         default, took {first:?}",
     );
 
     // Behind it the breaker is open, so this one costs nothing at all —

--- a/crates/aisix-redis/src/lib.rs
+++ b/crates/aisix-redis/src/lib.rs
@@ -818,17 +818,22 @@ mod guard_tests {
         assert!(!g.breaker.is_open(), "the window has expired");
 
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (admitted_tx, admitted_rx) = tokio::sync::oneshot::channel::<()>();
         let probe = tokio::spawn({
             let g = Arc::clone(&g);
             async move {
                 g.run(async move {
+                    // Sent from inside the guarded future, so receiving it
+                    // proves `admit` already ran. Yielding would only
+                    // *probably* get the task that far.
+                    let _ = admitted_tx.send(());
                     let _ = rx.await;
                     Ok::<_, redis::RedisError>(1)
                 })
                 .await
             }
         });
-        tokio::task::yield_now().await;
+        admitted_rx.await.expect("the probe was admitted");
 
         let started = Instant::now();
         let err = g
@@ -859,18 +864,22 @@ mod guard_tests {
         let g = Arc::new(guard(2_000, 5_000));
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 
+        let (admitted_tx, admitted_rx) = tokio::sync::oneshot::channel::<()>();
         let inflight = tokio::spawn({
             let g = Arc::clone(&g);
             async move {
                 g.run(async move {
+                    let _ = admitted_tx.send(());
                     let _ = rx.await;
                     Ok::<_, redis::RedisError>(1)
                 })
                 .await
             }
         });
-        // Let it enter `run` and read the generation before anything fails.
-        tokio::task::yield_now().await;
+        // Sent from inside the guarded future, so receiving it proves the
+        // generation was read before anything below fails. Yielding would
+        // only *probably* get the task that far.
+        admitted_rx.await.expect("the in-flight command started");
 
         g.run(async { Err::<(), _>(dropped_connection()) })
             .await

--- a/crates/aisix-redis/src/lib.rs
+++ b/crates/aisix-redis/src/lib.rs
@@ -103,6 +103,14 @@ enum ConnKind {
 pub struct SentinelPool {
     client: Arc<Mutex<SentinelClient>>,
     cached: Arc<Mutex<Option<MultiplexedConnection>>>,
+    /// Budget for one master discovery, which is NOT one round trip: the
+    /// client library walks the sentinels **serially** and applies no
+    /// timeout of its own to the sentinel hops, so a single budget for
+    /// the whole walk would let one unreachable sentinel consume it and
+    /// starve the healthy ones — they would never be tried, and the
+    /// master would never resolve even with quorum intact. One budget per
+    /// sentinel, plus one for the master connection that follows.
+    discovery_timeout: Duration,
 }
 
 /// A live connection usable for one or more operations. Implements
@@ -140,28 +148,45 @@ impl Guard {
         &self,
         fut: impl std::future::Future<Output = RedisResult<T>>,
     ) -> RedisResult<T> {
-        if self.breaker.is_open() {
+        self.run_with(self.timeout, fut).await
+    }
+
+    /// [`Guard::run`] with a budget other than the per-command one. Only
+    /// sentinel master discovery uses it — see [`SentinelPool`].
+    async fn run_with<T>(
+        &self,
+        budget: Duration,
+        fut: impl std::future::Future<Output = RedisResult<T>>,
+    ) -> RedisResult<T> {
+        // `admit` both decides and, when it lets a probe through, re-arms
+        // the window behind it. The generation it returns is read before
+        // the await, because a command already in flight when the outage
+        // began can land its success after a *concurrent* command opened
+        // the breaker, and closing on that stale evidence would send the
+        // requests behind it back into the full budget.
+        let Some(seen) = self.breaker.admit() else {
             return Err(breaker_open_error());
-        }
-        // Read before awaiting: a command already in flight when the
-        // outage began can land its success after a *concurrent* command
-        // has opened the breaker, and closing on that stale evidence
-        // would send the requests behind it back into the full timeout.
-        let seen = self.breaker.generation();
-        match tokio::time::timeout(self.timeout, fut).await {
+        };
+        match tokio::time::timeout(budget, fut).await {
             Ok(Ok(v)) => {
                 self.breaker.close_unless_reopened(seen);
                 Ok(v)
             }
             Ok(Err(e)) => {
-                if e.is_io_error() || e.is_timeout() || e.is_connection_dropped() {
+                // `is_io_error` is the whole test: `is_timeout` and
+                // `is_connection_dropped` are strict subsets of it, and
+                // the connectivity errors that are NOT io errors —
+                // `ClusterConnectionNotFound`, `MasterNameNotFoundBySentinel`
+                // — return instantly, so the caller already failed open
+                // without paying anything and has nothing to cool off from.
+                if e.is_io_error() {
                     self.breaker.open();
                 }
                 Err(e)
             }
             Err(_) => {
                 self.breaker.open();
-                Err(timed_out_error(self.timeout))
+                Err(timed_out_error(budget))
             }
         }
     }
@@ -206,8 +231,26 @@ impl Breaker {
             .is_some_and(|until| Instant::now() < until)
     }
 
-    fn generation(&self) -> u64 {
-        self.lock().generation
+    /// Decide whether this command reaches Redis, and hand back the
+    /// generation it is allowed to close.
+    ///
+    /// `None` short-circuits. Once the window expires, exactly ONE caller
+    /// is admitted as the probe and the window is re-armed behind it:
+    /// without that, every command arriving while the probe is in flight
+    /// is admitted too and pays the full budget, which during a sustained
+    /// outage is most of them. A probe whose caller is dropped rather
+    /// than finishing leaves nothing stuck — the re-armed window simply
+    /// expires and the next caller probes.
+    fn admit(&self) -> Option<u64> {
+        let mut st = self.lock();
+        match st.open_until {
+            None => Some(st.generation),
+            Some(until) if Instant::now() < until => None,
+            Some(_) => {
+                st.open_until = Some(Instant::now() + self.window);
+                Some(st.generation)
+            }
+        }
     }
 
     fn open(&self) {
@@ -274,7 +317,10 @@ impl RedisConn {
                         let cfg = conn_config(self.guard.timeout);
                         let conn = self
                             .guard
-                            .run(client.get_async_connection_with_config(&cfg))
+                            .run_with(
+                                pool.discovery_timeout,
+                                client.get_async_connection_with_config(&cfg),
+                            )
                             .await?;
                         *pool.cached.lock().await = Some(conn.clone());
                         HandleKind::Sentinel(conn)
@@ -291,6 +337,13 @@ impl RedisConn {
     /// Invalidate any cached connection after an operation error. Only
     /// meaningful for `sentinel`, where it forces the next [`acquire`] to
     /// re-resolve the master (the prior one may have failed over).
+    ///
+    /// Re-resolution is not immediate any more: the failure that prompted
+    /// this call also opened the breaker, so the next `acquire` inside
+    /// [`BREAKER_WINDOW`] short-circuits and the master is re-discovered
+    /// by the first probe after it. A failover therefore costs up to one
+    /// window of per-replica counting / cache misses — fail-open, and the
+    /// alternative is every request racing to re-walk the sentinels.
     ///
     /// [`acquire`]: RedisConn::acquire
     pub async fn note_error(&self) {
@@ -424,6 +477,7 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
                 .filter(|s| !s.is_empty())
                 .map(|s| insecure_url(s, cfg))
                 .collect();
+            let sentinels_len = sentinels.len().max(1) as u32;
             let master_name = cfg.master_name.clone().unwrap_or_default();
             // The master/data node may need its own auth and TLS; the
             // sentinels themselves carry theirs in `sentinels` URLs. Derive
@@ -484,12 +538,13 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
             // connect attempts inside it — so the whole exchange gets an
             // outer budget too, or an unreachable sentinel stalls the
             // boot attempt indefinitely.
+            let discovery_timeout = timeout * (sentinels_len + 1);
             let conn = tokio::time::timeout(
-                timeout,
+                discovery_timeout,
                 client.get_async_connection_with_config(&conn_config(timeout)),
             )
             .await
-            .map_err(|_| timed_out_error(timeout))??;
+            .map_err(|_| timed_out_error(discovery_timeout))??;
             tracing::info!(
                 target: "aisix::redis",
                 mode = "sentinel",
@@ -500,6 +555,7 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
             ConnKind::Sentinel(SentinelPool {
                 client: Arc::new(Mutex::new(client)),
                 cached: Arc::new(Mutex::new(Some(conn))),
+                discovery_timeout,
             })
         }
     };
@@ -746,6 +802,52 @@ mod guard_tests {
             .await
             .expect("the probe reaches Redis again");
         assert!(!g.breaker.is_open(), "a success closes the breaker");
+    }
+
+    /// A cool-off that only gates the window itself still lets every
+    /// command that arrives while the probe is in flight pay the full
+    /// budget — during a sustained outage that is most of them, and no
+    /// serial test can see it.
+    #[tokio::test]
+    async fn only_one_command_probes_when_the_window_expires() {
+        let g = Arc::new(guard(2_000, 60));
+        g.run(async { Err::<(), _>(dropped_connection()) })
+            .await
+            .expect_err("the failure opens the breaker");
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert!(!g.breaker.is_open(), "the window has expired");
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let probe = tokio::spawn({
+            let g = Arc::clone(&g);
+            async move {
+                g.run(async move {
+                    let _ = rx.await;
+                    Ok::<_, redis::RedisError>(1)
+                })
+                .await
+            }
+        });
+        tokio::task::yield_now().await;
+
+        let started = Instant::now();
+        let err = g
+            .run(pending::<RedisResult<()>>())
+            .await
+            .expect_err("only the probe reaches Redis");
+        assert!(
+            started.elapsed() < Duration::from_millis(40),
+            "a command behind the probe must not pay the budget, took {:?}",
+            started.elapsed()
+        );
+        assert!(err.to_string().contains("cool-off"), "{err}");
+
+        tx.send(()).expect("the probe is still waiting");
+        probe.await.expect("join").expect("the probe succeeds");
+        assert!(
+            !g.breaker.is_open(),
+            "a successful probe closes the breaker"
+        );
     }
 
     /// A command that was already in flight when the outage began can

--- a/crates/aisix-redis/src/lib.rs
+++ b/crates/aisix-redis/src/lib.rs
@@ -58,7 +58,6 @@
 //! consumers' existing `aisix_redis_failures_total{operation=...}` calls
 //! with no new metric.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -144,9 +143,14 @@ impl Guard {
         if self.breaker.is_open() {
             return Err(breaker_open_error());
         }
+        // Read before awaiting: a command already in flight when the
+        // outage began can land its success after a *concurrent* command
+        // has opened the breaker, and closing on that stale evidence
+        // would send the requests behind it back into the full timeout.
+        let seen = self.breaker.generation();
         match tokio::time::timeout(self.timeout, fut).await {
             Ok(Ok(v)) => {
-                self.breaker.close();
+                self.breaker.close_unless_reopened(seen);
                 Ok(v)
             }
             Ok(Err(e)) => {
@@ -163,40 +167,61 @@ impl Guard {
     }
 }
 
-/// A fixed-window cool-off. Open until `open_until_ms` has passed, then
-/// the next command probes Redis for real.
+/// A fixed-window cool-off. Open until `open_until` has passed, then the
+/// next command probes Redis for real.
+///
+/// `generation` counts openings, so a success can tell "the breaker I saw
+/// closed when I started" from "a breaker something else opened while I
+/// was in flight". A plain timestamp comparison cannot: the two events
+/// are microseconds apart.
 struct Breaker {
-    origin: Instant,
     window: Duration,
-    /// Milliseconds since `origin` until which commands short-circuit.
-    /// `0` means closed.
-    open_until_ms: AtomicU64,
+    state: std::sync::Mutex<BreakerState>,
+}
+
+#[derive(Default)]
+struct BreakerState {
+    open_until: Option<Instant>,
+    generation: u64,
 }
 
 impl Breaker {
     fn new(window: Duration) -> Self {
         Self {
-            origin: Instant::now(),
             window,
-            open_until_ms: AtomicU64::new(0),
+            state: std::sync::Mutex::new(BreakerState::default()),
         }
     }
 
-    fn now_ms(&self) -> u64 {
-        self.origin.elapsed().as_millis() as u64
+    fn lock(&self) -> std::sync::MutexGuard<'_, BreakerState> {
+        // Nothing under this lock can panic, so it cannot be poisoned;
+        // taking the value through a poisoned guard would be equally
+        // correct if it ever were.
+        self.state.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     fn is_open(&self) -> bool {
-        self.open_until_ms.load(Ordering::Relaxed) > self.now_ms()
+        self.lock()
+            .open_until
+            .is_some_and(|until| Instant::now() < until)
+    }
+
+    fn generation(&self) -> u64 {
+        self.lock().generation
     }
 
     fn open(&self) {
-        let until = self.now_ms() + self.window.as_millis() as u64;
-        self.open_until_ms.store(until, Ordering::Relaxed);
+        let mut st = self.lock();
+        st.open_until = Some(Instant::now() + self.window);
+        st.generation = st.generation.wrapping_add(1);
     }
 
-    fn close(&self) {
-        self.open_until_ms.store(0, Ordering::Relaxed);
+    /// Close the breaker unless it was opened after `seen` was read.
+    fn close_unless_reopened(&self, seen: u64) {
+        let mut st = self.lock();
+        if st.generation == seen {
+            st.open_until = None;
+        }
     }
 }
 
@@ -657,6 +682,10 @@ mod guard_tests {
         }
     }
 
+    fn dropped_connection() -> redis::RedisError {
+        redis::RedisError::from(std::io::Error::from(std::io::ErrorKind::ConnectionReset))
+    }
+
     fn server_side_error() -> redis::RedisError {
         // What a live Redis returns for, say, a bad script: it answered,
         // so it is not a connectivity failure.
@@ -717,6 +746,44 @@ mod guard_tests {
             .await
             .expect("the probe reaches Redis again");
         assert!(!g.breaker.is_open(), "a success closes the breaker");
+    }
+
+    /// A command that was already in flight when the outage began can
+    /// land its success *after* another command has opened the breaker.
+    /// Closing on that stale evidence puts every request behind it back
+    /// on the full budget.
+    #[tokio::test]
+    async fn a_success_that_started_first_does_not_wipe_a_newer_cool_off() {
+        let g = Arc::new(guard(2_000, 5_000));
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+        let inflight = tokio::spawn({
+            let g = Arc::clone(&g);
+            async move {
+                g.run(async move {
+                    let _ = rx.await;
+                    Ok::<_, redis::RedisError>(1)
+                })
+                .await
+            }
+        });
+        // Let it enter `run` and read the generation before anything fails.
+        tokio::task::yield_now().await;
+
+        g.run(async { Err::<(), _>(dropped_connection()) })
+            .await
+            .expect_err("the concurrent command fails");
+        assert!(g.breaker.is_open());
+
+        tx.send(()).expect("the in-flight command is still waiting");
+        inflight
+            .await
+            .expect("join")
+            .expect("the in-flight command succeeds");
+        assert!(
+            g.breaker.is_open(),
+            "a success from before the failure must not clear the cool-off"
+        );
     }
 
     /// A reply from a live Redis — a script error, `WRONGTYPE`, an ACL

--- a/crates/aisix-redis/src/lib.rs
+++ b/crates/aisix-redis/src/lib.rs
@@ -28,25 +28,70 @@
 //!   connection, so on a master failover the cached connection breaks;
 //!   [`RedisConn::note_error`] drops it and the next `acquire` re-resolves
 //!   the new master through the sentinels.
+//!
+//! # Bounded failure
+//!
+//! Every consumer of this layer fails **open** on a Redis error — the
+//! rate limiter degrades to per-replica counters, the caches to a miss —
+//! but that only helps if the error *arrives*. A peer that stops
+//! answering without closing the socket (host down, network partition, a
+//! stopped container) leaves a command blocked on TCP retransmission for
+//! minutes, so the fallback is never reached and the request hangs.
+//!
+//! Two mechanisms, both applied here so no consumer can forget them:
+//!
+//! - **A timeout on every command and every connection attempt**, from
+//!   `redis.timeout_secs` (default 5s). It is set natively on the driver
+//!   for all three topologies *and* enforced around each command, because
+//!   the native response timeout does not cover time spent waiting on the
+//!   connection manager's own in-progress reconnect — which is where the
+//!   remaining unbounded wait lived.
+//! - **A cool-off breaker.** Paying the timeout on *every* request during
+//!   an outage is still a several-second latency floor for as long as the
+//!   outage lasts. After a connectivity failure the connection is held
+//!   open for [`BREAKER_WINDOW`]; commands issued inside that window
+//!   return an error immediately, with no round trip, so each consumer's
+//!   existing fail-open branch runs at once. The first command after the
+//!   window probes Redis normally and closes the breaker on success.
+//!
+//! Breaker short-circuits are ordinary `Err`s, so they are counted by the
+//! consumers' existing `aisix_redis_failures_total{operation=...}` calls
+//! with no new metric.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use aisix_core::{RedisConnConfig, RedisMode};
-use redis::aio::{ConnectionLike, ConnectionManager, MultiplexedConnection};
+use redis::aio::{
+    ConnectionLike, ConnectionManager, ConnectionManagerConfig, MultiplexedConnection,
+};
 use redis::cluster::ClusterClient;
 use redis::cluster_async::ClusterConnection;
 use redis::sentinel::{SentinelClient, SentinelNodeConnectionInfo, SentinelServerType};
-use redis::RedisResult;
+use redis::{AsyncConnectionConfig, RedisResult};
 use tokio::sync::Mutex;
+
+/// How long commands short-circuit after a connectivity failure. Fixed,
+/// not configurable: it trades at most this much staleness (a Redis that
+/// recovered mid-window is not noticed until the window ends) for a hard
+/// ceiling on how often a request pays the full timeout during an outage.
+pub const BREAKER_WINDOW: Duration = Duration::from_secs(5);
 
 /// A long-lived Redis client handle. Cheap to [`Clone`] (every variant is
 /// `Arc`-backed). Build one with [`connect`].
+#[derive(Clone)]
+pub struct RedisConn {
+    inner: ConnKind,
+    guard: Arc<Guard>,
+}
+
 // `Single` (the hot, common path) is the largest variant; boxing it to
 // equalize variant size would add an allocation to the common case to
 // shrink the rarer ones — not worth it for a handful of instances.
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
-pub enum RedisConn {
+enum ConnKind {
     Single(ConnectionManager),
     Cluster(ClusterConnection),
     Sentinel(SentinelPool),
@@ -62,12 +107,120 @@ pub struct SentinelPool {
 }
 
 /// A live connection usable for one or more operations. Implements
-/// [`ConnectionLike`] by delegating to the underlying connection.
+/// [`ConnectionLike`] by delegating to the underlying connection, with
+/// the timeout and breaker of the [`RedisConn`] it came from applied to
+/// every command.
+pub struct RedisConnHandle {
+    inner: HandleKind,
+    guard: Arc<Guard>,
+}
+
 #[allow(clippy::large_enum_variant)]
-pub enum RedisConnHandle {
+enum HandleKind {
     Single(ConnectionManager),
     Cluster(ClusterConnection),
     Sentinel(MultiplexedConnection),
+}
+
+/// The per-connection failure policy: one command budget and one breaker,
+/// shared by every handle [`RedisConn::acquire`] hands out.
+struct Guard {
+    timeout: Duration,
+    breaker: Breaker,
+}
+
+impl Guard {
+    /// Run one Redis operation under the breaker and the command budget.
+    ///
+    /// A success closes the breaker; a *connectivity* failure or a
+    /// timeout opens it. A failure the server itself reported (a script
+    /// error, `WRONGTYPE`, an ACL refusal) is returned untouched — Redis
+    /// answered, so short-circuiting the next five seconds of traffic
+    /// would be wrong.
+    async fn run<T>(
+        &self,
+        fut: impl std::future::Future<Output = RedisResult<T>>,
+    ) -> RedisResult<T> {
+        if self.breaker.is_open() {
+            return Err(breaker_open_error());
+        }
+        match tokio::time::timeout(self.timeout, fut).await {
+            Ok(Ok(v)) => {
+                self.breaker.close();
+                Ok(v)
+            }
+            Ok(Err(e)) => {
+                if e.is_io_error() || e.is_timeout() || e.is_connection_dropped() {
+                    self.breaker.open();
+                }
+                Err(e)
+            }
+            Err(_) => {
+                self.breaker.open();
+                Err(timed_out_error(self.timeout))
+            }
+        }
+    }
+}
+
+/// A fixed-window cool-off. Open until `open_until_ms` has passed, then
+/// the next command probes Redis for real.
+struct Breaker {
+    origin: Instant,
+    window: Duration,
+    /// Milliseconds since `origin` until which commands short-circuit.
+    /// `0` means closed.
+    open_until_ms: AtomicU64,
+}
+
+impl Breaker {
+    fn new(window: Duration) -> Self {
+        Self {
+            origin: Instant::now(),
+            window,
+            open_until_ms: AtomicU64::new(0),
+        }
+    }
+
+    fn now_ms(&self) -> u64 {
+        self.origin.elapsed().as_millis() as u64
+    }
+
+    fn is_open(&self) -> bool {
+        self.open_until_ms.load(Ordering::Relaxed) > self.now_ms()
+    }
+
+    fn open(&self) {
+        let until = self.now_ms() + self.window.as_millis() as u64;
+        self.open_until_ms.store(until, Ordering::Relaxed);
+    }
+
+    fn close(&self) {
+        self.open_until_ms.store(0, Ordering::Relaxed);
+    }
+}
+
+/// The error a short-circuited command returns. `IoError` so consumers
+/// classify it exactly as they classify the real connectivity failure it
+/// stands in for.
+fn breaker_open_error() -> redis::RedisError {
+    redis::RedisError::from((
+        redis::ErrorKind::IoError,
+        "redis is in a failure cool-off",
+        format!(
+            "a Redis command failed within the last {}s; commands short-circuit until the \
+             cool-off expires so the caller's fallback runs without paying the timeout again",
+            BREAKER_WINDOW.as_secs()
+        ),
+    ))
+}
+
+fn timed_out_error(budget: Duration) -> redis::RedisError {
+    redis::RedisError::from((
+        redis::ErrorKind::IoError,
+        "redis command timed out",
+        format!("no reply within redis.timeout_secs ({}s)", budget.as_secs()),
+    ))
 }
 
 impl RedisConn {
@@ -75,20 +228,39 @@ impl RedisConn {
     /// infallible cheap clone of the multiplexed connection. For
     /// `sentinel` it returns the cached master connection, resolving one
     /// through the sentinels on the first call or after a failover.
+    ///
+    /// While the breaker is open this returns the short-circuit error
+    /// without touching the network, so the caller's fail-open branch
+    /// runs immediately — including for `sentinel`, whose master
+    /// re-resolution is itself a round trip to a host that may be gone.
     pub async fn acquire(&self) -> RedisResult<RedisConnHandle> {
-        match self {
-            RedisConn::Single(c) => Ok(RedisConnHandle::Single(c.clone())),
-            RedisConn::Cluster(c) => Ok(RedisConnHandle::Cluster(c.clone())),
-            RedisConn::Sentinel(pool) => {
-                if let Some(conn) = pool.cached.lock().await.clone() {
-                    return Ok(RedisConnHandle::Sentinel(conn));
-                }
-                let mut client = pool.client.lock().await;
-                let conn = client.get_async_connection().await?;
-                *pool.cached.lock().await = Some(conn.clone());
-                Ok(RedisConnHandle::Sentinel(conn))
-            }
+        if self.guard.breaker.is_open() {
+            return Err(breaker_open_error());
         }
+        let inner = match &self.inner {
+            ConnKind::Single(c) => HandleKind::Single(c.clone()),
+            ConnKind::Cluster(c) => HandleKind::Cluster(c.clone()),
+            ConnKind::Sentinel(pool) => {
+                let cached = pool.cached.lock().await.clone();
+                match cached {
+                    Some(conn) => HandleKind::Sentinel(conn),
+                    None => {
+                        let mut client = pool.client.lock().await;
+                        let cfg = conn_config(self.guard.timeout);
+                        let conn = self
+                            .guard
+                            .run(client.get_async_connection_with_config(&cfg))
+                            .await?;
+                        *pool.cached.lock().await = Some(conn.clone());
+                        HandleKind::Sentinel(conn)
+                    }
+                }
+            }
+        };
+        Ok(RedisConnHandle {
+            inner,
+            guard: Arc::clone(&self.guard),
+        })
     }
 
     /// Invalidate any cached connection after an operation error. Only
@@ -97,22 +269,34 @@ impl RedisConn {
     ///
     /// [`acquire`]: RedisConn::acquire
     pub async fn note_error(&self) {
-        if let RedisConn::Sentinel(pool) = self {
+        if let ConnKind::Sentinel(pool) = &self.inner {
             *pool.cached.lock().await = None;
         }
     }
 }
 
+/// The driver-native timeouts, shared by every topology that accepts them.
+fn conn_config(timeout: Duration) -> AsyncConnectionConfig {
+    AsyncConnectionConfig::new()
+        .set_connection_timeout(timeout)
+        .set_response_timeout(timeout)
+}
+
+// Every command from every consumer — `Script::invoke_async`,
+// `cmd().query_async`, pipelines — funnels through this impl, which is
+// why the budget and the breaker live here rather than in each store.
 impl ConnectionLike for RedisConnHandle {
     fn req_packed_command<'a>(
         &'a mut self,
         cmd: &'a redis::Cmd,
     ) -> redis::RedisFuture<'a, redis::Value> {
-        match self {
-            RedisConnHandle::Single(c) => c.req_packed_command(cmd),
-            RedisConnHandle::Cluster(c) => c.req_packed_command(cmd),
-            RedisConnHandle::Sentinel(c) => c.req_packed_command(cmd),
-        }
+        let guard = Arc::clone(&self.guard);
+        let fut = match &mut self.inner {
+            HandleKind::Single(c) => c.req_packed_command(cmd),
+            HandleKind::Cluster(c) => c.req_packed_command(cmd),
+            HandleKind::Sentinel(c) => c.req_packed_command(cmd),
+        };
+        Box::pin(async move { guard.run(fut).await })
     }
 
     fn req_packed_commands<'a>(
@@ -121,18 +305,20 @@ impl ConnectionLike for RedisConnHandle {
         offset: usize,
         count: usize,
     ) -> redis::RedisFuture<'a, Vec<redis::Value>> {
-        match self {
-            RedisConnHandle::Single(c) => c.req_packed_commands(cmd, offset, count),
-            RedisConnHandle::Cluster(c) => c.req_packed_commands(cmd, offset, count),
-            RedisConnHandle::Sentinel(c) => c.req_packed_commands(cmd, offset, count),
-        }
+        let guard = Arc::clone(&self.guard);
+        let fut = match &mut self.inner {
+            HandleKind::Single(c) => c.req_packed_commands(cmd, offset, count),
+            HandleKind::Cluster(c) => c.req_packed_commands(cmd, offset, count),
+            HandleKind::Sentinel(c) => c.req_packed_commands(cmd, offset, count),
+        };
+        Box::pin(async move { guard.run(fut).await })
     }
 
     fn get_db(&self) -> i64 {
-        match self {
-            RedisConnHandle::Single(c) => c.get_db(),
-            RedisConnHandle::Cluster(c) => c.get_db(),
-            RedisConnHandle::Sentinel(c) => c.get_db(),
+        match &self.inner {
+            HandleKind::Single(c) => c.get_db(),
+            HandleKind::Cluster(c) => c.get_db(),
+            HandleKind::Sentinel(c) => c.get_db(),
         }
     }
 }
@@ -144,16 +330,32 @@ impl ConnectionLike for RedisConnHandle {
 /// passed (the boot path validates before calling this).
 pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
     let tls = load_tls(cfg)?;
-    match cfg.mode {
+    let timeout = Duration::from_secs(cfg.timeout_secs.max(1));
+    let guard = Arc::new(Guard {
+        timeout,
+        breaker: Breaker::new(BREAKER_WINDOW),
+    });
+    let inner = match cfg.mode {
         RedisMode::Single => {
             let url = insecure_url(cfg.url.as_deref().unwrap_or_default(), cfg);
             let client = match &tls {
                 Some(certs) => redis::Client::build_with_tls(url.as_str(), certs.clone())?,
                 None => redis::Client::open(url.as_str())?,
             };
-            let conn = ConnectionManager::new(client).await?;
-            tracing::info!(target: "aisix::redis", mode = "single", "connected");
-            Ok(RedisConn::Single(conn))
+            // Only the two timeouts are set; the retry policy stays the
+            // library default, which is what the boot retry loop is tuned
+            // around.
+            let manager_cfg = ConnectionManagerConfig::new()
+                .set_connection_timeout(timeout)
+                .set_response_timeout(timeout);
+            let conn = ConnectionManager::new_with_config(client, manager_cfg).await?;
+            tracing::info!(
+                target: "aisix::redis",
+                mode = "single",
+                timeout_secs = timeout.as_secs(),
+                "connected"
+            );
+            ConnKind::Single(conn)
         }
         RedisMode::Cluster => {
             let nodes: Vec<String> = cfg
@@ -166,7 +368,9 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
             // ACL creds for the nodes can travel in the node URLs, or be
             // set explicitly here (applied to every node). Cluster has no
             // DB index, so `database` is ignored in this mode.
-            let mut builder = ClusterClient::builder(nodes);
+            let mut builder = ClusterClient::builder(nodes)
+                .connection_timeout(timeout)
+                .response_timeout(timeout);
             if let Some(u) = &cfg.username {
                 builder = builder.username(u.clone());
             }
@@ -182,9 +386,10 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
                 target: "aisix::redis",
                 mode = "cluster",
                 nodes = cfg.nodes.len(),
+                timeout_secs = timeout.as_secs(),
                 "connected"
             );
-            Ok(RedisConn::Cluster(conn))
+            ConnKind::Cluster(conn)
         }
         RedisMode::Sentinel => {
             let sentinels: Vec<String> = cfg
@@ -248,19 +453,32 @@ pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
             )?;
             // Eagerly resolve the master once so a broken sentinel/master
             // setup fails at boot, and seed the cache.
-            let conn = client.get_async_connection().await?;
+            //
+            // Discovery talks to the sentinels before it reaches the
+            // master, and `connection_timeout` bounds only the individual
+            // connect attempts inside it — so the whole exchange gets an
+            // outer budget too, or an unreachable sentinel stalls the
+            // boot attempt indefinitely.
+            let conn = tokio::time::timeout(
+                timeout,
+                client.get_async_connection_with_config(&conn_config(timeout)),
+            )
+            .await
+            .map_err(|_| timed_out_error(timeout))??;
             tracing::info!(
                 target: "aisix::redis",
                 mode = "sentinel",
                 master = %cfg.master_name.as_deref().unwrap_or_default(),
+                timeout_secs = timeout.as_secs(),
                 "connected"
             );
-            Ok(RedisConn::Sentinel(SentinelPool {
+            ConnKind::Sentinel(SentinelPool {
                 client: Arc::new(Mutex::new(client)),
                 cached: Arc::new(Mutex::new(Some(conn))),
-            }))
+            })
         }
-    }
+    };
+    Ok(RedisConn { inner, guard })
 }
 
 /// Read the `redis.tls` PEM files into the shape redis-rs wants, or
@@ -417,5 +635,104 @@ mod tests {
         };
         // Any error is fine — the point is it returns Err, not panics.
         assert!(connect(&cfg).await.is_err());
+    }
+}
+
+/// The failure policy in isolation: what a command does when Redis stops
+/// answering, and what the command after it does.
+///
+/// Exercised here rather than only through a live Redis because the
+/// property under test is a *timing* one — that the caller regains
+/// control — and a store integration test can only observe it by waiting
+/// out the very budget it is meant to prove exists.
+#[cfg(test)]
+mod guard_tests {
+    use super::*;
+    use std::future::pending;
+
+    fn guard(timeout_ms: u64, window_ms: u64) -> Guard {
+        Guard {
+            timeout: Duration::from_millis(timeout_ms),
+            breaker: Breaker::new(Duration::from_millis(window_ms)),
+        }
+    }
+
+    fn server_side_error() -> redis::RedisError {
+        // What a live Redis returns for, say, a bad script: it answered,
+        // so it is not a connectivity failure.
+        redis::RedisError::from((redis::ErrorKind::ExtensionError, "ERR bad script"))
+    }
+
+    /// The bug: with no budget the command never returns, so the caller's
+    /// fail-open branch is never reached and the request hangs.
+    #[tokio::test]
+    async fn a_peer_that_never_answers_gives_the_caller_control_back() {
+        let g = guard(80, 5_000);
+        let started = Instant::now();
+        let err = g
+            .run(pending::<RedisResult<()>>())
+            .await
+            .expect_err("a silent peer must surface as an error, not a hang");
+        assert!(err.is_timeout() || err.is_io_error(), "{err:?}");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "{:?}",
+            started.elapsed()
+        );
+    }
+
+    /// Paying the budget on every request during an outage is still a
+    /// multi-second latency floor for as long as the outage lasts.
+    #[tokio::test]
+    async fn the_command_after_a_failure_short_circuits_without_waiting() {
+        let g = guard(80, 5_000);
+        let _ = g.run(pending::<RedisResult<()>>()).await;
+
+        let started = Instant::now();
+        let err = g
+            .run(pending::<RedisResult<()>>())
+            .await
+            .expect_err("the breaker is open");
+        assert!(
+            started.elapsed() < Duration::from_millis(40),
+            "short-circuit must not pay the budget, took {:?}",
+            started.elapsed()
+        );
+        assert!(err.is_io_error(), "{err:?}");
+        assert!(err.to_string().contains("cool-off"), "{err}");
+    }
+
+    /// The window is a cool-off, not a latch: Redis coming back must be
+    /// noticed without anything resetting the breaker by hand.
+    #[tokio::test]
+    async fn the_window_expires_and_the_next_command_probes_for_real() {
+        let g = guard(80, 60);
+        let _ = g.run(pending::<RedisResult<()>>()).await;
+        assert!(g.breaker.is_open());
+
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert!(!g.breaker.is_open(), "the window must expire on its own");
+
+        g.run(async { Ok::<_, redis::RedisError>(7) })
+            .await
+            .expect("the probe reaches Redis again");
+        assert!(!g.breaker.is_open(), "a success closes the breaker");
+    }
+
+    /// A reply from a live Redis — a script error, `WRONGTYPE`, an ACL
+    /// refusal — is not an outage. Tripping on it would short-circuit
+    /// five seconds of healthy traffic every time one command is wrong.
+    #[tokio::test]
+    async fn an_error_redis_itself_reported_does_not_open_the_breaker() {
+        let g = guard(80, 5_000);
+        let err = g
+            .run(async { Err::<(), _>(server_side_error()) })
+            .await
+            .expect_err("the server error is passed through");
+        assert!(!err.is_io_error(), "{err:?}");
+        assert!(
+            !g.breaker.is_open(),
+            "a server reply is not a connectivity failure"
+        );
     }
 }

--- a/crates/aisix-redis/tests/sentinel_failover.rs
+++ b/crates/aisix-redis/tests/sentinel_failover.rs
@@ -97,8 +97,14 @@ async fn sentinel_reresolves_master_after_failover() {
     // A write must succeed again — proving acquire followed the promotion.
     // Retry briefly: the freshly promoted master may take a moment to
     // accept writes after role change.
+    //
+    // The budget is deliberately longer than the role change needs. The
+    // failure that triggered the failover also opened the connection
+    // layer's cool-off, so the first `BREAKER_WINDOW` of this loop is
+    // spent short-circuiting rather than re-resolving; sizing the loop to
+    // the role change alone would leave it racing the window.
     let mut wrote = false;
-    for _ in 0..40 {
+    for _ in 0..80 {
         // acquire itself can fail transiently right after a failover (the
         // sentinel master lookup may briefly error); retry rather than
         // abort, since absorbing that instability is the loop's whole job.

--- a/tests/e2e/src/cases/ratelimit-cluster-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-cluster-e2e.test.ts
@@ -222,18 +222,23 @@ describe("rate limit is NOT shared with backend=memory (per-replica, the #798 bu
 
 
 /**
- * A TCP relay in front of Redis that the test can cut.
+ * A TCP relay in front of Redis that the test can break, in either of the
+ * two shapes a real outage takes.
  *
- * Until cut, every byte is forwarded both ways. Afterwards each client
- * request is answered with a Redis error instead of being forwarded — an
- * error reply rather than a dropped socket, because a dropped socket sends
- * the gateway's connection manager into its own multi-minute reconnect
- * backoff and the request under measurement would not return inside the
- * test. Both shapes reach the store as the same failed operation.
+ * `cut()` answers each client request with a Redis error instead of
+ * forwarding it: Redis is reachable and refusing, so the gateway learns
+ * of the failure immediately.
+ *
+ * `blackhole()` keeps the socket open and never forwards or answers
+ * anything, which is what a stopped container, a downed host or a
+ * partitioned network looks like from the client end. Nothing arrives and
+ * nothing is refused, so without a command budget the gateway waits on TCP
+ * retransmission — for minutes.
  */
 async function startRedisCutoff(upstreamUrl: string): Promise<{
   url: string;
   cut(): void;
+  blackhole(): void;
   close(): Promise<void>;
 }> {
   const m = /^redis:\/\/(?:[^@/]*@)?([^:/]+)(?::(\d+))?/.exec(upstreamUrl);
@@ -241,16 +246,22 @@ async function startRedisCutoff(upstreamUrl: string): Promise<{
   const host = m[1];
   const port = m[2] ? Number(m[2]) : 6379;
   let cut = false;
+  let hole = false;
   const live = new Set<Socket>();
   const server: Server = createServer((client) => {
     live.add(client);
     const server = connect({ host, port });
     live.add(server);
     client.on("data", (buf) => {
+      // Swallowed under blackhole: no forward, no reply, no close.
+      if (hole) return;
       if (cut) client.write("-ERR simulated redis outage\r\n");
       else server.write(buf);
     });
-    server.on("data", (buf) => client.write(buf));
+    server.on("data", (buf) => {
+      if (hole) return;
+      client.write(buf);
+    });
     const bin = () => {
       client.destroy();
       server.destroy();
@@ -269,6 +280,9 @@ async function startRedisCutoff(upstreamUrl: string): Promise<{
     url: `redis://127.0.0.1:${addr.port}`,
     cut: () => {
       cut = true;
+    },
+    blackhole: () => {
+      hole = true;
     },
     close: () =>
       new Promise<void>((r) => {
@@ -346,5 +360,118 @@ describe("a Redis outage on the shared rate-limit backend is scrapeable (#1060)"
         labels.operation.startsWith("ratelimit_"),
       ),
     ).toBeGreaterThan(0);
+  });
+});
+
+
+/** Seed one model + an ApiKey whose limit is high enough that every
+ *  request in the outage suite is admitted — what is under test is how
+ *  long the limiter takes to answer, not whether it refuses. */
+async function seedGenerousLimit(
+  etcdRoot: string,
+  upstreamBase: string,
+  model: string,
+) {
+  const seed = new SeedClient(new EtcdClient(), etcdRoot);
+  const pk = await seed.createProviderKey({
+    display_name: `${model}-pk`,
+    secret: "sk-mock",
+    api_base: `${upstreamBase}/v1`,
+  });
+  await seed.createModel({
+    display_name: model,
+    provider: "openai",
+    model_name: "gpt-4o-mini",
+    provider_key_id: pk.id,
+  });
+  await seed.createApiKey({
+    key_hash: CALLER_KEY_HASH,
+    allowed_models: [model],
+    rate_limit: { rpm: 1000 },
+  });
+}
+
+// A Redis that stops answering without closing the socket must degrade the
+// request, not hold it.
+//
+// The limiter has always failed open on a Redis *error* — the describe
+// above pins that — but with no bound on a command the error never
+// arrived: `docker stop` of the Redis container left every rate-limited
+// request unanswered past three minutes (curl exit 28), while requests
+// matching no policy answered in milliseconds. Redis unreachable is the
+// case the fail-open path exists for, and it was the one case it did not
+// cover.
+//
+// Two properties, because each is worthless without the other: the request
+// that meets the silence must come back inside the command budget, and the
+// requests behind it must not each pay that budget again for as long as
+// the outage lasts.
+describe("an unreachable Redis degrades the limiter instead of hanging the request", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let relay: Awaited<ReturnType<typeof startRedisCutoff>> | undefined;
+  let infraReady = false;
+  const prefix = `/aisix-e2e-rl-redisblackhole-${randomUUID()}`;
+  const model = "rl-redis-blackhole";
+  // Short enough that the assertions below fit a normal test timeout, and
+  // still long enough that no healthy round trip on this host trips it.
+  const TIMEOUT_SECS = 2;
+
+  beforeAll(async () => {
+    infraReady = (await new EtcdClient().ping()) && (await redisPing(REDIS_URL));
+    if (!infraReady) return;
+
+    upstream = await startOpenAiUpstream();
+    relay = await startRedisCutoff(REDIS_URL);
+    app = await spawnApp({
+      extra: {
+        etcd: sharedEtcd(prefix),
+        ratelimit: {
+          backend: "redis",
+          redis: { url: relay.url, timeout_secs: TIMEOUT_SECS },
+        },
+      },
+    });
+    await seedGenerousLimit(prefix, upstream.baseUrl, model);
+    await waitModelLive(app.proxyUrl, model);
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await relay?.close();
+    if (infraReady) await new EtcdClient().deletePrefix(prefix);
+  });
+
+  test("the request completes on the local fallback, and the next one costs nothing", async (ctx) => {
+    if (!infraReady || !app || !relay) {
+      ctx.skip();
+      return;
+    }
+
+    const healthy = await chatRequest(app.proxyUrl, model);
+    expect(healthy.status).toBe(200);
+    await healthy.body?.cancel();
+
+    relay.blackhole();
+
+    const firstStarted = Date.now();
+    const first = await chatRequest(app.proxyUrl, model);
+    const firstMs = Date.now() - firstStarted;
+    expect(first.status).toBe(200);
+    await first.body?.cancel();
+    // Before the budget existed this never returned at all; the bound is
+    // the budget plus room for the mock upstream and process scheduling.
+    expect(firstMs).toBeLessThan((TIMEOUT_SECS + 8) * 1000);
+
+    // And the one behind it short-circuits: without the cool-off every
+    // request for the length of the outage carries the budget as added
+    // latency.
+    const secondStarted = Date.now();
+    const second = await chatRequest(app.proxyUrl, model);
+    const secondMs = Date.now() - secondStarted;
+    expect(second.status).toBe(200);
+    await second.body?.cancel();
+    expect(secondMs).toBeLessThan(TIMEOUT_SECS * 1000);
   });
 });

--- a/tests/e2e/src/cases/ratelimit-cluster-e2e.test.ts
+++ b/tests/e2e/src/cases/ratelimit-cluster-e2e.test.ts
@@ -415,6 +415,9 @@ describe("an unreachable Redis degrades the limiter instead of hanging the reque
   const model = "rl-redis-blackhole";
   // Short enough that the assertions below fit a normal test timeout, and
   // still long enough that no healthy round trip on this host trips it.
+  // It is also deliberately below the 5s default: the first-request bound
+  // is what shows the per-block field reached the connection, and a bound
+  // above the default would pass either way.
   const TIMEOUT_SECS = 2;
 
   beforeAll(async () => {
@@ -460,9 +463,12 @@ describe("an unreachable Redis degrades the limiter instead of hanging the reque
     const firstMs = Date.now() - firstStarted;
     expect(first.status).toBe(200);
     await first.body?.cancel();
-    // Before the budget existed this never returned at all; the bound is
-    // the budget plus room for the mock upstream and process scheduling.
-    expect(firstMs).toBeLessThan((TIMEOUT_SECS + 8) * 1000);
+    // Before the budget existed this never returned at all. The bound is
+    // the configured budget plus room for the mock upstream and process
+    // scheduling, and stays under the 5s default so a gateway that ignored
+    // `timeout_secs` fails here.
+    expect(firstMs).toBeGreaterThanOrEqual(TIMEOUT_SECS * 1000);
+    expect(firstMs).toBeLessThan(TIMEOUT_SECS * 1000 + 2000);
 
     // And the one behind it short-circuits: without the cool-off every
     // request for the length of the outage carries the budget as added
@@ -472,6 +478,6 @@ describe("an unreachable Redis degrades the limiter instead of hanging the reque
     const secondMs = Date.now() - secondStarted;
     expect(second.status).toBe(200);
     await second.body?.cancel();
-    expect(secondMs).toBeLessThan(TIMEOUT_SECS * 1000);
+    expect(secondMs).toBeLessThan(1000);
   });
 });


### PR DESCRIPTION
Fixes api7/AISIX-Cloud#1519

## Problem

With `ratelimit.backend=redis`, once Redis becomes unreachable every request that matches a rate-limit policy hangs indefinitely — reproduced past 180s with no status line (curl exit 28) on both 1.2.0-rc.1 and v1.1.0, while requests matching no policy answered in ~4ms. Recovery was equally slow: the first request after Redis returned took ~9s.

The fail-open design was already there and already wired. On a Redis error the rate-limit store falls back to per-process counters, and the caches fall back to a miss. It never ran, because **no error ever arrived**: `aisix-redis` built its connections with neither `response_timeout` nor `connection_timeout` (both driver defaults are unset), so a command issued to a peer that stopped answering *without closing the socket* — a stopped container, a downed host, a partitioned network — blocked on TCP retransmission for minutes. `aisix_redis_failures_total` did eventually rise, but only long after the request had been held.

This was one defect at one site with three victims: the rate-limit store, the response cache and the semantic cache all reach Redis through `aisix_redis::RedisConn`, and each already had the fail-open branch that a prompt error now reaches.

## Change

Two mechanisms, both in the shared connection layer so every consumer gets them and none can forget them.

**A command budget — `redis.timeout_secs`, new, default 5.** It bounds one Redis round trip and one connection attempt. Set natively on the driver for all three topologies (`ConnectionManagerConfig` for `single`, `ClusterClientBuilder` for `cluster`, `AsyncConnectionConfig` for the sentinel-discovered master, plus an outer bound on sentinel discovery itself), *and* enforced around each command in `RedisConnHandle`'s `ConnectionLike` impl. The second half is not redundant: the native response timeout does not cover time spent waiting on the connection manager's own in-progress reconnect, which is where the remaining unbounded wait lived.

**A fixed 5s cool-off breaker.** Paying the budget on every request for the length of an outage is still a multi-second latency floor. After a connectivity failure, commands short-circuit with no round trip until the window ends. When it ends, exactly **one** command is admitted as a probe and the window is re-armed behind it, so an outage costs the budget about once per five seconds rather than once per request — gating only the window itself would still let everything arriving during the probe's flight pay in full. A success closes the breaker, and only the breaker the successful command started under, so a command that was already in flight when the outage began cannot wipe a newer cool-off. An error Redis itself reported — a script error, `WRONGTYPE`, an ACL refusal — does not open it, because Redis answered. The window is deliberately not configurable.

Breaker short-circuits are ordinary `Err`s, so they flow into each consumer's existing `aisix_redis_failures_total{operation=...}` call. No new metric and no new label.

Startup connect/retry behaviour is unchanged: only the two timeouts are set on the connection manager, the retry policy stays the library default.

## Behavior change

- **New startup config field `timeout_secs` on every `redis:` block** — `cache.redis.timeout_secs` and `ratelimit.redis.timeout_secs`, i.e. `AISIX_CACHE__REDIS__TIMEOUT_SECS` / `AISIX_RATELIMIT__REDIS__TIMEOUT_SECS`. Unsigned seconds, **default 5**, minimum 1; `0` is rejected at boot with a message naming the field, since "wait forever" is the defect being removed. Nothing has to be edited on upgrade — existing configurations pick up the default.
- **A Redis outage now degrades a request instead of holding it.** Where a request previously hung for minutes, it now completes on the local fallback within roughly the budget, and subsequent requests during the outage complete immediately. The answer a caller gets is unchanged (the limiter was already fail-open); what changes is that it arrives.
- Deployments with an unusually slow Redis path should raise `timeout_secs`; a healthy in-cluster round trip is orders of magnitude below 5s.

Two things the budget is deliberately not, both stated in `config.example.yaml` so nobody sizes a latency ceiling from the wrong number:

- **It is per connection, not per request.** The rate limiter, the response cache and the semantic cache each open their own connection and cool off independently, so a request that uses more than one of them can pay a budget for each while a shared Redis is down.
- **Sentinel master discovery is not one round trip.** The client library walks the configured sentinels one at a time and applies no timeout to the sentinel hops, so that step gets one budget per sentinel plus one for the master. A single unreachable sentinel would otherwise consume the whole budget and starve the healthy ones. A failover also costs up to one cool-off window before the master is re-resolved, during which the limiter counts per replica — fail-open, and the alternative is every request racing to re-walk the sentinels.

In `cluster` mode the breaker covers the connection, not the slot, so one unreachable shard cools off traffic to the healthy ones as well. The client library exposes no per-node handle to hang a finer breaker on, and the consequence is the fail-open degradation this design already chose.

This is a gateway process setting, not a resource the control plane manages, so there is no paired CP change and no etcd projection to keep compatible — the same shape as the existing `ratelimit.concurrency_ttl_secs`.

## Tests

Each was mutation-checked — the fix reverted, the test observed going red.

- **DP e2e** (`tests/e2e/src/cases/ratelimit-cluster-e2e.test.ts`): the relay in front of a real Redis gains a `blackhole()` mode that keeps the socket open and never forwards or answers anything. That is deliberately the reported reproduction — pausing the container or dropping the packets, so the connection never sees a refusal — and not a stopped container, which can surface an immediate refusal and would exercise the *cheap* failure the existing `cut()` already covers. Through a spawned gateway: the request that meets the silence completes 200 on the local fallback inside the budget, and the request behind it completes without paying the budget again. Reverted, this test times out at 60s — the reported hang, reproduced end to end.
- **Store integration** (`crates/aisix-ratelimit/tests/redis_integration.rs`): the same two properties directly against `RedisStore` and a live Redis. Reverted, it hangs past 60s.
- **Connection layer** (`crates/aisix-redis/src/lib.rs`): the failure policy in isolation — a peer that never answers returns control to the caller; the command behind a failure short-circuits without waiting; only one command probes when the window expires; a success that started before a concurrent failure does not wipe the newer cool-off; the window expires on its own; an error Redis itself reported does not open the breaker. The last three are concurrency properties, which is why they are here and not in a serial store test.
- **Config** (`crates/aisix-core/src/config.rs`): the default is 5 in both the parsed config and `RedisConnConfig::default()`, the field parses per block, and `0` is rejected.

The baseline for the fix's shape is how mainstream gateways handle the same failure: a socket timeout on every Redis client with failures swallowed, admission when the cache returns nothing, and a breaker so the timeout is not paid on every request. This change matches that shape.
