### PR TITLE
feat(apikey): grant models by resource id, so a rename keeps the grant

### DIFF
--- a/crates/aisix-admin/src/apikeys_handlers.rs
+++ b/crates/aisix-admin/src/apikeys_handlers.rs
@@ -20,9 +20,10 @@ use crate::state::AdminState;
 pub struct PublicApiKey {
     pub key_hash: String,
     pub allowed_models: Vec<String>,
-    /// Shown whenever the stored key carries it, because it is then the
-    /// field that decides access and `allowed_models` is ignored — an
-    /// operator reading only the names would misread the key's ACL.
+    /// Shown whenever the stored key carries it, because an array here —
+    /// `[]` included — decides access on its own and `allowed_models` is
+    /// ignored, so an operator reading only the names would misread the
+    /// key's ACL.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_model_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/aisix-admin/src/apikeys_handlers.rs
+++ b/crates/aisix-admin/src/apikeys_handlers.rs
@@ -20,6 +20,11 @@ use crate::state::AdminState;
 pub struct PublicApiKey {
     pub key_hash: String,
     pub allowed_models: Vec<String>,
+    /// Shown whenever the stored key carries it, because it is then the
+    /// field that decides access and `allowed_models` is ignored — an
+    /// operator reading only the names would misread the key's ACL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_model_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<aisix_core::models::RateLimit>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -37,6 +42,7 @@ impl From<ApiKey> for PublicApiKey {
         Self {
             key_hash: value.key_hash,
             allowed_models: value.allowed_models,
+            allowed_model_ids: value.allowed_model_ids,
             rate_limit: value.rate_limit,
             mcp_access: value.mcp_access,
             allowed_agents: value.allowed_agents,

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1528,7 +1528,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "Model names this caller API key may use, matched as single-`*` globs. Read only when `allowed_model_ids` is absent.",
+            "description": "Model names this caller API key may use, matched as single-`*` globs. Read only when `allowed_model_ids` is omitted or null; an array there, `[]` included, takes over entirely.",
             "example": [
               "gpt-4o"
             ]
@@ -1541,7 +1541,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "Models this caller API key may use, named by resource id. Present, it decides access and `allowed_models` is ignored.",
+            "description": "Models this caller API key may use, named by resource id. An array here, `[]` included, is authoritative and `allowed_models` is ignored: each id resolves against the models currently in the configuration and the resolved name is glob-matched, and an id resolving to no model grants nothing. Omitted or null falls back to `allowed_models`, so `[]` and not null is how access is removed.",
             "example": [
               "9b1b6d9c-1f5e-4c1e-9f8f-2f5f5b9d1c11"
             ]

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1528,9 +1528,22 @@ const OPENAPI_JSON_BASE: &str = r##"{
             "items": {
               "type": "string"
             },
-            "description": "Model aliases this caller API key may use.",
+            "description": "Model names this caller API key may use, matched as single-`*` globs. Read only when `allowed_model_ids` is absent.",
             "example": [
               "gpt-4o"
+            ]
+          },
+          "allowed_model_ids": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "Models this caller API key may use, named by resource id. Present, it decides access and `allowed_models` is ignored.",
+            "example": [
+              "9b1b6d9c-1f5e-4c1e-9f8f-2f5f5b9d1c11"
             ]
           },
           "rate_limit": {

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -388,6 +388,24 @@ pub fn load_from_str(
             continue;
         }
 
+        // `allowed_model_ids` is a control-plane projection: it names
+        // models by the id the control plane assigned them, while a file's
+        // ids are derived from the entry names, so no id a file can carry
+        // ever resolves. Accepting it would make the key grant nothing at
+        // all — silently, and with `allowed_models` ignored on top — so the
+        // file rejects the field instead. (The etcd path is the opposite:
+        // there an id that resolves to no model simply grants nothing and
+        // must never fail the row, because a rejected api_key stops
+        // authenticating entirely.)
+        if entry.kind == "api_keys" && entry.doc.get("allowed_model_ids").is_some() {
+            errors.push(LoadError {
+                scope,
+                message: "the resources file does not accept `allowed_model_ids` — it names                           models by control-plane id, which a file cannot resolve; grant                           models by name with `allowed_models`"
+                    .into(),
+            });
+            continue;
+        }
+
         let sugar_result = match entry.kind {
             "models" => desugar::desugar_model(&mut entry.doc, &identity_maps),
             "api_keys" => desugar::desugar_api_key(&mut entry.doc, env),

--- a/crates/aisix-core/src/filesource/tests.rs
+++ b/crates/aisix-core/src/filesource/tests.rs
@@ -444,6 +444,45 @@ models:
 }
 
 #[test]
+fn allowed_model_ids_is_rejected_by_the_file_source() {
+    // A file's ids are derived from entry names, so no id written here
+    // resolves to a model — the key would silently grant nothing, with
+    // `allowed_models` ignored on top of that. Fail loudly instead.
+    let contents = r#"
+_format_version: "1"
+models:
+  - display_name: m
+    provider: openai
+    model_name: x
+    provider_key: pk
+provider_keys:
+  - display_name: pk
+    api_key: sk-x
+api_keys:
+  - display_name: k
+    key_env: CALLER_KEY
+    allowed_models: ["m"]
+    allowed_model_ids: ["11111111-1111-1111-1111-111111111111"]
+"#;
+    let env = env_of(&[("CALLER_KEY", "sk-caller")]);
+    let errs = errors_of(load(contents, &env));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].contains("does not accept `allowed_model_ids`")
+            && errs[0].contains("allowed_models"),
+        "{errs:?}"
+    );
+
+    // The same file without the field loads, so the rejection is the
+    // field and not anything else in the fixture.
+    let ok = contents.replace(
+        "    allowed_model_ids: [\"11111111-1111-1111-1111-111111111111\"]\n",
+        "",
+    );
+    load(&ok, &env).expect("the same file without the field loads");
+}
+
+#[test]
 fn canonical_validation_failures_carry_entry_scope() {
     // Empty display_name violates the model schema (minLength 1)…
     // after passing identity extraction? No — identity extraction

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -31,8 +31,24 @@ pub struct ApiKey {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
 
-    /// Model identifiers this key may use. An empty array denies access to every model.
+    /// Model names this key may use, matched as single-`*` globs. Read only
+    /// when `allowed_model_ids` is absent; ignored entirely when it is
+    /// present. When both are omitted the key may use no model — model
+    /// access is granted explicitly.
+    #[serde(default)]
     pub allowed_models: Vec<String>,
+
+    /// Models this key may use, named by resource id rather than by name, so
+    /// renaming a model does not change what this key may reach. Present —
+    /// including as an empty array — it is authoritative and `allowed_models`
+    /// is ignored; each id is resolved against the current models in the
+    /// snapshot and the resolved name is matched with the same single-`*`
+    /// glob rule, so an id naming a wildcard model still grants every name
+    /// that model's pattern covers. An id matching no model grants nothing.
+    /// Set to `null` it means the same as omitted: the key falls back to
+    /// `allowed_models`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_model_ids: Option<Vec<String>>,
 
     /// Request, token, and concurrency limits for this key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -151,16 +167,42 @@ impl ApiKey {
         self.expires_at.is_some_and(|deadline| deadline < now)
     }
 
-    /// True if this key is allowed to call the given Model.
+    /// True if this key is allowed to call the model the caller addressed.
     ///
-    /// Entries are matched as single-`*` globs, so `"*"` grants every model and
-    /// `"openai/*"` grants every `openai/*` name (pairing with wildcard Models);
-    /// entries without a `*` match exactly. An empty `allowed_models` list denies
-    /// everything (spec §3 authz rule).
-    pub fn can_access(&self, model_name: &str) -> bool {
-        self.allowed_models
-            .iter()
-            .any(|n| crate::wildcard::wildcard_matches(n, model_name))
+    /// **The single chokepoint for the key→model ACL.** Every request path
+    /// that gates on model access calls this and nothing else, so the two
+    /// grant shapes below can never diverge across the endpoint family. It
+    /// keys on the caller-addressed entry — the name the request names, or
+    /// the stored name of the entry it references — and never on whatever
+    /// target dispatch later picks, for every model kind.
+    ///
+    /// The key grants models one of two ways:
+    ///
+    /// - `allowed_model_ids` present (an empty array included): each id is
+    ///   resolved to the current name of the model carrying it and that name
+    ///   is matched as a single-`*` glob, so an id naming a wildcard model
+    ///   still grants every name its pattern covers. An id resolving to no
+    ///   model grants nothing. `allowed_models` is not read at all.
+    /// - `allowed_model_ids` absent: `allowed_models` names are matched as
+    ///   single-`*` globs — `"*"` grants every model, `"openai/*"` every
+    ///   `openai/*` name, an entry without a `*` matches exactly.
+    ///
+    /// With neither present the key may use no model. Resolution is done per
+    /// request against the live table rather than cached, so a model rename
+    /// takes effect on the next request with no rewrite of any key document.
+    pub fn can_access(&self, snapshot: &super::AisixSnapshot, model_name: &str) -> bool {
+        match &self.allowed_model_ids {
+            Some(ids) => ids.iter().any(|id| {
+                snapshot
+                    .models
+                    .get_by_id(id)
+                    .is_some_and(|m| crate::wildcard::wildcard_matches(m.value.name(), model_name))
+            }),
+            None => self
+                .allowed_models
+                .iter()
+                .any(|n| crate::wildcard::wildcard_matches(n, model_name)),
+        }
     }
 
     /// The limits this key carries for one MCP server, named as it is
@@ -204,13 +246,16 @@ impl ApiKey {
 
     /// Iterate over the names of models this key may access, filtering them
     /// against a known universe of model names. Delegates to [`Self::can_access`]
-    /// so glob entries stay consistent with per-request authz: `*` expands to
-    /// the full universe and `openai/*` to every matching name.
+    /// so the listing can never advertise a name the request path would
+    /// reject, whichever grant shape the key carries.
     pub fn accessible_models<'a>(
         &'a self,
+        snapshot: &super::AisixSnapshot,
         all_models: impl Iterator<Item = &'a str> + 'a,
     ) -> Vec<&'a str> {
-        all_models.filter(|name| self.can_access(name)).collect()
+        all_models
+            .filter(|name| self.can_access(snapshot, name))
+            .collect()
     }
 }
 
