### PR TITLE
fix(redis): cool off per subsystem, so one request pays the cache budget once

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -265,8 +265,12 @@ cache:
   #   # The cool-off is per SUBSYSTEM, not per connection. This cache
   #   # opens two connections to this Redis — the exact-KV one and, for
   #   # policies with a `semantic` block, the vector-search one — and they
-  #   # share one cool-off, so a request that uses both pays this budget at
-  #   # most once rather than once per operation.
+  #   # share one cool-off, so CONSECUTIVE cache operations pay this budget
+  #   # once between them rather than once each. A request whose upstream
+  #   # call outlives the cool-off can still pay it a second time on the
+  #   # cache write that follows, because the window will have expired by
+  #   # then: expect one budget when the upstream answers quickly and two
+  #   # when it does not.
   #   #
   #   # In sentinel mode, discovering the master is not one round trip —
   #   # the client walks the sentinels one at a time — so that step gets

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -262,6 +262,12 @@ cache:
   #   # probes, so an outage costs this budget roughly once per five
   #   # seconds rather than once per request. Must be >= 1.
   #   #
+  #   # The cool-off is per SUBSYSTEM, not per connection. This cache
+  #   # opens two connections to this Redis — the exact-KV one and, for
+  #   # policies with a `semantic` block, the vector-search one — and they
+  #   # share one cool-off, so a request that uses both pays this budget at
+  #   # most once rather than once per operation.
+  #   #
   #   # In sentinel mode, discovering the master is not one round trip —
   #   # the client walks the sentinels one at a time — so that step gets
   #   # this budget once per configured sentinel, plus one for the master.
@@ -292,8 +298,10 @@ ratelimit:
   #   # it an unreachable Redis blocks every rate-limited request for
   #   # minutes instead of degrading it. Must be >= 1.
   #   #
-  #   # The cache and the limiter cool off independently, so a request that
-  #   # uses both can pay one budget for each while a shared Redis is down.
+  #   # The limiter is a separate subsystem from the cache and cools off
+  #   # independently, so a request that uses both can pay one budget for
+  #   # each while a shared Redis is down — but only one within each,
+  #   # however many connections that subsystem holds.
   #   # timeout_secs: 5
   # Seconds before an unreleased concurrency slot (crashed replica /
   # hung upstream) is reclaimed. Redis backend only.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -258,19 +258,19 @@ cache:
   #   # A Redis that stops answering without closing the socket (host down,
   #   # network partition, stopped container) would otherwise block the
   #   # request for minutes instead of degrading it. After a failure,
-  #   # commands short-circuit for about five seconds and then ONE request
-  #   # probes, so an outage costs this budget roughly once per five
-  #   # seconds rather than once per request. Must be >= 1.
+  #   # commands short-circuit for 30 seconds and then ONE request probes,
+  #   # so an outage costs this budget roughly once per 30 seconds rather
+  #   # than once per request. Must be >= 1.
   #   #
   #   # The cool-off is per SUBSYSTEM, not per connection. This cache
   #   # opens two connections to this Redis — the exact-KV one and, for
   #   # policies with a `semantic` block, the vector-search one — and they
-  #   # share one cool-off, so CONSECUTIVE cache operations pay this budget
-  #   # once between them rather than once each. A request whose upstream
-  #   # call outlives the cool-off can still pay it a second time on the
-  #   # cache write that follows, because the window will have expired by
-  #   # then: expect one budget when the upstream answers quickly and two
-  #   # when it does not.
+  #   # share one cool-off, so a request pays this budget once for the
+  #   # cache rather than once per cache operation. The 30-second cool-off
+  #   # is sized to outlast an upstream call, because a request's cache
+  #   # read and its cache write straddle that call; a request whose
+  #   # upstream leg runs longer than 30 seconds finds the cool-off expired
+  #   # and pays a second budget on the write.
   #   #
   #   # In sentinel mode, discovering the master is not one round trip —
   #   # the client walks the sentinels one at a time — so that step gets
@@ -305,7 +305,7 @@ ratelimit:
   #   # The limiter is a separate subsystem from the cache and cools off
   #   # independently, so a request that uses both can pay one budget for
   #   # each while a shared Redis is down — but only one within each,
-  #   # however many connections that subsystem holds.
+  #   # however many Redis operations that subsystem performs.
   #   # timeout_secs: 5
   # Seconds before an unreleased concurrency slot (crashed replica /
   # hung upstream) is reclaimed. Redis backend only.

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -34,7 +34,10 @@
 # The limiter fails open to per-replica counting when Redis errors, but an
 # unreachable Redis produces no error at all until something times out, so
 # without the bound a rate-limited request waits on TCP retransmission for
-# minutes. Lower it for a Redis on the same node; it must be >= 1.
+# minutes. Lower it for a Redis on the same node; it must be >= 1. After a
+# failure the limiter short-circuits for 30 seconds and then lets one
+# request probe, so an outage costs this budget once per 30 seconds rather
+# than once per request.
 #
 # Subsequent boots re-use the mTLS bundle written under
 # `managed.mtls_dir`.

--- a/crates/aisix-cache/src/lib.rs
+++ b/crates/aisix-cache/src/lib.rs
@@ -34,6 +34,12 @@ mod semantic;
 #[cfg(feature = "redis")]
 mod semantic_redis;
 
+/// Re-exported so the bootstrap can build ONE policy for the whole cache
+/// subsystem without taking a direct dependency on the connection crate.
+/// Both stores here must be constructed from the same value — see
+/// [`RedisCache::connect_with`].
+#[cfg(feature = "redis")]
+pub use aisix_redis::FailurePolicy;
 pub use cache::{Cache, CacheError, CacheOutcome};
 pub use key::{semantic_prompt_text, CacheKey};
 pub use memory::{MemoryCache, DEFAULT_CAPACITY, DEFAULT_TTL};