@@ -243,6 +288,30 @@ mod tests {
     /// SHA-256 hex of `"sk-my-api-key-123"`.
     const SAMPLE_PLAINTEXT: &str = "sk-my-api-key-123";
     const SAMPLE_HASH: &str = "91ed2dbc407561556f3e7be98ba0bd2a57986d6a868c482d867d19c6d40d201c";
+
+    /// A snapshot holding one model per `(id, display_name)` pair, so an
+    /// `allowed_model_ids` entry has something to resolve against.
+    fn snapshot_with_models(models: &[(&str, &str)]) -> super::super::AisixSnapshot {
+        let snap = super::super::AisixSnapshot::default();
+        for (id, display_name) in models {
+            let model: crate::models::Model = serde_json::from_str(&format!(
+                r#"{{
+                  "display_name": "{display_name}",
+                  "provider": "openai",
+                  "model_name": "gpt-4o",
+                  "provider_key_id": "11111111-1111-1111-1111-111111111111"
+                }}"#
+            ))
+            .unwrap();
+            snap.models
+                .insert(crate::resource::ResourceEntry::new(*id, model, 1));
+        }
+        snap
+    }
+
+    fn empty_snapshot() -> super::super::AisixSnapshot {
+        super::super::AisixSnapshot::default()
+    }
 
     fn sample() -> ApiKey {
         serde_json::from_str(&format!(
@@ -280,6 +349,7 @@ mod tests {
             key_hash: "abc".into(),
             display_name: None,
             allowed_models: vec![],
+            allowed_model_ids: None,
             rate_limit: None,
             team_id: None,
             user_id: None,
@@ -294,8 +364,9 @@ mod tests {
             disabled: false,
             runtime_id: String::new(),
         };
-        assert!(!k.can_access("my-gpt4"));
-        assert!(!k.can_access("anything"));
+        let snap = empty_snapshot();
+        assert!(!k.can_access(&snap, "my-gpt4"));
+        assert!(!k.can_access(&snap, "anything"));
     }
 
     #[test]
@@ -363,27 +434,30 @@ mod tests {
     #[test]
     fn can_access_checks_whitelist() {
         let k = sample();
-        assert!(k.can_access("my-gpt4"));
-        assert!(k.can_access("my-claude"));
-        assert!(!k.can_access("other"));
+        let snap = empty_snapshot();
+        assert!(k.can_access(&snap, "my-gpt4"));
+        assert!(k.can_access(&snap, "my-claude"));
+        assert!(!k.can_access(&snap, "other"));
     }
 
     #[test]
     fn wildcard_grants_access_to_any_model() {
         let k: ApiKey =
             serde_json::from_str(r#"{"key_hash":"abc","allowed_models":["*"]}"#).unwrap();
-        assert!(k.can_access("my-gpt4"));
-        assert!(k.can_access("literally-anything"));
+        let snap = empty_snapshot();
+        assert!(k.can_access(&snap, "my-gpt4"));
+        assert!(k.can_access(&snap, "literally-anything"));
     }
 
     #[test]
     fn glob_entry_grants_matching_names() {
         let k: ApiKey =
             serde_json::from_str(r#"{"key_hash":"abc","allowed_models":["openai/*"]}"#).unwrap();
-        assert!(k.can_access("openai/gpt-4o"));
-        assert!(k.can_access("openai/gpt-4o-mini"));
-        assert!(!k.can_access("anthropic/claude"));
-        assert!(!k.can_access("openai")); // prefix must be followed by the glob
+        let snap = empty_snapshot();
+        assert!(k.can_access(&snap, "openai/gpt-4o"));
+        assert!(k.can_access(&snap, "openai/gpt-4o-mini"));
+        assert!(!k.can_access(&snap, "anthropic/claude"));
+        assert!(!k.can_access(&snap, "openai")); // prefix must be followed by the glob
     }
 
     #[test]
@@ -391,7 +465,7 @@ mod tests {
         let k: ApiKey =
             serde_json::from_str(r#"{"key_hash":"abc","allowed_models":["openai/*"]}"#).unwrap();
         let universe = ["openai/gpt-4o", "openai/o1", "anthropic/claude"];
-        let mut accessible = k.accessible_models(universe.iter().copied());
+        let mut accessible = k.accessible_models(&empty_snapshot(), universe.iter().copied());
         accessible.sort_unstable();
         assert_eq!(accessible, vec!["openai/gpt-4o", "openai/o1"]);
     }
@@ -401,7 +475,7 @@ mod tests {
         let k: ApiKey =
             serde_json::from_str(r#"{"key_hash":"abc","allowed_models":["*"]}"#).unwrap();
         let universe = ["a", "b", "c"];
-        let accessible = k.accessible_models(universe.iter().copied());
+        let accessible = k.accessible_models(&empty_snapshot(), universe.iter().copied());
         assert_eq!(accessible, vec!["a", "b", "c"]);
     }
 
@@ -409,7 +483,7 @@ mod tests {
     fn accessible_models_filters_explicit_list() {
         let k = sample(); // allowed: ["my-gpt4", "my-claude"]
         let universe = ["my-gpt4", "my-claude", "other"];
-        let mut accessible = k.accessible_models(universe.iter().copied());
+        let mut accessible = k.accessible_models(&empty_snapshot(), universe.iter().copied());
         accessible.sort_unstable();
         assert_eq!(accessible, vec!["my-claude", "my-gpt4"]);
     }
@@ -418,7 +492,9 @@ mod tests {
     fn accessible_models_empty_list_returns_nothing() {
         let k: ApiKey = serde_json::from_str(r#"{"key_hash":"abc","allowed_models":[]}"#).unwrap();
         let universe = ["a", "b"];
-        assert!(k.accessible_models(universe.iter().copied()).is_empty());
+        assert!(k
+            .accessible_models(&empty_snapshot(), universe.iter().copied())
+            .is_empty());
     }
 
     #[test]
@@ -546,5 +622,99 @@ mod tests {
         let v = serde_json::to_value(sample()).unwrap();
         assert!(v.get("disabled").is_none());
         assert!(v.get("expires_at").is_none());
+    }
+
+    #[test]
+    fn allowed_model_ids_grant_by_resource_id() {
+        let snap = snapshot_with_models(&[("m-1", "my-gpt4"), ("m-2", "my-claude")]);
+        let k: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_model_ids":["m-1"]}"#).unwrap();
+        assert!(k.can_access(&snap, "my-gpt4"));
+        assert!(!k.can_access(&snap, "my-claude"));
+    }
+
+    #[test]
+    fn allowed_model_ids_follow_a_rename() {
+        let snap = snapshot_with_models(&[("m-1", "my-gpt4")]);
+        let k: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_model_ids":["m-1"]}"#).unwrap();
+        assert!(k.can_access(&snap, "my-gpt4"));
+
+        // Same id, new name: the key document is untouched.
+        let renamed = snapshot_with_models(&[("m-1", "my-gpt4-v2")]);
+        assert!(renamed.models.get_by_name("my-gpt4").is_none());
+        assert!(k.can_access(&renamed, "my-gpt4-v2"));
+        assert!(!k.can_access(&renamed, "my-gpt4"));
+    }
+
+    #[test]
+    fn allowed_model_ids_naming_a_wildcard_model_keep_its_pattern() {
+        let snap = snapshot_with_models(&[("m-1", "gpt-*")]);
+        let k: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_model_ids":["m-1"]}"#).unwrap();
+        assert!(k.can_access(&snap, "gpt-4o"));
+        assert!(!k.can_access(&snap, "claude-sonnet"));
+    }
+
+    #[test]
+    fn allowed_model_ids_win_over_allowed_models() {
+        let snap = snapshot_with_models(&[("m-1", "my-gpt4"), ("m-2", "my-claude")]);
+        let k: ApiKey = serde_json::from_str(
+            r#"{"key_hash":"h","allowed_models":["my-claude"],"allowed_model_ids":["m-1"]}"#,
+        )
+        .unwrap();
+        assert!(k.can_access(&snap, "my-gpt4"));
+        assert!(!k.can_access(&snap, "my-claude"));
+
+        // Even `allowed_models: ["*"]` is ignored once ids are present.
+        let widened: ApiKey = serde_json::from_str(
+            r#"{"key_hash":"h","allowed_models":["*"],"allowed_model_ids":[]}"#,
+        )
+        .unwrap();
+        assert!(!widened.can_access(&snap, "my-gpt4"));
+    }
+
+    #[test]
+    fn unresolvable_id_grants_nothing_but_leaves_the_rest() {
+        let snap = snapshot_with_models(&[("m-1", "my-gpt4")]);
+        let k: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_model_ids":["m-1","m-gone"]}"#)
+                .unwrap();
+        assert!(k.can_access(&snap, "my-gpt4"));
+        assert!(!k.can_access(&snap, "m-gone"));
+        assert!(!k.can_access(&snap, "anything-else"));
+    }
+
+    #[test]
+    fn neither_grant_field_loads_and_denies_everything() {
+        let snap = snapshot_with_models(&[("m-1", "my-gpt4")]);
+        let k: ApiKey = serde_json::from_str(r#"{"key_hash":"h"}"#).unwrap();
+        assert!(k.allowed_models.is_empty());
+        assert!(k.allowed_model_ids.is_none());
+        assert!(!k.can_access(&snap, "my-gpt4"));
+        assert!(!k.can_access(&snap, "*"));
+    }
+
+    #[test]
+    fn allowed_model_ids_stays_off_the_wire_when_absent() {
+        let v = serde_json::to_value(sample()).unwrap();
+        assert!(v.get("allowed_model_ids").is_none());
+
+        let k: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_model_ids":["m-1"]}"#).unwrap();
+        let v = serde_json::to_value(&k).unwrap();
+        assert_eq!(v["allowed_model_ids"], serde_json::json!(["m-1"]));
+    }
+
+    #[test]
+    fn accessible_models_follows_the_id_grant() {
+        let snap = snapshot_with_models(&[("m-1", "my-gpt4"), ("m-2", "my-claude")]);
+        let k: ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_model_ids":["m-2"]}"#).unwrap();
+        let names = ["my-gpt4", "my-claude"];
+        assert_eq!(
+            k.accessible_models(&snap, names.iter().copied()),
+            vec!["my-claude"]
+        );
     }
 }

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -47,8 +47,11 @@ pub struct ApiKey {
     /// that model's pattern covers — including a name an exact-match model
     /// of its own serves, which is how the name form behaves too. An id
     /// matching no model grants nothing.
+    ///
     /// Set to `null` it means the same as omitted: the key falls back to
-    /// `allowed_models`.
+    /// `allowed_models`. A producer must therefore write `[]`, never
+    /// `null`, for a key that is meant to grant no model — the two are
+    /// opposite grants, and an empty list is the one that is authoritative.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_model_ids: Option<Vec<String>>,
 

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -43,8 +43,10 @@ pub struct ApiKey {
     /// including as an empty array — it is authoritative and `allowed_models`
     /// is ignored; each id is resolved against the current models in the
     /// snapshot and the resolved name is matched with the same single-`*`
-    /// glob rule, so an id naming a wildcard model still grants every name
-    /// that model's pattern covers. An id matching no model grants nothing.
+    /// glob rule. An id naming a wildcard model therefore grants every name
+    /// that model's pattern covers — including a name an exact-match model
+    /// of its own serves, which is how the name form behaves too. An id
+    /// matching no model grants nothing.
     /// Set to `null` it means the same as omitted: the key falls back to
     /// `allowed_models`.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -2444,11 +2444,29 @@ mod tests {
     }
 
     #[test]
-    fn apikey_missing_allowed_models_fails() {
+    fn apikey_grant_fields_are_both_optional() {
+        // A key may grant models by name, by id, or (having neither)
+        // not at all — so neither field is required on either path.
         let v =
             json!({"key_hash":"9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20"});
-        let err = validate_apikey(&v).unwrap_err();
-        assert!(err.message.to_lowercase().contains("allowed_models"));
+        validate_apikey(&v).unwrap();
+        validate_apikey_lenient(&v).unwrap();
+    }
+
+    #[test]
+    fn apikey_allowed_model_ids_is_accepted() {
+        let hash = "9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20";
+        for ids in [json!(["m-1", "m-2"]), json!([]), json!(null)] {
+            let v = json!({"key_hash": hash, "allowed_model_ids": ids});
+            validate_apikey(&v).unwrap();
+            validate_apikey_lenient(&v).unwrap();
+        }
+        // Both grant shapes may be written together; the runtime lets the
+        // ids decide.
+        let v = json!({"key_hash": hash, "allowed_models": ["a"], "allowed_model_ids": ["m-1"]});
+        validate_apikey(&v).unwrap();
+        // Ids are resource ids, not numbers or objects.
+        assert!(validate_apikey(&json!({"key_hash": hash, "allowed_model_ids": [1]})).is_err());
     }
 
     #[test]

--- a/crates/aisix-core/tests/resource_schema_characterization.rs
+++ b/crates/aisix-core/tests/resource_schema_characterization.rs
@@ -142,7 +142,21 @@ fn apikey_corpus() {
                 true,
                 json!({"key_hash": "h", "allowed_models": []}),
             ),
-            ("missing allowed_models", false, json!({"key_hash": "h"})),
+            // Neither grant field: a key may grant models by name
+            // (`allowed_models`) or by resource id (`allowed_model_ids`),
+            // so neither is required — carrying neither is a valid
+            // document that grants no model access.
+            ("no grant field at all", true, json!({"key_hash": "h"})),
+            (
+                "allowed_model_ids alone",
+                true,
+                json!({"key_hash": "h", "allowed_model_ids": ["m-1"]}),
+            ),
+            (
+                "allowed_model_ids of non-strings",
+                false,
+                json!({"key_hash": "h", "allowed_model_ids": [1]}),
+            ),
             ("missing key_hash", false, json!({"allowed_models": ["a"]})),
             (
                 "empty key_hash",

--- a/crates/aisix-proxy/src/audio.rs
+++ b/crates/aisix-proxy/src/audio.rs
@@ -884,7 +884,7 @@ async fn multipart_dispatch(
     let model_entry = crate::model_resolve::resolve_model(snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
-    if !auth.key().can_access(&model_name) {
+    if !auth.key().can_access(snapshot, &model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
 
@@ -1671,7 +1671,7 @@ async fn speech_dispatch(
     let model_entry = crate::model_resolve::resolve_model(snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
-    if !auth.key().can_access(&model_name) {
+    if !auth.key().can_access(snapshot, &model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
 

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1341,7 +1341,7 @@ async fn dispatch(
     // (manually, not via this helper).
     let with_model = |e: ProxyError| DispatchFailure::new(Some(model_id.clone()), None, e);
 
-    if !auth.key().can_access(&req.model) {
+    if !auth.key().can_access(snapshot, &req.model) {
         return Err(with_model(ProxyError::ModelForbidden(req.model.clone())));
     }
 

--- a/crates/aisix-proxy/src/completions.rs
+++ b/crates/aisix-proxy/src/completions.rs
@@ -331,7 +331,7 @@ async fn dispatch(
     let model_entry = crate::model_resolve::resolve_model(snapshot, model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.to_string()))?;
 
-    if !auth.key().can_access(model_name) {
+    if !auth.key().can_access(snapshot, model_name) {
         return Err(ProxyError::ModelForbidden(model_name.to_string()));
     }
 

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -403,7 +403,7 @@ async fn dispatch(
     let model_entry = crate::model_resolve::resolve_model(snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
-    if !auth.key().can_access(&model_name) {
+    if !auth.key().can_access(snapshot, &model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
 

--- a/crates/aisix-proxy/src/embeddings.rs
+++ b/crates/aisix-proxy/src/embeddings.rs
@@ -316,7 +316,7 @@ async fn dispatch(
     let model_entry = crate::model_resolve::resolve_model(snapshot, &body.model)
         .ok_or_else(|| ProxyError::ModelNotFound(body.model.clone()))?;
 
-    if !auth.key().can_access(&body.model) {
+    if !auth.key().can_access(snapshot, &body.model) {
         return Err(ProxyError::ModelForbidden(body.model.clone()));
     }
 

--- a/crates/aisix-proxy/src/images.rs
+++ b/crates/aisix-proxy/src/images.rs
@@ -273,7 +273,7 @@ async fn dispatch(
     let model_entry = crate::model_resolve::resolve_model(snapshot, model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.to_string()))?;
 
-    if !auth.key().can_access(model_name) {
+    if !auth.key().can_access(snapshot, model_name) {
         return Err(ProxyError::ModelForbidden(model_name.to_string()));
     }
 

--- a/crates/aisix-proxy/src/images_edits.rs
+++ b/crates/aisix-proxy/src/images_edits.rs
@@ -286,7 +286,7 @@ async fn dispatch(
     let model_entry = crate::model_resolve::resolve_model(snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
-    if !auth.key().can_access(&model_name) {
+    if !auth.key().can_access(snapshot, &model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
 

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -203,7 +203,7 @@ pub(crate) fn resolve_target(
         Some(name) => {
             let entry = crate::model_resolve::resolve_model(snapshot, name)
                 .ok_or_else(|| ProxyError::ModelNotFound(format!("model {name:?} not found")))?;
-            if !auth.key().can_access(name) {
+            if !auth.key().can_access(snapshot, name) {
                 return Err(ProxyError::ModelForbidden(format!(
                     "api key is not authorized for model {name:?}"
                 )));
@@ -227,7 +227,7 @@ pub(crate) fn resolve_target(
                     && !m.is_ensemble()
                     && !m.is_semantic()
                     && !m.display_name.contains('*')
-                    && auth.key().can_access(&m.display_name)
+                    && auth.key().can_access(snapshot, &m.display_name)
                     && m.provider_key_id
                         .as_deref()
                         .and_then(|id| snapshot.provider_keys.get_by_id(id))

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -604,7 +604,7 @@ async fn dispatch(
     let model_entry = crate::model_resolve::resolve_model(snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
-    if !auth.key().can_access(&model_name) {
+    if !auth.key().can_access(snapshot, &model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()).into());
     }
 

--- a/crates/aisix-proxy/src/models.rs
+++ b/crates/aisix-proxy/src/models.rs
@@ -9,7 +9,7 @@
 //! `model` field*, so every dispatch shape qualifies: direct models and
 //! the virtual aliases (routing / semantic / ensemble) alike. A Model
 //! Group is the stable public entry point its operator intends callers
-//! to use, and the same `allowed_models` ACL that authorizes the request
+//! to use, and the same key→model ACL that authorizes the request
 //! decides whether it appears here.
 //!
 //! Each Model surfaces as:
@@ -76,7 +76,7 @@ pub async fn list_models(
 
     let api_key = auth.key();
     let permitted: Vec<&str> =
-        api_key.accessible_models(all_names.iter().map(|s: &String| s.as_str()));
+        api_key.accessible_models(&snapshot, all_names.iter().map(|s: &String| s.as_str()));
 
     let mut data: Vec<ModelObject> = permitted
         .into_iter()

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -336,7 +336,7 @@ async fn prepare(
 
     let model_entry = crate::model_resolve::resolve_model(snapshot, &requested_model)
         .ok_or_else(|| ProxyError::ModelNotFound(format!("model {requested_model:?} not found")))?;
-    if !auth.key().can_access(&requested_model) {
+    if !auth.key().can_access(snapshot, &requested_model) {
         return Err(ProxyError::ModelForbidden(format!(
             "api key is not authorized for model {requested_model:?}"
         )));

--- a/crates/aisix-proxy/src/rerank.rs
+++ b/crates/aisix-proxy/src/rerank.rs
@@ -289,7 +289,7 @@ async fn dispatch(
     let model_entry = crate::model_resolve::resolve_model(snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
-    if !auth.key().can_access(&model_name) {
+    if !auth.key().can_access(snapshot, &model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()));
     }
 

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -558,7 +558,7 @@ async fn dispatch(
     let model_entry = crate::model_resolve::resolve_model(snapshot, &model_name)
         .ok_or_else(|| ProxyError::ModelNotFound(model_name.clone()))?;
 
-    if !auth.key().can_access(&model_name) {
+    if !auth.key().can_access(snapshot, &model_name) {
         return Err(ProxyError::ModelForbidden(model_name.clone()).into());
     }
 

--- a/crates/aisix-proxy/src/videos.rs
+++ b/crates/aisix-proxy/src/videos.rs
@@ -1063,7 +1063,7 @@ fn resolve_video_target(
     acl_name: &str,
     client_ctx: &ClientContext,
 ) -> Result<Result<VideoTarget, Response>, ProxyError> {
-    if !auth.key().can_access(acl_name) {
+    if !auth.key().can_access(snapshot, acl_name) {
         return Err(ProxyError::ModelForbidden(acl_name.to_string()));
     }
     crate::dispatch::check_ip_access(&model_entry.value, &client_ctx.source_ip)?;

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -148,10 +148,11 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
             |k| synthetic_api_key_name(&k.key_hash),
             "api_keys",
             &mut diag,
-            |doc, identity, _warnings| {
+            |doc, identity, diag| {
                 if let Value::Object(map) = doc {
                     map.insert("display_name".into(), Value::String(identity.to_string()));
                 }
+                resugar_allowed_models(doc, identity, &model_names, diag);
             },
             |_, _| {},
         ),
@@ -647,6 +648,44 @@ fn resugar_provider_key(
              will not load until it is resolved)"
         )),
     }
+}
+
+/// `api_key.allowed_model_ids` (etcd ids) → `allowed_models` names.
+///
+/// The file source grants models by name, so the export resolves each id to
+/// the identity the models collection is keyed by and emits the name form the
+/// key already carries a field for. The id form is a control-plane projection
+/// and is never written to a resources file.
+///
+/// An id naming no exported model is dropped with a warning rather than kept:
+/// dropping it makes the key reach LESS, while emitting an unresolvable name
+/// would fail the loader's model cross-reference and take the whole file down.
+fn resugar_allowed_models(
+    doc: &mut Value,
+    api_key: &str,
+    model_names: &BTreeMap<String, String>,
+    diag: &mut Diagnostics,
+) {
+    let Some(map) = doc.as_object_mut() else {
+        return;
+    };
+    let Some(Value::Array(ids)) = map.remove("allowed_model_ids") else {
+        return;
+    };
+
+    let mut names = Vec::with_capacity(ids.len());
+    for id in &ids {
+        let Some(id) = id.as_str() else { continue };
+        match model_names.get(id) {
+            Some(name) => names.push(Value::String(name.clone())),
+            None => diag.warnings.push(format!(
+                "api key {api_key:?} grants model id {id:?}, which is not among the exported \
+                 models — the grant is dropped (the gateway already treats it as granting \
+                 nothing)"
+            )),
+        }
+    }
+    map.insert("allowed_models".into(), Value::Array(names));
 }
 
 /// `claim_mapping.resolve.api_key_id` (etcd id) → `resolve.api_key`

--- a/crates/aisix-server/src/export/document_tests.rs
+++ b/crates/aisix-server/src/export/document_tests.rs
@@ -670,3 +670,97 @@ fn a_team_scope_is_carried_through_verbatim() {
         doc.warnings
     );
 }
+
+#[test]
+fn api_key_allowed_model_ids_resugar_to_names() {
+    let snap = AisixSnapshot::new();
+    snap.provider_keys
+        .insert(ResourceEntry::new("pk", provider_key("pk", "sk"), 1));
+    for (id, display_name) in [("m-uuid-1", "gpt-4o"), ("m-uuid-2", "claude")] {
+        snap.models.insert(ResourceEntry::new(
+            id,
+            model_value(json!({
+                "display_name": display_name,
+                "provider": "openai",
+                "model_name": "x",
+                "provider_key_id": "pk"
+            })),
+            1,
+        ));
+    }
+    snap.apikeys.insert(ResourceEntry::new(
+        "k-uuid-1",
+        serde_json::from_value(json!({
+            "key_hash": "aa".repeat(32),
+            "allowed_models": ["stale-name"],
+            "allowed_model_ids": ["m-uuid-2"]
+        }))
+        .unwrap(),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    let keys = find(&doc, "api_keys");
+    // The file source grants by name only: the id form never reaches it,
+    // and the name it resolves to replaces whatever `allowed_models` held.
+    assert!(keys[0].get("allowed_model_ids").is_none());
+    assert_eq!(keys[0]["allowed_models"], json!(["claude"]));
+    assert!(doc.warnings.is_empty(), "{:?}", doc.warnings);
+    assert!(doc.blocking.is_empty(), "{:?}", doc.blocking);
+}
+
+#[test]
+fn api_key_unresolvable_model_id_is_dropped_and_warned() {
+    let snap = AisixSnapshot::new();
+    snap.provider_keys
+        .insert(ResourceEntry::new("pk", provider_key("pk", "sk"), 1));
+    snap.models.insert(ResourceEntry::new(
+        "m-uuid-1",
+        model_value(
+            json!({"display_name": "gpt-4o", "provider": "openai", "model_name": "x", "provider_key_id": "pk"}),
+        ),
+        1,
+    ));
+    snap.apikeys.insert(ResourceEntry::new(
+        "k-uuid-1",
+        serde_json::from_value(json!({
+            "key_hash": "aa".repeat(32),
+            "allowed_model_ids": ["m-uuid-1", "m-gone"]
+        }))
+        .unwrap(),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    let keys = find(&doc, "api_keys");
+    // Emitting "m-gone" as a name would fail the loader's model
+    // cross-reference and take the whole file down; dropping it only
+    // narrows the key, which is what the gateway already does.
+    assert_eq!(keys[0]["allowed_models"], json!(["gpt-4o"]));
+    assert!(
+        doc.warnings.iter().any(|w| w.contains("m-gone")),
+        "{:?}",
+        doc.warnings
+    );
+    assert!(doc.blocking.is_empty(), "{:?}", doc.blocking);
+}
+
+#[test]
+fn api_key_empty_allowed_model_ids_export_as_no_grant() {
+    let snap = AisixSnapshot::new();
+    snap.apikeys.insert(ResourceEntry::new(
+        "k-uuid-1",
+        serde_json::from_value(json!({
+            "key_hash": "aa".repeat(32),
+            "allowed_models": ["*"],
+            "allowed_model_ids": []
+        }))
+        .unwrap(),
+        1,
+    ));
+    let doc = build_export_document(&snap, false);
+    let keys = find(&doc, "api_keys");
+    // An empty id list is authoritative at runtime, so the exported file
+    // must not resurrect the ignored `allowed_models: ["*"]`.
+    assert_eq!(keys[0]["allowed_models"], json!([]));
+}

--- a/schemas/resources-lenient/api_key.schema.json
+++ b/schemas/resources-lenient/api_key.schema.json
@@ -154,7 +154,7 @@
       ]
     },
     "allowed_model_ids": {
-      "description": "Models this key may use, named by resource id rather than by name, so renaming a model does not change what this key may reach. Present — including as an empty array — it is authoritative and `allowed_models` is ignored; each id is resolved against the current models in the snapshot and the resolved name is matched with the same single-`*` glob rule, so an id naming a wildcard model still grants every name that model's pattern covers. An id matching no model grants nothing. Set to `null` it means the same as omitted: the key falls back to `allowed_models`.",
+      "description": "Models this key may use, named by resource id rather than by name, so renaming a model does not change what this key may reach. Present — including as an empty array — it is authoritative and `allowed_models` is ignored; each id is resolved against the current models in the snapshot and the resolved name is matched with the same single-`*` glob rule. An id naming a wildcard model therefore grants every name that model's pattern covers — including a name an exact-match model of its own serves, which is how the name form behaves too. An id matching no model grants nothing. Set to `null` it means the same as omitted: the key falls back to `allowed_models`.",
       "items": {
         "type": "string"
       },

--- a/schemas/resources-lenient/api_key.schema.json
+++ b/schemas/resources-lenient/api_key.schema.json
@@ -154,7 +154,7 @@
       ]
     },
     "allowed_model_ids": {
-      "description": "Models this key may use, named by resource id rather than by name, so renaming a model does not change what this key may reach. Present — including as an empty array — it is authoritative and `allowed_models` is ignored; each id is resolved against the current models in the snapshot and the resolved name is matched with the same single-`*` glob rule. An id naming a wildcard model therefore grants every name that model's pattern covers — including a name an exact-match model of its own serves, which is how the name form behaves too. An id matching no model grants nothing. Set to `null` it means the same as omitted: the key falls back to `allowed_models`.",
+      "description": "Models this key may use, named by resource id rather than by name, so renaming a model does not change what this key may reach. Present — including as an empty array — it is authoritative and `allowed_models` is ignored; each id is resolved against the current models in the snapshot and the resolved name is matched with the same single-`*` glob rule. An id naming a wildcard model therefore grants every name that model's pattern covers — including a name an exact-match model of its own serves, which is how the name form behaves too. An id matching no model grants nothing.\n\nSet to `null` it means the same as omitted: the key falls back to `allowed_models`. A producer must therefore write `[]`, never `null`, for a key that is meant to grant no model — the two are opposite grants, and an empty list is the one that is authoritative.",
       "items": {
         "type": "string"
       },

--- a/schemas/resources-lenient/api_key.schema.json
+++ b/schemas/resources-lenient/api_key.schema.json
@@ -153,8 +153,19 @@
         "null"
       ]
     },
+    "allowed_model_ids": {
+      "description": "Models this key may use, named by resource id rather than by name, so renaming a model does not change what this key may reach. Present — including as an empty array — it is authoritative and `allowed_models` is ignored; each id is resolved against the current models in the snapshot and the resolved name is matched with the same single-`*` glob rule, so an id naming a wildcard model still grants every name that model's pattern covers. An id matching no model grants nothing. Set to `null` it means the same as omitted: the key falls back to `allowed_models`.",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
     "allowed_models": {
-      "description": "Model identifiers this key may use. An empty array denies access to every model.",
+      "default": [],
+      "description": "Model names this key may use, matched as single-`*` globs. Read only when `allowed_model_ids` is absent; ignored entirely when it is present. When both are omitted the key may use no model — model access is granted explicitly.",
       "items": {
         "type": "string"
       },
@@ -267,7 +278,6 @@
     }
   },
   "required": [
-    "allowed_models",
     "key_hash"
   ],
   "title": "ApiKey",

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -161,7 +161,7 @@
       ]
     },
     "allowed_model_ids": {
-      "description": "Models this key may use, named by resource id rather than by name, so renaming a model does not change what this key may reach. Present — including as an empty array — it is authoritative and `allowed_models` is ignored; each id is resolved against the current models in the snapshot and the resolved name is matched with the same single-`*` glob rule, so an id naming a wildcard model still grants every name that model's pattern covers. An id matching no model grants nothing. Set to `null` it means the same as omitted: the key falls back to `allowed_models`.",
+      "description": "Models this key may use, named by resource id rather than by name, so renaming a model does not change what this key may reach. Present — including as an empty array — it is authoritative and `allowed_models` is ignored; each id is resolved against the current models in the snapshot and the resolved name is matched with the same single-`*` glob rule. An id naming a wildcard model therefore grants every name that model's pattern covers — including a name an exact-match model of its own serves, which is how the name form behaves too. An id matching no model grants nothing. Set to `null` it means the same as omitted: the key falls back to `allowed_models`.",
       "items": {
         "type": "string"
       },

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -160,8 +160,19 @@
         "null"
       ]
     },
+    "allowed_model_ids": {
+      "description": "Models this key may use, named by resource id rather than by name, so renaming a model does not change what this key may reach. Present — including as an empty array — it is authoritative and `allowed_models` is ignored; each id is resolved against the current models in the snapshot and the resolved name is matched with the same single-`*` glob rule, so an id naming a wildcard model still grants every name that model's pattern covers. An id matching no model grants nothing. Set to `null` it means the same as omitted: the key falls back to `allowed_models`.",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
     "allowed_models": {
-      "description": "Model identifiers this key may use. An empty array denies access to every model.",
+      "default": [],
+      "description": "Model names this key may use, matched as single-`*` globs. Read only when `allowed_model_ids` is absent; ignored entirely when it is present. When both are omitted the key may use no model — model access is granted explicitly.",
       "items": {
         "type": "string"
       },
@@ -274,7 +285,6 @@
     }
   },
   "required": [
-    "allowed_models",
     "key_hash"
   ],
   "title": "ApiKey",

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -161,7 +161,7 @@
       ]
     },
     "allowed_model_ids": {
-      "description": "Models this key may use, named by resource id rather than by name, so renaming a model does not change what this key may reach. Present — including as an empty array — it is authoritative and `allowed_models` is ignored; each id is resolved against the current models in the snapshot and the resolved name is matched with the same single-`*` glob rule. An id naming a wildcard model therefore grants every name that model's pattern covers — including a name an exact-match model of its own serves, which is how the name form behaves too. An id matching no model grants nothing. Set to `null` it means the same as omitted: the key falls back to `allowed_models`.",
+      "description": "Models this key may use, named by resource id rather than by name, so renaming a model does not change what this key may reach. Present — including as an empty array — it is authoritative and `allowed_models` is ignored; each id is resolved against the current models in the snapshot and the resolved name is matched with the same single-`*` glob rule. An id naming a wildcard model therefore grants every name that model's pattern covers — including a name an exact-match model of its own serves, which is how the name form behaves too. An id matching no model grants nothing.\n\nSet to `null` it means the same as omitted: the key falls back to `allowed_models`. A producer must therefore write `[]`, never `null`, for a key that is meant to grant no model — the two are opposite grants, and an empty list is the one that is authoritative.",
       "items": {
         "type": "string"
       },

--- a/tests/e2e/src/cases/apikey-allowed-model-ids-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-allowed-model-ids-e2e.test.ts
@@ -1,0 +1,197 @@
+import { createHash, randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: an API key may grant models by resource id (`allowed_model_ids`)
+// instead of by name (`allowed_models`). The id form is authoritative
+// when present, resolves to whatever name the model currently carries,
+// and grants nothing for an id that names no model.
+//
+// Reference: OpenAI Chat Completions and Models API specs
+// (https://platform.openai.com/docs/api-reference/chat/create,
+// https://platform.openai.com/docs/api-reference/models/list).
+
+const hash = (plaintext: string) =>
+  createHash("sha256").update(plaintext).digest("hex");
+
+const KEYS = {
+  idsOnly: "sk-ami-e2e-ids-only",
+  wildcard: "sk-ami-e2e-wildcard",
+  rename: "sk-ami-e2e-rename",
+  conflict: "sk-ami-e2e-conflict",
+  partial: "sk-ami-e2e-partial",
+  nothing: "sk-ami-e2e-nothing",
+  sentinel: "sk-ami-e2e-sentinel",
+};
+
+describe("api key allowed_model_ids: grants follow the model id, not its name", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  let renameModelId = "";
+  let providerKeyId = "";
+
+  const proxy = (plaintext: string) =>
+    new ProxyClient(app!.proxyUrl, plaintext);
+
+  const chat = (plaintext: string, model: string) =>
+    proxy(plaintext).chat({
+      model,
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "ami-e2e-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    providerKeyId = pk.id;
+    const model = (display_name: string) =>
+      seed!.createModel({
+        display_name,
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pk.id,
+      });
+
+    const alpha = await model("ami-alpha");
+    const beta = await model("ami-beta");
+    const wildcard = await model("ami-gpt-*");
+    const renamed = await model("ami-before");
+    renameModelId = renamed.id;
+
+    // Every caller key is seeded after every model, and the sentinel key
+    // last of all, so gating on the sentinel implies the whole seed set
+    // has landed without exercising any behavior under test.
+    await seed.createApiKey({
+      key_hash: hash(KEYS.idsOnly),
+      allowed_model_ids: [alpha.id],
+    });
+    await seed.createApiKey({
+      key_hash: hash(KEYS.wildcard),
+      allowed_model_ids: [wildcard.id],
+    });
+    await seed.createApiKey({
+      key_hash: hash(KEYS.rename),
+      allowed_model_ids: [renamed.id],
+    });
+    await seed.createApiKey({
+      key_hash: hash(KEYS.conflict),
+      allowed_models: ["ami-beta"],
+      allowed_model_ids: [alpha.id],
+    });
+    await seed.createApiKey({
+      key_hash: hash(KEYS.partial),
+      allowed_model_ids: [alpha.id, randomUUID()],
+    });
+    await seed.createApiKey({ key_hash: hash(KEYS.nothing) });
+    await seed.createApiKey({
+      key_hash: hash(KEYS.sentinel),
+      allowed_models: ["*"],
+    });
+
+    await waitConfigPropagation(
+      async () => (await proxy(KEYS.sentinel).listModels()).status === 200,
+    );
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  test("a key granted by id reaches that model and no other", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    expect((await chat(KEYS.idsOnly, "ami-alpha")).status).toBe(200);
+    // `ami-beta` exists in the snapshot, so a 403 here is authorization
+    // and not "model not found".
+    expect((await chat(KEYS.idsOnly, "ami-beta")).status).toBe(403);
+  });
+
+  test("an id naming a wildcard model grants every name its pattern covers", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    expect((await chat(KEYS.wildcard, "ami-gpt-4o")).status).toBe(200);
+    expect((await chat(KEYS.wildcard, "ami-alpha")).status).toBe(403);
+  });
+
+  test("both fields present: the ids decide and the names are ignored", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    expect((await chat(KEYS.conflict, "ami-alpha")).status).toBe(200);
+    expect((await chat(KEYS.conflict, "ami-beta")).status).toBe(403);
+  });
+
+  test("an id that names no model grants nothing and leaves the rest intact", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    expect((await chat(KEYS.partial, "ami-alpha")).status).toBe(200);
+    expect((await chat(KEYS.partial, "ami-beta")).status).toBe(403);
+    // The key itself still authenticates — an unusable entry must not
+    // cost the caller its credential.
+    expect((await proxy(KEYS.partial).listModels()).status).toBe(200);
+  });
+
+  test("a key granting no models at all still authenticates and reaches nothing", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    // 200 (not 401) proves the document loaded and the key authenticates;
+    // the empty listing and the 403 prove it grants no model.
+    const listed = await proxy(KEYS.nothing).listModels();
+    expect(listed.status).toBe(200);
+    expect((listed.body as { data: unknown[] }).data).toEqual([]);
+    expect((await chat(KEYS.nothing, "ami-alpha")).status).toBe(403);
+  });
+
+  // Last: the rename mutates shared state, and the model it renames is
+  // used by no other case.
+  test("renaming a model moves the grant with it, key document untouched", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return ctx.skip();
+
+    expect((await chat(KEYS.rename, "ami-before")).status).toBe(200);
+
+    // Same etcd key (same resource id), new display name. The api key
+    // document is not rewritten anywhere in this test.
+    await seed.update("models", renameModelId, {
+      display_name: "ami-after",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: providerKeyId,
+    });
+    // Gate on the rename landing, observed through the unrestricted
+    // sentinel key rather than through the key under test.
+    await waitConfigPropagation(async () => {
+      const listed = await proxy(KEYS.sentinel).listModels();
+      if (listed.status !== 200) return false;
+      const names = (listed.body as { data: { id: string }[] }).data.map(
+        (m) => m.id,
+      );
+      return names.includes("ami-after") && !names.includes("ami-before");
+    });
+
+    expect((await chat(KEYS.rename, "ami-after")).status).toBe(200);
+    // No model carries the old name any more, so the old name is simply
+    // unknown — the grant did not stay behind on it.
+    expect((await chat(KEYS.rename, "ami-before")).status).toBe(404);
+  });
+});

--- a/tests/e2e/src/cases/apikey-allowed-model-ids-e2e.test.ts
+++ b/tests/e2e/src/cases/apikey-allowed-model-ids-e2e.test.ts
@@ -29,6 +29,8 @@ const KEYS = {
   rename: "sk-ami-e2e-rename",
   conflict: "sk-ami-e2e-conflict",
   partial: "sk-ami-e2e-partial",
+  emptyIds: "sk-ami-e2e-empty-ids",
+  unresolvedOnly: "sk-ami-e2e-unresolved-only",
   nothing: "sk-ami-e2e-nothing",
   sentinel: "sk-ami-e2e-sentinel",
 };
@@ -103,6 +105,16 @@ describe("api key allowed_model_ids: grants follow the model id, not its name", 
       key_hash: hash(KEYS.partial),
       allowed_model_ids: [alpha.id, randomUUID()],
     });
+    await seed.createApiKey({
+      key_hash: hash(KEYS.emptyIds),
+      allowed_models: ["*"],
+      allowed_model_ids: [],
+    });
+    await seed.createApiKey({
+      key_hash: hash(KEYS.unresolvedOnly),
+      allowed_models: ["*"],
+      allowed_model_ids: [randomUUID()],
+    });
     await seed.createApiKey({ key_hash: hash(KEYS.nothing) });
     await seed.createApiKey({
       key_hash: hash(KEYS.sentinel),
@@ -150,6 +162,27 @@ describe("api key allowed_model_ids: grants follow the model id, not its name", 
     // The key itself still authenticates — an unusable entry must not
     // cost the caller its credential.
     expect((await proxy(KEYS.partial).listModels()).status).toBe(200);
+  });
+
+  test("an empty id list is an authoritative deny, not a fallback to the names", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    const listed = await proxy(KEYS.emptyIds).listModels();
+    expect(listed.status).toBe(200);
+    expect((listed.body as { data: unknown[] }).data).toEqual([]);
+    // `allowed_models: ["*"]` would grant everything if the empty id list
+    // fell back to it.
+    expect((await chat(KEYS.emptyIds, "ami-alpha")).status).toBe(403);
+  });
+
+  test("a list of only unresolvable ids grants nothing at all", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    const listed = await proxy(KEYS.unresolvedOnly).listModels();
+    expect(listed.status).toBe(200);
+    expect((listed.body as { data: unknown[] }).data).toEqual([]);
+    expect((await chat(KEYS.unresolvedOnly, "ami-alpha")).status).toBe(403);
+    expect((await chat(KEYS.unresolvedOnly, "ami-beta")).status).toBe(403);
   });
 
   test("a key granting no models at all still authenticates and reaches nothing", async (ctx) => {


### PR DESCRIPTION
Ref api7/AISIX-Cloud#1546

## Problem

An API key's model allowlist is a list of model **names**, so the control plane
has to keep those names current: renaming one model rewrites every api_key
document that references it.

That rewrite is atomic in the control plane's own database, but not from here.
Each document reaches the gateway as its own etcd revision, so a rename of a
model that N keys reference lands as N separate watch events, and for a moment
some keys carry the new name while others still carry the old one. It is also
write amplification on the configuration path that has already cost us once:
editing one resource fanning out into an unbounded number of document writes is
the shape behind the `/livez` starvation incident.

The name is the only reason those writes exist. If a key names the model by its
id instead, the gateway can resolve the current name itself, and a rename is one
document.

## What changed

A new optional field on the `api_key` document:

```jsonc
{
  "key_hash": "...",
  "allowed_model_ids": ["<model resource id>", "..."]
}
```

`allowed_model_ids` names Model resources by their resource id, and the gateway
resolves each id against the current models table on every request.

- **Present — an empty array included — it is authoritative and
  `allowed_models` is ignored entirely.** Each id resolves to the name the model
  currently carries, and that name goes through the same single-`*` glob rule as
  before, so an id naming a wildcard model (`gpt-*`) still grants every name its
  pattern covers.
- **An id that names no model grants nothing.** That entry is fail-closed; the
  key itself still loads and authenticates, and its other entries still grant.
- **Absent, behaviour is exactly what it was**: `allowed_models` names, which is
  what the resources file and older control planes write. `null` reads as
  absent.
- **Neither field: the key loads, authenticates, and reaches no model.**

A rename now takes effect on the next request with no rewrite of any key
document. Nothing is cached — resolution reads the live snapshot table, which is
a handful of map lookups against a list that is a few entries long.

## One chokepoint for the whole endpoint family

`ApiKey::can_access` is the single place this is decided. It now takes the
snapshot, so the compiler forced every endpoint that gates on model access
through it and none of them can drift apart again: chat completions, legacy
completions, messages (and `count_tokens`), responses, embeddings, rerank, audio
(transcription and speech), images (and edits), videos, realtime, the
files/batches/fine-tuning surface, and the `/v1/models` listing, which filters
through the same call so it can never advertise a name the request path would
reject. MCP and A2A gate on tools and agents, not models, and are untouched.

## Schemas

Both `schemas/resources/api_key.schema.json` and its lenient counterpart gain
`allowed_model_ids` (optional array of string) and drop `allowed_models` from
`required`, giving it a default of `[]`.

## Export

`aisix export` stays name-based — the resources file grants models by name, and
the id form is a control-plane projection that has no meaning in a file. The
export resolves the ids back to names and emits them as `allowed_models`. An id
naming no exported model is dropped with a warning: emitting an unresolvable
name would fail the file loader's model cross-reference and take the whole file
down, while dropping it only narrows the key the same way the gateway already
does.

## Behaviour changes on upgrade

None for an existing key — a document without the new field behaves exactly as
before. Two write-path changes: `allowed_models` is no longer required, so a key
document carrying neither grant field is now accepted and grants nothing; and a
resources file carrying `allowed_model_ids` is now rejected with a clear message
instead of loading into a key that reaches nothing.

`null` and `[]` are opposite grants — null falls back to the names, an empty
list is an authoritative deny — so a producer must write `[]` and never `null`
for a key meant to reach no model. The field description says so, since a
generator that serializes an empty list as null would flip one into the other.

## The resources file rejects the field

`allowed_model_ids` is a control-plane projection. A resources file derives its
ids from the entry names, so no id written in a file can ever resolve — the key
would grant nothing at all, silently, with `allowed_models` ignored on top of
that. The file source and `aisix validate` therefore reject the field outright
with a message pointing at `allowed_models`.

The etcd path is deliberately the opposite: there an id that resolves to no
model simply grants nothing and must never fail the row, because a rejected
`api_key` row stops authenticating that key entirely.

## For the control plane

A data plane at or below the current support floor still has `allowed_models` in
its **lenient** `required` list, and an `api_key` row that fails to load stops
authenticating that key entirely rather than degrading. So a control plane that
writes `allowed_model_ids` must keep writing the resolved `allowed_models` names
alongside it, and keep the rename fan-out, until the floor passes this release.

That means the write amplification above is not removed by this PR — it is
removed when the floor moves and the name half can be dropped. What lands now is
the primary form the gateway reads, and the compatibility shim keeping older
data planes working until then.

## Tests

`tests/e2e/src/cases/apikey-allowed-model-ids-e2e.test.ts` drives a real gateway
against etcd and a mock upstream and covers the six cases: granted by id only;
an id naming a wildcard model; a rename moving the grant with the model while
the key document is untouched; both fields present and disagreeing; one
unresolvable id among valid ones; and a key with neither field. Each case was
confirmed to go red under a mutation of the rule it pins — one that ignores the
ids, and one that makes an unresolvable id and an empty allowlist fail open.
Unit coverage for the resolution rule and the schema shape sits beside the model
and the export.