--- a/crates/aisix-cache/src/redis.rs
+++ b/crates/aisix-cache/src/redis.rs
@@ -51,11 +51,24 @@ impl std::fmt::Debug for RedisCache {
 }
 
 impl RedisCache {
-    /// Connect using the operator's `cache.redis` config. The topology
-    /// (`single` / `cluster` / `sentinel`) is selected by `mode`; see
-    /// [`aisix_redis::connect`].
+    /// Connect on a policy of this cache's own.
+    ///
+    /// Only for a standalone exact cache. The gateway's cache subsystem
+    /// also holds a vector-search connection to the same `cache.redis`,
+    /// and the two must cool off together or one request pays the command
+    /// budget on each — use [`RedisCache::connect_with`] there.
     pub async fn connect(cfg: &RedisConnConfig) -> Result<Self, CacheError> {
-        let conn = aisix_redis::connect(cfg)
+        Self::connect_with(cfg, &aisix_redis::FailurePolicy::new(cfg)).await
+    }
+
+    /// Connect sharing `policy` with the rest of the cache subsystem. The
+    /// topology (`single` / `cluster` / `sentinel`) is selected by `mode`;
+    /// see [`aisix_redis::connect_with`].
+    pub async fn connect_with(
+        cfg: &RedisConnConfig,
+        policy: &aisix_redis::FailurePolicy,
+    ) -> Result<Self, CacheError> {
+        let conn = aisix_redis::connect_with(cfg, policy)
             .await
             .map_err(|e| CacheError::Backend(format!("redis connect: {e}")))?;
         Ok(Self {

--- a/crates/aisix-cache/src/semantic_redis.rs
+++ b/crates/aisix-cache/src/semantic_redis.rs
@@ -73,11 +73,27 @@ impl std::fmt::Debug for RedisSemanticCache {
 }
 
 impl RedisSemanticCache {
-    /// Connect using the operator's `cache.redis` config — the same
-    /// config the exact redis cache uses; this opens its own
-    /// connection so the two caches don't serialize on one pipeline.
+    /// Connect on a policy of this store's own.
+    ///
+    /// Only for a standalone vector store. In the gateway this is the
+    /// second connection of the cache subsystem and must share the exact
+    /// cache's policy — use [`RedisSemanticCache::connect_with`].
     pub async fn connect(cfg: &RedisConnConfig) -> Result<Self, CacheError> {
-        let conn = aisix_redis::connect(cfg)
+        Self::connect_with(cfg, &aisix_redis::FailurePolicy::new(cfg)).await
+    }
+
+    /// Connect sharing `policy` with the exact cache.
+    ///
+    /// Same `cache.redis` config the exact cache uses, and still its OWN
+    /// connection so the two do not serialize on one pipeline — only the
+    /// failure policy is shared, so a request that already paid the
+    /// command budget on the exact half short-circuits here instead of
+    /// paying it again.
+    pub async fn connect_with(
+        cfg: &RedisConnConfig,
+        policy: &aisix_redis::FailurePolicy,
+    ) -> Result<Self, CacheError> {
+        let conn = aisix_redis::connect_with(cfg, policy)
             .await
             .map_err(|e| CacheError::Backend(format!("redis connect: {e}")))?;
         Ok(Self {

--- a/crates/aisix-cache/src/semantic_redis.rs
+++ b/crates/aisix-cache/src/semantic_redis.rs
@@ -159,7 +159,9 @@ impl RedisSemanticCache {
                 // the life of the pod.
                 if e.is_io_error() {
                     CacheError::Backend(format!(
-                        "vector-search probe did not complete (cache.redis unreachable or                          too slow; this does not mean the server lacks vector search): {e}"
+                        "vector-search probe did not complete (cache.redis unreachable \
+                         or too slow; this does not mean the server lacks vector \
+                         search): {e}"
                     ))
                 } else {
                     CacheError::Backend(format!(

--- a/crates/aisix-cache/tests/redis_integration.rs
+++ b/crates/aisix-cache/tests/redis_integration.rs
@@ -9,7 +9,7 @@
 
 use std::time::Duration;
 
-use aisix_cache::{Cache, RedisCache};
+use aisix_cache::{Cache, RedisCache, SemanticCacheStore};
 use aisix_core::{RedisConnConfig, RedisMode};
 use aisix_gateway::{ChatMessage, ChatResponse, FinishReason, UsageStats};
 
@@ -297,4 +297,152 @@ fn uuid_like() -> String {
         .map(|d| d.as_nanos())
         .unwrap_or_default();
     format!("{nanos:x}-{:?}", std::thread::current().id()).replace(['(', ')', ' '], "")
+}
+
+/// A TCP relay in front of Redis that a test can black-hole: the socket
+/// stays open and nothing is ever forwarded or answered, which is what a
+/// paused container, a downed host or a partitioned network looks like
+/// from the client end. An error reply would be the *cheap* failure —
+/// the client learns immediately and no budget is spent.
+struct RedisBlackhole {
+    port: u16,
+    hole: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl RedisBlackhole {
+    async fn start(upstream: &str) -> Self {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let upstream = upstream
+            .trim_start_matches("redis://")
+            .trim_end_matches('/')
+            .to_string();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let hole = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = hole.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut client, _)) = listener.accept().await else {
+                    return;
+                };
+                let Ok(mut server) = tokio::net::TcpStream::connect(&upstream).await else {
+                    continue;
+                };
+                let flag = flag.clone();
+                tokio::spawn(async move {
+                    let mut from_client = [0u8; 8192];
+                    let mut from_server = [0u8; 8192];
+                    loop {
+                        let held = || flag.load(std::sync::atomic::Ordering::Relaxed);
+                        tokio::select! {
+                            n = client.read(&mut from_client) => {
+                                let Ok(n) = n else { return };
+                                if n == 0 {
+                                    return;
+                                }
+                                if held() {
+                                    continue;
+                                }
+                                if server.write_all(&from_client[..n]).await.is_err() {
+                                    return;
+                                }
+                            }
+                            n = server.read(&mut from_server) => {
+                                let Ok(n) = n else { return };
+                                if n == 0 {
+                                    return;
+                                }
+                                if held() {
+                                    continue;
+                                }
+                                if client.write_all(&from_server[..n]).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+        Self { port, hole }
+    }
+
+    fn url(&self) -> String {
+        format!("redis://127.0.0.1:{}", self.port)
+    }
+
+    fn blackhole(&self) {
+        self.hole.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// One request against a black-holed Redis must cost the cache ONE
+/// command budget, not one per connection.
+///
+/// The cache subsystem holds two connections to the same `cache.redis` —
+/// exact-KV and vector search — and a single chat request touches both
+/// twice: exact lookup, semantic lookup, exact write, semantic write. A
+/// breaker per connection meant each of those four found a breaker no
+/// earlier operation had opened, so the request paid the budget four
+/// times over (release QA measured 20.0s at the default 5s budget, 4.0s
+/// at 2s, against 5.0s for an exact-only policy). The two connections
+/// stay separate — they must not serialize on one pipeline — so what is
+/// shared is the failure policy.
+#[tokio::test]
+async fn the_whole_cache_subsystem_pays_one_budget_per_request() {
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: CACHE_TEST_REDIS_URL not set");
+        return;
+    };
+    // Below the 5s default so the bound below cannot pass on a build
+    // that ignored the configured budget.
+    const BUDGET_SECS: u64 = 2;
+    let relay = RedisBlackhole::start(&url).await;
+    let cfg = RedisConnConfig {
+        timeout_secs: BUDGET_SECS,
+        ..single(&relay.url())
+    };
+
+    // Exactly how the bootstrap wires them: one policy, two connections.
+    let policy = aisix_cache::FailurePolicy::new(&cfg);
+    let exact = aisix_cache::RedisCache::connect_with(&cfg, &policy)
+        .await
+        .expect("exact cache connects through the relay");
+    let vector = aisix_cache::RedisSemanticCache::connect_with(&cfg, &policy)
+        .await
+        .expect("vector store connects through the relay");
+
+    relay.blackhole();
+
+    let started = std::time::Instant::now();
+    // The four operations one chat request performs, in order.
+    let _ = exact.get("subsystem-budget").await;
+    let _ = vector
+        .lookup("policy-1", 1, "scope", &[1.0, 0.0], 0.5)
+        .await;
+    let _ = exact.put("subsystem-budget", sample("hi")).await;
+    let _ = vector
+        .store(
+            "policy-1",
+            1,
+            "scope",
+            "subsystem-budget",
+            vec![1.0, 0.0],
+            sample("hi"),
+            Duration::from_secs(60),
+            100,
+        )
+        .await;
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed >= Duration::from_secs(BUDGET_SECS),
+        "one operation must actually reach the blackhole and spend its \
+         budget; {elapsed:?} means the relay was never in the path",
+    );
+    assert!(
+        elapsed < Duration::from_millis(BUDGET_SECS * 1000 + 1_500),
+        "the request must pay ONE budget for the subsystem, not one per \
+         connection; took {elapsed:?}",
+    );
 }

--- a/crates/aisix-redis/src/lib.rs
+++ b/crates/aisix-redis/src/lib.rs
@@ -152,8 +152,17 @@ struct Guard {
 /// semantic write. With a breaker per connection each of those four
 /// operations found a breaker that no earlier operation had opened, so
 /// one request against a black-holed Redis paid the budget four times
-/// (measured: 20s at the default 5s budget) instead of once. Sharing the
-/// policy makes the first failure short-circuit the rest of the request.
+/// (measured: 20s at the default 5s budget). Sharing the policy makes the
+/// first failure short-circuit the operations that follow it inside the
+/// cool-off window.
+///
+/// That is not the same as "once per request", and the difference is
+/// worth knowing: the two lookups run back to back, but the two writes
+/// run after the upstream call, so a request whose upstream leg outlives
+/// [`BREAKER_WINDOW`] finds the window expired and its write is admitted
+/// as the next probe. Such a request pays two budgets rather than four.
+/// Closing that last gap needs either a window longer than an upstream
+/// call or per-request degradation state; neither is decided here.
 ///
 /// Sharing the policy does NOT share the connection: the two cache
 /// connections stay separate so they do not serialize on one pipeline.
@@ -863,8 +872,10 @@ mod guard_tests {
     #[tokio::test]
     async fn the_window_dates_from_when_the_command_returned() {
         // Window shorter than the budget, so "from start" and "from
-        // return" give opposite answers.
-        let g = guard(200, 100);
+        // return" give opposite answers. Both are generous: the margin
+        // between them is the whole tolerance for scheduling delay on a
+        // loaded CI runner.
+        let g = guard(400, 300);
         g.run(pending::<RedisResult<()>>())
             .await
             .expect_err("the command spends its budget and gives up");
@@ -900,7 +911,8 @@ mod guard_tests {
             .expect_err("the second connection short-circuits on the shared cool-off");
         assert!(
             started.elapsed() < Duration::from_millis(40),
-            "a second connection of the same subsystem must not pay the              budget again, took {:?}",
+            "a second connection of the same subsystem must not pay the budget \
+             again, took {:?}",
             started.elapsed()
         );
     }

--- a/crates/aisix-redis/src/lib.rs
+++ b/crates/aisix-redis/src/lib.rs
@@ -48,8 +48,10 @@
 //!   remaining unbounded wait lived.
 //! - **A cool-off breaker, shared per subsystem.** Paying the timeout on *every* request during
 //!   an outage is still a several-second latency floor for as long as the
-//!   outage lasts. After a connectivity failure the connection is held
-//!   open for [`BREAKER_WINDOW`]; commands issued inside that window
+//!   outage lasts. After a connectivity failure the subsystem is held
+//!   open for [`BREAKER_WINDOW`] — 30s, long enough to span an upstream
+//!   call so a request's cache write is still covered by the cool-off its
+//!   cache read opened; commands issued inside that window
 //!   return an error immediately, with no round trip, so each consumer's
 //!   existing fail-open branch runs at once. The first command after the
 //!   window probes Redis normally and closes the breaker on success.
@@ -81,7 +83,14 @@ use tokio::sync::Mutex;
 /// not configurable: it trades at most this much staleness (a Redis that
 /// recovered mid-window is not noticed until the window ends) for a hard
 /// ceiling on how often a request pays the full timeout during an outage.
-pub const BREAKER_WINDOW: Duration = Duration::from_secs(5);
+///
+/// Sized to outlast an upstream call, not to be a small multiple of the
+/// command budget. A request's cache read and its cache write straddle
+/// the upstream leg, so a window shorter than that leg leaves the write
+/// to find the cool-off expired and pay the budget a second time — which
+/// is what a 5s window did, since the non-streaming completions this
+/// cache stores routinely take longer than that.
+pub const BREAKER_WINDOW: Duration = Duration::from_secs(30);
 
 /// A long-lived Redis client handle. Cheap to [`Clone`] (every variant is
 /// `Arc`-backed). Build one with [`connect`].
@@ -156,13 +165,12 @@ struct Guard {
 /// first failure short-circuit the operations that follow it inside the
 /// cool-off window.
 ///
-/// That is not the same as "once per request", and the difference is
-/// worth knowing: the two lookups run back to back, but the two writes
-/// run after the upstream call, so a request whose upstream leg outlives
-/// [`BREAKER_WINDOW`] finds the window expired and its write is admitted
-/// as the next probe. Such a request pays two budgets rather than four.
-/// Closing that last gap needs either a window longer than an upstream
-/// call or per-request degradation state; neither is decided here.
+/// The two lookups run back to back, but the two writes run after the
+/// upstream call, so this holds for a whole request only while
+/// [`BREAKER_WINDOW`] outlasts that upstream leg — which is why the
+/// window is 30s rather than a small multiple of the budget. A request
+/// whose upstream call runs longer than the window still finds it
+/// expired and pays a second budget on the write that follows.
 ///
 /// Sharing the policy does NOT share the connection: the two cache
 /// connections stay separate so they do not serialize on one pipeline.
@@ -195,8 +203,8 @@ impl Guard {
     /// A success closes the breaker; a *connectivity* failure or a
     /// timeout opens it. A failure the server itself reported (a script
     /// error, `WRONGTYPE`, an ACL refusal) is returned untouched — Redis
-    /// answered, so short-circuiting the next five seconds of traffic
-    /// would be wrong.
+    /// answered, so short-circuiting the subsystem's next half minute of
+    /// traffic would be wrong.
     async fn run<T>(
         &self,
         fut: impl std::future::Future<Output = RedisResult<T>>,
@@ -1012,7 +1020,8 @@ mod guard_tests {
 
     /// A reply from a live Redis — a script error, `WRONGTYPE`, an ACL
     /// refusal — is not an outage. Tripping on it would short-circuit
-    /// five seconds of healthy traffic every time one command is wrong.
+    /// the whole cool-off of healthy traffic every time one command is
+    /// wrong.
     #[tokio::test]
     async fn an_error_redis_itself_reported_does_not_open_the_breaker() {
         let g = guard(80, 5_000);

--- a/crates/aisix-redis/src/lib.rs
+++ b/crates/aisix-redis/src/lib.rs
@@ -46,13 +46,19 @@
 //!   the native response timeout does not cover time spent waiting on the
 //!   connection manager's own in-progress reconnect — which is where the
 //!   remaining unbounded wait lived.
-//! - **A cool-off breaker.** Paying the timeout on *every* request during
+//! - **A cool-off breaker, shared per subsystem.** Paying the timeout on *every* request during
 //!   an outage is still a several-second latency floor for as long as the
 //!   outage lasts. After a connectivity failure the connection is held
 //!   open for [`BREAKER_WINDOW`]; commands issued inside that window
 //!   return an error immediately, with no round trip, so each consumer's
 //!   existing fail-open branch runs at once. The first command after the
 //!   window probes Redis normally and closes the breaker on success.
+//!
+//! The breaker belongs to a **subsystem**, not to a connection — see
+//! [`FailurePolicy`]. A subsystem may hold several connections (the cache
+//! holds two: exact-KV and vector search) and one request touches all of
+//! them, so a per-connection breaker let a single request pay the budget
+//! once per connection.
 //!
 //! Breaker short-circuits are ordinary `Err`s, so they are counted by the
 //! consumers' existing `aisix_redis_failures_total{operation=...}` calls
@@ -129,11 +135,49 @@ enum HandleKind {
     Sentinel(MultiplexedConnection),
 }
 
-/// The per-connection failure policy: one command budget and one breaker,
-/// shared by every handle [`RedisConn::acquire`] hands out.
+/// One command budget and one breaker. Reached through [`FailurePolicy`],
+/// which is what decides how widely it is shared.
 struct Guard {
     timeout: Duration,
     breaker: Breaker,
+}
+
+/// The failure policy of one Redis **subsystem**: a command budget and a
+/// cool-off window shared by every connection that subsystem opens.
+///
+/// A subsystem is the unit that fails open together, and it is not the
+/// same thing as a connection. The cache is one subsystem holding two
+/// connections — exact-KV and vector search — and a single chat request
+/// touches both twice: exact lookup, semantic lookup, exact write,
+/// semantic write. With a breaker per connection each of those four
+/// operations found a breaker that no earlier operation had opened, so
+/// one request against a black-holed Redis paid the budget four times
+/// (measured: 20s at the default 5s budget) instead of once. Sharing the
+/// policy makes the first failure short-circuit the rest of the request.
+///
+/// Sharing the policy does NOT share the connection: the two cache
+/// connections stay separate so they do not serialize on one pipeline.
+///
+/// One policy per `redis:` config block. The rate limiter reads a
+/// different block and is a different subsystem, so it holds its own —
+/// a Redis outage that is really one outage still costs a request one
+/// budget for the cache and one for the limiter, which is the price of
+/// letting the two degrade independently.
+#[derive(Clone)]
+pub struct FailurePolicy(Arc<Guard>);
+
+impl FailurePolicy {
+    /// Build the policy for one `redis:` config block. Pass the same
+    /// value to every [`connect_with`] call for that block.
+    pub fn new(cfg: &RedisConnConfig) -> Self {
+        Self(Arc::new(Guard {
+            // `validate` rejects 0, but this type is constructible from a
+            // hand-built config in tests; clamping keeps "no budget at
+            // all" unreachable rather than merely unconfigurable.
+            timeout: Duration::from_secs(cfg.timeout_secs.max(1)),
+            breaker: Breaker::new(BREAKER_WINDOW),
+        }))
+    }
 }
 
 impl Guard {
@@ -407,12 +451,18 @@ impl ConnectionLike for RedisConnHandle {
 /// rather than per request. Assumes [`RedisConnConfig::validate`] already
 /// passed (the boot path validates before calling this).
 pub async fn connect(cfg: &RedisConnConfig) -> RedisResult<RedisConn> {
+    connect_with(cfg, &FailurePolicy::new(cfg)).await
+}
+
+/// [`connect`] against an existing [`FailurePolicy`].
+///
+/// Every connection a subsystem opens from the same `redis:` block must
+/// be built this way from ONE policy, or the subsystem's operations each
+/// pay the command budget separately — see [`FailurePolicy`].
+pub async fn connect_with(cfg: &RedisConnConfig, policy: &FailurePolicy) -> RedisResult<RedisConn> {
     let tls = load_tls(cfg)?;
-    let timeout = Duration::from_secs(cfg.timeout_secs.max(1));
-    let guard = Arc::new(Guard {
-        timeout,
-        breaker: Breaker::new(BREAKER_WINDOW),
-    });
+    let guard = Arc::clone(&policy.0);
+    let timeout = guard.timeout;
     let inner = match cfg.mode {
         RedisMode::Single => {
             let url = insecure_url(cfg.url.as_deref().unwrap_or_default(), cfg);
@@ -802,6 +852,57 @@ mod guard_tests {
             .await
             .expect("the probe reaches Redis again");
         assert!(!g.breaker.is_open(), "a success closes the breaker");
+    }
+
+    /// The window has to date from when the failing command RETURNED.
+    /// Dating it from when the command started would leave it already
+    /// expired by the time that command gave up whenever the window is
+    /// not longer than the budget — and the next operation of the same
+    /// request would then probe and pay the budget all over again, which
+    /// is how one request came to pay four.
+    #[tokio::test]
+    async fn the_window_dates_from_when_the_command_returned() {
+        // Window shorter than the budget, so "from start" and "from
+        // return" give opposite answers.
+        let g = guard(200, 100);
+        g.run(pending::<RedisResult<()>>())
+            .await
+            .expect_err("the command spends its budget and gives up");
+
+        let started = Instant::now();
+        let err = g
+            .run(pending::<RedisResult<()>>())
+            .await
+            .expect_err("the operation behind it short-circuits");
+        assert!(
+            started.elapsed() < Duration::from_millis(40),
+            "the cool-off must still be open when the failure returns, took {:?}",
+            started.elapsed()
+        );
+        assert!(err.to_string().contains("cool-off"), "{err}");
+    }
+
+    /// Two connections of one subsystem share the policy, so the budget a
+    /// request spends on the first is not spent again on the second.
+    #[tokio::test]
+    async fn connections_sharing_a_policy_share_the_cool_off() {
+        let policy = FailurePolicy(Arc::new(guard(2_000, 5_000)));
+        let a = Arc::clone(&policy.0);
+        let b = Arc::clone(&policy.0);
+
+        a.run(async { Err::<(), _>(dropped_connection()) })
+            .await
+            .expect_err("the first connection fails");
+
+        let started = Instant::now();
+        b.run(pending::<RedisResult<()>>())
+            .await
+            .expect_err("the second connection short-circuits on the shared cool-off");
+        assert!(
+            started.elapsed() < Duration::from_millis(40),
+            "a second connection of the same subsystem must not pay the              budget again, took {:?}",
+            started.elapsed()
+        );
     }
 
     /// A cool-off that only gates the window itself still lets every

--- a/crates/aisix-redis/tests/sentinel_failover.rs
+++ b/crates/aisix-redis/tests/sentinel_failover.rs
@@ -98,13 +98,16 @@ async fn sentinel_reresolves_master_after_failover() {
     // Retry briefly: the freshly promoted master may take a moment to
     // accept writes after role change.
     //
-    // The budget is deliberately longer than the role change needs. The
-    // failure that triggered the failover also opened the connection
+    // The budget is deliberately much longer than the role change needs.
+    // The failure that triggered the failover also opened the connection
     // layer's cool-off, so the first `BREAKER_WINDOW` of this loop is
-    // spent short-circuiting rather than re-resolving; sizing the loop to
-    // the role change alone would leave it racing the window.
+    // spent short-circuiting rather than re-resolving. That window is 30s
+    // — sized to outlast an upstream call, not a role change — so the loop
+    // is sized as `BREAKER_WINDOW` plus room for the promotion. Shorten it
+    // and the test starts failing on the cool-off rather than on anything
+    // about failover.
     let mut wrote = false;
-    for _ in 0..80 {
+    for _ in 0..200 {
         // acquire itself can fail transiently right after a failover (the
         // sentinel master lookup may briefly error); retry rather than
         // abort, since absorbing that instability is the loop's whole job.

--- a/crates/aisix-redis/tests/sentinel_failover.rs
+++ b/crates/aisix-redis/tests/sentinel_failover.rs
@@ -99,13 +99,14 @@ async fn sentinel_reresolves_master_after_failover() {
     // accept writes after role change.
     //
     // The budget is deliberately much longer than the role change needs.
-    // The failure that triggered the failover also opened the connection
-    // layer's cool-off, so the first `BREAKER_WINDOW` of this loop is
-    // spent short-circuiting rather than re-resolving. That window is 30s
-    // — sized to outlast an upstream call, not a role change — so the loop
-    // is sized as `BREAKER_WINDOW` plus room for the promotion. Shorten it
-    // and the test starts failing on the cool-off rather than on anything
-    // about failover.
+    // Nothing above has failed a command through THIS connection — the
+    // failover and the promotion poll both use their own clients, and
+    // `note_error` only drops the cached master — so the cool-off is
+    // normally closed here and the first iteration re-resolves straight
+    // away. What the budget is for is the case where it is not: if a write
+    // below lands on a socket the failover dropped, that is an I/O error,
+    // the cool-off opens, and nothing gets through for `BREAKER_WINDOW`
+    // (30s). Sized to outlast one such window rather than to race it.
     let mut wrote = false;
     for _ in 0..200 {
         // acquire itself can fail transiently right after a failover (the

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -928,10 +928,27 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     if cfg.cache.backend == CacheBackend::Redis && cfg.cache.redis.is_none() {
         anyhow::bail!("cache.backend = redis but cache.redis missing");
     }
-    let redis_cache: Option<Arc<dyn Cache>> = match cfg.cache.redis.as_ref() {
-        Some(redis_cfg) => {
+    // ONE failure policy for the whole cache subsystem. The exact-KV and
+    // vector-search stores below open separate connections to the same
+    // `cache.redis` — deliberately, so they do not serialize on one
+    // pipeline — but a single chat request touches both twice (lookup,
+    // lookup, write, write). A breaker per connection therefore let one
+    // request pay the command budget four times over while Redis was
+    // black-holed; sharing the policy makes the first failure
+    // short-circuit the rest of the request. The rate-limit store reads
+    // a different config block and keeps its own.
+    let cache_failure_policy = cfg
+        .cache
+        .redis
+        .as_ref()
+        .map(aisix_cache::FailurePolicy::new);
+    let redis_cache: Option<Arc<dyn Cache>> = match (
+        cfg.cache.redis.as_ref(),
+        &cache_failure_policy,
+    ) {
+        (Some(redis_cfg), Some(policy)) => {
             tracing::info!(target: "aisix::cache", backend = "redis", "connecting cache backend");
-            let redis = RedisCache::connect(redis_cfg)
+            let redis = RedisCache::connect_with(redis_cfg, policy)
                 .await
                 .map_err(|e| {
                     // Deliberately no URL in the message: redis URLs carry
@@ -943,7 +960,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 .with_metrics((*metrics).clone());
             Some(Arc::new(redis) as Arc<dyn Cache>)
         }
-        None => None,
+        _ => None,
     };
     // Shared semantic (L2) store for `backend: redis` policies. Wired
     // only when the server passes the vector-search probe — a plain
@@ -964,7 +981,13 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 // Degrade (never abort) on any failure here: the exact
                 // redis cache above is the load-bearing connection; the
                 // semantic store is an optimization layer.
-                match aisix_cache::RedisSemanticCache::connect(redis_cfg).await {
+                //
+                // `connect_with`, on the policy the exact cache is already
+                // running under: separate connection, one shared cool-off.
+                let policy = cache_failure_policy
+                    .clone()
+                    .unwrap_or_else(|| aisix_cache::FailurePolicy::new(redis_cfg));
+                match aisix_cache::RedisSemanticCache::connect_with(redis_cfg, &policy).await {
                     Err(e) => {
                         tracing::warn!(
                             target: "aisix::cache",

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -937,16 +937,17 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
     // black-holed; sharing the policy makes the first failure
     // short-circuit the rest of the request. The rate-limit store reads
     // a different config block and keeps its own.
-    let cache_failure_policy = cfg
+    //
+    // The config and its policy travel as one value so the two stores
+    // cannot be built from the same block under different policies —
+    // which is the whole defect, and it reads as ordinary wiring.
+    let cache_redis = cfg
         .cache
         .redis
         .as_ref()
-        .map(aisix_cache::FailurePolicy::new);
-    let redis_cache: Option<Arc<dyn Cache>> = match (
-        cfg.cache.redis.as_ref(),
-        &cache_failure_policy,
-    ) {
-        (Some(redis_cfg), Some(policy)) => {
+        .map(|c| (c, aisix_cache::FailurePolicy::new(c)));
+    let redis_cache: Option<Arc<dyn Cache>> = match &cache_redis {
+        Some((redis_cfg, policy)) => {
             tracing::info!(target: "aisix::cache", backend = "redis", "connecting cache backend");
             let redis = RedisCache::connect_with(redis_cfg, policy)
                 .await
@@ -960,88 +961,84 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 .with_metrics((*metrics).clone());
             Some(Arc::new(redis) as Arc<dyn Cache>)
         }
-        _ => None,
+        None => None,
     };
     // Shared semantic (L2) store for `backend: redis` policies. Wired
     // only when the server passes the vector-search probe — a plain
     // Redis 6/7 (or cluster mode, unsupported yet) degrades those
     // policies to exact-only, loudly, HERE at boot rather than
     // silently per request.
-    let semantic_redis: Option<Arc<dyn aisix_cache::SemanticCacheStore>> =
-        match cfg.cache.redis.as_ref() {
-            Some(redis_cfg) if redis_cfg.mode == aisix_core::RedisMode::Cluster => {
-                tracing::warn!(
-                    target: "aisix::cache",
-                    "cache.redis is in cluster mode; semantic matching on backend=redis \
-                     policies is not supported yet and stays exact-only"
-                );
-                None
-            }
-            Some(redis_cfg) => {
-                // Degrade (never abort) on any failure here: the exact
-                // redis cache above is the load-bearing connection; the
-                // semantic store is an optimization layer.
-                //
-                // `connect_with`, on the policy the exact cache is already
-                // running under: separate connection, one shared cool-off.
-                let policy = cache_failure_policy
-                    .clone()
-                    .unwrap_or_else(|| aisix_cache::FailurePolicy::new(redis_cfg));
-                match aisix_cache::RedisSemanticCache::connect_with(redis_cfg, &policy).await {
-                    Err(e) => {
-                        tracing::warn!(
-                            target: "aisix::cache",
-                            error = %e,
-                            "redis semantic cache connect failed; semantic matching \
-                             on backend=redis policies stays exact-only"
-                        );
-                        None
-                    }
-                    Ok(store) => {
-                        let store = store
-                            .with_env_namespace(&cfg.etcd.env_id)
-                            .with_metrics((*metrics).clone());
-                        match store.probe().await {
-                            Ok(()) => {
-                                match store.sweep_empty_indexes().await {
-                                    Ok(dropped) if dropped > 0 => {
-                                        tracing::info!(
-                                            target: "aisix::cache",
-                                            dropped,
-                                            "reclaimed empty semantic-cache indexes"
-                                        );
-                                    }
-                                    Ok(_) => {}
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            target: "aisix::cache",
-                                            error = %e,
-                                            "semantic-cache index sweep failed; continuing"
-                                        );
-                                    }
+    let semantic_redis: Option<Arc<dyn aisix_cache::SemanticCacheStore>> = match &cache_redis {
+        Some((redis_cfg, _)) if redis_cfg.mode == aisix_core::RedisMode::Cluster => {
+            tracing::warn!(
+                target: "aisix::cache",
+                "cache.redis is in cluster mode; semantic matching on backend=redis \
+                 policies is not supported yet and stays exact-only"
+            );
+            None
+        }
+        Some((redis_cfg, policy)) => {
+            // Degrade (never abort) on any failure here: the exact
+            // redis cache above is the load-bearing connection; the
+            // semantic store is an optimization layer.
+            //
+            // `connect_with`, on the policy the exact cache is already
+            // running under: separate connection, one shared cool-off.
+            match aisix_cache::RedisSemanticCache::connect_with(redis_cfg, policy).await {
+                Err(e) => {
+                    tracing::warn!(
+                        target: "aisix::cache",
+                        error = %e,
+                        "redis semantic cache connect failed; semantic matching \
+                         on backend=redis policies stays exact-only"
+                    );
+                    None
+                }
+                Ok(store) => {
+                    let store = store
+                        .with_env_namespace(&cfg.etcd.env_id)
+                        .with_metrics((*metrics).clone());
+                    match store.probe().await {
+                        Ok(()) => {
+                            match store.sweep_empty_indexes().await {
+                                Ok(dropped) if dropped > 0 => {
+                                    tracing::info!(
+                                        target: "aisix::cache",
+                                        dropped,
+                                        "reclaimed empty semantic-cache indexes"
+                                    );
                                 }
-                                tracing::info!(
-                                    target: "aisix::cache",
-                                    "cache.redis supports vector search; semantic matching \
-                                     enabled for backend=redis policies"
-                                );
-                                Some(Arc::new(store) as Arc<dyn aisix_cache::SemanticCacheStore>)
+                                Ok(_) => {}
+                                Err(e) => {
+                                    tracing::warn!(
+                                        target: "aisix::cache",
+                                        error = %e,
+                                        "semantic-cache index sweep failed; continuing"
+                                    );
+                                }
                             }
-                            Err(e) => {
-                                tracing::warn!(
-                                    target: "aisix::cache",
-                                    error = %e,
-                                    "cache.redis has no vector-search support; semantic matching \
-                                     on backend=redis policies stays exact-only"
-                                );
-                                None
-                            }
+                            tracing::info!(
+                                target: "aisix::cache",
+                                "cache.redis supports vector search; semantic matching \
+                                 enabled for backend=redis policies"
+                            );
+                            Some(Arc::new(store) as Arc<dyn aisix_cache::SemanticCacheStore>)
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "aisix::cache",
+                                error = %e,
+                                "cache.redis has no vector-search support; semantic matching \
+                                 on backend=redis policies stays exact-only"
+                            );
+                            None
                         }
                     }
                 }
             }
-            None => None,
-        };
+        }
+        None => None,
+    };
     let mut cache_backends =
         CacheBackends::new(Arc::new(MemoryCache::with_defaults()), redis_cache);
     if let Some(store) = semantic_redis {

--- a/tests/e2e/src/cases/cache-redis-outage-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-redis-outage-e2e.test.ts
@@ -1,0 +1,327 @@
+import { createHash, randomUUID } from "node:crypto";
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import { connect, createServer, type Server, type Socket } from "node:net";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  etcdEndpoint,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { pickFreePort } from "../harness/ports.js";
+
+// E2E: what a Redis outage costs ONE request when the cache is on the
+// shared backend.
+//
+// The cache subsystem holds two connections to the same `cache.redis` —
+// exact-KV and vector search — and a single chat request against a
+// policy with a `semantic` block touches both twice: exact lookup,
+// semantic lookup, exact write, semantic write. Each failure was bounded
+// (that is #1147) but each was bounded SEPARATELY, because the cool-off
+// belonged to the connection rather than to the subsystem, so the request
+// paid the command budget once per operation. Release QA measured 20.0s
+// at the default 5s budget against 5.0s for an exact-only policy.
+//
+// The outage shape is a black hole — the socket stays open and nothing is
+// ever answered, which is what a paused container or a dropped-packet
+// policy looks like from the client end. A stopped container can answer
+// with a refusal instead, and a refusal is the cheap failure: the client
+// learns immediately and no budget is spent, so it would not exercise
+// this at all.
+
+const ETCD_ENDPOINT = etcdEndpoint();
+const REDIS_URL = process.env.AISIX_E2E_REDIS ?? "redis://127.0.0.1:6379";
+
+const CALLER_PLAINTEXT = "sk-cache-outage-caller";
+const CALLER_KEY_HASH = createHash("sha256")
+  .update(CALLER_PLAINTEXT)
+  .digest("hex");
+
+// Below the 5s default on purpose: a bound derived from it cannot pass on
+// a gateway that ignored the configured budget.
+const TIMEOUT_SECS = 2;
+// One budget plus room for the mock upstream, the embedding call and
+// process scheduling. It has to stay under TWO budgets, which is what the
+// defect costs at this setting (measured 4.0s).
+const ONE_BUDGET_MS = TIMEOUT_SECS * 1000 + 1_500;
+
+/** Does the server speak FT.* (vector search)? `null` = unreachable.
+ *  Without it the semantic half of a policy never wires up and the case
+ *  under test cannot occur, so the suite skips honestly. */
+async function redisVectorSupport(url: string): Promise<boolean | null> {
+  const m = /^redis:\/\/(?:[^@/]*@)?([^:/]+)(?::(\d+))?/.exec(url);
+  if (!m) return null;
+  const host = m[1];
+  const port = m[2] ? Number(m[2]) : 6379;
+  return new Promise((resolve) => {
+    const sock = connect({ host, port }, () => sock.write("FT._LIST\r\n"));
+    const done = (v: boolean | null) => {
+      sock.destroy();
+      resolve(v);
+    };
+    sock.once("data", (buf) => {
+      const head = buf.toString();
+      if (head.startsWith("*")) return done(true);
+      if (/^-ERR unknown command/i.test(head)) return done(false);
+      done(null);
+    });
+    sock.once("error", () => done(null));
+    sock.setTimeout(1000, () => done(null));
+  });
+}
+
+/** A TCP relay in front of Redis that the test can black-hole: after
+ *  `blackhole()` the sockets stay open and nothing is forwarded or
+ *  answered, ever. */
+async function startRedisBlackhole(upstreamUrl: string): Promise<{
+  url: string;
+  blackhole(): void;
+  close(): Promise<void>;
+}> {
+  const m = /^redis:\/\/(?:[^@/]*@)?([^:/]+)(?::(\d+))?/.exec(upstreamUrl);
+  if (!m) throw new Error(`unparseable redis url: ${upstreamUrl}`);
+  const host = m[1];
+  const port = m[2] ? Number(m[2]) : 6379;
+  let hole = false;
+  const live = new Set<Socket>();
+  const server: Server = createServer((client) => {
+    live.add(client);
+    const upstream = connect({ host, port });
+    live.add(upstream);
+    client.on("data", (buf) => {
+      if (hole) return;
+      upstream.write(buf);
+    });
+    upstream.on("data", (buf) => {
+      if (hole) return;
+      client.write(buf);
+    });
+    const bin = () => {
+      client.destroy();
+      upstream.destroy();
+      live.delete(client);
+      live.delete(upstream);
+    };
+    for (const s of [client, upstream]) {
+      s.on("error", bin);
+      s.on("close", bin);
+    }
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const addr = server.address();
+  if (typeof addr === "string" || addr === null) throw new Error("no relay port");
+  return {
+    url: `redis://127.0.0.1:${addr.port}`,
+    blackhole: () => {
+      hole = true;
+    },
+    close: () =>
+      new Promise<void>((r) => {
+        for (const s of live) s.destroy();
+        server.close(() => r());
+      }),
+  };
+}
+
+/** Deterministic 4-d embedding so the semantic layer has a real vector
+ *  to store and search on. */
+function keywordVector(text: string): number[] {
+  return text.toLowerCase().includes("alpha") ? [1, 0, 0, 0] : [0, 0, 0, 1];
+}
+
+async function startEmbeddingMock(): Promise<{
+  baseUrl: string;
+  close(): Promise<void>;
+}> {
+  const server: HttpServer = createHttpServer((req, res) => {
+    res.on("error", () => {});
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      const body = JSON.parse(raw || "{}") as { input?: string | string[] };
+      const inputs = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          object: "list",
+          model: "embed-mock",
+          data: inputs.map((text, index) => ({
+            object: "embedding",
+            index,
+            embedding: keywordVector(text),
+          })),
+          usage: { prompt_tokens: inputs.length, total_tokens: inputs.length },
+        }),
+      );
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((r) => server.listen(port, "127.0.0.1", r));
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+const SEMANTIC_MODEL = "cache-outage-semantic";
+const EXACT_MODEL = "cache-outage-exact";
+
+/** Two chat models, each with its own redis cache policy — one carrying a
+ *  `semantic` block, one exact-only — plus the embedding model the
+ *  semantic layer needs. The caller key is seeded LAST, per
+ *  tests/e2e/AGENTS.md, so gating on it implies the whole set. */
+async function seed(etcdRoot: string, embedBase: string, upstreamBase: string) {
+  const seed = new SeedClient(new EtcdClient(), etcdRoot);
+  const embedPk = await seed.createProviderKey({
+    display_name: "cache-outage-embed-pk",
+    secret: "sk-mock",
+    api_base: `${embedBase}/v1`,
+  });
+  await seed.createModel({
+    display_name: "cache-outage-embed",
+    provider: "openai",
+    model_name: "embed-mock",
+    provider_key_id: embedPk.id,
+    embedding: { dimensions: 4, normalize: true },
+  });
+  const chatPk = await seed.createProviderKey({
+    display_name: "cache-outage-chat-pk",
+    secret: "sk-mock",
+    api_base: `${upstreamBase}/v1`,
+  });
+  for (const model of [SEMANTIC_MODEL, EXACT_MODEL]) {
+    await seed.createModel({
+      display_name: model,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: chatPk.id,
+    });
+  }
+  await seed.createCachePolicy({
+    name: "cache-outage-semantic-policy",
+    backend: "redis",
+    applies_to: `model:${SEMANTIC_MODEL}`,
+    ttl_seconds: 600,
+    semantic: { embedding_model: "cache-outage-embed", threshold: 0.85 },
+  });
+  await seed.createCachePolicy({
+    name: "cache-outage-exact-policy",
+    backend: "redis",
+    applies_to: `model:${EXACT_MODEL}`,
+    ttl_seconds: 600,
+  });
+  await seed.createApiKey({
+    key_hash: CALLER_KEY_HASH,
+    allowed_models: ["*"],
+  });
+}
+
+/** Returns the wall-clock cost of one completed chat request. */
+async function timeChat(
+  proxyUrl: string,
+  model: string,
+  prompt: string,
+): Promise<{ status: number; ms: number }> {
+  const started = Date.now();
+  const res = await fetch(`${proxyUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${CALLER_PLAINTEXT}`,
+    },
+    body: JSON.stringify({ model, messages: [{ role: "user", content: prompt }] }),
+  });
+  await res.text();
+  return { status: res.status, ms: Date.now() - started };
+}
+
+describe("a Redis outage costs one request one budget for the whole cache", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let embed: Awaited<ReturnType<typeof startEmbeddingMock>> | undefined;
+  let relay: Awaited<ReturnType<typeof startRedisBlackhole>> | undefined;
+  let ready = false;
+  const prefix = `/aisix-e2e-cache-outage-${randomUUID()}`;
+
+  beforeAll(async () => {
+    const vector = await redisVectorSupport(REDIS_URL);
+    ready = (await new EtcdClient().ping()) && vector === true;
+    if (!ready) return;
+
+    upstream = await startOpenAiUpstream();
+    embed = await startEmbeddingMock();
+    relay = await startRedisBlackhole(REDIS_URL);
+    app = await spawnApp({
+      extra: {
+        etcd: { endpoints: [ETCD_ENDPOINT], prefix },
+        cache: {
+          backend: "redis",
+          redis: { url: relay.url, timeout_secs: TIMEOUT_SECS },
+        },
+      },
+    });
+    await seed(prefix, embed.baseUrl, upstream.baseUrl);
+    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(
+      async () => (await probe.listModels()).status === 200,
+    );
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+    await embed?.close();
+    await relay?.close();
+    if (ready) await new EtcdClient().deletePrefix(prefix);
+  });
+
+  test("a semantic policy pays one budget, not one per cache connection", async (ctx) => {
+    if (!ready || !app || !relay) {
+      ctx.skip();
+      return;
+    }
+
+    // Healthy first, so both cache connections are established and the
+    // semantic index exists before anything is broken.
+    const warm = await timeChat(app.proxyUrl, SEMANTIC_MODEL, "alpha warm");
+    expect(warm.status).toBe(200);
+
+    relay.blackhole();
+
+    const degraded = await timeChat(app.proxyUrl, SEMANTIC_MODEL, "alpha cold");
+    expect(degraded.status).toBe(200);
+    expect(degraded.ms).toBeGreaterThanOrEqual(TIMEOUT_SECS * 1000);
+    expect(degraded.ms).toBeLessThan(ONE_BUDGET_MS);
+
+    // Behind it the cool-off is open, so the next request costs nothing.
+    const behind = await timeChat(app.proxyUrl, SEMANTIC_MODEL, "alpha behind");
+    expect(behind.status).toBe(200);
+    expect(behind.ms).toBeLessThan(1_000);
+  }, 60_000);
+
+  test("an exact-only policy still pays one budget", async (ctx) => {
+    if (!ready || !app || !relay) {
+      ctx.skip();
+      return;
+    }
+
+    // The previous test left the cool-off open; wait it out so this
+    // request is admitted as a probe and genuinely reaches the black
+    // hole, rather than passing by short-circuiting.
+    await new Promise((r) => setTimeout(r, 6_000));
+
+    const degraded = await timeChat(app.proxyUrl, EXACT_MODEL, "exact cold");
+    expect(degraded.status).toBe(200);
+    expect(degraded.ms).toBeGreaterThanOrEqual(TIMEOUT_SECS * 1000);
+    expect(degraded.ms).toBeLessThan(ONE_BUDGET_MS);
+  }, 60_000);
+});

--- a/tests/e2e/src/cases/cache-redis-outage-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-redis-outage-e2e.test.ts
@@ -121,9 +121,9 @@ async function startRedisBlackhole(upstreamUrl: string): Promise<{
       hole = true;
     },
     close: () =>
-      new Promise<void>((r) => {
+      new Promise<void>((resolve, reject) => {
         for (const s of live) s.destroy();
-        server.close(() => r());
+        server.close((err) => (err ? reject(err) : resolve()));
       }),
   };
 }
@@ -363,6 +363,11 @@ describe("an upstream slower than the old cool-off still costs one budget", () =
 
     const degraded = await timeChat(f.app.proxyUrl, SEMANTIC_MODEL, "alpha cold");
     expect(degraded.status).toBe(200);
+    // Both cache layers are unreachable, so neither can serve this — the
+    // request must have gone upstream, and the timing below is only
+    // meaningful if it did. Asserted on the upstream's own record rather
+    // than inferred from the clock.
+    expect(f.upstream.receivedRequests.length).toBe(2);
     // The exact lookup spends one budget, then the upstream runs; the
     // writes that follow must short-circuit.
     expect(degraded.ms).toBeGreaterThanOrEqual(

--- a/tests/e2e/src/cases/cache-redis-outage-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-redis-outage-e2e.test.ts
@@ -44,7 +44,7 @@ const CALLER_KEY_HASH = createHash("sha256")
 
 // Below the 5s default on purpose: a bound derived from it cannot pass on
 // a gateway that ignored the configured budget.
-const TIMEOUT_SECS = 2;
+const TIMEOUT_SECS = 3;
 // One budget plus room for the mock upstream, the embedding call and
 // process scheduling. It has to stay under TWO budgets, which is what the
 // defect costs at this setting (measured 4.0s).
@@ -174,6 +174,11 @@ async function startEmbeddingMock(): Promise<{
 
 const SEMANTIC_MODEL = "cache-outage-semantic";
 const EXACT_MODEL = "cache-outage-exact";
+// Longer than the OLD 5s cool-off and shorter than the 30s one, so the
+// window length alone decides whether the cache write pays a second
+// budget. Non-streaming completions — the only responses this cache
+// stores — routinely run this long.
+const UPSTREAM_DELAY_MS = 7_000;
 
 /** Two chat models, each with its own redis cache policy — one carrying a
  *  `semantic` block, one exact-only — plus the embedding model the
@@ -244,82 +249,158 @@ async function timeChat(
   return { status: res.status, ms: Date.now() - started };
 }
 
+interface Fixture {
+  app: SpawnedApp;
+  upstream: OpenAiUpstream;
+  embed: Awaited<ReturnType<typeof startEmbeddingMock>>;
+  relay: Awaited<ReturnType<typeof startRedisBlackhole>>;
+  prefix: string;
+}
+
+/** One gateway with its own relay, so each case starts on a cool-off that
+ *  nothing has opened. Waiting one out instead would mean sleeping 30s. */
+async function bringUp(tag: string, responseDelayMs?: number): Promise<Fixture> {
+  const prefix = `/aisix-e2e-cache-outage-${tag}-${randomUUID()}`;
+  const upstream = await startOpenAiUpstream(
+    responseDelayMs ? { responseDelayMs } : {},
+  );
+  const embed = await startEmbeddingMock();
+  const relay = await startRedisBlackhole(REDIS_URL);
+  const app = await spawnApp({
+    extra: {
+      etcd: { endpoints: [ETCD_ENDPOINT], prefix },
+      cache: {
+        backend: "redis",
+        redis: { url: relay.url, timeout_secs: TIMEOUT_SECS },
+      },
+    },
+  });
+  await seed(prefix, embed.baseUrl, upstream.baseUrl);
+  const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+  await waitConfigPropagation(
+    async () => (await probe.listModels()).status === 200,
+  );
+  return { app, upstream, embed, relay, prefix };
+}
+
+async function tearDown(f: Fixture | undefined) {
+  if (!f) return;
+  await f.app.exit();
+  await f.upstream.close();
+  await f.embed.close();
+  await f.relay.close();
+  await new EtcdClient().deletePrefix(f.prefix);
+}
+
+async function vectorRedisReady(): Promise<boolean> {
+  return (await new EtcdClient().ping()) && (await redisVectorSupport(REDIS_URL)) === true;
+}
+
 describe("a Redis outage costs one request one budget for the whole cache", () => {
-  let app: SpawnedApp | undefined;
-  let upstream: OpenAiUpstream | undefined;
-  let embed: Awaited<ReturnType<typeof startEmbeddingMock>> | undefined;
-  let relay: Awaited<ReturnType<typeof startRedisBlackhole>> | undefined;
+  let f: Fixture | undefined;
   let ready = false;
-  const prefix = `/aisix-e2e-cache-outage-${randomUUID()}`;
 
   beforeAll(async () => {
-    const vector = await redisVectorSupport(REDIS_URL);
-    ready = (await new EtcdClient().ping()) && vector === true;
-    if (!ready) return;
-
-    upstream = await startOpenAiUpstream();
-    embed = await startEmbeddingMock();
-    relay = await startRedisBlackhole(REDIS_URL);
-    app = await spawnApp({
-      extra: {
-        etcd: { endpoints: [ETCD_ENDPOINT], prefix },
-        cache: {
-          backend: "redis",
-          redis: { url: relay.url, timeout_secs: TIMEOUT_SECS },
-        },
-      },
-    });
-    await seed(prefix, embed.baseUrl, upstream.baseUrl);
-    const probe = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
-    await waitConfigPropagation(
-      async () => (await probe.listModels()).status === 200,
-    );
+    ready = await vectorRedisReady();
+    if (ready) f = await bringUp("fast");
   });
-
   afterAll(async () => {
-    await app?.exit();
-    await upstream?.close();
-    await embed?.close();
-    await relay?.close();
-    if (ready) await new EtcdClient().deletePrefix(prefix);
+    await tearDown(f);
   });
 
   test("a semantic policy pays one budget, not one per cache connection", async (ctx) => {
-    if (!ready || !app || !relay) {
+    if (!ready || !f) {
       ctx.skip();
       return;
     }
 
     // Healthy first, so both cache connections are established and the
     // semantic index exists before anything is broken.
-    const warm = await timeChat(app.proxyUrl, SEMANTIC_MODEL, "alpha warm");
+    const warm = await timeChat(f.app.proxyUrl, SEMANTIC_MODEL, "alpha warm");
     expect(warm.status).toBe(200);
 
-    relay.blackhole();
+    f.relay.blackhole();
 
-    const degraded = await timeChat(app.proxyUrl, SEMANTIC_MODEL, "alpha cold");
+    const degraded = await timeChat(f.app.proxyUrl, SEMANTIC_MODEL, "alpha cold");
     expect(degraded.status).toBe(200);
     expect(degraded.ms).toBeGreaterThanOrEqual(TIMEOUT_SECS * 1000);
     expect(degraded.ms).toBeLessThan(ONE_BUDGET_MS);
 
     // Behind it the cool-off is open, so the next request costs nothing.
-    const behind = await timeChat(app.proxyUrl, SEMANTIC_MODEL, "alpha behind");
+    const behind = await timeChat(f.app.proxyUrl, SEMANTIC_MODEL, "alpha behind");
     expect(behind.status).toBe(200);
     expect(behind.ms).toBeLessThan(1_000);
   }, 60_000);
+});
 
-  test("an exact-only policy still pays one budget", async (ctx) => {
-    if (!ready || !app || !relay) {
+// The cache read and the cache write of one request straddle the upstream
+// call, so "one budget per request" holds only while the cool-off outlasts
+// that call. At the 5s window this case paid a second budget on the write
+// — the reason the window is 30s. The case above cannot see it: its
+// upstream answers instantly, so its write lands inside any window.
+describe("an upstream slower than the old cool-off still costs one budget", () => {
+  let f: Fixture | undefined;
+  let ready = false;
+
+  beforeAll(async () => {
+    ready = await vectorRedisReady();
+    if (ready) f = await bringUp("slow", UPSTREAM_DELAY_MS);
+  }, 60_000);
+  afterAll(async () => {
+    await tearDown(f);
+  });
+
+  test("the cache write is still covered by the cool-off its read opened", async (ctx) => {
+    if (!ready || !f) {
       ctx.skip();
       return;
     }
 
-    // The previous test left the cool-off open; wait it out so this
-    // request is admitted as a probe and genuinely reaches the black
-    // hole, rather than passing by short-circuiting.
-    await new Promise((r) => setTimeout(r, 6_000));
+    const warm = await timeChat(f.app.proxyUrl, SEMANTIC_MODEL, "alpha warm");
+    expect(warm.status).toBe(200);
 
-    const degraded = await timeChat(app.proxyUrl, EXACT_MODEL, "exact cold");
+    f.relay.blackhole();
+
+    const degraded = await timeChat(f.app.proxyUrl, SEMANTIC_MODEL, "alpha cold");
+    expect(degraded.status).toBe(200);
+    // The exact lookup spends one budget, then the upstream runs; the
+    // writes that follow must short-circuit.
+    expect(degraded.ms).toBeGreaterThanOrEqual(
+      UPSTREAM_DELAY_MS + TIMEOUT_SECS * 1000,
+    );
+    // The bound sits between "one budget" (delay + budget) and "two"
+    // (delay + 2 x budget), with at least a second of room on each side
+    // so neither verdict rides on scheduling noise.
+    expect(degraded.ms).toBeLessThan(
+      UPSTREAM_DELAY_MS + TIMEOUT_SECS * 1000 + 2_000,
+    );
+  }, 60_000);
+});
+
+describe("an exact-only policy still pays one budget", () => {
+  let f: Fixture | undefined;
+  let ready = false;
+
+  beforeAll(async () => {
+    ready = await vectorRedisReady();
+    if (ready) f = await bringUp("exact");
+  });
+  afterAll(async () => {
+    await tearDown(f);
+  });
+
+  test("one connection, one budget", async (ctx) => {
+    if (!ready || !f) {
+      ctx.skip();
+      return;
+    }
+
+    const warm = await timeChat(f.app.proxyUrl, EXACT_MODEL, "exact warm");
+    expect(warm.status).toBe(200);
+
+    f.relay.blackhole();
+
+    const degraded = await timeChat(f.app.proxyUrl, EXACT_MODEL, "exact cold");
     expect(degraded.status).toBe(200);
     expect(degraded.ms).toBeGreaterThanOrEqual(TIMEOUT_SECS * 1000);
     expect(degraded.ms).toBeLessThan(ONE_BUDGET_MS);


### PR DESCRIPTION
Follow-up to #1147, found by release QA on 1.2.0-rc.1.

## Problem

With `cache.backend=redis` and Redis black-holed with `docker pause` — the socket stays open and nothing ever answers — a request against a cache policy carrying a `semantic` block completed 200 (fail-open worked) but took **20.0 s** at the default `timeout_secs: 5`, and 4.0 s at `timeout_secs: 2`. An exact-only policy took 5.0 s, one budget. The gateway's own log showed four sequential timeouts inside a single request:

```
cache lookup failed            t=0  → 5
semantic cache lookup failed   t=5  → 10
cache write failed             t=10 → 15
semantic cache write failed    t=15 → 20
```

The cache subsystem opens **two** connections to the same `cache.redis` — the exact-KV one and the vector-search one. That is deliberate: they must not serialize on one pipeline. #1147 gave the cool-off to the *connection*, so each of those four operations found a breaker that no earlier operation had opened.

The exact 4× is not a coincidence, and startup logs two `connected mode="single" timeout_secs=5` lines for the cache which is the visible tell. With a 5 s window and a 5 s budget the two connections alternate exactly out of phase: the exact lookup fails at t=5 and opens connection A until t=10; the semantic lookup runs t=5→10 on B; the exact write at t=10 finds A's window just expired, is admitted as its probe, and pays again. At `timeout_secs: 2` the 5 s window outlasts the 2 s budget, so only two budgets are paid — which is the measured 4.0 s.

## Change

Two things, and the second only became visible once the first was in review.

**The cool-off belongs to a subsystem, not to a connection.**

`aisix_redis::FailurePolicy` carries the command budget and the breaker. Every connection a subsystem opens from one `redis:` block is built from one policy (`connect_with`), so the first failed operation short-circuits the rest of that request — including the two writes later in the same request, on either connection. The connections themselves stay separate.

The bootstrap builds one policy per `cache.redis` and hands it to both `RedisCache::connect_with` and `RedisSemanticCache::connect_with`. The rate-limit store reads a different config block and is a different subsystem, so it keeps its own policy and the two still degrade independently. `RedisCache::connect` / `RedisSemanticCache::connect` remain for standalone use and each build a policy of their own; their docs say why production must not use them.

**The cool-off window is 30 s, sized to outlast an upstream call.** Sharing it only collapsed the two lookups, which run back to back; the two cache *writes* run after the upstream call. At the old 5 s window a request whose upstream leg took longer than that found the cool-off expired and its write was admitted as the next probe, paying a second budget — and non-streaming completions, the only responses this cache stores, routinely take longer than 5 s. So the window is no longer a multiple of the command budget; what it has to outlast is an upstream call. Still fixed, still not configurable.

The window already dated from when the failing command *returned* rather than from when it started. That is now pinned by a test rather than left as a property of how the code happens to read, because dating it from the start reopens exactly this gap whenever the window is not longer than the budget.

## Behavior change

- With Redis unreachable, a request whose cache policy has a `semantic` block costs the cache **one** command budget instead of four. At the default `timeout_secs: 5` that is 20 s → 5 s. Nothing else about the answer changes; the caller already got a 200.
- No new or changed configuration. `timeout_secs` keeps its name, its default of 5, and its meaning — what changes is how many times one request can spend it.
- **A recovered Redis is noticed up to 30 s later**, where it used to be 5 s, and a sentinel failover leaves the limiter counting per replica for up to 30 s before the master is re-resolved. That is the other side of the same trade, and it is the reason the window is a decision rather than a tuning detail.

### What this still does not fix

A request whose upstream call runs longer than 30 s finds the cool-off expired and pays a second budget on the cache write that follows. Bounding that for any upstream latency would need per-request degradation state threaded through the cache traits rather than a window; 30 s covers the completions this cache actually stores.

## Tests

Each of the two discriminating e2e fixtures and the integration test was mutation-checked — the relevant half of the fix reverted, the test observed going red. The exact-only e2e case is a control, not a discriminator: a single-connection subsystem always paid one budget. It is there to catch the opposite regression, a cool-off that never probes again.

- **DP e2e** (`tests/e2e/src/cases/cache-redis-outage-e2e.test.ts`, new): a TCP relay in front of a real vector-capable Redis, black-holed mid-test — the reported shape, sockets open and nothing answered, not a stopped container whose refusal is the *cheap* failure that spends no budget at all. Three fixtures, each with its own gateway so none starts on a cool-off another opened (waiting one out would now mean sleeping 30 s):
  - a semantic policy with an instant upstream: one budget, and the request behind it costs nothing. On the pre-fix wiring this measures 4039 ms against a 3500 ms bound — QA's 4.0 s, reproduced end to end.
  - a semantic policy whose upstream delays 7 s, longer than the old window and shorter than the new one, so the window length alone decides: 10.1 s against a 12.0 s bound, versus 13.1 s at the 5 s window. This is the case the first fixture structurally cannot see.
  - an exact-only policy: still one budget.
- **Cache subsystem integration** (`crates/aisix-cache/tests/redis_integration.rs`): the two stores wired exactly as the bootstrap wires them, then the four operations of one chat request against a black-holed Redis. 2.00 s shared, 4.00 s with a policy each.
- **Connection layer** (`crates/aisix-redis/src/lib.rs`): two connections sharing a policy share the cool-off; and the window dates from when the command returned — with a window shorter than the budget, so "from start" and "from return" give opposite answers.

Bounds are derived from the configured budget and sit below the 5 s default, so a build that ignored `timeout_secs` fails them, and each has a lower bound too so a return that is too fast (the black hole never reached) fails as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redis outages now use one shared failure and cool-off budget across cache operations, reducing delays during unavailable Redis conditions.
  * The Redis cool-off period is standardized at 30 seconds, with one probe request allowed before retrying.
  * Cache and rate-limiter Redis subsystems now recover independently.

* **Documentation**
  * Updated configuration guidance to explain outage behavior, shared cache policies, and subsystem-specific recovery timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->