### PR TITLE
feat(config): reference models by resource id, so a rename keeps the reference

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3368,6 +3368,19 @@ mod tests {
                 for key in ["oneOf", "anyOf"] {
                     if let Some(serde_json::Value::Array(variants)) = map.get(key) {
                         for (index, variant) in variants.iter().enumerate() {
+                            // A branch that declares nothing but `required`
+                            // is a cross-field CONSTRAINT, not a shape a
+                            // reader picks between — the "name or id" pairs
+                            // on every model reference are written this way.
+                            // ReDoc gives it no tab, so a title on it would
+                            // name something nobody sees. Same exemption the
+                            // `not` subschemas get below.
+                            if variant
+                                .as_object()
+                                .is_some_and(|b| b.len() == 1 && b.contains_key("required"))
+                            {
+                                continue;
+                            }
                             if variant["title"].as_str().is_none_or(str::is_empty) {
                                 missing.push(format!("{path}/{key}/{index}"));
                             }

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -3236,11 +3236,44 @@ mod tests {
         );
     }
 
+    /// A subschema that states a cross-field REQUIREMENT and nothing
+    /// else: `required`, optionally with a bare type pin on each field it
+    /// names. The "name or id" alternative every model reference carries
+    /// is written this way — the type pin is there because `required` in
+    /// JSON Schema is satisfied by a key whose value is `null`, and the
+    /// id fields accept `null`.
+    ///
+    /// ReDoc renders no tab for such a branch and it defines no property
+    /// of its own, so the title and description guards below skip it —
+    /// exactly as they already skip `if`/`then`/`else`.
+    fn is_requiredness_constraint(node: &serde_json::Value) -> bool {
+        let Some(map) = node.as_object() else {
+            return false;
+        };
+        if !map.contains_key("required")
+            || !map
+                .keys()
+                .all(|k| matches!(k.as_str(), "required" | "properties"))
+        {
+            return false;
+        }
+        let Some(serde_json::Value::Object(properties)) = map.get("properties") else {
+            return true;
+        };
+        properties.values().all(|p| {
+            p.as_object()
+                .is_some_and(|o| o.len() == 1 && o.contains_key("type"))
+        })
+    }
+
     fn collect_missing_property_descriptions(
         value: &serde_json::Value,
         path: String,
         missing: &mut Vec<String>,
     ) {
+        if is_requiredness_constraint(value) {
+            return;
+        }
         match value {
             serde_json::Value::Object(map) => {
                 if map.get("type").is_some_and(|kind| kind == "object")
@@ -3368,17 +3401,12 @@ mod tests {
                 for key in ["oneOf", "anyOf"] {
                     if let Some(serde_json::Value::Array(variants)) = map.get(key) {
                         for (index, variant) in variants.iter().enumerate() {
-                            // A branch that declares nothing but `required`
-                            // is a cross-field CONSTRAINT, not a shape a
-                            // reader picks between — the "name or id" pairs
-                            // on every model reference are written this way.
-                            // ReDoc gives it no tab, so a title on it would
-                            // name something nobody sees. Same exemption the
-                            // `not` subschemas get below.
-                            if variant
-                                .as_object()
-                                .is_some_and(|b| b.len() == 1 && b.contains_key("required"))
-                            {
+                            // A cross-field requirement is not a shape a
+                            // reader picks between, so ReDoc gives it no
+                            // tab and a title on it would name something
+                            // nobody sees. Same exemption the `not`
+                            // subschemas get below.
+                            if is_requiredness_constraint(variant) {
                                 continue;
                             }
                             if variant["title"].as_str().is_none_or(str::is_empty) {

--- a/crates/aisix-core/src/bin/dump-schema.rs
+++ b/crates/aisix-core/src/bin/dump-schema.rs
@@ -106,25 +106,27 @@ fn dump<T: JsonSchema>(out_dir: &Path, lenient_dir: &Path, name: &str) {
     // and the enforced copy is the embedding resource's `definitions` entry.
     let mut lenient = serde_json::to_value(&root).expect("serialize schema");
     schema::open_unknown_fields(&mut lenient);
+    schema::apply_model_ref_alternatives(&mut lenient);
     dump_value(lenient_dir, name, lenient);
 
-    // Serialize the `RootSchema` directly to preserve schemars' native key
-    // ordering. (Routing through `serde_json::Value` would re-sort keys.)
     // These nested types belong to closed resources, so re-close the root
-    // and every struct-shaped definition on the typed schema — the same
-    // strictness `schema::close_unknown_fields` applies to the resource
-    // documents, kept typed here so the key order stays schemars-native.
+    // and every struct-shaped definition — the same strictness
+    // `schema::close_unknown_fields` applies to the resource documents.
     close_object_schema(&mut root.schema);
     for def in root.definitions.values_mut() {
         if let schemars::schema::Schema::Object(obj) = def {
             close_object_schema(obj);
         }
     }
-    let mut json = serde_json::to_string_pretty(&root).expect("serialize schema");
-    json.push('\n');
-    let path = out_dir.join(format!("{name}.schema.json"));
-    fs::write(&path, json).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
-    println!("wrote {}", path.display());
+    // A model reference is "name OR id", and `schemars` cannot express
+    // that from the struct — the name field carries a serde default, so a
+    // bare derive would publish it as simply optional and these files
+    // would say a routing target may name no model at all. Applied to the
+    // JSON, which is also why these two files sort their keys like the
+    // resource ones rather than in schemars' emission order.
+    let mut strict = serde_json::to_value(&root).expect("serialize schema");
+    schema::apply_model_ref_alternatives(&mut strict);
+    dump_value(out_dir, name, strict);
 }
 
 /// Insert `additionalProperties: false` on a struct-shaped schema object

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -162,29 +162,61 @@ const KINDS: [(&str, IdentityField); 14] = [
     ),
 ];
 
-/// The id-form model references a document of `kind` can carry, paired
-/// with the name-form field each replaces.
+/// One id-form model reference a document can carry: the field, the
+/// name-form field that replaces it, and how an operator should spell that
+/// name form.
+///
+/// `hint` is not decoration. It is the same as `name_field` for every
+/// reference whose name form takes a bare model name, and differs for the
+/// one that does not: a cache policy's model scope is written into the
+/// free-form `applies_to`, where a bare name parses as no discriminator at
+/// all and the policy silently WIDENS to every request instead of failing.
+/// An error message that told an operator to "use `applies_to`" would be
+/// walking them into that.
+pub struct ModelRefIdField {
+    pub field: &'static str,
+    pub name_field: &'static str,
+    pub hint: &'static str,
+}
+
+const fn pair(field: &'static str, name_field: &'static str) -> ModelRefIdField {
+    ModelRefIdField {
+        field,
+        name_field,
+        hint: name_field,
+    }
+}
+
+/// The id-form model references a document of `kind` can carry.
 ///
 /// A projected document may point at a Model by resource id instead of by
 /// display name, which is what makes a reference survive a rename of the
-/// model. The pairing is public because two consumers must agree on it:
-/// the resources file refuses the id form (see [`load_from_str`]) and
-/// `aisix export` rewrites it back to the name form, and a field one of
-/// them knows about and the other does not is a silent round-trip loss.
-pub fn model_ref_id_fields(kind: &str) -> &'static [(&'static str, &'static str)] {
+/// model. The list is public because two consumers must agree on it: the
+/// resources file refuses the id form (see [`load_from_str`]) and `aisix
+/// export` rewrites it back to the name form, and a field one of them
+/// knows about and the other does not is a silent round-trip loss.
+pub fn model_ref_id_fields(kind: &str) -> &'static [ModelRefIdField] {
+    const API_KEYS: [ModelRefIdField; 1] = [pair("allowed_model_ids", "allowed_models")];
+    const MODELS: [ModelRefIdField; 4] = [
+        pair("model_id", "model"),
+        pair("target_id", "target"),
+        pair("embedding_model_id", "embedding_model"),
+        pair("default_id", "default"),
+    ];
+    const CACHE_POLICIES: [ModelRefIdField; 2] = [
+        ModelRefIdField {
+            field: "applies_to_model_id",
+            name_field: "applies_to",
+            hint: "applies_to: \"model:<name>\"",
+        },
+        pair("embedding_model_id", "embedding_model"),
+    ];
+    const GUARDRAILS: [ModelRefIdField; 1] = [pair("embedding_model_id", "embedding_model")];
     match kind {
-        "api_keys" => &[("allowed_model_ids", "allowed_models")],
-        "models" => &[
-            ("model_id", "model"),
-            ("target_id", "target"),
-            ("embedding_model_id", "embedding_model"),
-            ("default_id", "default"),
-        ],
-        "cache_policies" => &[
-            ("applies_to_model_id", "applies_to"),
-            ("embedding_model_id", "embedding_model"),
-        ],
-        "guardrails" => &[("embedding_model_id", "embedding_model")],
+        "api_keys" => &API_KEYS,
+        "models" => &MODELS,
+        "cache_policies" => &CACHE_POLICIES,
+        "guardrails" => &GUARDRAILS,
         _ => &[],
     }
 }
@@ -249,9 +281,8 @@ pub fn for_each_model_ref_node(
     }
 }
 
-/// The first id-form model reference `doc` carries, as `(field, name-form
-/// replacement)`.
-fn model_ref_id_field(kind: &str, doc: &mut Value) -> Option<(&'static str, &'static str)> {
+/// The first id-form model reference `doc` carries.
+fn model_ref_id_field(kind: &str, doc: &mut Value) -> Option<&'static ModelRefIdField> {
     let fields = model_ref_id_fields(kind);
     if fields.is_empty() {
         return None;
@@ -259,10 +290,7 @@ fn model_ref_id_field(kind: &str, doc: &mut Value) -> Option<(&'static str, &'st
     let mut found = None;
     for_each_model_ref_node(kind, doc, &mut |node| {
         if found.is_none() {
-            found = fields
-                .iter()
-                .find(|(field, _)| node.contains_key(*field))
-                .copied();
+            found = fields.iter().find(|f| node.contains_key(f.field));
         }
     });
     found
@@ -503,13 +531,14 @@ pub fn load_from_str(
         // path is the opposite: there an id that resolves to no model
         // degrades that one reference and must never fail the row, because
         // a rejected api_key stops authenticating entirely.)
-        if let Some((field, name_field)) = model_ref_id_field(entry.kind, &mut entry.doc) {
+        if let Some(reference) = model_ref_id_field(entry.kind, &mut entry.doc) {
+            let (field, hint) = (reference.field, reference.hint);
             errors.push(LoadError {
                 scope,
                 message: format!(
                     "the resources file does not accept `{field}` — it names a model by \
                      control-plane id, which a file cannot resolve; name the model with \
-                     `{name_field}` instead"
+                     `{hint}` instead"
                 ),
             });
             continue;

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -162,6 +162,112 @@ const KINDS: [(&str, IdentityField); 14] = [
     ),
 ];
 
+/// The id-form model references a document of `kind` can carry, paired
+/// with the name-form field each replaces.
+///
+/// A projected document may point at a Model by resource id instead of by
+/// display name, which is what makes a reference survive a rename of the
+/// model. The pairing is public because two consumers must agree on it:
+/// the resources file refuses the id form (see [`load_from_str`]) and
+/// `aisix export` rewrites it back to the name form, and a field one of
+/// them knows about and the other does not is a silent round-trip loss.
+pub fn model_ref_id_fields(kind: &str) -> &'static [(&'static str, &'static str)] {
+    match kind {
+        "api_keys" => &[("allowed_model_ids", "allowed_models")],
+        "models" => &[
+            ("model_id", "model"),
+            ("target_id", "target"),
+            ("embedding_model_id", "embedding_model"),
+            ("default_id", "default"),
+        ],
+        "cache_policies" => &[
+            ("applies_to_model_id", "applies_to"),
+            ("embedding_model_id", "embedding_model"),
+        ],
+        "guardrails" => &[("embedding_model_id", "embedding_model")],
+        _ => &[],
+    }
+}
+
+/// Call `f` on every object in `doc` that may carry one of
+/// [`model_ref_id_fields`]'s fields, for a document of `kind`.
+///
+/// Addressed by path rather than by walking the whole document for the
+/// field names: `secrets` and `headers` on a guardrail are operator-keyed
+/// maps, so a blind walk would treat a secret named `model_id` as a model
+/// reference and rewrite it. Extend this when a new nesting site gains a
+/// model reference.
+pub fn for_each_model_ref_node(
+    kind: &str,
+    doc: &mut Value,
+    f: &mut dyn FnMut(&mut serde_json::Map<String, Value>),
+) {
+    let Some(root) = doc.as_object_mut() else {
+        return;
+    };
+    let objects_in =
+        |node: &mut Value, key: &str, f: &mut dyn FnMut(&mut serde_json::Map<String, Value>)| {
+            if let Some(Value::Array(items)) = node.get_mut(key) {
+                for item in items {
+                    if let Some(obj) = item.as_object_mut() {
+                        f(obj);
+                    }
+                }
+            }
+        };
+    match kind {
+        // The key's grant list is a root field; a guardrail's kind config
+        // is `#[serde(flatten)]`ed onto the root, so its embedder is too.
+        "api_keys" | "guardrails" => f(root),
+        "cache_policies" => {
+            f(root);
+            if let Some(Value::Object(semantic)) = root.get_mut("semantic") {
+                f(semantic);
+            }
+        }
+        "models" => {
+            if let Some(routing) = root.get_mut("routing") {
+                objects_in(routing, "targets", f);
+            }
+            if let Some(ensemble) = root.get_mut("ensemble") {
+                objects_in(ensemble, "panel", f);
+                if let Some(Value::Object(judge)) = ensemble.get_mut("judge") {
+                    f(judge);
+                }
+            }
+            if let Some(semantic) = root.get_mut("semantic") {
+                objects_in(semantic, "routes", f);
+                if let Some(Value::Object(on_failure)) = semantic.get_mut("on_embedding_failure") {
+                    f(on_failure);
+                }
+                if let Some(semantic) = semantic.as_object_mut() {
+                    f(semantic);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// The first id-form model reference `doc` carries, as `(field, name-form
+/// replacement)`.
+fn model_ref_id_field(kind: &str, doc: &mut Value) -> Option<(&'static str, &'static str)> {
+    let fields = model_ref_id_fields(kind);
+    if fields.is_empty() {
+        return None;
+    }
+    let mut found = None;
+    for_each_model_ref_node(kind, doc, &mut |node| {
+        if found.is_none() {
+            found = fields
+                .iter()
+                .find(|(field, _)| node.contains_key(*field))
+                .copied();
+        }
+    });
+    found
+}
+
 /// Load `path` into a fresh [`AisixSnapshot`], resolving `${VAR}`
 /// interpolation against the current process environment. `revision` is
 /// stamped on every entry (the file source's generation counter: 1 at
@@ -388,20 +494,23 @@ pub fn load_from_str(
             continue;
         }
 
-        // `allowed_model_ids` is a control-plane projection: it names
-        // models by the id the control plane assigned them, while a file's
-        // ids are derived from the entry names, so no id a file can carry
-        // ever resolves. Accepting it would make the key grant nothing at
-        // all — silently, and with `allowed_models` ignored on top — so the
-        // file rejects the field instead. (The etcd path is the opposite:
-        // there an id that resolves to no model simply grants nothing and
-        // must never fail the row, because a rejected api_key stops
-        // authenticating entirely.)
-        if entry.kind == "api_keys" && entry.doc.get("allowed_model_ids").is_some() {
+        // Every model reference has an id spelling that names the model by
+        // the id the control plane assigned it. A file's ids are derived
+        // from its entry names, so no id a file can carry ever resolves:
+        // accepting one would make the reference point at nothing —
+        // silently, and with the name spelling ignored on top. The file
+        // rejects the id spelling instead, wherever it appears. (The etcd
+        // path is the opposite: there an id that resolves to no model
+        // degrades that one reference and must never fail the row, because
+        // a rejected api_key stops authenticating entirely.)
+        if let Some((field, name_field)) = model_ref_id_field(entry.kind, &mut entry.doc) {
             errors.push(LoadError {
                 scope,
-                message: "the resources file does not accept `allowed_model_ids` — it names                           models by control-plane id, which a file cannot resolve; grant                           models by name with `allowed_models`"
-                    .into(),
+                message: format!(
+                    "the resources file does not accept `{field}` — it names a model by \
+                     control-plane id, which a file cannot resolve; name the model with \
+                     `{name_field}` instead"
+                ),
             });
             continue;
         }
@@ -578,7 +687,7 @@ pub fn load_from_str(
                     &route.target,
                 );
             }
-            if let crate::models::OnEmbeddingFailure::Target { target } =
+            if let crate::models::OnEmbeddingFailure::Target { target, .. } =
                 &semantic.on_embedding_failure
             {
                 check_model_ref(scope, "semantic on_embedding_failure target", target);

--- a/crates/aisix-core/src/filesource/tests.rs
+++ b/crates/aisix-core/src/filesource/tests.rs
@@ -482,6 +482,254 @@ api_keys:
     load(&ok, &env).expect("the same file without the field loads");
 }
 
+/// Every other id-form model reference is refused the same way, at every
+/// nesting site it can appear. Each fixture is asserted twice: once with
+/// the id field (one error naming it and the name-form field that
+/// replaces it) and once without (the file loads), so the rejection is
+/// pinned to the field rather than to anything else in the fixture.
+#[test]
+fn model_reference_ids_are_rejected_by_the_file_source() {
+    const PRELUDE: &str = r#"
+_format_version: "1"
+provider_keys:
+  - display_name: pk
+    api_key: sk-x
+models:
+  - display_name: m
+    provider: openai
+    model_name: x
+    provider_key: pk
+  - display_name: e
+    provider: openai
+    model_name: x
+    provider_key: pk
+    embedding:
+      dimensions: 4
+"#;
+    let cases: &[(&str, &str, &str)] = &[
+        (
+            "routing target",
+            "model_id",
+            r#"
+  - display_name: group
+    routing:
+      targets:
+        - model: m
+          model_id: 11111111-1111-1111-1111-111111111111
+"#,
+        ),
+        (
+            "ensemble panel member",
+            "model_id",
+            r#"
+  - display_name: panel
+    ensemble:
+      panel:
+        - model: m
+          model_id: 11111111-1111-1111-1111-111111111111
+      judge:
+        model: m
+"#,
+        ),
+        (
+            "ensemble judge",
+            "model_id",
+            r#"
+  - display_name: judged
+    ensemble:
+      panel:
+        - model: m
+      judge:
+        model: m
+        model_id: 11111111-1111-1111-1111-111111111111
+"#,
+        ),
+        (
+            "semantic embedding model",
+            "embedding_model_id",
+            r#"
+  - display_name: router
+    semantic:
+      embedding_model: e
+      embedding_model_id: 11111111-1111-1111-1111-111111111111
+      routes:
+        - name: r
+          target: m
+          examples: ["hi"]
+      default: m
+      match:
+        threshold: 0.5
+"#,
+        ),
+        (
+            "semantic default",
+            "default_id",
+            r#"
+  - display_name: router
+    semantic:
+      embedding_model: e
+      routes:
+        - name: r
+          target: m
+          examples: ["hi"]
+      default: m
+      default_id: 11111111-1111-1111-1111-111111111111
+      match:
+        threshold: 0.5
+"#,
+        ),
+        (
+            "semantic route target",
+            "target_id",
+            r#"
+  - display_name: router
+    semantic:
+      embedding_model: e
+      routes:
+        - name: r
+          target: m
+          target_id: 11111111-1111-1111-1111-111111111111
+          examples: ["hi"]
+      default: m
+      match:
+        threshold: 0.5
+"#,
+        ),
+        (
+            "semantic on_embedding_failure target",
+            "target_id",
+            r#"
+  - display_name: router
+    semantic:
+      embedding_model: e
+      routes:
+        - name: r
+          target: m
+          examples: ["hi"]
+      default: m
+      match:
+        threshold: 0.5
+      on_embedding_failure:
+        target: m
+        target_id: 11111111-1111-1111-1111-111111111111
+"#,
+        ),
+    ];
+
+    for (label, field, fragment) in cases {
+        let contents = format!("{PRELUDE}{fragment}");
+        let errs = errors_of(load(&contents, &env_of(&[])));
+        assert_eq!(errs.len(), 1, "{label}: {errs:?}");
+        assert!(
+            errs[0].contains(&format!("does not accept `{field}`")),
+            "{label}: {errs:?}"
+        );
+        let without = contents.replace(
+            &format!("          {field}: 11111111-1111-1111-1111-111111111111\n"),
+            "",
+        );
+        let without = without.replace(
+            &format!("      {field}: 11111111-1111-1111-1111-111111111111\n"),
+            "",
+        );
+        let without = without.replace(
+            &format!("        {field}: 11111111-1111-1111-1111-111111111111\n"),
+            "",
+        );
+        assert_ne!(without, contents, "{label}: fixture edit did not apply");
+        load(&without, &env_of(&[]))
+            .unwrap_or_else(|e| panic!("{label}: the same file without the field loads: {e:?}"));
+    }
+}
+
+#[test]
+fn cache_policy_and_guardrail_model_reference_ids_are_rejected() {
+    let with_scope = r#"
+_format_version: "1"
+cache_policies:
+  - name: p
+    applies_to: all
+    applies_to_model_id: 11111111-1111-1111-1111-111111111111
+"#;
+    let errs = errors_of(load(with_scope, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].contains("does not accept `applies_to_model_id`") && errs[0].contains("applies_to"),
+        "{errs:?}"
+    );
+
+    let with_cache_embedder = r#"
+_format_version: "1"
+provider_keys:
+  - display_name: pk
+    api_key: sk-x
+models:
+  - display_name: e
+    provider: openai
+    model_name: x
+    provider_key: pk
+    embedding:
+      dimensions: 4
+cache_policies:
+  - name: p
+    semantic:
+      embedding_model: e
+      embedding_model_id: 11111111-1111-1111-1111-111111111111
+      threshold: 0.9
+"#;
+    let errs = errors_of(load(with_cache_embedder, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].contains("does not accept `embedding_model_id`"),
+        "{errs:?}"
+    );
+    let without = with_cache_embedder.replace(
+        "      embedding_model_id: 11111111-1111-1111-1111-111111111111\n",
+        "",
+    );
+    load(&without, &env_of(&[])).expect("the same file without the field loads");
+
+    let with_guardrail_embedder = r#"
+_format_version: "1"
+guardrails:
+  - name: g
+    kind: semantic
+    embedding_model: e
+    embedding_model_id: 11111111-1111-1111-1111-111111111111
+    deny_examples: ["x"]
+    deny_threshold: 0.8
+"#;
+    let errs = errors_of(load(with_guardrail_embedder, &env_of(&[])));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].contains("does not accept `embedding_model_id`"),
+        "{errs:?}"
+    );
+    let without = with_guardrail_embedder.replace(
+        "    embedding_model_id: 11111111-1111-1111-1111-111111111111\n",
+        "",
+    );
+    load(&without, &env_of(&[])).expect("the same file without the field loads");
+}
+
+/// A guardrail's operator-keyed maps are NOT model references: a
+/// `kind: custom` row may name a script secret anything, including a
+/// string the refusal list happens to contain, and refusing it would make
+/// a valid file unloadable.
+#[test]
+fn an_operator_keyed_secret_named_like_a_model_reference_still_loads() {
+    let contents = r#"
+_format_version: "1"
+guardrails:
+  - name: g
+    kind: custom
+    script: "export function input(ctx) { return { action: 'allow' }; }"
+    secrets:
+      embedding_model_id: shhh
+"#;
+    load(contents, &env_of(&[])).expect("an operator-named secret is not a model reference");
+}
+
 #[test]
 fn canonical_validation_failures_carry_entry_scope() {
     // Empty display_name violates the model schema (minLength 1)…

--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -477,6 +477,24 @@ mod tests {
         assert!(sem.embedding_model.is_empty());
     }
 
+    /// The shape a producer that spells "not model-scoped" as `null`
+    /// writes: the policy keeps whatever `applies_to` says.
+    #[test]
+    fn a_null_applies_to_model_id_falls_back_to_applies_to() {
+        let snap = snapshot_with_models(&[("m-1", "gpt-4o")]);
+        let p: CachePolicy = serde_json::from_value(json!({
+            "name": "x",
+            "applies_to": "model:gpt-4o",
+            "applies_to_model_id": null
+        }))
+        .unwrap();
+        assert!(p.applies_to_model_id.is_none());
+        assert_eq!(
+            p.parsed_applies_to(&snap),
+            AppliesTo::Model("gpt-4o".into())
+        );
+    }
+
     #[test]
     fn absent_id_fields_stay_off_the_wire() {
         let p: CachePolicy =

--- a/crates/aisix-core/src/models/cache_policy.rs
+++ b/crates/aisix-core/src/models/cache_policy.rs
@@ -61,9 +61,21 @@ pub struct SemanticCacheConfig {
     /// Name of the `embedding` model used to embed requests. The model
     /// must exist in the same environment and carry an `embedding`
     /// block; its `dimensions` value fixes the vector size for this
-    /// policy's entries.
+    /// policy's entries. Read only when `embedding_model_id` is absent.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     #[schemars(length(min = 1))]
     pub embedding_model: String,
+
+    /// Resource id of the `embedding` model used to embed requests.
+    /// Present, it is authoritative and `embedding_model` is ignored: the
+    /// id is resolved against the models in the current configuration, so
+    /// renaming that model keeps this policy pointing at it with no edit
+    /// to this document. An id resolving to no model leaves similarity
+    /// matching off for the policy, exactly as an `embedding_model` naming
+    /// no model does.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub embedding_model_id: Option<String>,
 
     /// Minimum cosine similarity for a stored entry to be served, in
     /// `[0, 1]`. Higher is stricter. Values below `0.9` noticeably
@@ -127,10 +139,22 @@ pub struct CachePolicy {
     pub ttl_seconds: u32,
 
     /// Free-form scope. Supports `"all"`, `"model:<name>"`, and
-    /// `"api_key:<id>"`. See `parsed_applies_to`.
+    /// `"api_key:<id>"`. Read only when `applies_to_model_id` is absent.
+    /// See `parsed_applies_to`.
     #[serde(default = "default_applies_to")]
     #[schemars(length(min = 1, max = 255))]
     pub applies_to: String,
+
+    /// Scopes the policy to one model, named by resource id. Present, it
+    /// is authoritative and `applies_to` is ignored entirely — the policy
+    /// applies to the model this id resolves to and to nothing else. The
+    /// id is resolved against the models in the current configuration, so
+    /// renaming that model keeps the policy scoped to it with no edit to
+    /// this document. An id resolving to no model makes the policy match
+    /// nothing, exactly as `"model:<name>"` naming no model does.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub applies_to_model_id: Option<String>,
 
     /// Sharing boundary for entries created under this policy:
     /// `api_key` (default) keeps entries private to the caller that
@@ -193,7 +217,11 @@ impl CachePolicy {
         self
     }
 
-    /// Parse `applies_to` into a typed matcher. Stage 3 understands:
+    /// Parse this policy's scope into a typed matcher.
+    ///
+    /// `applies_to_model_id`, when present, decides on its own: the policy
+    /// is scoped to the model that id resolves to, and `applies_to` is not
+    /// read. Otherwise `applies_to` is parsed. Stage 3 understands:
     ///
     ///   - `"all"`            → matches every request in the env
     ///   - `"model:<name>"`   → matches requests targeting that model alias
@@ -205,7 +233,13 @@ impl CachePolicy {
     /// cp-api validation prevents the empty-string case at write time
     /// (see internal/cpapi/resources/cache_policies.go::validateCachePolicyShape),
     /// so the conservative branch is dead in practice.
-    pub fn parsed_applies_to(&self) -> AppliesTo {
+    pub fn parsed_applies_to(&self, snapshot: &super::AisixSnapshot) -> AppliesTo {
+        if let Some(id) = self.applies_to_model_id.as_deref() {
+            // `resolve_model_ref` hands back the id itself when it names no
+            // model, which matches no request's model name — the same
+            // no-op an `applies_to: "model:<gone>"` already is.
+            return AppliesTo::Model(super::resolve_model_ref(snapshot, "", Some(id)).into_owned());
+        }
         let raw = self.applies_to.trim();
         if let Some(rest) = raw.strip_prefix("model:") {
             return AppliesTo::Model(rest.trim().to_string());
@@ -252,7 +286,31 @@ impl AppliesTo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resource::ResourceEntry;
     use serde_json::json;
+
+    /// A snapshot holding one model per `(id, display_name)` pair, so an
+    /// `applies_to_model_id` has something to resolve against.
+    fn snapshot_with_models(models: &[(&str, &str)]) -> crate::models::AisixSnapshot {
+        let snap = crate::models::AisixSnapshot::default();
+        for (id, display_name) in models {
+            let model: crate::models::Model = serde_json::from_str(&format!(
+                r#"{{
+                  "display_name": "{display_name}",
+                  "provider": "openai",
+                  "model_name": "gpt-4o",
+                  "provider_key_id": "11111111-1111-1111-1111-111111111111"
+                }}"#
+            ))
+            .unwrap();
+            snap.models.insert(ResourceEntry::new(*id, model, 1));
+        }
+        snap
+    }
+
+    fn empty_snapshot() -> crate::models::AisixSnapshot {
+        crate::models::AisixSnapshot::default()
+    }
 
     #[test]
     fn deserialises_minimal_memory_policy() {
@@ -301,17 +359,26 @@ mod tests {
     fn applies_to_all_matches_anything() {
         let p: CachePolicy =
             serde_json::from_value(json!({"name": "x", "applies_to": "all"})).unwrap();
-        assert_eq!(p.parsed_applies_to(), AppliesTo::All);
-        assert!(p.parsed_applies_to().matches("any-model", "any-key"));
+        assert_eq!(p.parsed_applies_to(&empty_snapshot()), AppliesTo::All);
+        assert!(p
+            .parsed_applies_to(&empty_snapshot())
+            .matches("any-model", "any-key"));
     }
 
     #[test]
     fn applies_to_model_matches_only_named_model() {
         let p: CachePolicy =
             serde_json::from_value(json!({"name": "x", "applies_to": "model:gpt-4o"})).unwrap();
-        assert_eq!(p.parsed_applies_to(), AppliesTo::Model("gpt-4o".into()));
-        assert!(p.parsed_applies_to().matches("gpt-4o", "any-key"));
-        assert!(!p.parsed_applies_to().matches("claude-3-opus", "any-key"));
+        assert_eq!(
+            p.parsed_applies_to(&empty_snapshot()),
+            AppliesTo::Model("gpt-4o".into())
+        );
+        assert!(p
+            .parsed_applies_to(&empty_snapshot())
+            .matches("gpt-4o", "any-key"));
+        assert!(!p
+            .parsed_applies_to(&empty_snapshot())
+            .matches("claude-3-opus", "any-key"));
     }
 
     #[test]
@@ -322,9 +389,100 @@ mod tests {
             "applies_to": format!("api_key:{kid}")
         }))
         .unwrap();
-        assert_eq!(p.parsed_applies_to(), AppliesTo::ApiKey(kid.into()));
-        assert!(p.parsed_applies_to().matches("gpt-4o", kid));
-        assert!(!p.parsed_applies_to().matches("gpt-4o", "different-key-id"));
+        assert_eq!(
+            p.parsed_applies_to(&empty_snapshot()),
+            AppliesTo::ApiKey(kid.into())
+        );
+        assert!(p
+            .parsed_applies_to(&empty_snapshot())
+            .matches("gpt-4o", kid));
+        assert!(!p
+            .parsed_applies_to(&empty_snapshot())
+            .matches("gpt-4o", "different-key-id"));
+    }
+
+    #[test]
+    fn applies_to_model_id_scopes_the_policy_by_resource_id() {
+        let snap = snapshot_with_models(&[("m-1", "gpt-4o"), ("m-2", "claude")]);
+        let p: CachePolicy = serde_json::from_value(json!({
+            "name": "x",
+            "applies_to_model_id": "m-1"
+        }))
+        .unwrap();
+        assert_eq!(
+            p.parsed_applies_to(&snap),
+            AppliesTo::Model("gpt-4o".into())
+        );
+        assert!(p.parsed_applies_to(&snap).matches("gpt-4o", "any-key"));
+        assert!(!p.parsed_applies_to(&snap).matches("claude", "any-key"));
+    }
+
+    #[test]
+    fn applies_to_model_id_follows_a_rename() {
+        let p: CachePolicy =
+            serde_json::from_value(json!({"name": "x", "applies_to_model_id": "m-1"})).unwrap();
+        let before = snapshot_with_models(&[("m-1", "gpt-4o")]);
+        assert!(p.parsed_applies_to(&before).matches("gpt-4o", "k"));
+        // Same id, new name; the policy document is untouched.
+        let after = snapshot_with_models(&[("m-1", "gpt-4o-v2")]);
+        assert!(p.parsed_applies_to(&after).matches("gpt-4o-v2", "k"));
+        assert!(!p.parsed_applies_to(&after).matches("gpt-4o", "k"));
+    }
+
+    #[test]
+    fn applies_to_model_id_wins_over_applies_to() {
+        let snap = snapshot_with_models(&[("m-1", "gpt-4o")]);
+        // Even the widest `applies_to` loses to an explicit model id.
+        let p: CachePolicy = serde_json::from_value(json!({
+            "name": "x",
+            "applies_to": "all",
+            "applies_to_model_id": "m-1"
+        }))
+        .unwrap();
+        assert!(p.parsed_applies_to(&snap).matches("gpt-4o", "k"));
+        assert!(!p.parsed_applies_to(&snap).matches("claude", "k"));
+    }
+
+    /// An id that resolves to no model scopes the policy to a model name
+    /// nothing answers to — byte-for-byte the matcher a dangling
+    /// `applies_to: "model:<gone>"` already produces, so the policy stops
+    /// matching real traffic rather than falling back to `all`.
+    #[test]
+    fn unresolvable_applies_to_model_id_matches_what_a_dangling_name_matches() {
+        let snap = snapshot_with_models(&[("m-1", "gpt-4o")]);
+        let by_id: CachePolicy = serde_json::from_value(json!({
+            "name": "x",
+            "applies_to": "all",
+            "applies_to_model_id": "m-gone"
+        }))
+        .unwrap();
+        let by_name: CachePolicy =
+            serde_json::from_value(json!({"name": "x", "applies_to": "model:m-gone"})).unwrap();
+        assert_eq!(
+            by_id.parsed_applies_to(&snap),
+            by_name.parsed_applies_to(&snap)
+        );
+        assert!(!by_id.parsed_applies_to(&snap).matches("gpt-4o", "k"));
+    }
+
+    #[test]
+    fn semantic_embedding_model_id_is_carried_through() {
+        let p: CachePolicy = serde_json::from_value(json!({
+            "name": "faq",
+            "semantic": {"embedding_model_id": "m-e", "threshold": 0.9}
+        }))
+        .unwrap();
+        let sem = p.semantic.as_ref().unwrap();
+        assert_eq!(sem.embedding_model_id.as_deref(), Some("m-e"));
+        assert!(sem.embedding_model.is_empty());
+    }
+
+    #[test]
+    fn absent_id_fields_stay_off_the_wire() {
+        let p: CachePolicy =
+            serde_json::from_value(json!({"name": "x", "applies_to": "all"})).unwrap();
+        let v = serde_json::to_value(&p).unwrap();
+        assert!(v.get("applies_to_model_id").is_none());
     }
 
     #[test]
@@ -334,7 +492,7 @@ mod tests {
         // All rather than disabling caching on an unknown discriminator.
         let p: CachePolicy =
             serde_json::from_value(json!({"name": "x", "applies_to": "team:eng"})).unwrap();
-        assert_eq!(p.parsed_applies_to(), AppliesTo::All);
+        assert_eq!(p.parsed_applies_to(&empty_snapshot()), AppliesTo::All);
     }
 
     #[test]

--- a/crates/aisix-core/src/models/ensemble.rs
+++ b/crates/aisix-core/src/models/ensemble.rs
@@ -13,12 +13,25 @@
 
 use serde::{Deserialize, Serialize};
 
-/// One member of an ensemble panel. `model` references a direct model alias.
+/// One member of an ensemble panel. The member model is named either by
+/// `model` (its display name) or by `model_id` (its resource id); a member
+/// must carry at least one of the two.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 pub struct PanelMember {
     /// Model alias for a direct model that receives one panel request.
+    /// Read only when `model_id` is absent.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     #[schemars(length(min = 1))]
     pub model: String,
+    /// Resource id of the direct model that receives one panel request.
+    /// Present, it is authoritative and `model` is ignored: the id is
+    /// resolved against the models in the current configuration, so
+    /// renaming that model keeps this member pointing at it with no edit
+    /// to this document. An id resolving to no model is a panel member
+    /// that does not exist, exactly as a `model` naming no model is.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub model_id: Option<String>,
     /// Sampling temperature for this panel member. Omit it to keep the request's temperature.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 0.0))]
@@ -33,9 +46,17 @@ pub struct PanelMember {
 }
 
 impl PanelMember {
+    /// The display name of the model this member points at, resolved
+    /// against the current configuration: `model_id` when it is set,
+    /// `model` otherwise.
+    pub fn model_ref<'a>(&'a self, snapshot: &super::AisixSnapshot) -> std::borrow::Cow<'a, str> {
+        super::resolve_model_ref(snapshot, &self.model, self.model_id.as_deref())
+    }
+
     pub fn new(model: impl Into<String>) -> Self {
         Self {
             model: model.into(),
+            model_id: None,
             temperature: None,
             seed: None,
             weight: None,
@@ -44,12 +65,25 @@ impl PanelMember {
 }
 
 /// The judge model that synthesizes the panel responses into one answer.
-/// `model` references a direct model alias.
+/// The judge model is named either by `model` (its display name) or by
+/// `model_id` (its resource id); the judge must carry at least one of the
+/// two.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct Judge {
     /// Model alias for the direct model that synthesizes panel responses.
+    /// Read only when `model_id` is absent.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     #[schemars(length(min = 1))]
     pub model: String,
+    /// Resource id of the direct model that synthesizes panel responses.
+    /// Present, it is authoritative and `model` is ignored: the id is
+    /// resolved against the models in the current configuration, so
+    /// renaming that model keeps the judge pointing at it with no edit to
+    /// this document. An id resolving to no model is a judge that does not
+    /// exist, exactly as a `model` naming no model is.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub model_id: Option<String>,
     /// Override for the built-in synthesis prompt template.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(length(min = 1))]
@@ -57,9 +91,17 @@ pub struct Judge {
 }
 
 impl Judge {
+    /// The display name of the model this judge points at, resolved
+    /// against the current configuration: `model_id` when it is set,
+    /// `model` otherwise.
+    pub fn model_ref<'a>(&'a self, snapshot: &super::AisixSnapshot) -> std::borrow::Cow<'a, str> {
+        super::resolve_model_ref(snapshot, &self.model, self.model_id.as_deref())
+    }
+
     pub fn new(model: impl Into<String>) -> Self {
         Self {
             model: model.into(),
+            model_id: None,
             synthesis_prompt: None,
         }
     }
@@ -88,6 +130,37 @@ pub struct EnsembleConfig {
 }
 
 impl EnsembleConfig {
+    /// This config with every model reference resolved to the display name
+    /// the models table is keyed by — `model_id` when a member or the
+    /// judge sets one, `model` otherwise.
+    ///
+    /// Resolved once per request, up front, rather than at each of the
+    /// dozen places the fan-out reads a member or judge name (dispatch,
+    /// quota reservation, per-sub-call usage attribution, the streamed
+    /// judge's own bridge lookup): a reference the ensemble path resolved
+    /// in only some of them would dispatch to one model and bill another.
+    /// The returned copy carries no ids, so nothing downstream has a second
+    /// spelling to consider.
+    pub fn with_refs_resolved(&self, snapshot: &super::AisixSnapshot) -> Self {
+        Self {
+            panel: self
+                .panel
+                .iter()
+                .map(|m| PanelMember {
+                    model: m.model_ref(snapshot).into_owned(),
+                    model_id: None,
+                    ..m.clone()
+                })
+                .collect(),
+            judge: Judge {
+                model: self.judge.model_ref(snapshot).into_owned(),
+                model_id: None,
+                ..self.judge.clone()
+            },
+            ..self.clone()
+        }
+    }
+
     /// Effective minimum successful panel responses. Defaults to
     /// [`DEFAULT_MIN_RESPONSES`], never exceeds the panel size, and is at
     /// least 1 for a non-empty panel.

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -758,6 +758,22 @@ pub struct SemanticConfig {
     #[serde(default)]
     #[schemars(length(min = 1))]
     pub embedding_model: String,
+    /// Resource id of the `embedding`-kind Model used to embed both the
+    /// examples and the screened text. Present, it is authoritative and
+    /// `embedding_model` is ignored: the id is resolved against the models
+    /// in the current configuration, so renaming that model keeps this row
+    /// screening with it and needs no edit here. An id resolving to no
+    /// model is an embedder that cannot be resolved, exactly as an
+    /// `embedding_model` naming no model is — the row degrades per
+    /// `fail_open`, fail-closed by default.
+    ///
+    /// Defaulted at the type level for the same reason `embedding_model`
+    /// is: the strict write schema requires one of the two, the read path
+    /// requires neither, and a screening row that fails to load is
+    /// fail-OPEN.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub embedding_model_id: Option<String>,
     /// Example texts whose meaning must be REFUSED. A screened text
     /// scoring at or above `deny_threshold` against any of them blocks.
     #[serde(default)]

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -27,6 +27,7 @@ pub mod mcp_auth_settings;
 pub mod mcp_policy;
 pub mod mcp_server;
 pub mod model;
+pub mod model_ref;
 pub mod observability_exporter;
 pub mod oidc_provider;
 pub mod passthrough_route;
@@ -60,6 +61,7 @@ pub use mcp_server::{McpAuthType, McpProtocolVersion, McpServer, McpServerType, 
 pub use model::{
     Adapter, BackgroundModelCheck, CooldownConfig, Model, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
+pub use model_ref::resolve_model_ref;
 pub use observability_exporter::{
     AliyunSlsConfig, DatadogConfig, ExporterKind, ObjectStoreCompression, ObjectStoreConfig,
     ObjectStoreProvider, ObservabilityExporter, OtlpHttpConfig, SlsContentMode,

--- a/crates/aisix-core/src/models/model_ref.rs
+++ b/crates/aisix-core/src/models/model_ref.rs
@@ -1,0 +1,100 @@
+//! Resolving a document's reference to another Model.
+//!
+//! Several projected documents point at a Model: a routing target, an
+//! ensemble panel member and its judge, a semantic router's embedding
+//! model / default / route targets, a cache policy's scope and its
+//! semantic embedder, a `kind: semantic` guardrail's embedder. Each was
+//! written as a display NAME, which means renaming the referenced model
+//! silently breaks every document that named it — the reference resolves
+//! to nothing and the site degrades.
+//!
+//! Every one of those sites now also accepts the referenced model's
+//! resource id, resolved through [`resolve_model_ref`]. The id is stable
+//! across renames, so the referencing document never has to be rewritten.
+
+use super::AisixSnapshot;
+use std::borrow::Cow;
+
+/// Resolve a model reference written as a display name plus an optional
+/// resource id, yielding the name the models table is keyed by.
+///
+/// The id decides whenever it is present: it is looked up in the models
+/// table and the entry's CURRENT display name is returned, so renaming the
+/// referenced model takes effect on the next request with no change to the
+/// referencing document. `name` is not consulted at all in that case.
+/// Resolution happens per request against the live table rather than being
+/// cached, and the table is the only input, so nothing derived from an
+/// unrelated resource can hold a stale answer.
+///
+/// An id matching no model yields the id itself. Every caller goes on to
+/// look the result up by name and finds nothing — which is exactly what a
+/// DANGLING NAME does at the same site. So an unresolvable id degrades the
+/// way the site already degrades (a routing target that does not exist, an
+/// embedder that cannot be resolved, a cache policy that matches nothing)
+/// rather than introducing a failure mode of its own, and in particular
+/// never fails the row.
+pub fn resolve_model_ref<'a>(
+    snapshot: &AisixSnapshot,
+    name: &'a str,
+    id: Option<&'a str>,
+) -> Cow<'a, str> {
+    match id {
+        Some(id) => match snapshot.models.get_by_id(id) {
+            Some(entry) => Cow::Owned(entry.value.display_name.clone()),
+            None => Cow::Borrowed(id),
+        },
+        None => Cow::Borrowed(name),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Model;
+    use crate::resource::ResourceEntry;
+
+    fn snapshot_with(models: &[(&str, &str)]) -> AisixSnapshot {
+        let snap = AisixSnapshot::default();
+        for (id, display_name) in models {
+            let model: Model = serde_json::from_str(&format!(
+                r#"{{
+                  "display_name": "{display_name}",
+                  "provider": "openai",
+                  "model_name": "gpt-4o",
+                  "provider_key_id": "11111111-1111-1111-1111-111111111111"
+                }}"#
+            ))
+            .unwrap();
+            snap.models.insert(ResourceEntry::new(*id, model, 1));
+        }
+        snap
+    }
+
+    #[test]
+    fn absent_id_keeps_the_name() {
+        let snap = snapshot_with(&[("m-1", "gpt")]);
+        assert_eq!(resolve_model_ref(&snap, "whatever", None), "whatever");
+    }
+
+    #[test]
+    fn present_id_wins_over_the_name() {
+        let snap = snapshot_with(&[("m-1", "gpt"), ("m-2", "claude")]);
+        assert_eq!(resolve_model_ref(&snap, "claude", Some("m-1")), "gpt");
+    }
+
+    #[test]
+    fn present_id_follows_a_rename() {
+        let before = snapshot_with(&[("m-1", "gpt")]);
+        assert_eq!(resolve_model_ref(&before, "", Some("m-1")), "gpt");
+        let after = snapshot_with(&[("m-1", "gpt-v2")]);
+        assert_eq!(resolve_model_ref(&after, "", Some("m-1")), "gpt-v2");
+    }
+
+    #[test]
+    fn unresolvable_id_yields_a_name_that_resolves_to_nothing() {
+        let snap = snapshot_with(&[("m-1", "gpt")]);
+        let resolved = resolve_model_ref(&snap, "gpt", Some("m-gone"));
+        assert_eq!(resolved, "m-gone");
+        assert!(snap.models.get_by_name(&resolved).is_none());
+    }
+}

--- a/crates/aisix-core/src/models/routing.rs
+++ b/crates/aisix-core/src/models/routing.rs
@@ -153,12 +153,31 @@ impl RoutingStrategy {
     }
 }
 
-/// One destination in a routing configuration. `model` references a direct model alias.
+/// One destination in a routing configuration. The target model is named
+/// either by `model` (its display name) or by `model_id` (its resource
+/// id); a target must carry at least one of the two.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 pub struct RoutingTarget {
     /// Model alias for a direct model that can receive routed traffic.
+    /// Read only when `model_id` is absent.
+    ///
+    /// Defaulted at the type level and required by the schemas instead —
+    /// as one half of a "`model` or `model_id`" alternative, so a target
+    /// naming its model by id alone validates while one naming it neither
+    /// way is still rejected.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     #[schemars(length(min = 1))]
     pub model: String,
+    /// Resource id of the direct model that can receive routed traffic.
+    /// Present, it is authoritative and `model` is ignored: the id is
+    /// resolved against the models in the current configuration and the
+    /// name it resolves to is the target, so renaming that model keeps
+    /// this target pointing at it with no edit to this document. An id
+    /// resolving to no model is a target that does not exist, exactly as
+    /// a `model` naming no model is.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub model_id: Option<String>,
     /// Target weight, default `1`. Used by `round_robin` (rotation share),
     /// `consistent_hash` (share of the hash ring), and `least_busy`
     /// (in-flight divided by weight). `failover`, `least_cost`, and
@@ -190,6 +209,18 @@ impl RoutingTarget {
     pub fn new(model: impl Into<String>) -> Self {
         Self {
             model: model.into(),
+            model_id: None,
+            weight: None,
+            priority: None,
+            tags: None,
+        }
+    }
+
+    /// A target that names its model by resource id instead of by name.
+    pub fn by_id(model_id: impl Into<String>) -> Self {
+        Self {
+            model: String::new(),
+            model_id: Some(model_id.into()),
             weight: None,
             priority: None,
             tags: None,
@@ -209,6 +240,15 @@ impl RoutingTarget {
     pub fn with_tags(mut self, tags: Vec<String>) -> Self {
         self.tags = Some(tags);
         self
+    }
+
+    /// The display name of the model this target points at, resolved
+    /// against the current configuration: `model_id` when it is set (so a
+    /// rename of the target model needs no edit here), `model` otherwise.
+    /// See [`crate::models::resolve_model_ref`] for what an unresolvable
+    /// id yields.
+    pub fn model_ref<'a>(&'a self, snapshot: &super::AisixSnapshot) -> std::borrow::Cow<'a, str> {
+        super::resolve_model_ref(snapshot, &self.model, self.model_id.as_deref())
     }
 
     pub fn weight_or_default(&self) -> u32 {

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -922,6 +922,15 @@ fn allow_null_on_model_ref_ids(schema: &mut Value) {
                     let Some(Value::Object(property)) = properties.get_mut(*field) else {
                         continue;
                     };
+                    // A property whose whole schema is a `type` is not a
+                    // DECLARATION, it is the pin inside a requiredness
+                    // clause ([`require_name_or_id`]), which exists to
+                    // reject exactly the `null` this would let through.
+                    // A real declaration always carries its description
+                    // and length bound beside the type.
+                    if property.len() == 1 {
+                        continue;
+                    }
                     if property.get("type") == Some(&json!("string")) {
                         property.insert("type".to_string(), json!(["string", "null"]));
                     }
@@ -2341,10 +2350,50 @@ mod tests {
         validate_guardrail_lenient(&guardrail).unwrap();
 
         // A null id is not a way to name the model, though: it satisfies
-        // neither half of the alternative.
-        assert!(validate_model(&json!({
-            "display_name": "g",
-            "routing": {"targets": [{"model_id": null}]},
+        // neither half of the alternative. Asserted at every site,
+        // because the requiredness clause and the nullability widening
+        // are two passes over the same schema and one can undo the other.
+        let rejected = [
+            json!({"display_name": "g", "routing": {"targets": [{"model_id": null}]}}),
+            json!({"display_name": "e", "ensemble": {
+                "panel": [{"model_id": null}], "judge": {"model": "j"}}}),
+            json!({"display_name": "e", "ensemble": {
+                "panel": [{"model": "a"}], "judge": {"model_id": null}}}),
+            json!({"display_name": "s", "semantic": {
+                "embedding_model_id": null,
+                "routes": [{"name": "r", "target": "t", "examples": ["x"]}],
+                "default": "d", "match": {"threshold": 0.5}}}),
+            json!({"display_name": "s", "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "r", "target": "t", "examples": ["x"]}],
+                "default_id": null, "match": {"threshold": 0.5}}}),
+            json!({"display_name": "s", "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "r", "target_id": null, "examples": ["x"]}],
+                "default": "d", "match": {"threshold": 0.5}}}),
+            json!({"display_name": "s", "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "r", "target": "t", "examples": ["x"]}],
+                "default": "d", "match": {"threshold": 0.5},
+                "on_embedding_failure": {"target_id": null}}}),
+        ];
+        for case in rejected {
+            assert!(
+                validate_model(&case).is_err(),
+                "strict accepted a null id as naming a model: {case}"
+            );
+            assert!(
+                validate_model_lenient(&case).is_err(),
+                "lenient accepted a null id as naming a model: {case}"
+            );
+        }
+        assert!(validate_cache_policy(&json!({
+            "name": "p", "semantic": {"embedding_model_id": null, "threshold": 0.9}
+        }))
+        .is_err());
+        assert!(validate_guardrail(&json!({
+            "name": "g", "kind": "semantic", "embedding_model_id": null,
+            "deny_examples": ["x"], "deny_threshold": 0.8
         }))
         .is_err());
     }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -857,17 +857,113 @@ pub fn model_root_schema(strict: bool) -> Value {
     // reference as a name or as a resource id. Applied to both contracts:
     // these fields were required on the read path too, so relaxing only the
     // write path would leave a stored id-only reference dropping its row.
-    for (definition, name, id) in [
-        ("RoutingTarget", "model", "model_id"),
-        ("PanelMember", "model", "model_id"),
-        ("Judge", "model", "model_id"),
-        ("SemanticRoute", "target", "target_id"),
-        ("Semantic", "embedding_model", "embedding_model_id"),
-        ("Semantic", "default", "default_id"),
-    ] {
-        require_name_or_id_in(&mut schema, definition, name, id);
-    }
+    apply_model_ref_alternatives(&mut schema);
     schema
+}
+
+/// Every `(type, name field, id field)` a model reference is written as.
+///
+/// One table, applied by [`apply_model_ref_alternatives`] to whatever
+/// schema carries the type — the resource root schemas here, and the
+/// standalone nested-type files `dump-schema` publishes beside them.
+/// Without it those files would say a routing target requires no fields
+/// at all, which is not the contract the enforced copy states.
+///
+/// The `kind: semantic` guardrail's embedder is not here: it lives in a
+/// `oneOf` branch rather than a named type, and it is required on the
+/// write path only (see [`guardrail_root_schema`]).
+pub const MODEL_REF_TYPES: &[(&str, &str, &str)] = &[
+    ("RoutingTarget", "model", "model_id"),
+    ("PanelMember", "model", "model_id"),
+    ("Judge", "model", "model_id"),
+    ("SemanticRoute", "target", "target_id"),
+    ("Semantic", "embedding_model", "embedding_model_id"),
+    ("Semantic", "default", "default_id"),
+    (
+        "SemanticCacheConfig",
+        "embedding_model",
+        "embedding_model_id",
+    ),
+];
+
+/// Every id-form model-reference FIELD, wherever it appears.
+///
+/// Distinct from [`MODEL_REF_TYPES`], which is keyed by the type carrying
+/// the pair: two of these sit somewhere no named type covers — a cache
+/// policy's `applies_to_model_id` on the resource root, and the
+/// `kind: semantic` guardrail's `embedding_model_id` inside a `oneOf`
+/// branch.
+const MODEL_REF_ID_FIELDS: &[&str] = &[
+    "model_id",
+    "target_id",
+    "embedding_model_id",
+    "default_id",
+    "applies_to_model_id",
+];
+
+/// Let every [`MODEL_REF_ID_FIELDS`] property accept an explicit `null`,
+/// at any depth.
+///
+/// A producer that spells "no id here" as `null` rather than by omitting
+/// the key must mean the same thing — the reference falls back to its
+/// name — and it does at the type level, where serde reads `null` into
+/// `None`. The schema is what decides whether serde ever sees the
+/// document: these resources render `Option` WITHOUT the null type
+/// (`struct_root_schema(false)`), so an explicit `null` would fail
+/// validation and the loader would skip the whole row. `api_key`, which
+/// renders with it, already accepts `null` on `allowed_model_ids` — this
+/// keeps the id form answering to `null` the same way on every resource
+/// rather than only on the one that happens to render nullably.
+fn allow_null_on_model_ref_ids(schema: &mut Value) {
+    match schema {
+        Value::Object(map) => {
+            if let Some(Value::Object(properties)) = map.get_mut("properties") {
+                for field in MODEL_REF_ID_FIELDS {
+                    let Some(Value::Object(property)) = properties.get_mut(*field) else {
+                        continue;
+                    };
+                    if property.get("type") == Some(&json!("string")) {
+                        property.insert("type".to_string(), json!(["string", "null"]));
+                    }
+                }
+            }
+            for child in map.values_mut() {
+                allow_null_on_model_ref_ids(child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                allow_null_on_model_ref_ids(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Turn every [`MODEL_REF_TYPES`] entry `schema` carries into a "name or
+/// id" alternative — whether the type is the schema's ROOT (a standalone
+/// nested-type file) or one of its `definitions`. Types the schema does
+/// not carry are skipped. Also widens every id field to accept `null`
+/// (see [`allow_null_on_model_ref_ids`]).
+pub fn apply_model_ref_alternatives(schema: &mut Value) {
+    allow_null_on_model_ref_ids(schema);
+    let root_title = schema
+        .get("title")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    for (type_name, name, id) in MODEL_REF_TYPES {
+        if root_title.as_deref() == Some(*type_name) {
+            if let Some(root) = schema.as_object_mut() {
+                require_name_or_id(root, name, id);
+            }
+        }
+        if let Some(node) = schema
+            .pointer_mut(&format!("/definitions/{type_name}"))
+            .and_then(Value::as_object_mut)
+        {
+            require_name_or_id(node, name, id);
+        }
+    }
 }
 
 /// Canonical JSON Schema for the `api_key` resource, derived from the
@@ -944,22 +1040,23 @@ fn require_name_or_id(node: &mut serde_json::Map<String, Value>, name: &str, id:
             node.remove("required");
         }
     }
-    let clause = json!({"anyOf": [{"required": [name]}, {"required": [id]}]});
+    // Each branch pins its field to a STRING, not merely to being
+    // present: `required` in JSON Schema is satisfied by a key whose
+    // value is `null`, and the id fields accept `null` (see
+    // `allow_null_on_model_ref_ids`). Without the type, `{"model_id":
+    // null}` — which names no model at all — would validate.
+    let clause = json!({
+        "anyOf": [
+            {"required": [name], "properties": {name: {"type": "string"}}},
+            {"required": [id], "properties": {id: {"type": "string"}}},
+        ]
+    });
     match node.get_mut("allOf").and_then(Value::as_array_mut) {
         Some(list) => list.push(clause),
         None => {
             node.insert("allOf".to_string(), json!([clause]));
         }
     }
-}
-
-/// [`require_name_or_id`] addressed at one `definitions` entry.
-fn require_name_or_id_in(schema: &mut Value, definition: &str, name: &str, id: &str) {
-    let node = schema
-        .pointer_mut(&format!("/definitions/{definition}"))
-        .and_then(Value::as_object_mut)
-        .unwrap_or_else(|| panic!("schema defines {definition}"));
-    require_name_or_id(node, name, id);
 }
 
 /// Canonical JSON Schema for the `provider_key` resource, derived from the
@@ -1649,6 +1746,10 @@ pub fn guardrail_root_schema(strict: bool) -> Value {
         }
     }
     close_definitions(&mut schema);
+    // On BOTH contracts, unlike the requirement injected above: an
+    // explicit `null` must mean the same as omitting the key on the read
+    // path too, or a row that spells it that way is skipped whole.
+    allow_null_on_model_ref_ids(&mut schema);
     schema
 }
 
@@ -1807,12 +1908,7 @@ pub fn cache_policy_root_schema() -> Value {
     // The similarity layer's embedding model is named either way, like
     // every other model reference. `applies_to` needs no alternative: it
     // has a default, and `applies_to_model_id` simply overrides it.
-    require_name_or_id_in(
-        &mut schema,
-        "SemanticCacheConfig",
-        "embedding_model",
-        "embedding_model_id",
-    );
+    apply_model_ref_alternatives(&mut schema);
     schema
 }
 
@@ -2182,6 +2278,75 @@ mod tests {
             unknown_field_paths("model", &bogus),
             vec!["routing.targets.0.bogus_id"]
         );
+    }
+
+    /// An explicit `null` id means the same as omitting the key — the
+    /// reference falls back to its name — on BOTH contracts, and at every
+    /// site.
+    ///
+    /// The write path is the smaller half. On the read path a `null` the
+    /// schema rejects does not "ignore the field", it skips the whole
+    /// stored row: the model disappears, or the guardrail stops screening.
+    /// `api_key.allowed_model_ids` has accepted `null` since #1148 because
+    /// that resource happens to render `Option` nullably; a producer that
+    /// spells "unset" as `null` there and copies the idiom here must not
+    /// fall off a cliff.
+    #[test]
+    fn a_null_model_reference_id_means_the_same_as_an_absent_one() {
+        let model = json!({
+            "display_name": "g",
+            "routing": {"targets": [{"model": "a", "model_id": null}]},
+        });
+        validate_model(&model).unwrap();
+        validate_model_lenient(&model).unwrap();
+        assert_eq!(
+            serde_json::from_value::<crate::models::Model>(model.clone())
+                .unwrap()
+                .routing
+                .unwrap()
+                .targets[0]
+                .model_id,
+            None,
+            "serde reads a null id as absent; the schema must let it through to serde"
+        );
+
+        let semantic = json!({
+            "display_name": "s",
+            "semantic": {
+                "embedding_model": "e", "embedding_model_id": null,
+                "routes": [{"name": "r", "target": "t", "target_id": null, "examples": ["x"]}],
+                "default": "d", "default_id": null,
+                "match": {"threshold": 0.5},
+                "on_embedding_failure": {"target": "safe", "target_id": null}
+            }
+        });
+        validate_model(&semantic).unwrap();
+        validate_model_lenient(&semantic).unwrap();
+
+        let policy = json!({
+            "name": "p",
+            "applies_to": "all",
+            "applies_to_model_id": null,
+            "semantic": {"embedding_model": "e", "embedding_model_id": null, "threshold": 0.9}
+        });
+        validate_cache_policy(&policy).unwrap();
+        validate_cache_policy_lenient(&policy).unwrap();
+
+        let guardrail = json!({
+            "name": "g", "kind": "semantic",
+            "embedding_model": "e", "embedding_model_id": null,
+            "deny_examples": ["x"], "deny_threshold": 0.8
+        });
+        validate_guardrail(&guardrail).unwrap();
+        validate_guardrail_lenient(&guardrail).unwrap();
+
+        // A null id is not a way to name the model, though: it satisfies
+        // neither half of the alternative.
+        assert!(validate_model(&json!({
+            "display_name": "g",
+            "routing": {"targets": [{"model_id": null}]},
+        }))
+        .is_err());
     }
 
     /// Relaxing the name field must not make "names the model no way at

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -848,9 +848,24 @@ pub fn model_root_schema(strict: bool) -> Value {
             if branch.get("type").and_then(Value::as_str) == Some("object") {
                 if let Some(obj) = branch.as_object_mut() {
                     obj.insert("additionalProperties".to_string(), json!(false));
+                    require_name_or_id(obj, "target", "target_id");
                 }
             }
         }
+    }
+    // Every place a model document points at ANOTHER model accepts the
+    // reference as a name or as a resource id. Applied to both contracts:
+    // these fields were required on the read path too, so relaxing only the
+    // write path would leave a stored id-only reference dropping its row.
+    for (definition, name, id) in [
+        ("RoutingTarget", "model", "model_id"),
+        ("PanelMember", "model", "model_id"),
+        ("Judge", "model", "model_id"),
+        ("SemanticRoute", "target", "target_id"),
+        ("Semantic", "embedding_model", "embedding_model_id"),
+        ("Semantic", "default", "default_id"),
+    ] {
+        require_name_or_id_in(&mut schema, definition, name, id);
     }
     schema
 }
@@ -906,6 +921,45 @@ fn require_branch_property(branch: &mut serde_json::Map<String, Value>, name: &s
             branch.insert("required".to_string(), json!([name]));
         }
     }
+}
+
+/// Turn a required model-reference field into a "name **or** id" pair.
+///
+/// Every document that points at a Model may name it by display name or by
+/// resource id ([`crate::models::resolve_model_ref`]). Requiredness moves
+/// off the name alone and onto the alternative: `name` is dropped from
+/// `required` and an `allOf` member `{"anyOf": [{"required": [name]},
+/// {"required": [id]}]}` is added, so a document naming the model either
+/// way validates while one naming it NEITHER way is rejected exactly as a
+/// missing name was.
+///
+/// Appends to `allOf` rather than replacing it — the `semantic` guardrail
+/// branch already carries threshold rules there, and one object can need
+/// two alternatives (a semantic router names both an embedding model and a
+/// default).
+fn require_name_or_id(node: &mut serde_json::Map<String, Value>, name: &str, id: &str) {
+    if let Some(list) = node.get_mut("required").and_then(Value::as_array_mut) {
+        list.retain(|v| v.as_str() != Some(name));
+        if list.is_empty() {
+            node.remove("required");
+        }
+    }
+    let clause = json!({"anyOf": [{"required": [name]}, {"required": [id]}]});
+    match node.get_mut("allOf").and_then(Value::as_array_mut) {
+        Some(list) => list.push(clause),
+        None => {
+            node.insert("allOf".to_string(), json!([clause]));
+        }
+    }
+}
+
+/// [`require_name_or_id`] addressed at one `definitions` entry.
+fn require_name_or_id_in(schema: &mut Value, definition: &str, name: &str, id: &str) {
+    let node = schema
+        .pointer_mut(&format!("/definitions/{definition}"))
+        .and_then(Value::as_object_mut)
+        .unwrap_or_else(|| panic!("schema defines {definition}"));
+    require_name_or_id(node, name, id);
 }
 
 /// Canonical JSON Schema for the `provider_key` resource, derived from the
@@ -1464,10 +1518,6 @@ pub fn guardrail_root_schema(strict: bool) -> Value {
                     // field defaulting. What an operator may save is the
                     // stricter question, and it is asked here.
                     if strict {
-                        // A row saved without an embedding model would
-                        // screen every request against a model that
-                        // resolves to nothing.
-                        require_branch_property(b, "embedding_model");
                         // …and the type-level default goes with them. It
                         // exists so a STORED row without the key still
                         // loads; advertised on the write contract it reads
@@ -1508,6 +1558,13 @@ pub fn guardrail_root_schema(strict: bool) -> Value {
                                 }
                             ]),
                         );
+                        // A row saved without an embedding model would
+                        // screen every request against a model that
+                        // resolves to nothing. Either spelling satisfies
+                        // it — the id form survives a rename of the model.
+                        // AFTER the `allOf` above, which is written rather
+                        // than appended to.
+                        require_name_or_id(b, "embedding_model", "embedding_model_id");
                     }
                 }
                 "custom" => {
@@ -1746,7 +1803,17 @@ fn set_property_additional_properties_description(
 /// has no `deny_unknown_fields`, so the schema omits `additionalProperties`
 /// (i.e. `true`) — forward-compat fields from a newer cp-api are tolerated.
 pub fn cache_policy_root_schema() -> Value {
-    struct_root_schema::<crate::models::CachePolicy>(false)
+    let mut schema = struct_root_schema::<crate::models::CachePolicy>(false);
+    // The similarity layer's embedding model is named either way, like
+    // every other model reference. `applies_to` needs no alternative: it
+    // has a default, and `applies_to_model_id` simply overrides it.
+    require_name_or_id_in(
+        &mut schema,
+        "SemanticCacheConfig",
+        "embedding_model",
+        "embedding_model_id",
+    );
+    schema
 }
 
 /// Canonical JSON Schema for the `observability_exporter` resource, derived
@@ -2039,6 +2106,172 @@ mod tests {
             }
         });
         assert!(validate_model(&v).is_err());
+    }
+
+    // ---- model references by resource id (`<field>_id`) ----
+
+    /// Every place a model document points at another model takes the id
+    /// spelling on BOTH contracts. The lenient half is the one that
+    /// matters most: a stored document the read schema rejects is a row
+    /// the loader skips whole.
+    #[test]
+    fn model_references_accept_the_id_spelling() {
+        let cases = [
+            json!({"display_name": "g", "routing": {"targets": [{"model_id": "m-1"}]}}),
+            json!({"display_name": "g", "routing": {
+                "targets": [{"model": "a", "model_id": "m-1"}, {"model": "b"}]}}),
+            json!({"display_name": "e", "ensemble": {
+                "panel": [{"model_id": "m-1"}], "judge": {"model_id": "m-2"}}}),
+            json!({"display_name": "s", "semantic": {
+                "embedding_model_id": "m-e",
+                "routes": [{"name": "r", "target_id": "m-1", "examples": ["x"]}],
+                "default_id": "m-2",
+                "match": {"threshold": 0.5}}}),
+            json!({"display_name": "s", "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "r", "target": "t", "examples": ["x"]}],
+                "default": "d",
+                "match": {"threshold": 0.5},
+                "on_embedding_failure": {"target_id": "m-9"}}}),
+        ];
+        for case in cases {
+            validate_model(&case).unwrap_or_else(|e| panic!("strict rejected {case}: {e}"));
+            validate_model_lenient(&case)
+                .unwrap_or_else(|e| panic!("lenient rejected {case}: {e}"));
+        }
+    }
+
+    /// A field the strict schema does not declare is reported as unknown
+    /// on every row that carries it, and `model` takes its partial-compat
+    /// report from the schema rather than from `serde_ignored` (untagged
+    /// and flattened content is invisible to that). So the id spellings
+    /// have to be visible to the walk, not merely accepted by the
+    /// validator.
+    #[test]
+    fn model_reference_ids_are_not_reported_as_unknown_fields() {
+        let v = json!({
+            "display_name": "everything",
+            "semantic": {
+                "embedding_model_id": "m-e",
+                "routes": [{"name": "r", "target_id": "m-1", "examples": ["x"]}],
+                "default_id": "m-2",
+                "match": {"threshold": 0.5},
+                "on_embedding_failure": {"target_id": "m-3"}
+            }
+        });
+        assert!(unknown_field_paths("model", &v).is_empty());
+
+        let group = json!({
+            "display_name": "g",
+            "routing": {"targets": [{"model_id": "m-1", "weight": 2}]}
+        });
+        assert!(unknown_field_paths("model", &group).is_empty());
+
+        let panel = json!({
+            "display_name": "e",
+            "ensemble": {"panel": [{"model_id": "m-1"}], "judge": {"model_id": "m-2"}}
+        });
+        assert!(unknown_field_paths("model", &panel).is_empty());
+
+        // The walk still works: a genuinely unknown sibling is reported.
+        let bogus = json!({
+            "display_name": "g",
+            "routing": {"targets": [{"model_id": "m-1", "bogus_id": "x"}]}
+        });
+        assert_eq!(
+            unknown_field_paths("model", &bogus),
+            vec!["routing.targets.0.bogus_id"]
+        );
+    }
+
+    /// Relaxing the name field must not make "names the model no way at
+    /// all" valid — that is the same missing reference it always was, and
+    /// it stays rejected on both contracts.
+    #[test]
+    fn model_reference_naming_neither_field_is_still_rejected() {
+        let cases = [
+            json!({"display_name": "g", "routing": {"targets": [{"weight": 2}]}}),
+            json!({"display_name": "e", "ensemble": {
+                "panel": [{"temperature": 0.5}], "judge": {"model": "j"}}}),
+            json!({"display_name": "e", "ensemble": {
+                "panel": [{"model": "a"}], "judge": {"synthesis_prompt": "x"}}}),
+            json!({"display_name": "s", "semantic": {
+                "routes": [{"name": "r", "target": "t", "examples": ["x"]}],
+                "default": "d", "match": {"threshold": 0.5}}}),
+            json!({"display_name": "s", "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "r", "target": "t", "examples": ["x"]}],
+                "match": {"threshold": 0.5}}}),
+            json!({"display_name": "s", "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "r", "examples": ["x"]}],
+                "default": "d", "match": {"threshold": 0.5}}}),
+            json!({"display_name": "s", "semantic": {
+                "embedding_model": "e",
+                "routes": [{"name": "r", "target": "t", "examples": ["x"]}],
+                "default": "d", "match": {"threshold": 0.5},
+                "on_embedding_failure": {"synthesis_prompt": "not a target"}}}),
+        ];
+        for case in cases {
+            assert!(
+                validate_model(&case).is_err(),
+                "strict accepted a reference naming no model: {case}"
+            );
+            assert!(
+                validate_model_lenient(&case).is_err(),
+                "lenient accepted a reference naming no model: {case}"
+            );
+        }
+    }
+
+    /// A cache policy's model scope and its similarity embedder both take
+    /// the id spelling; the embedder's requirement moves onto the pair.
+    #[test]
+    fn cache_policy_model_references_accept_the_id_spelling() {
+        let scoped = json!({"name": "p", "applies_to_model_id": "m-1"});
+        validate_cache_policy(&scoped).unwrap();
+        validate_cache_policy_lenient(&scoped).unwrap();
+
+        let embedder = json!({
+            "name": "p",
+            "semantic": {"embedding_model_id": "m-e", "threshold": 0.9}
+        });
+        validate_cache_policy(&embedder).unwrap();
+        validate_cache_policy_lenient(&embedder).unwrap();
+
+        let neither = json!({"name": "p", "semantic": {"threshold": 0.9}});
+        assert!(validate_cache_policy(&neither).is_err());
+        assert!(validate_cache_policy_lenient(&neither).is_err());
+    }
+
+    /// The guardrail embedder keeps its strict/lenient split: the write
+    /// path demands one of the two spellings, the read path neither — a
+    /// screening row that fails to load is fail-OPEN.
+    #[test]
+    fn guardrail_semantic_embedder_accepts_the_id_spelling() {
+        let by_id = json!({
+            "name": "g", "kind": "semantic",
+            "embedding_model_id": "m-e",
+            "deny_examples": ["x"], "deny_threshold": 0.8
+        });
+        validate_guardrail(&by_id).unwrap();
+        validate_guardrail_lenient(&by_id).unwrap();
+
+        // Neither spelling: refused on write, still loaded on read.
+        let neither = json!({
+            "name": "g", "kind": "semantic",
+            "deny_examples": ["x"], "deny_threshold": 0.8
+        });
+        assert!(validate_guardrail(&neither).is_err());
+        validate_guardrail_lenient(&neither).unwrap();
+
+        // The threshold coupling still fires alongside the new
+        // alternative — both live in the same `allOf`.
+        let unthresholded = json!({
+            "name": "g", "kind": "semantic",
+            "embedding_model_id": "m-e", "deny_examples": ["x"]
+        });
+        assert!(validate_guardrail(&unthresholded).is_err());
     }
 
     // ---- semantic-routing + embedding-modality schema tests (#641) ----

--- a/crates/aisix-core/src/models/semantic.rs
+++ b/crates/aisix-core/src/models/semantic.rs
@@ -55,8 +55,19 @@ pub struct SemanticRoute {
     #[schemars(length(min = 1))]
     pub name: String,
     /// Direct model alias that receives traffic matching this route.
+    /// Read only when `target_id` is absent.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     #[schemars(length(min = 1))]
     pub target: String,
+    /// Resource id of the direct model that receives traffic matching this
+    /// route. Present, it is authoritative and `target` is ignored: the id
+    /// is resolved against the models in the current configuration, so
+    /// renaming that model keeps this route pointing at it with no edit to
+    /// this document. An id resolving to no model is a route target that
+    /// does not exist, exactly as a `target` naming no model is.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub target_id: Option<String>,
     /// Human-facing description. Documentation only — v1 matches on
     /// `examples`, not on this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -73,6 +84,15 @@ pub struct SemanticRoute {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 0.0, max = 1.0))]
     pub threshold: Option<f32>,
+}
+
+impl SemanticRoute {
+    /// The display name of the model this route dispatches to, resolved
+    /// against the current configuration: `target_id` when it is set,
+    /// `target` otherwise.
+    pub fn target_ref<'a>(&'a self, snapshot: &super::AisixSnapshot) -> std::borrow::Cow<'a, str> {
+        super::resolve_model_ref(snapshot, &self.target, self.target_id.as_deref())
+    }
 }
 
 /// Matching parameters shared across every route in a semantic router.
@@ -113,11 +133,21 @@ pub enum EmbeddingFailureMode {
 pub enum OnEmbeddingFailure {
     /// `"default"` or `"fail"`.
     Mode(EmbeddingFailureMode),
-    /// `{ "target": "<direct alias>" }` — route to a specific safe model.
+    /// `{ "target": "<direct alias>" }` (or `{ "target_id": "<id>" }`) —
+    /// route to a specific safe model.
     Target {
-        /// Direct-model alias to route to when embedding fails.
+        /// Direct-model alias to route to when embedding fails. Read only
+        /// when `target_id` is absent.
+        #[serde(default, skip_serializing_if = "String::is_empty")]
         #[schemars(length(min = 1))]
         target: String,
+        /// Resource id of the direct model to route to when embedding
+        /// fails. Present, it is authoritative and `target` is ignored, so
+        /// renaming that model keeps this fallback pointing at it with no
+        /// edit to this document.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[schemars(length(min = 1))]
+        target_id: Option<String>,
     },
 }
 
@@ -131,15 +161,37 @@ impl Default for OnEmbeddingFailure {
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq)]
 pub struct Semantic {
     /// Alias of an `embedding`-modality Model used to embed the request
-    /// and (at apply time) the route examples.
+    /// and (at apply time) the route examples. Read only when
+    /// `embedding_model_id` is absent.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     #[schemars(length(min = 1))]
     pub embedding_model: String,
+    /// Resource id of the `embedding`-modality Model used to embed the
+    /// request and the route examples. Present, it is authoritative and
+    /// `embedding_model` is ignored: the id is resolved against the models
+    /// in the current configuration, so renaming that model keeps this
+    /// router pointing at it with no edit to this document. An id
+    /// resolving to no model is an embedding model that does not exist,
+    /// exactly as an `embedding_model` naming no model is — the router
+    /// applies `on_embedding_failure`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub embedding_model_id: Option<String>,
     /// Routes evaluated for each request. At least one is required.
     #[schemars(length(min = 1))]
     pub routes: Vec<SemanticRoute>,
-    /// Direct model alias used when no route clears its threshold.
+    /// Direct model alias used when no route clears its threshold. Read
+    /// only when `default_id` is absent.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     #[schemars(length(min = 1))]
     pub default: String,
+    /// Resource id of the direct model used when no route clears its
+    /// threshold. Present, it is authoritative and `default` is ignored,
+    /// so renaming that model keeps this router pointing at it with no
+    /// edit to this document.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub default_id: Option<String>,
     /// Shared matching parameters (metric, aggregation, default threshold).
     pub r#match: SemanticMatch,
     /// Per-call deadline for the embedding request in milliseconds. `0` or
@@ -157,6 +209,27 @@ fn is_default_failure(p: &OnEmbeddingFailure) -> bool {
 }
 
 impl Semantic {
+    /// The display name of the embedding model this router uses, resolved
+    /// against the current configuration: `embedding_model_id` when it is
+    /// set, `embedding_model` otherwise.
+    pub fn embedding_model_ref<'a>(
+        &'a self,
+        snapshot: &super::AisixSnapshot,
+    ) -> std::borrow::Cow<'a, str> {
+        super::resolve_model_ref(
+            snapshot,
+            &self.embedding_model,
+            self.embedding_model_id.as_deref(),
+        )
+    }
+
+    /// The display name of the model this router falls through to,
+    /// resolved against the current configuration: `default_id` when it is
+    /// set, `default` otherwise.
+    pub fn default_ref<'a>(&'a self, snapshot: &super::AisixSnapshot) -> std::borrow::Cow<'a, str> {
+        super::resolve_model_ref(snapshot, &self.default, self.default_id.as_deref())
+    }
+
     /// Effective threshold for a route: its own `threshold` if set,
     /// otherwise the router-level `match.threshold`.
     pub fn route_threshold(&self, route: &SemanticRoute) -> f32 {
@@ -171,9 +244,11 @@ impl Semantic {
             .map(std::time::Duration::from_millis)
     }
 
-    /// Every direct-model alias this router can dispatch to: each route's
-    /// `target` plus `default`. Used by the loader for reference-integrity
-    /// checks and the runtime for resolution.
+    /// Every direct-model alias this router can dispatch to, as CONFIGURED:
+    /// each route's `target` plus `default`. Name form only — a reference
+    /// written as `target_id` / `default_id` is not reported here, so this
+    /// is usable only where the id form cannot appear (the resources file,
+    /// which rejects it).
     pub fn referenced_targets(&self) -> impl Iterator<Item = &str> {
         self.routes
             .iter()
@@ -228,7 +303,8 @@ mod tests {
         assert_eq!(
             s.on_embedding_failure,
             OnEmbeddingFailure::Target {
-                target: "gpt-4o-mini".into()
+                target: "gpt-4o-mini".into(),
+                target_id: None,
             }
         );
     }
@@ -316,6 +392,7 @@ mod tests {
         // Target round-trips as { "target": "alias" }, not a nested object.
         let target = OnEmbeddingFailure::Target {
             target: "safe".into(),
+            target_id: None,
         };
         assert_eq!(
             serde_json::to_value(&target).unwrap(),

--- a/crates/aisix-core/tests/resource_schema_characterization.rs
+++ b/crates/aisix-core/tests/resource_schema_characterization.rs
@@ -83,6 +83,26 @@ fn cache_policy_corpus() {
                 true,
                 json!({"name": "k", "applies_to": "api_key:11111111-1111-1111-1111-111111111111"}),
             ),
+            (
+                "model scope by resource id",
+                true,
+                json!({"name": "k", "applies_to_model_id": "m-1"}),
+            ),
+            (
+                "similarity embedder named by resource id alone",
+                true,
+                json!({"name": "k", "semantic": {"embedding_model_id": "m-e", "threshold": 0.9}}),
+            ),
+            (
+                "similarity embedder named neither way",
+                false,
+                json!({"name": "k", "semantic": {"threshold": 0.9}}),
+            ),
+            (
+                "empty applies_to_model_id",
+                false,
+                json!({"name": "k", "applies_to_model_id": ""}),
+            ),
             // CachePolicy has no deny_unknown_fields → forward-compat fields tolerated.
             (
                 "unknown field tolerated",
@@ -649,6 +669,24 @@ fn guardrail_corpus() {
                 false,
                 json!({"name": "k", "kind": "keyword", "patterns": [{"kind": "literal", "value": "x", "extra": 1}]}),
             ),
+            (
+                "semantic embedder named by resource id alone",
+                true,
+                json!({"name": "s", "kind": "semantic", "embedding_model_id": "m-e",
+                       "deny_examples": ["x"], "deny_threshold": 0.8}),
+            ),
+            (
+                "semantic embedder named neither way",
+                false,
+                json!({"name": "s", "kind": "semantic",
+                       "deny_examples": ["x"], "deny_threshold": 0.8}),
+            ),
+            (
+                "semantic embedder id present but empty",
+                false,
+                json!({"name": "s", "kind": "semantic", "embedding_model_id": "",
+                       "deny_examples": ["x"], "deny_threshold": 0.8}),
+            ),
             // top-level / kind discriminator
             (
                 "missing name",
@@ -966,7 +1004,6 @@ const EXTRA_RELAXATIONS: &[(&str, &[&str])] = &[
             "/oneOf/10/allOf",
             "/oneOf/10/properties/allow_threshold/default",
             "/oneOf/10/properties/deny_threshold/default",
-            "/oneOf/10/required",
             "/oneOf/11/properties/script/default",
         ],
     ),

--- a/crates/aisix-core/tests/resource_schema_characterization.rs
+++ b/crates/aisix-core/tests/resource_schema_characterization.rs
@@ -1057,7 +1057,8 @@ fn every_refused_model_reference_id_is_a_declared_field() {
             !fields.is_empty(),
             "{kind} has model references but refuses none"
         );
-        for (id_field, name_field) in fields {
+        for reference in fields {
+            let (id_field, name_field) = (reference.field, reference.name_field);
             assert!(
                 declares(&schema, id_field),
                 "{kind} refuses `{id_field}`, which the {resource} schema does not declare"
@@ -1066,6 +1067,88 @@ fn every_refused_model_reference_id_is_a_declared_field() {
                 declares(&schema, name_field),
                 "{kind} rewrites `{id_field}` to `{name_field}`, which the {resource} schema \
                  does not declare"
+            );
+            // The hint is what an operator is told to write instead, so it
+            // has to START with the name field — a hint naming a different
+            // field would send them somewhere the reference does not live.
+            assert!(
+                reference.hint.starts_with(name_field),
+                "{kind}'s hint for `{id_field}` ({:?}) does not name `{name_field}`",
+                reference.hint
+            );
+        }
+    }
+}
+
+/// Every `<name>` / `<name>_id` pair a resource declares is registered as
+/// a model reference.
+///
+/// The other direction of the check above, and the one that actually
+/// rots: a future site gains an id spelling, nobody adds it to
+/// `filesource::model_ref_id_fields`, and from then on the resources file
+/// SILENTLY accepts an id it can never resolve (with the name spelling
+/// ignored on top) while `aisix export` silently drops it. Nothing else
+/// notices, because a field no table mentions simply never matches.
+///
+/// Detected structurally rather than by name or by prose: a property
+/// ending `_id` (or `_ids`) whose name-form sibling is declared on the
+/// SAME object is the shape every model reference has. Sibling-less ids
+/// — `provider_key_id`, `team_id`, `user_id` — are not pairs and are not
+/// reported. A reference whose name form is spelled differently
+/// (`applies_to_model_id` → `applies_to`) cannot be found this way, which
+/// is why it is registered by hand; this check only ever demands MORE
+/// registration, never less.
+#[test]
+fn every_declared_name_and_id_pair_is_registered_as_a_model_reference() {
+    /// The name-form sibling `field` would pair with, if any.
+    fn name_form(field: &str) -> Option<String> {
+        if let Some(stem) = field.strip_suffix("_ids") {
+            return Some(format!("{stem}s"));
+        }
+        field.strip_suffix("_id").map(str::to_owned)
+    }
+
+    fn collect_pairs(node: &Value, out: &mut Vec<String>) {
+        match node {
+            Value::Object(map) => {
+                if let Some(Value::Object(properties)) = map.get("properties") {
+                    for field in properties.keys() {
+                        if name_form(field).is_some_and(|n| properties.contains_key(&n)) {
+                            out.push(field.clone());
+                        }
+                    }
+                }
+                for child in map.values() {
+                    collect_pairs(child, out);
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    collect_pairs(item, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    for (kind, resource) in [
+        ("api_keys", "api_key"),
+        ("models", "model"),
+        ("cache_policies", "cache_policy"),
+        ("guardrails", "guardrail"),
+    ] {
+        let mut found = Vec::new();
+        collect_pairs(&resource_root_schema(resource, true), &mut found);
+        found.sort();
+        found.dedup();
+        let registered = aisix_core::filesource::model_ref_id_fields(kind);
+        for field in found {
+            assert!(
+                registered.iter().any(|r| r.field == field),
+                "the {resource} schema declares `{field}` beside its name form, but \
+                 `filesource::model_ref_id_fields(\"{kind}\")` does not list it — the \
+                 resources file would accept an id it can never resolve, and `aisix export` \
+                 would drop it"
             );
         }
     }

--- a/crates/aisix-core/tests/resource_schema_characterization.rs
+++ b/crates/aisix-core/tests/resource_schema_characterization.rs
@@ -1019,6 +1019,58 @@ const EXTRA_RELAXATIONS: &[(&str, &[&str])] = &[
     ),
 ];
 
+/// Every field the resources file refuses as an id-form model reference
+/// is a field this build's schema actually declares.
+///
+/// The refusal list (`filesource::model_ref_id_fields`) is written by
+/// hand, and `aisix export` rewrites the same list back to name form. A
+/// typo in either half is silent in both directions: the file would
+/// accept an id that resolves to nothing, and the export would leave one
+/// in a file that then refuses to load. Neither shows up as a test
+/// failure anywhere else, because a name nothing declares simply never
+/// matches.
+#[test]
+fn every_refused_model_reference_id_is_a_declared_field() {
+    fn declares(node: &Value, field: &str) -> bool {
+        match node {
+            Value::Object(map) => {
+                map.get("properties")
+                    .and_then(Value::as_object)
+                    .is_some_and(|p| p.contains_key(field))
+                    || map.values().any(|v| declares(v, field))
+            }
+            Value::Array(items) => items.iter().any(|v| declares(v, field)),
+            _ => false,
+        }
+    }
+
+    // (resources-file collection, the resource whose schema declares it)
+    for (kind, resource) in [
+        ("api_keys", "api_key"),
+        ("models", "model"),
+        ("cache_policies", "cache_policy"),
+        ("guardrails", "guardrail"),
+    ] {
+        let schema = resource_root_schema(resource, true);
+        let fields = aisix_core::filesource::model_ref_id_fields(kind);
+        assert!(
+            !fields.is_empty(),
+            "{kind} has model references but refuses none"
+        );
+        for (id_field, name_field) in fields {
+            assert!(
+                declares(&schema, id_field),
+                "{kind} refuses `{id_field}`, which the {resource} schema does not declare"
+            );
+            assert!(
+                declares(&schema, name_field),
+                "{kind} rewrites `{id_field}` to `{name_field}`, which the {resource} schema \
+                 does not declare"
+            );
+        }
+    }
+}
+
 /// The published files are exactly the ones `dump-schema` emits today.
 ///
 /// `dump-schema` only ever writes, so a file it STOPPED emitting would sit in

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -3483,6 +3483,7 @@ mod tests {
         async fn embed(
             &self,
             _model_alias: &str,
+            _model_id: Option<&str>,
             texts: &[String],
             _cacheable: bool,
             _timeout: std::time::Duration,

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -3487,8 +3487,11 @@ mod tests {
             texts: &[String],
             _cacheable: bool,
             _timeout: std::time::Duration,
-        ) -> Result<Vec<Vec<f32>>, crate::EmbedFailure> {
-            Ok(texts.iter().map(|_| vec![1.0, 0.0]).collect())
+        ) -> Result<crate::Embedded, crate::EmbedFailure> {
+            Ok(crate::Embedded {
+                model: "stub-embedder".to_owned(),
+                vectors: texts.iter().map(|_| vec![1.0, 0.0]).collect(),
+            })
         }
     }
 
@@ -3554,7 +3557,9 @@ mod tests {
         assert_eq!(scores[0].guardrail_name, "semantic-row");
         assert_eq!(scores[0].hook, "input");
         assert_eq!(scores[0].direction, "deny");
-        assert_eq!(scores[0].embedding_model, "embed-1");
+        // The model the embedder RESOLVED for this call, not the alias
+        // the row configures — the row may name its embedder by id.
+        assert_eq!(scores[0].embedding_model, "stub-embedder");
         assert!(scores[0].matched);
     }
 

--- a/crates/aisix-guardrails/src/custom.rs
+++ b/crates/aisix-guardrails/src/custom.rs
@@ -978,7 +978,9 @@ async fn host_embed(
         Ok(t) => t,
         Err(e) => return embed_error(format!("invalid texts argument: {e}")),
     };
-    match embedder.embed(&model, &texts, false, budget).await {
+    // The script names the model by alias — `aisix.embed(name, texts)` is
+    // the whole surface — so there is no id spelling to pass here.
+    match embedder.embed(&model, None, &texts, false, budget).await {
         Ok(vectors) => serde_json::to_string(&EmbedResult {
             error: None,
             vectors,
@@ -1812,6 +1814,7 @@ mod tests {
             async fn embed(
                 &self,
                 _model: &str,
+                _model_id: Option<&str>,
                 texts: &[String],
                 _cacheable: bool,
                 _timeout: Duration,

--- a/crates/aisix-guardrails/src/custom.rs
+++ b/crates/aisix-guardrails/src/custom.rs
@@ -981,9 +981,9 @@ async fn host_embed(
     // The script names the model by alias — `aisix.embed(name, texts)` is
     // the whole surface — so there is no id spelling to pass here.
     match embedder.embed(&model, None, &texts, false, budget).await {
-        Ok(vectors) => serde_json::to_string(&EmbedResult {
+        Ok(embedded) => serde_json::to_string(&EmbedResult {
             error: None,
-            vectors,
+            vectors: embedded.vectors,
         })
         .unwrap_or_else(|e| embed_error(e.to_string())),
         Err(failure) => {
@@ -1818,9 +1818,9 @@ mod tests {
                 texts: &[String],
                 _cacheable: bool,
                 _timeout: Duration,
-            ) -> Result<Vec<Vec<f32>>, crate::EmbedFailure> {
+            ) -> Result<crate::Embedded, crate::EmbedFailure> {
                 // "jailbreak" points one way, everything else the other.
-                Ok(texts
+                let vectors = texts
                     .iter()
                     .map(|t| {
                         if t.contains("jailbreak") {
@@ -1829,7 +1829,11 @@ mod tests {
                             vec![0.0, 1.0]
                         }
                     })
-                    .collect())
+                    .collect();
+                Ok(crate::Embedded {
+                    model: "stub-embedder".to_owned(),
+                    vectors,
+                })
             }
         }
         let cfg = config(

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -257,8 +257,15 @@ impl EmbedFailure {
 /// implementation keeps only the hub plus a snapshot handle.
 #[async_trait]
 pub trait GuardrailEmbedder: Send + Sync + 'static {
-    /// Embed `texts` with the `embedding`-kind Model aliased
-    /// `model_alias`, returning one vector per input, in input order.
+    /// Embed `texts` with the `embedding`-kind Model the row names,
+    /// returning one vector per input, in input order.
+    ///
+    /// The model is named by alias, by resource id, or by both. `model_id`
+    /// decides whenever it is `Some` and `model_alias` is then ignored, so
+    /// a row that names its embedder by id keeps working after that model
+    /// is renamed. Neither spelling resolving to an `embedding`-kind Model
+    /// is [`EmbedFailure::Unresolved`] — an id naming nothing behaves as a
+    /// dangling alias does, and the row degrades per its `fail_open`.
     ///
     /// `cacheable` marks CONFIG-derived text — the example prototypes,
     /// which are fixed per row and worth memoising process-wide so a
@@ -268,6 +275,7 @@ pub trait GuardrailEmbedder: Send + Sync + 'static {
     async fn embed(
         &self,
         model_alias: &str,
+        model_id: Option<&str>,
         texts: &[String],
         cacheable: bool,
         timeout: std::time::Duration,

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -279,7 +279,23 @@ pub trait GuardrailEmbedder: Send + Sync + 'static {
         texts: &[String],
         cacheable: bool,
         timeout: std::time::Duration,
-    ) -> Result<Vec<Vec<f32>>, EmbedFailure>;
+    ) -> Result<Embedded, EmbedFailure>;
+}
+
+/// One embedding call's result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Embedded {
+    /// Current display name of the `embedding`-kind Model that produced
+    /// these vectors.
+    ///
+    /// Returned rather than taken from the row's config because a score is
+    /// unreadable without the model that produced it, and the row's own
+    /// `embedding_model` is not reliably that model: under an id-form
+    /// reference it is ignored, may be stale after a rename, and may be
+    /// absent entirely.
+    pub model: String,
+    /// One vector per input, in input order.
+    pub vectors: Vec<Vec<f32>>,
 }
 
 /// The process-wide guardrail embedder, passed to the chain builders.

--- a/crates/aisix-guardrails/src/semantic.rs
+++ b/crates/aisix-guardrails/src/semantic.rs
@@ -110,14 +110,10 @@ struct SemanticParams {
     /// what telemetry reports.
     embedding_model: String,
     embedding_model_id: Option<String>,
-    /// What a [`GuardrailScore`] names as the model that produced it: the
-    /// id when the row names its embedder by one, the alias otherwise.
-    /// Cosine scores are not comparable across embedding models, so a
-    /// score is unreadable without knowing which model produced it — and
-    /// under an id-form reference the alias is not that model (it is
-    /// ignored, and may be empty). Neither spelling changes across
-    /// requests, so the identity in a stored event stays stable even
-    /// though the model's display name may not.
+    /// What the failure log names when nothing resolved: the id when the
+    /// row names its embedder by one, the alias otherwise. A SCORE never
+    /// uses this — it carries the display name the embedder resolved,
+    /// which is the model that actually produced the number.
     embedding_model_identity: String,
     deny_examples: Vec<String>,
     allow_examples: Vec<String>,
@@ -222,7 +218,7 @@ impl SemanticGuardrail {
             )
             .await
         {
-            Ok(v) if v.len() == prototypes.len() => v,
+            Ok(v) if v.vectors.len() == prototypes.len() => v.vectors,
             Ok(_) => return self.on_failure(EmbedFailure::Upstream, fail_open),
             Err(failure) => return self.on_failure(failure, fail_open),
         };
@@ -239,10 +235,15 @@ impl SemanticGuardrail {
             )
             .await
         {
-            Ok(v) if v.len() == texts.len() => v,
+            Ok(v) if v.vectors.len() == texts.len() => v,
             Ok(_) => return self.on_failure(EmbedFailure::Upstream, fail_open),
             Err(failure) => return self.on_failure(failure, fail_open),
         };
+        // The model that actually produced these numbers, by its current
+        // display name — what a score has to carry, and what neither
+        // spelling in the row reliably is.
+        let scored_by = candidate_vecs.model;
+        let candidate_vecs = candidate_vecs.vectors;
 
         let (deny_vecs, allow_vecs) = prototype_vecs.split_at(self.cfg.deny_examples.len());
 
@@ -273,8 +274,14 @@ impl SemanticGuardrail {
             }
         }
 
-        self.report(hook, "deny", self.cfg.deny_threshold, deny_peak);
-        self.report(hook, "allow", self.cfg.allow_threshold, allow_trough);
+        self.report(hook, "deny", self.cfg.deny_threshold, deny_peak, &scored_by);
+        self.report(
+            hook,
+            "allow",
+            self.cfg.allow_threshold,
+            allow_trough,
+            &scored_by,
+        );
         verdict
     }
 
@@ -288,6 +295,7 @@ impl SemanticGuardrail {
         direction: &'static str,
         threshold: f32,
         extreme: Option<(usize, f32)>,
+        scored_by: &str,
     ) {
         let (Some(log), Some((index, score))) = (self.scores.as_ref(), extreme) else {
             return;
@@ -300,7 +308,7 @@ impl SemanticGuardrail {
             threshold,
             matched: score >= threshold,
             top_example_index: index as u32,
-            embedding_model: self.cfg.embedding_model_identity.clone(),
+            embedding_model: scored_by.to_owned(),
         });
     }
 
@@ -557,7 +565,7 @@ mod tests {
             texts: &[String],
             _cacheable: bool,
             _timeout: Duration,
-        ) -> Result<Vec<Vec<f32>>, EmbedFailure> {
+        ) -> Result<crate::Embedded, EmbedFailure> {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             self.calls.lock().unwrap().push(texts.to_vec());
             if let Some(failure) = self.fail {
@@ -567,7 +575,13 @@ mod tests {
             if self.wrong_length {
                 out.pop();
             }
-            Ok(out)
+            Ok(crate::Embedded {
+                // The name the embedder RESOLVED, deliberately unlike the
+                // alias the row is configured with (`embed-1`), so a score
+                // reporting the configured spelling is visible as wrong.
+                model: "resolved-embedder".to_owned(),
+                vectors: out,
+            })
         }
     }
 
@@ -989,7 +1003,11 @@ mod tests {
         let deny = score_of(&scores, "deny");
         assert_eq!(deny.guardrail_name, ROW);
         assert_eq!(deny.hook, "input");
-        assert_eq!(deny.embedding_model, "embed-1");
+        // The model the EMBEDDER resolved, not the alias the row was
+        // configured with — a row referencing its embedder by id has no
+        // reliable alias, and one referencing it by a name that has since
+        // been renamed has a stale one.
+        assert_eq!(deny.embedding_model, "resolved-embedder");
         assert_eq!(deny.threshold, 0.75);
         assert_eq!(deny.score, 0.0, "orthogonal topics score exactly 0");
         assert!(!deny.matched);

--- a/crates/aisix-guardrails/src/semantic.rs
+++ b/crates/aisix-guardrails/src/semantic.rs
@@ -105,7 +105,20 @@ struct SemanticParams {
     /// The kind's static `name()` is `"semantic"` for every row, which
     /// would make two rows' scores indistinguishable.
     row_name: String,
+    /// The embedder as configured: the alias, plus the resource id when
+    /// the row names its model that way. `embedding_model_identity` is
+    /// what telemetry reports.
     embedding_model: String,
+    embedding_model_id: Option<String>,
+    /// What a [`GuardrailScore`] names as the model that produced it: the
+    /// id when the row names its embedder by one, the alias otherwise.
+    /// Cosine scores are not comparable across embedding models, so a
+    /// score is unreadable without knowing which model produced it — and
+    /// under an id-form reference the alias is not that model (it is
+    /// ignored, and may be empty). Neither spelling changes across
+    /// requests, so the identity in a stored event stays stable even
+    /// though the model's display name may not.
+    embedding_model_identity: String,
     deny_examples: Vec<String>,
     allow_examples: Vec<String>,
     deny_threshold: f32,
@@ -147,6 +160,11 @@ impl SemanticGuardrail {
                 embedder,
                 row_name: row_name.into(),
                 embedding_model: cfg.embedding_model.clone(),
+                embedding_model_id: cfg.embedding_model_id.clone(),
+                embedding_model_identity: cfg
+                    .embedding_model_id
+                    .clone()
+                    .unwrap_or_else(|| cfg.embedding_model.clone()),
                 deny_examples: cfg.deny_examples.clone(),
                 allow_examples: cfg.allow_examples.clone(),
                 deny_threshold: cfg.deny_threshold,
@@ -197,6 +215,7 @@ impl SemanticGuardrail {
             .embedder
             .embed(
                 &self.cfg.embedding_model,
+                self.cfg.embedding_model_id.as_deref(),
                 &prototypes,
                 true,
                 self.cfg.timeout,
@@ -211,7 +230,13 @@ impl SemanticGuardrail {
         let candidate_vecs = match self
             .cfg
             .embedder
-            .embed(&self.cfg.embedding_model, &texts, false, self.cfg.timeout)
+            .embed(
+                &self.cfg.embedding_model,
+                self.cfg.embedding_model_id.as_deref(),
+                &texts,
+                false,
+                self.cfg.timeout,
+            )
             .await
         {
             Ok(v) if v.len() == texts.len() => v,
@@ -275,7 +300,7 @@ impl SemanticGuardrail {
             threshold,
             matched: score >= threshold,
             top_example_index: index as u32,
-            embedding_model: self.cfg.embedding_model.clone(),
+            embedding_model: self.cfg.embedding_model_identity.clone(),
         });
     }
 
@@ -323,7 +348,7 @@ impl SemanticGuardrail {
         let tag = failure.as_str();
         tracing::warn!(
             guardrail = "semantic",
-            embedding_model = %self.cfg.embedding_model,
+            embedding_model = %self.cfg.embedding_model_identity,
             failure = tag,
             fail_open,
             "semantic guardrail could not embed"
@@ -528,6 +553,7 @@ mod tests {
         async fn embed(
             &self,
             _model_alias: &str,
+            _model_id: Option<&str>,
             texts: &[String],
             _cacheable: bool,
             _timeout: Duration,
@@ -548,6 +574,7 @@ mod tests {
     fn cfg(deny: &[&str], allow: &[&str]) -> SemanticConfig {
         SemanticConfig {
             embedding_model: "embed-1".into(),
+            embedding_model_id: None,
             deny_examples: deny.iter().map(|s| (*s).to_string()).collect(),
             allow_examples: allow.iter().map(|s| (*s).to_string()).collect(),
             deny_threshold: 0.75,

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -2380,7 +2380,7 @@ async fn dispatch(
             entry.value.enabled
                 && entry
                     .value
-                    .parsed_applies_to()
+                    .parsed_applies_to(snapshot)
                     .matches(&req.model, &auth.entry.id)
         })
         .cloned();
@@ -2454,7 +2454,12 @@ async fn dispatch(
                     .semantic_for_policy_backend(entry.value.backend, &entry.id, &entry.value.name)?
                     .clone();
                 let text = semantic_prompt_text(req)?;
-                let embed_entry = match snapshot.models.get_by_name(&cfg.embedding_model) {
+                let embedding_model = aisix_core::models::resolve_model_ref(
+                    snapshot,
+                    &cfg.embedding_model,
+                    cfg.embedding_model_id.as_deref(),
+                );
+                let embed_entry = match snapshot.models.get_by_name(&embedding_model) {
                     Some(e) if e.value.is_embedding() => e.clone(),
                     other => {
                         // A stable config error, not a per-request one:
@@ -2467,7 +2472,7 @@ async fn dispatch(
                             tracing::warn!(
                                 target: "aisix::cache",
                                 policy_name = %entry.value.name,
-                                embedding_model = %cfg.embedding_model,
+                                embedding_model = %embedding_model,
                                 found = other.is_some(),
                                 "cache policy references a missing or non-embedding \
                                  embedding_model; semantic matching is skipped until \
@@ -3441,6 +3446,13 @@ async fn dispatch_ensemble(
             "model is not an ensemble".into(),
         ))
     })?;
+    // Resolve the panel's and the judge's model references once, here, so
+    // every read below sees one spelling. A member or judge written as
+    // `model_id` follows a rename of the model it points at; one whose id
+    // resolves to nothing keeps the id as its name and is reported as the
+    // missing member it is, exactly as a dangling `model` is.
+    let ensemble_cfg = ensemble_cfg.with_refs_resolved(snapshot);
+    let ensemble_cfg = &ensemble_cfg;
 
     // Resolve a sub-call's target by display_name → (model_id, provider_key_id,
     // upstream_model). The first two are telemetry attribution; the third is

--- a/crates/aisix-proxy/src/guardrail_embedder.rs
+++ b/crates/aisix-proxy/src/guardrail_embedder.rs
@@ -64,6 +64,7 @@ impl GuardrailEmbedder for ProxyGuardrailEmbedder {
     async fn embed(
         &self,
         model_alias: &str,
+        model_id: Option<&str>,
         texts: &[String],
         cacheable: bool,
         timeout: Duration,
@@ -72,7 +73,11 @@ impl GuardrailEmbedder for ProxyGuardrailEmbedder {
             return Ok(Vec::new());
         }
         let snapshot = self.snapshot.load();
-        let Some(entry) = snapshot.models.get_by_name(model_alias) else {
+        // Resolved per call against the live table, so a rename of the
+        // embedding model takes effect on the next screened request
+        // without the guardrail row being rewritten or its chain rebuilt.
+        let alias = aisix_core::models::resolve_model_ref(&snapshot, model_alias, model_id);
+        let Some(entry) = snapshot.models.get_by_name(&alias) else {
             return Err(EmbedFailure::Unresolved);
         };
         // The alias must name an EMBEDDING model. A chat model would

--- a/crates/aisix-proxy/src/guardrail_embedder.rs
+++ b/crates/aisix-proxy/src/guardrail_embedder.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, Model};
 use aisix_gateway::{BridgeError, Hub};
-use aisix_guardrails::{EmbedFailure, GuardrailEmbedder};
+use aisix_guardrails::{EmbedFailure, Embedded, GuardrailEmbedder};
 use async_trait::async_trait;
 
 use crate::error::ProxyError;
@@ -68,9 +68,18 @@ impl GuardrailEmbedder for ProxyGuardrailEmbedder {
         texts: &[String],
         cacheable: bool,
         timeout: Duration,
-    ) -> Result<Vec<Vec<f32>>, EmbedFailure> {
+    ) -> Result<Embedded, EmbedFailure> {
         if texts.is_empty() {
-            return Ok(Vec::new());
+            // No call, so nothing resolved and nothing to name. Safe
+            // because a caller with no texts also produces no score: the
+            // semantic guardrail's report is driven by the candidates it
+            // judged, and an empty batch judges none. A score carrying an
+            // empty `embedding_model` would be dropped whole downstream
+            // rather than shown without one.
+            return Ok(Embedded {
+                model: String::new(),
+                vectors: Vec::new(),
+            });
         }
         let snapshot = self.snapshot.load();
         // Resolved per call against the live table, so a rename of the
@@ -105,7 +114,10 @@ impl GuardrailEmbedder for ProxyGuardrailEmbedder {
             cached.push(hit);
         }
         if misses.is_empty() {
-            return Ok(cached.into_iter().map(Option::unwrap).collect());
+            return Ok(Embedded {
+                model: entry.value.display_name.clone(),
+                vectors: cached.into_iter().map(Option::unwrap).collect(),
+            });
         }
 
         let fetched = crate::semantic::embed_texts(
@@ -132,13 +144,16 @@ impl GuardrailEmbedder for ProxyGuardrailEmbedder {
         // Re-interleave: `fetched` is in `misses` order, which is the
         // order the `None` holes appear in.
         let mut fetched = fetched.into_iter();
-        Ok(cached
-            .into_iter()
-            .map(|slot| match slot {
-                Some(v) => v,
-                None => fetched.next().expect("miss count checked above"),
-            })
-            .collect())
+        Ok(Embedded {
+            model: entry.value.display_name.clone(),
+            vectors: cached
+                .into_iter()
+                .map(|slot| match slot {
+                    Some(v) => v,
+                    None => fetched.next().expect("miss count checked above"),
+                })
+                .collect(),
+        })
     }
 }
 

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -1499,6 +1499,122 @@ mod tests {
         );
     }
 
+    // ───────────────── targets named by resource id ─────────────────
+
+    /// A routing model whose targets are named by `model_id`. Every stage
+    /// downstream of the normalization keys on `target.model`, so the
+    /// assertion that matters is what the whole resolution walk hands back.
+    fn resolve_group(
+        snapshot: &AisixSnapshot,
+        targets: Vec<RoutingTarget>,
+    ) -> Result<Vec<String>, ProxyError> {
+        let group: Model = serde_json::from_value(serde_json::json!({
+            "display_name": "group",
+            "routing": {"strategy": "failover", "targets": []},
+        }))
+        .unwrap();
+        let mut group = group;
+        group.routing = Some(r(RoutingStrategy::Failover, targets, None));
+        resolve_attempt_models(
+            &RoutingRegistry::new(),
+            &crate::ModelRuntimeStatusTracker::new(),
+            snapshot,
+            "group",
+            "g-1",
+            &group,
+            RoutingRequest::default(),
+        )
+        .map(|attempts| {
+            attempts
+                .into_iter()
+                .map(|a| a.model.display_name)
+                .collect()
+        })
+    }
+
+    #[test]
+    fn a_target_named_by_id_resolves_to_that_model() {
+        // `ip_snapshot` assigns ids `m-0`, `m-1`, … in declaration order.
+        let snap = ip_snapshot(&[("alpha", None), ("beta", None)]);
+        assert_eq!(
+            resolve_group(&snap, vec![RoutingTarget::by_id("m-1")]).unwrap(),
+            vec!["beta"]
+        );
+    }
+
+    #[test]
+    fn a_target_named_by_id_follows_a_rename() {
+        let target = vec![RoutingTarget::by_id("m-0")];
+        let before = ip_snapshot(&[("alpha", None)]);
+        assert_eq!(
+            resolve_group(&before, target.clone()).unwrap(),
+            vec!["alpha"]
+        );
+        // Same id, new display name; the routing document is untouched.
+        let after = ip_snapshot(&[("alpha-v2", None)]);
+        assert_eq!(resolve_group(&after, target).unwrap(), vec!["alpha-v2"]);
+    }
+
+    #[test]
+    fn an_id_target_wins_over_the_name_beside_it() {
+        let snap = ip_snapshot(&[("alpha", None), ("beta", None)]);
+        let conflicting = RoutingTarget {
+            model: "alpha".into(),
+            model_id: Some("m-1".into()),
+            weight: None,
+            priority: None,
+            tags: None,
+        };
+        assert_eq!(resolve_group(&snap, vec![conflicting]).unwrap(), vec!["beta"]);
+    }
+
+    #[test]
+    fn an_unresolvable_id_target_fails_like_an_unresolvable_name() {
+        let snap = ip_snapshot(&[("alpha", None)]);
+        let by_id = resolve_group(&snap, vec![RoutingTarget::by_id("m-gone")]).unwrap_err();
+        let by_name = resolve_group(&snap, vec![RoutingTarget::new("m-gone")]).unwrap_err();
+        assert!(
+            matches!(by_id, ProxyError::InvalidRequest(_)),
+            "expected the same config error a dangling name raises, got {by_id:?}"
+        );
+        assert_eq!(by_id.to_string(), by_name.to_string());
+    }
+
+    /// The per-target IP allowlist keys on the target's Model, so it has to
+    /// see the resolved one — a group that gated only name-form targets
+    /// would let an id-form target through a restriction the operator set.
+    #[test]
+    fn an_id_target_is_still_subject_to_its_own_ip_allowlist() {
+        let snap = ip_snapshot(&[("restricted", Some(vec!["10.0.0.0/8"]))]);
+        let group: Model = serde_json::from_value(serde_json::json!({
+            "display_name": "group",
+            "routing": {"strategy": "failover", "targets": []},
+        }))
+        .unwrap();
+        let mut group = group;
+        group.routing = Some(r(
+            RoutingStrategy::Failover,
+            vec![RoutingTarget::by_id("m-0")],
+            None,
+        ));
+        let out_of_range = resolve_attempt_models(
+            &RoutingRegistry::new(),
+            &crate::ModelRuntimeStatusTracker::new(),
+            &snap,
+            "group",
+            "g-1",
+            &group,
+            RoutingRequest {
+                source_ip: "8.8.8.8",
+                ..Default::default()
+            },
+        );
+        assert!(matches!(
+            out_of_range,
+            Err(ProxyError::ModelIpRestricted(_))
+        ));
+    }
+
     // ───────────────── per-target client-IP allowlist ─────────────────
 
     fn ip_snapshot(models: &[(&str, Option<Vec<&str>>)]) -> AisixSnapshot {

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -1524,12 +1524,7 @@ mod tests {
             &group,
             RoutingRequest::default(),
         )
-        .map(|attempts| {
-            attempts
-                .into_iter()
-                .map(|a| a.model.display_name)
-                .collect()
-        })
+        .map(|attempts| attempts.into_iter().map(|a| a.model.display_name).collect())
     }
 
     #[test]
@@ -1565,7 +1560,10 @@ mod tests {
             priority: None,
             tags: None,
         };
-        assert_eq!(resolve_group(&snap, vec![conflicting]).unwrap(), vec!["beta"]);
+        assert_eq!(
+            resolve_group(&snap, vec![conflicting]).unwrap(),
+            vec!["beta"]
+        );
     }
 
     #[test]

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -1186,6 +1186,26 @@ pub(crate) fn resolve_attempt_models(
             req.tags
         )));
     }
+    // Normalize each target's model reference to the display name the
+    // models table is keyed by, before ANY of the machinery below looks one
+    // up: the IP pre-filter, the balancing state (WRR fingerprints, hash
+    // rings) and the resolution loop all key on `target.model`, so
+    // resolving once here is what keeps a `model_id` target from having to
+    // be handled at each of them. A target written as `model_id` follows a
+    // rename of the model it points at; one whose id resolves to nothing
+    // keeps the id as its name and is reported below as the missing target
+    // it is — the same outcome a dangling `model` gets.
+    let eligible: Vec<RoutingTarget> = eligible
+        .into_iter()
+        .map(|t| {
+            let model = t.model_ref(snapshot).into_owned();
+            RoutingTarget {
+                model,
+                model_id: None,
+                ..t
+            }
+        })
+        .collect();
     // Client-IP pre-filter (AISIX-Cloud#1087 follow-up): a target whose own
     // `allowed_cidrs` excludes this caller is not a candidate. Applied BEFORE
     // the strategy picks, so `max_fallbacks` budgets attempts across the

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -1195,15 +1195,33 @@ pub(crate) fn resolve_attempt_models(
     // rename of the model it points at; one whose id resolves to nothing
     // keeps the id as its name and is reported below as the missing target
     // it is — the same outcome a dangling `model` gets.
+    //
+    // Collapsing to one entry per resolved model is part of the same step,
+    // and not an optimisation: the loop below finds a picked name's target
+    // with `find`, so two entries resolving to the same model would give
+    // the second attempt the FIRST one's weight and priority and spend two
+    // `max_fallbacks` slots on one upstream. The write path rejects
+    // duplicate targets, but it can only compare the spelling each entry
+    // used — `{"model": "beta"}` beside `{"model_id": "<beta>"}` is one
+    // model written two ways and reaches this side intact.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let eligible: Vec<RoutingTarget> = eligible
         .into_iter()
-        .map(|t| {
+        .filter_map(|t| {
             let model = t.model_ref(snapshot).into_owned();
-            RoutingTarget {
+            if !seen.insert(model.clone()) {
+                tracing::debug!(
+                    virtual_model = %virtual_name,
+                    target_model = %model,
+                    "routing targets resolve to the same model; keeping the first",
+                );
+                return None;
+            }
+            Some(RoutingTarget {
                 model,
                 model_id: None,
                 ..t
-            }
+            })
         })
         .collect();
     // Client-IP pre-filter (AISIX-Cloud#1087 follow-up): a target whose own
@@ -1243,8 +1261,8 @@ pub(crate) fn resolve_attempt_models(
                 "routing target {name:?} does not resolve to a Model"
             ))
         })?;
-        // Duplicate target models are rejected at the write path, so the
-        // first match is the only match.
+        // One entry per resolved model (see the normalization above), so
+        // the first match is the only match.
         let target = routing
             .targets
             .iter()

--- a/crates/aisix-proxy/src/semantic.rs
+++ b/crates/aisix-proxy/src/semantic.rs
@@ -12,11 +12,12 @@
 //! ([`SemanticVectorCache`]) are pure and unit-tested in isolation; the
 //! async embedding call lives in [`resolve`].
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use dashmap::DashMap;
 
-use aisix_core::models::{EmbeddingFailureMode, OnEmbeddingFailure, Semantic};
+use aisix_core::models::{resolve_model_ref, EmbeddingFailureMode, OnEmbeddingFailure, Semantic};
 use aisix_core::resource::ResourceEntry;
 use aisix_core::{AisixSnapshot, Model};
 use aisix_gateway::{EmbeddingRequest, EmbeddingVector};
@@ -75,11 +76,23 @@ pub(crate) fn decide(
 /// Direct-model alias to dispatch to when the embedding call fails, per
 /// `on_embedding_failure`. `None` means the policy is `fail` — the caller
 /// returns `503`.
-pub(crate) fn embedding_failure_target(semantic: &Semantic) -> Option<&str> {
+///
+/// Each of the two aliases it can return is a model reference in its own
+/// right, so both are resolved against the snapshot: an id spelling follows
+/// a rename, and an id that resolves to nothing comes back as itself and
+/// dispatches nowhere, exactly as a dangling alias does.
+pub(crate) fn embedding_failure_target<'a>(
+    snapshot: &AisixSnapshot,
+    semantic: &'a Semantic,
+) -> Option<Cow<'a, str>> {
     match &semantic.on_embedding_failure {
-        OnEmbeddingFailure::Mode(EmbeddingFailureMode::Default) => Some(&semantic.default),
+        OnEmbeddingFailure::Mode(EmbeddingFailureMode::Default) => {
+            Some(semantic.default_ref(snapshot))
+        }
         OnEmbeddingFailure::Mode(EmbeddingFailureMode::Fail) => None,
-        OnEmbeddingFailure::Target { target } => Some(target),
+        OnEmbeddingFailure::Target { target, target_id } => {
+            Some(resolve_model_ref(snapshot, target, target_id.as_deref()))
+        }
     }
 }
 
@@ -142,21 +155,27 @@ pub(crate) async fn resolve(
     // No user text to classify (e.g. a system-only or tool-only request):
     // route to `default` without an embedding call rather than embedding an
     // empty string, which could spuriously match a route.
+    // Every alias below is resolved through the model reference helpers:
+    // a router that names its targets by id keeps working across a rename
+    // of any of them, and an id that resolves to nothing behaves as the
+    // dangling alias it stands in for.
+    let default_target = semantic.default_ref(snapshot);
     if prompt.trim().is_empty() {
         let (attempt, _) =
-            select_eligible(state, snapshot, router, source_ip, &semantic.default, None)?;
+            select_eligible(state, snapshot, router, source_ip, &default_target, None)?;
         return Ok((vec![attempt], None));
     }
 
     // Resolve the embedding model + its modality metadata. A dangling or
     // wrong-kind reference is a config error; degrade via the failure
     // policy rather than 500.
-    let embed_entry = match snapshot.models.get_by_name(&semantic.embedding_model) {
+    let embedding_model = semantic.embedding_model_ref(snapshot);
+    let embed_entry = match snapshot.models.get_by_name(&embedding_model) {
         Some(e) if e.value.is_embedding() => e,
         other => {
             tracing::warn!(
                 router = %router_entry.value.display_name,
-                embedding_model = %semantic.embedding_model,
+                embedding_model = %embedding_model,
                 found = other.is_some(),
                 "semantic router references a missing or non-embedding embedding_model; \
                  applying on_embedding_failure",
@@ -250,8 +269,8 @@ pub(crate) async fn resolve(
                 snapshot,
                 router,
                 source_ip,
-                semantic.routes[i].target.as_str(),
-                Some(semantic.default.as_str()),
+                &semantic.routes[i].target_ref(snapshot),
+                Some(&default_target),
             )?;
             // `x-aisix-route` reports the route that actually served the
             // request: a winner displaced by its target's gates is a
@@ -260,14 +279,8 @@ pub(crate) async fn resolve(
             (attempt, name)
         }
         None => {
-            let (attempt, _) = select_eligible(
-                state,
-                snapshot,
-                router,
-                source_ip,
-                semantic.default.as_str(),
-                None,
-            )?;
+            let (attempt, _) =
+                select_eligible(state, snapshot, router, source_ip, &default_target, None)?;
             (attempt, None)
         }
     };
@@ -289,9 +302,9 @@ fn fallback(
     source_ip: &str,
     semantic: &Semantic,
 ) -> Result<(Vec<AttemptModel>, Option<String>), ProxyError> {
-    match embedding_failure_target(semantic) {
+    match embedding_failure_target(snapshot, semantic) {
         Some(alias) => {
-            let (attempt, _) = select_eligible(state, snapshot, router, source_ip, alias, None)?;
+            let (attempt, _) = select_eligible(state, snapshot, router, source_ip, &alias, None)?;
             Ok((vec![attempt], None))
         }
         None => Err(ProxyError::ProviderUnavailable),
@@ -479,6 +492,7 @@ pub(crate) async fn embed_texts(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aisix_core::resource::ResourceEntry;
 
     fn semantic(json: &str) -> Semantic {
         serde_json::from_str(json).unwrap()
@@ -559,20 +573,73 @@ mod tests {
 
     #[test]
     fn embedding_failure_target_maps_each_policy() {
+        let snap = AisixSnapshot::default();
         let default_policy = router();
-        assert_eq!(embedding_failure_target(&default_policy), Some("gpt-4o"));
+        assert_eq!(
+            embedding_failure_target(&snap, &default_policy).as_deref(),
+            Some("gpt-4o")
+        );
 
         let fail = semantic(
             r#"{"embedding_model":"e","routes":[{"name":"a","target":"m","examples":["x"]}],
                 "default":"d","match":{"threshold":0.5},"on_embedding_failure":"fail"}"#,
         );
-        assert_eq!(embedding_failure_target(&fail), None);
+        assert!(embedding_failure_target(&snap, &fail).is_none());
 
         let target = semantic(
             r#"{"embedding_model":"e","routes":[{"name":"a","target":"m","examples":["x"]}],
                 "default":"d","match":{"threshold":0.5},"on_embedding_failure":{"target":"safe"}}"#,
         );
-        assert_eq!(embedding_failure_target(&target), Some("safe"));
+        assert_eq!(
+            embedding_failure_target(&snap, &target).as_deref(),
+            Some("safe")
+        );
+    }
+
+    /// The id spelling decides at both `on_embedding_failure` shapes, and
+    /// resolves against the live table — so a rename of the fallback model
+    /// needs no edit to the router.
+    #[test]
+    fn embedding_failure_target_follows_the_id_spelling() {
+        let snap = AisixSnapshot::default();
+        snap.models.insert(ResourceEntry::new(
+            "m-safe",
+            serde_json::from_str::<Model>(
+                r#"{"display_name":"safe-v2","provider":"openai","model_name":"gpt-4o",
+                    "provider_key_id":"11111111-1111-1111-1111-111111111111"}"#,
+            )
+            .unwrap(),
+            1,
+        ));
+
+        let explicit = semantic(
+            r#"{"embedding_model":"e","routes":[{"name":"a","target":"m","examples":["x"]}],
+                "default":"d","match":{"threshold":0.5},
+                "on_embedding_failure":{"target":"stale","target_id":"m-safe"}}"#,
+        );
+        assert_eq!(
+            embedding_failure_target(&snap, &explicit).as_deref(),
+            Some("safe-v2")
+        );
+
+        let by_default = semantic(
+            r#"{"embedding_model":"e","routes":[{"name":"a","target":"m","examples":["x"]}],
+                "default":"stale","default_id":"m-safe","match":{"threshold":0.5}}"#,
+        );
+        assert_eq!(
+            embedding_failure_target(&snap, &by_default).as_deref(),
+            Some("safe-v2")
+        );
+
+        // An id that resolves to nothing stands in as its own name, which
+        // dispatches nowhere — what a dangling alias already does.
+        let dangling = semantic(
+            r#"{"embedding_model":"e","routes":[{"name":"a","target":"m","examples":["x"]}],
+                "default":"d","default_id":"m-gone","match":{"threshold":0.5}}"#,
+        );
+        let resolved = embedding_failure_target(&snap, &dangling).unwrap();
+        assert_eq!(resolved, "m-gone");
+        assert!(snap.models.get_by_name(&resolved).is_none());
     }
 
     #[test]

--- a/crates/aisix-proxy/src/semantic.rs
+++ b/crates/aisix-proxy/src/semantic.rs
@@ -152,14 +152,15 @@ pub(crate) async fn resolve(
         .expect("resolve called on a non-semantic model");
     let router = &router_entry.value;
 
+    // Every alias this function dispatches to is read through the model
+    // reference helpers: a router that names its targets by id keeps
+    // working across a rename of any of them, and an id that resolves to
+    // nothing behaves as the dangling alias it stands in for.
+    let default_target = semantic.default_ref(snapshot);
+
     // No user text to classify (e.g. a system-only or tool-only request):
     // route to `default` without an embedding call rather than embedding an
     // empty string, which could spuriously match a route.
-    // Every alias below is resolved through the model reference helpers:
-    // a router that names its targets by id keeps working across a rename
-    // of any of them, and an id that resolves to nothing behaves as the
-    // dangling alias it stands in for.
-    let default_target = semantic.default_ref(snapshot);
     if prompt.trim().is_empty() {
         let (attempt, _) =
             select_eligible(state, snapshot, router, source_ip, &default_target, None)?;

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -134,7 +134,10 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
             |m| m.display_name.clone(),
             "models",
             &mut diag,
-            |doc, identity, diag| resugar_provider_key(doc, identity, &provider_key_names, diag),
+            |doc, identity, diag| {
+                resugar_provider_key(doc, identity, &provider_key_names, diag);
+                resugar_model_refs(doc, "models", "model", identity, &model_names, diag);
+            },
             |_, _| {},
         ),
     );
@@ -172,7 +175,9 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
         |g| g.name.clone(),
         "guardrails",
         &mut diag,
-        |_, _, _| {},
+        |doc, identity, diag| {
+            resugar_model_refs(doc, "guardrails", "guardrail", identity, &model_names, diag)
+        },
         |doc, identity| {
             let mut ctx = RedactionCtx {
                 kind_token: "GUARDRAIL",
@@ -255,7 +260,17 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
             |c| c.name.clone(),
             "cache_policies",
             &mut diag,
-            |doc, identity, diag| resugar_cache_applies_to(doc, identity, &api_key_names, diag),
+            |doc, identity, diag| {
+                resugar_cache_applies_to(doc, identity, &api_key_names, diag);
+                resugar_model_refs(
+                    doc,
+                    "cache_policies",
+                    "cache policy",
+                    identity,
+                    &model_names,
+                    diag,
+                );
+            },
             |_, _| {},
         ),
     );
@@ -686,6 +701,70 @@ fn resugar_allowed_models(
         }
     }
     map.insert("allowed_models".into(), Value::Array(names));
+}
+
+/// Every id-form model reference in `doc` → its name-form spelling.
+///
+/// The id form is a control-plane projection: it names a model by the id
+/// the control plane assigned it, and a file's ids are derived from its
+/// entry names, so the export resolves each id to the identity the models
+/// collection is keyed by and emits the name the document already has a
+/// field for. The fields and the places they can appear come from
+/// `aisix_core::filesource`, the same pair of tables the file source
+/// refuses them by, so the two cannot drift.
+///
+/// An id naming no exported model is emitted as the name form carrying the
+/// raw id, which is exactly how the gateway already treats it — the id
+/// stands in as a name that resolves to nothing. That keeps the export
+/// honest about a reference that was already dangling instead of inventing
+/// or silently dropping one. It is blocking for a model, whose targets the
+/// loader cross-checks (the file will not load until it is fixed), and a
+/// warning where the loader does not (the reference is simply inert, as it
+/// already was).
+fn resugar_model_refs(
+    doc: &mut Value,
+    kind: &'static str,
+    label: &str,
+    identity: &str,
+    model_names: &BTreeMap<String, String>,
+    diag: &mut Diagnostics,
+) {
+    let fields = aisix_core::filesource::model_ref_id_fields(kind);
+    let mut blocking: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+    aisix_core::filesource::for_each_model_ref_node(kind, doc, &mut |node| {
+        for (id_field, name_field) in fields {
+            let Some(Value::String(id)) = node.remove(*id_field) else {
+                continue;
+            };
+            let resolved = model_names.get(&id).cloned();
+            if resolved.is_none() {
+                let message = format!(
+                    "{label} {identity:?} references model id {id:?} in `{id_field}`, which is \
+                     not among the exported models — emitted under `{name_field}` as a name \
+                     that resolves to nothing (dangling reference in the source data)"
+                );
+                if kind == "models" {
+                    blocking.push(message);
+                } else {
+                    warnings.push(message);
+                }
+            }
+            let name = resolved.unwrap_or(id);
+            // A cache policy's model scope folds into the free-form
+            // `applies_to` string rather than a field of its own, and
+            // overrides whatever that string held — the same precedence
+            // the gateway applies.
+            let value = if *id_field == "applies_to_model_id" {
+                format!("model:{name}")
+            } else {
+                name
+            };
+            node.insert((*name_field).to_string(), Value::String(value));
+        }
+    });
+    diag.blocking.extend(blocking);
+    diag.warnings.extend(warnings);
 }
 
 /// `claim_mapping.resolve.api_key_id` (etcd id) → `resolve.api_key`

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -734,9 +734,15 @@ fn resugar_model_refs(
     let mut warnings: Vec<String> = Vec::new();
     aisix_core::filesource::for_each_model_ref_node(kind, doc, &mut |node| {
         for (id_field, name_field) in fields {
-            let Some(Value::String(id)) = node.remove(*id_field) else {
+            // Only a STRING id is rewritten here. `api_keys` carries an
+            // array of them and has its own resugar
+            // (`resugar_allowed_models`), so leaving a non-string in
+            // place is what keeps the two from colliding if this ever
+            // gains that kind.
+            let Some(Value::String(id)) = node.get(*id_field).cloned() else {
                 continue;
             };
+            node.remove(*id_field);
             let resolved = model_names.get(&id).cloned();
             if resolved.is_none() {
                 let message = format!(

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -733,16 +733,17 @@ fn resugar_model_refs(
     let mut blocking: Vec<String> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
     aisix_core::filesource::for_each_model_ref_node(kind, doc, &mut |node| {
-        for (id_field, name_field) in fields {
+        for reference in fields {
+            let (id_field, name_field) = (reference.field, reference.name_field);
             // Only a STRING id is rewritten here. `api_keys` carries an
             // array of them and has its own resugar
             // (`resugar_allowed_models`), so leaving a non-string in
             // place is what keeps the two from colliding if this ever
             // gains that kind.
-            let Some(Value::String(id)) = node.get(*id_field).cloned() else {
+            let Some(Value::String(id)) = node.get(id_field).cloned() else {
                 continue;
             };
-            node.remove(*id_field);
+            node.remove(id_field);
             let resolved = model_names.get(&id).cloned();
             if resolved.is_none() {
                 let message = format!(
@@ -761,12 +762,12 @@ fn resugar_model_refs(
             // `applies_to` string rather than a field of its own, and
             // overrides whatever that string held — the same precedence
             // the gateway applies.
-            let value = if *id_field == "applies_to_model_id" {
+            let value = if id_field == "applies_to_model_id" {
                 format!("model:{name}")
             } else {
                 name
             };
-            node.insert((*name_field).to_string(), Value::String(value));
+            node.insert(name_field.to_string(), Value::String(value));
         }
     });
     diag.blocking.extend(blocking);

--- a/crates/aisix-server/src/export/document_tests.rs
+++ b/crates/aisix-server/src/export/document_tests.rs
@@ -764,3 +764,219 @@ fn api_key_empty_allowed_model_ids_export_as_no_grant() {
     // must not resurrect the ignored `allowed_models: ["*"]`.
     assert_eq!(keys[0]["allowed_models"], json!([]));
 }
+
+/// Every id-form model reference in a model document leaves the export as
+/// the name form the resources file accepts — the file refuses the id
+/// form outright, so an export that kept it would not reload.
+#[test]
+fn model_reference_ids_resugar_to_names() {
+    let snap = AisixSnapshot::new();
+    snap.provider_keys
+        .insert(ResourceEntry::new("pk-1", provider_key("pk", "sk-x"), 1));
+    for (id, name) in [("m-a", "alpha"), ("m-b", "beta"), ("m-c", "gamma")] {
+        snap.models.insert(ResourceEntry::new(
+            id,
+            model_value(json!({
+                "display_name": name,
+                "provider": "openai",
+                "model_name": "gpt-4o",
+                "provider_key_id": "pk-1"
+            })),
+            1,
+        ));
+    }
+    snap.models.insert(ResourceEntry::new(
+        "m-embed",
+        model_value(json!({
+            "display_name": "embedder",
+            "provider": "openai",
+            "model_name": "text-embedding-3-small",
+            "provider_key_id": "pk-1",
+            "embedding": {"dimensions": 4}
+        })),
+        1,
+    ));
+    snap.models.insert(ResourceEntry::new(
+        "m-group",
+        model_value(json!({
+            "display_name": "group",
+            "routing": {"targets": [{"model_id": "m-a"}, {"model": "beta"}]}
+        })),
+        1,
+    ));
+    snap.models.insert(ResourceEntry::new(
+        "m-panel",
+        model_value(json!({
+            "display_name": "panel",
+            "ensemble": {
+                "panel": [{"model_id": "m-a"}, {"model_id": "m-b"}],
+                "judge": {"model_id": "m-c"}
+            }
+        })),
+        1,
+    ));
+    snap.models.insert(ResourceEntry::new(
+        "m-router",
+        model_value(json!({
+            "display_name": "router",
+            "semantic": {
+                "embedding_model_id": "m-embed",
+                "routes": [{"name": "r", "target_id": "m-a", "examples": ["hi"]}],
+                "default_id": "m-b",
+                "match": {"threshold": 0.5},
+                "on_embedding_failure": {"target_id": "m-c"}
+            }
+        })),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    let by_name = |name: &str| -> Value {
+        find(&doc, "models")
+            .iter()
+            .find(|m| m["display_name"] == json!(name))
+            .cloned()
+            .unwrap_or_else(|| panic!("{name} exported"))
+    };
+
+    let group = by_name("group");
+    assert_eq!(group["routing"]["targets"][0]["model"], json!("alpha"));
+    assert!(group["routing"]["targets"][0].get("model_id").is_none());
+    assert_eq!(group["routing"]["targets"][1]["model"], json!("beta"));
+
+    let panel = by_name("panel");
+    assert_eq!(panel["ensemble"]["panel"][0]["model"], json!("alpha"));
+    assert_eq!(panel["ensemble"]["panel"][1]["model"], json!("beta"));
+    assert_eq!(panel["ensemble"]["judge"]["model"], json!("gamma"));
+    assert!(panel["ensemble"]["judge"].get("model_id").is_none());
+
+    let router = by_name("router");
+    assert_eq!(router["semantic"]["embedding_model"], json!("embedder"));
+    assert_eq!(router["semantic"]["routes"][0]["target"], json!("alpha"));
+    assert_eq!(router["semantic"]["default"], json!("beta"));
+    assert_eq!(
+        router["semantic"]["on_embedding_failure"]["target"],
+        json!("gamma")
+    );
+    assert!(router["semantic"].get("embedding_model_id").is_none());
+    assert!(router["semantic"].get("default_id").is_none());
+
+    assert!(doc.blocking.is_empty(), "{:?}", doc.blocking);
+}
+
+/// An id no exported model answers to is emitted under the name field as
+/// itself — the same dangling reference the gateway already sees. For a
+/// model the loader cross-checks it, so it is blocking.
+#[test]
+fn dangling_model_reference_id_is_emitted_as_a_name_and_blocking() {
+    let snap = AisixSnapshot::new();
+    snap.models.insert(ResourceEntry::new(
+        "m-group",
+        model_value(json!({
+            "display_name": "group",
+            "routing": {"targets": [{"model_id": "m-gone"}]}
+        })),
+        1,
+    ));
+    let doc = build_export_document(&snap, false);
+    let group = &find(&doc, "models")[0];
+    assert_eq!(group["routing"]["targets"][0]["model"], json!("m-gone"));
+    assert!(group["routing"]["targets"][0].get("model_id").is_none());
+    assert!(
+        doc.blocking
+            .iter()
+            .any(|b| b.contains("dangling") && b.contains("m-gone")),
+        "{:?}",
+        doc.blocking
+    );
+}
+
+/// A cache policy's model scope collapses into the `applies_to` string the
+/// file understands, overriding whatever that string held — the same
+/// precedence the gateway applies.
+#[test]
+fn cache_policy_model_scope_id_resugars_into_applies_to() {
+    let snap = AisixSnapshot::new();
+    snap.provider_keys
+        .insert(ResourceEntry::new("pk-1", provider_key("pk", "sk-x"), 1));
+    snap.models.insert(ResourceEntry::new(
+        "m-embed",
+        model_value(json!({
+            "display_name": "embedder",
+            "provider": "openai",
+            "model_name": "text-embedding-3-small",
+            "provider_key_id": "pk-1",
+            "embedding": {"dimensions": 4}
+        })),
+        1,
+    ));
+    let policy: aisix_core::models::CachePolicy = serde_json::from_value(json!({
+        "name": "faq",
+        "applies_to": "all",
+        "applies_to_model_id": "m-embed",
+        "semantic": {"embedding_model_id": "m-embed", "threshold": 0.9}
+    }))
+    .unwrap();
+    snap.cache_policies
+        .insert(ResourceEntry::new("cp-1", policy, 1));
+
+    let doc = build_export_document(&snap, false);
+    let exported = &find(&doc, "cache_policies")[0];
+    assert_eq!(exported["applies_to"], json!("model:embedder"));
+    assert!(exported.get("applies_to_model_id").is_none());
+    assert_eq!(exported["semantic"]["embedding_model"], json!("embedder"));
+    assert!(exported["semantic"].get("embedding_model_id").is_none());
+}
+
+/// A semantic guardrail's embedder id becomes the name form. The loader
+/// does not cross-check it, so a dangling one is a warning and the file
+/// still loads (screening then refuses, fail-closed, as it already did).
+#[test]
+fn guardrail_embedder_id_resugars_to_a_name() {
+    let snap = AisixSnapshot::new();
+    snap.provider_keys
+        .insert(ResourceEntry::new("pk-1", provider_key("pk", "sk-x"), 1));
+    snap.models.insert(ResourceEntry::new(
+        "m-embed",
+        model_value(json!({
+            "display_name": "embedder",
+            "provider": "openai",
+            "model_name": "text-embedding-3-small",
+            "provider_key_id": "pk-1",
+            "embedding": {"dimensions": 4}
+        })),
+        1,
+    ));
+    let row = |name: &str, id: &str| -> aisix_core::models::Guardrail {
+        serde_json::from_value(json!({
+            "name": name,
+            "kind": "semantic",
+            "embedding_model_id": id,
+            "deny_examples": ["x"],
+            "deny_threshold": 0.8
+        }))
+        .unwrap()
+    };
+    snap.guardrails
+        .insert(ResourceEntry::new("g-1", row("resolved", "m-embed"), 1));
+    snap.guardrails
+        .insert(ResourceEntry::new("g-2", row("dangling", "m-gone"), 1));
+
+    let doc = build_export_document(&snap, false);
+    let by_name = |name: &str| -> Value {
+        find(&doc, "guardrails")
+            .iter()
+            .find(|g| g["name"] == json!(name))
+            .cloned()
+            .unwrap_or_else(|| panic!("{name} exported"))
+    };
+    assert_eq!(by_name("resolved")["embedding_model"], json!("embedder"));
+    assert!(by_name("resolved").get("embedding_model_id").is_none());
+    assert_eq!(by_name("dangling")["embedding_model"], json!("m-gone"));
+    assert!(doc.blocking.is_empty(), "{:?}", doc.blocking);
+    assert!(
+        doc.warnings.iter().any(|w| w.contains("m-gone")),
+        "{:?}",
+        doc.warnings
+    );
+}

--- a/crates/aisix-server/src/export/document_tests.rs
+++ b/crates/aisix-server/src/export/document_tests.rs
@@ -528,6 +528,19 @@ fn export_output_reloads_through_the_real_file_loader() {
         serde_json::from_value(attachment("g-1", "env", None)).unwrap(),
         1,
     ));
+    // A routing group whose target is named by RESOURCE ID — the form a
+    // control plane writes and the resources file refuses outright. The
+    // export has to hand back the name spelling or this file does not
+    // load at all: the loader cross-checks every routing target against
+    // the models it defines, and a raw etcd id matches none of them.
+    snap.models.insert(ResourceEntry::new(
+        "m-group",
+        model_value(json!({
+            "display_name": "group",
+            "routing": {"strategy": "failover", "targets": [{"model_id": "m-1"}]}
+        })),
+        1,
+    ));
     // A claim mapping whose `resolve.api_key_id` must resugar to the
     // key's (synthetic) file name and re-resolve on load — plus the key
     // and trust provider it references, so the loader's cross-checks
@@ -578,13 +591,25 @@ fn export_output_reloads_through_the_real_file_loader() {
     // Same resource set, and the reference resugared then re-resolved to
     // the same derived id the loader assigns.
     assert_eq!(loaded.provider_keys.len(), 1);
-    assert_eq!(loaded.models.len(), 1);
+    assert_eq!(loaded.models.len(), 2);
     assert_eq!(loaded.guardrails.len(), 1);
     let model = loaded.models.get_by_name("gpt-4o").unwrap();
     assert_eq!(
         model.value.provider_key_id.as_deref(),
         Some(derive_id("provider_keys", "openai-prod").as_str())
     );
+    // The id-named routing target came back as the name the file keys
+    // its models by. Reaching this line at all is most of the assertion:
+    // the load above would have failed had the id been emitted raw.
+    let group = loaded.models.get_by_name("group").unwrap();
+    assert_eq!(
+        group.value.routing.as_ref().unwrap().targets[0].model,
+        "gpt-4o"
+    );
+    assert!(group.value.routing.as_ref().unwrap().targets[0]
+        .model_id
+        .is_none());
+
     // The `${jndi:ldap}` literal came back byte-for-byte — not
     // interpolated, not corrupted.
     let guardrail = loaded.guardrails.get_by_name("log4shell").unwrap();

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -113,7 +113,7 @@ so a consumer that models the lenient set as "the strict set with
 | resource | additionally relaxed on read |
 | --- | --- |
 | `api_key` | `McpAccess.allow` is not required |
-| `guardrail` | the `semantic` kind requires neither `embedding_model` nor a threshold beside each example list |
+| `guardrail` | the `semantic` kind requires neither an embedding model (under either spelling) nor a threshold beside each example list |
 | `mcp_policy` | `allow` is not required |
 | `model` | the per-kind `not`/`anyOf` lists that forbid a knob a kind never resolves are shorter — a stored row keeps loading and `Model::strip_kind_inapplicable` drops the dead knob |
 

--- a/schemas/resources-lenient/cache_policy.schema.json
+++ b/schemas/resources-lenient/cache_policy.schema.json
@@ -29,10 +29,31 @@
       ]
     },
     "SemanticCacheConfig": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "embedding_model"
+              ]
+            },
+            {
+              "required": [
+                "embedding_model_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "Embedding-similarity matching for a cache policy. When present, a request that misses the exact layer is embedded and compared against stored entries; the nearest entry at or above `threshold` cosine similarity is served. Only requests whose messages are entirely text participate — requests containing images or audio never match by similarity.\n\nOn `backend: redis`, similarity matching requires a Redis server with vector search (Redis 8 or later, or the search module) in `single` or `sentinel` mode; without it — or in `cluster` mode — the policy keeps serving exact matches only and a warning is logged.",
       "properties": {
         "embedding_model": {
-          "description": "Name of the `embedding` model used to embed requests. The model must exist in the same environment and carry an `embedding` block; its `dimensions` value fixes the vector size for this policy's entries.",
+          "description": "Name of the `embedding` model used to embed requests. The model must exist in the same environment and carry an `embedding` block; its `dimensions` value fixes the vector size for this policy's entries. Read only when `embedding_model_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "embedding_model_id": {
+          "description": "Resource id of the `embedding` model used to embed requests. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this policy pointing at it with no edit to this document. An id resolving to no model leaves similarity matching off for the policy, exactly as an `embedding_model` naming no model does.",
           "minLength": 1,
           "type": "string"
         },
@@ -59,7 +80,6 @@
         }
       },
       "required": [
-        "embedding_model",
         "threshold"
       ],
       "type": "object"
@@ -69,8 +89,13 @@
   "properties": {
     "applies_to": {
       "default": "all",
-      "description": "Free-form scope. Supports `\"all\"`, `\"model:<name>\"`, and `\"api_key:<id>\"`. See `parsed_applies_to`.",
+      "description": "Free-form scope. Supports `\"all\"`, `\"model:<name>\"`, and `\"api_key:<id>\"`. Read only when `applies_to_model_id` is absent. See `parsed_applies_to`.",
       "maxLength": 255,
+      "minLength": 1,
+      "type": "string"
+    },
+    "applies_to_model_id": {
+      "description": "Scopes the policy to one model, named by resource id. Present, it is authoritative and `applies_to` is ignored entirely — the policy applies to the model this id resolves to and to nothing else. The id is resolved against the models in the current configuration, so renaming that model keeps the policy scoped to it with no edit to this document. An id resolving to no model makes the policy match nothing, exactly as `\"model:<name>\"` naming no model does.",
       "minLength": 1,
       "type": "string"
     },

--- a/schemas/resources-lenient/cache_policy.schema.json
+++ b/schemas/resources-lenient/cache_policy.schema.json
@@ -33,11 +33,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "embedding_model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "embedding_model"
               ]
             },
             {
+              "properties": {
+                "embedding_model_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "embedding_model_id"
               ]
@@ -55,7 +65,10 @@
         "embedding_model_id": {
           "description": "Resource id of the `embedding` model used to embed requests. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this policy pointing at it with no edit to this document. An id resolving to no model leaves similarity matching off for the policy, exactly as an `embedding_model` naming no model does.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "embedding_timeout_ms": {
           "description": "Per-call deadline for the embedding request in milliseconds. `0` or absent disables the embedding-specific deadline. On timeout the request proceeds to the upstream uncached.",
@@ -97,7 +110,10 @@
     "applies_to_model_id": {
       "description": "Scopes the policy to one model, named by resource id. Present, it is authoritative and `applies_to` is ignored entirely — the policy applies to the model this id resolves to and to nothing else. The id is resolved against the models in the current configuration, so renaming that model keeps the policy scoped to it with no edit to this document. An id resolving to no model makes the policy match nothing, exactly as `\"model:<name>\"` naming no model does.",
       "minLength": 1,
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "backend": {
       "allOf": [

--- a/schemas/resources-lenient/ensemble.schema.json
+++ b/schemas/resources-lenient/ensemble.schema.json
@@ -2,6 +2,32 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Judge": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "The judge model that synthesizes the panel responses into one answer. The judge model is named either by `model` (its display name) or by `model_id` (its resource id); the judge must carry at least one of the two.",
       "properties": {
         "model": {
@@ -29,6 +55,32 @@
       "type": "object"
     },
     "PanelMember": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "One member of an ensemble panel. The member model is named either by `model` (its display name) or by `model_id` (its resource id); a member must carry at least one of the two.",
       "properties": {
         "model": {

--- a/schemas/resources-lenient/ensemble.schema.json
+++ b/schemas/resources-lenient/ensemble.schema.json
@@ -2,12 +2,20 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Judge": {
-      "description": "The judge model that synthesizes the panel responses into one answer. `model` references a direct model alias.",
+      "description": "The judge model that synthesizes the panel responses into one answer. The judge model is named either by `model` (its display name) or by `model_id` (its resource id); the judge must carry at least one of the two.",
       "properties": {
         "model": {
-          "description": "Model alias for the direct model that synthesizes panel responses.",
+          "description": "Model alias for the direct model that synthesizes panel responses. Read only when `model_id` is absent.",
           "minLength": 1,
           "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that synthesizes panel responses. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps the judge pointing at it with no edit to this document. An id resolving to no model is a judge that does not exist, exactly as a `model` naming no model is.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "synthesis_prompt": {
           "description": "Override for the built-in synthesis prompt template.",
@@ -18,18 +26,23 @@
           ]
         }
       },
-      "required": [
-        "model"
-      ],
       "type": "object"
     },
     "PanelMember": {
-      "description": "One member of an ensemble panel. `model` references a direct model alias.",
+      "description": "One member of an ensemble panel. The member model is named either by `model` (its display name) or by `model_id` (its resource id); a member must carry at least one of the two.",
       "properties": {
         "model": {
-          "description": "Model alias for a direct model that receives one panel request.",
+          "description": "Model alias for a direct model that receives one panel request. Read only when `model_id` is absent.",
           "minLength": 1,
           "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that receives one panel request. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this member pointing at it with no edit to this document. An id resolving to no model is a panel member that does not exist, exactly as a `model` naming no model is.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "seed": {
           "description": "Sampling seed for this panel member.",
@@ -59,9 +72,6 @@
           ]
         }
       },
-      "required": [
-        "model"
-      ],
       "type": "object"
     }
   },

--- a/schemas/resources-lenient/guardrail.schema.json
+++ b/schemas/resources-lenient/guardrail.schema.json
@@ -1412,7 +1412,10 @@
         "embedding_model_id": {
           "description": "Resource id of the `embedding`-kind Model used to embed both the examples and the screened text. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this row screening with it and needs no edit here. An id resolving to no model is an embedder that cannot be resolved, exactly as an `embedding_model` naming no model is — the row degrades per `fail_open`, fail-closed by default.\n\nDefaulted at the type level for the same reason `embedding_model` is: the strict write schema requires one of the two, the read path requires neither, and a screening row that fails to load is fail-OPEN.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "enabled": {
           "default": true,

--- a/schemas/resources-lenient/guardrail.schema.json
+++ b/schemas/resources-lenient/guardrail.schema.json
@@ -1409,6 +1409,11 @@
           "minLength": 1,
           "type": "string"
         },
+        "embedding_model_id": {
+          "description": "Resource id of the `embedding`-kind Model used to embed both the examples and the screened text. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this row screening with it and needs no edit here. An id resolving to no model is an embedder that cannot be resolved, exactly as an `embedding_model` naming no model is — the row degrades per `fail_open`, fail-closed by default.\n\nDefaulted at the type level for the same reason `embedding_model` is: the strict write schema requires one of the two, the read path requires neither, and a screening row that fails to load is fail-OPEN.",
+          "minLength": 1,
+          "type": "string"
+        },
         "enabled": {
           "default": true,
           "description": "When false, the chain skips this rule entirely. Allows operators to stage a rule before enabling it.",

--- a/schemas/resources-lenient/model.schema.json
+++ b/schemas/resources-lenient/model.schema.json
@@ -290,11 +290,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model"
               ]
             },
             {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model_id"
               ]
@@ -312,7 +322,10 @@
         "model_id": {
           "description": "Resource id of the direct model that synthesizes panel responses. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps the judge pointing at it with no edit to this document. An id resolving to no model is a judge that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "synthesis_prompt": {
           "description": "Override for the built-in synthesis prompt template.",
@@ -359,11 +372,24 @@
             {
               "anyOf": [
                 {
+                  "properties": {
+                    "target": {
+                      "type": "string"
+                    }
+                  },
                   "required": [
                     "target"
                   ]
                 },
                 {
+                  "properties": {
+                    "target_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
                   "required": [
                     "target_id"
                   ]
@@ -381,7 +407,10 @@
             "target_id": {
               "description": "Resource id of the direct model to route to when embedding fails. Present, it is authoritative and `target` is ignored, so renaming that model keeps this fallback pointing at it with no edit to this document.",
               "minLength": 1,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -394,11 +423,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model"
               ]
             },
             {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model_id"
               ]
@@ -416,7 +455,10 @@
         "model_id": {
           "description": "Resource id of the direct model that receives one panel request. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this member pointing at it with no edit to this document. An id resolving to no model is a panel member that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "seed": {
           "description": "Sampling seed for this panel member.",
@@ -604,11 +646,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model"
               ]
             },
             {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model_id"
               ]
@@ -626,7 +678,10 @@
         "model_id": {
           "description": "Resource id of the direct model that can receive routed traffic. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration and the name it resolves to is the target, so renaming that model keeps this target pointing at it with no edit to this document. An id resolving to no model is a target that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "priority": {
           "description": "Priority tier, default `0`; a higher value is preferred (the APISIX node-priority convention — give backup targets `-1`). The strategy orders targets within each tier; a lower tier is only tried when every higher-tier target failed or is unavailable.",
@@ -655,11 +710,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "embedding_model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "embedding_model"
               ]
             },
             {
+              "properties": {
+                "embedding_model_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "embedding_model_id"
               ]
@@ -669,11 +734,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "default": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "default"
               ]
             },
             {
+              "properties": {
+                "default_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "default_id"
               ]
@@ -691,7 +766,10 @@
         "default_id": {
           "description": "Resource id of the direct model used when no route clears its threshold. Present, it is authoritative and `default` is ignored, so renaming that model keeps this router pointing at it with no edit to this document.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "embedding_model": {
           "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples. Read only when `embedding_model_id` is absent.",
@@ -701,7 +779,10 @@
         "embedding_model_id": {
           "description": "Resource id of the `embedding`-modality Model used to embed the request and the route examples. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this router pointing at it with no edit to this document. An id resolving to no model is an embedding model that does not exist, exactly as an `embedding_model` naming no model is — the router applies `on_embedding_failure`.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "embedding_timeout_ms": {
           "description": "Per-call deadline for the embedding request in milliseconds. `0` or absent disables the embedding-specific deadline.",
@@ -779,11 +860,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "target": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "target"
               ]
             },
             {
+              "properties": {
+                "target_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "target_id"
               ]
@@ -820,7 +911,10 @@
         "target_id": {
           "description": "Resource id of the direct model that receives traffic matching this route. Present, it is authoritative and `target` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this route pointing at it with no edit to this document. An id resolving to no model is a route target that does not exist, exactly as a `target` naming no model is.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "threshold": {
           "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level threshold applies.",

--- a/schemas/resources-lenient/model.schema.json
+++ b/schemas/resources-lenient/model.schema.json
@@ -286,10 +286,31 @@
       ]
     },
     "Judge": {
-      "description": "The judge model that synthesizes the panel responses into one answer. `model` references a direct model alias.",
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "The judge model that synthesizes the panel responses into one answer. The judge model is named either by `model` (its display name) or by `model_id` (its resource id); the judge must carry at least one of the two.",
       "properties": {
         "model": {
-          "description": "Model alias for the direct model that synthesizes panel responses.",
+          "description": "Model alias for the direct model that synthesizes panel responses. Read only when `model_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that synthesizes panel responses. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps the judge pointing at it with no edit to this document. An id resolving to no model is a judge that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
           "type": "string"
         },
@@ -299,9 +320,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "model"
-      ],
       "type": "object"
     },
     "ModelCost": {
@@ -337,27 +355,66 @@
           "description": "`\"default\"` or `\"fail\"`."
         },
         {
-          "description": "`{ \"target\": \"<direct alias>\" }` — route to a specific safe model.",
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "target"
+                  ]
+                },
+                {
+                  "required": [
+                    "target_id"
+                  ]
+                }
+              ]
+            }
+          ],
+          "description": "`{ \"target\": \"<direct alias>\" }` (or `{ \"target_id\": \"<id>\" }`) — route to a specific safe model.",
           "properties": {
             "target": {
-              "description": "Direct-model alias to route to when embedding fails.",
+              "description": "Direct-model alias to route to when embedding fails. Read only when `target_id` is absent.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "target_id": {
+              "description": "Resource id of the direct model to route to when embedding fails. Present, it is authoritative and `target` is ignored, so renaming that model keeps this fallback pointing at it with no edit to this document.",
               "minLength": 1,
               "type": "string"
             }
           },
-          "required": [
-            "target"
-          ],
           "type": "object"
         }
       ],
       "description": "What the router does when the embedding call errors or times out. Use `\"default\"` to route to the router's default model, `\"fail\"` to reject the request with `503`, or `{ \"target\": \"<direct alias>\" }` to route to a specific fallback model."
     },
     "PanelMember": {
-      "description": "One member of an ensemble panel. `model` references a direct model alias.",
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "One member of an ensemble panel. The member model is named either by `model` (its display name) or by `model_id` (its resource id); a member must carry at least one of the two.",
       "properties": {
         "model": {
-          "description": "Model alias for a direct model that receives one panel request.",
+          "description": "Model alias for a direct model that receives one panel request. Read only when `model_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that receives one panel request. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this member pointing at it with no edit to this document. An id resolving to no model is a panel member that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
           "type": "string"
         },
@@ -380,9 +437,6 @@
           "type": "integer"
         }
       },
-      "required": [
-        "model"
-      ],
       "type": "object"
     },
     "RateLimit": {
@@ -546,10 +600,31 @@
       ]
     },
     "RoutingTarget": {
-      "description": "One destination in a routing configuration. `model` references a direct model alias.",
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "One destination in a routing configuration. The target model is named either by `model` (its display name) or by `model_id` (its resource id); a target must carry at least one of the two.",
       "properties": {
         "model": {
-          "description": "Model alias for a direct model that can receive routed traffic.",
+          "description": "Model alias for a direct model that can receive routed traffic. Read only when `model_id` is absent.\n\nDefaulted at the type level and required by the schemas instead — as one half of a \"`model` or `model_id`\" alternative, so a target naming its model by id alone validates while one naming it neither way is still rejected.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that can receive routed traffic. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration and the name it resolves to is the target, so renaming that model keeps this target pointing at it with no edit to this document. An id resolving to no model is a target that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
           "type": "string"
         },
@@ -573,21 +648,58 @@
           "type": "integer"
         }
       },
-      "required": [
-        "model"
-      ],
       "type": "object"
     },
     "Semantic": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "embedding_model"
+              ]
+            },
+            {
+              "required": [
+                "embedding_model_id"
+              ]
+            }
+          ]
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "default"
+              ]
+            },
+            {
+              "required": [
+                "default_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "Semantic-routing config: pick a target by request meaning.",
       "properties": {
         "default": {
-          "description": "Direct model alias used when no route clears its threshold.",
+          "description": "Direct model alias used when no route clears its threshold. Read only when `default_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "default_id": {
+          "description": "Resource id of the direct model used when no route clears its threshold. Present, it is authoritative and `default` is ignored, so renaming that model keeps this router pointing at it with no edit to this document.",
           "minLength": 1,
           "type": "string"
         },
         "embedding_model": {
-          "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples.",
+          "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples. Read only when `embedding_model_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "embedding_model_id": {
+          "description": "Resource id of the `embedding`-modality Model used to embed the request and the route examples. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this router pointing at it with no edit to this document. An id resolving to no model is an embedding model that does not exist, exactly as an `embedding_model` naming no model is — the router applies `on_embedding_failure`.",
           "minLength": 1,
           "type": "string"
         },
@@ -623,8 +735,6 @@
         }
       },
       "required": [
-        "default",
-        "embedding_model",
         "match",
         "routes"
       ],
@@ -665,6 +775,22 @@
       "type": "object"
     },
     "SemanticRoute": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "target"
+              ]
+            },
+            {
+              "required": [
+                "target_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "One semantic route: a labeled set of example utterances whose embeddings define the route. A request that scores high enough against them dispatches to `target`.",
       "properties": {
         "description": {
@@ -687,7 +813,12 @@
           "type": "string"
         },
         "target": {
-          "description": "Direct model alias that receives traffic matching this route.",
+          "description": "Direct model alias that receives traffic matching this route. Read only when `target_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "target_id": {
+          "description": "Resource id of the direct model that receives traffic matching this route. Present, it is authoritative and `target` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this route pointing at it with no edit to this document. An id resolving to no model is a route target that does not exist, exactly as a `target` naming no model is.",
           "minLength": 1,
           "type": "string"
         },
@@ -701,8 +832,7 @@
       },
       "required": [
         "examples",
-        "name",
-        "target"
+        "name"
       ],
       "type": "object"
     },

--- a/schemas/resources-lenient/model.schema.json
+++ b/schemas/resources-lenient/model.schema.json
@@ -384,10 +384,7 @@
                 {
                   "properties": {
                     "target_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     }
                   },
                   "required": [

--- a/schemas/resources-lenient/routing.schema.json
+++ b/schemas/resources-lenient/routing.schema.json
@@ -106,6 +106,32 @@
       ]
     },
     "RoutingTarget": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "One destination in a routing configuration. The target model is named either by `model` (its display name) or by `model_id` (its resource id); a target must carry at least one of the two.",
       "properties": {
         "model": {

--- a/schemas/resources-lenient/routing.schema.json
+++ b/schemas/resources-lenient/routing.schema.json
@@ -106,12 +106,20 @@
       ]
     },
     "RoutingTarget": {
-      "description": "One destination in a routing configuration. `model` references a direct model alias.",
+      "description": "One destination in a routing configuration. The target model is named either by `model` (its display name) or by `model_id` (its resource id); a target must carry at least one of the two.",
       "properties": {
         "model": {
-          "description": "Model alias for a direct model that can receive routed traffic.",
+          "description": "Model alias for a direct model that can receive routed traffic. Read only when `model_id` is absent.\n\nDefaulted at the type level and required by the schemas instead — as one half of a \"`model` or `model_id`\" alternative, so a target naming its model by id alone validates while one naming it neither way is still rejected.",
           "minLength": 1,
           "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that can receive routed traffic. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration and the name it resolves to is the target, so renaming that model keeps this target pointing at it with no edit to this document. An id resolving to no model is a target that does not exist, exactly as a `model` naming no model is.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "priority": {
           "description": "Priority tier, default `0`; a higher value is preferred (the APISIX node-priority convention — give backup targets `-1`). The strategy orders targets within each tier; a lower tier is only tried when every higher-tier target failed or is unavailable.",
@@ -142,9 +150,6 @@
           ]
         }
       },
-      "required": [
-        "model"
-      ],
       "type": "object"
     },
     "WhenAllUnavailablePolicy": {

--- a/schemas/resources-lenient/semantic.schema.json
+++ b/schemas/resources-lenient/semantic.schema.json
@@ -1,5 +1,55 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "allOf": [
+    {
+      "anyOf": [
+        {
+          "properties": {
+            "embedding_model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "embedding_model"
+          ]
+        },
+        {
+          "properties": {
+            "embedding_model_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "embedding_model_id"
+          ]
+        }
+      ]
+    },
+    {
+      "anyOf": [
+        {
+          "properties": {
+            "default": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "default"
+          ]
+        },
+        {
+          "properties": {
+            "default_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "default_id"
+          ]
+        }
+      ]
+    }
+  ],
   "definitions": {
     "Aggregation": {
       "description": "How a request's per-example similarity scores collapse into one score for the route. v1 uses `max` (the single best-matching example), chosen for explainability — the UI surfaces \"the top matching example\" — over semantic-router's default sum/mean-over-top_k.",
@@ -111,6 +161,32 @@
       "type": "object"
     },
     "SemanticRoute": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "properties": {
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target"
+              ]
+            },
+            {
+              "properties": {
+                "target_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "One semantic route: a labeled set of example utterances whose embeddings define the route. A request that scores high enough against them dispatches to `target`.",
       "properties": {
         "description": {

--- a/schemas/resources-lenient/semantic.schema.json
+++ b/schemas/resources-lenient/semantic.schema.json
@@ -55,17 +55,22 @@
           "description": "`\"default\"` or `\"fail\"`."
         },
         {
-          "description": "`{ \"target\": \"<direct alias>\" }` — route to a specific safe model.",
+          "description": "`{ \"target\": \"<direct alias>\" }` (or `{ \"target_id\": \"<id>\" }`) — route to a specific safe model.",
           "properties": {
             "target": {
-              "description": "Direct-model alias to route to when embedding fails.",
+              "description": "Direct-model alias to route to when embedding fails. Read only when `target_id` is absent.",
               "minLength": 1,
               "type": "string"
+            },
+            "target_id": {
+              "description": "Resource id of the direct model to route to when embedding fails. Present, it is authoritative and `target` is ignored, so renaming that model keeps this fallback pointing at it with no edit to this document.",
+              "minLength": 1,
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": [
-            "target"
-          ],
           "type": "object"
         }
       ],
@@ -131,9 +136,17 @@
           "type": "string"
         },
         "target": {
-          "description": "Direct model alias that receives traffic matching this route.",
+          "description": "Direct model alias that receives traffic matching this route. Read only when `target_id` is absent.",
           "minLength": 1,
           "type": "string"
+        },
+        "target_id": {
+          "description": "Resource id of the direct model that receives traffic matching this route. Present, it is authoritative and `target` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this route pointing at it with no edit to this document. An id resolving to no model is a route target that does not exist, exactly as a `target` naming no model is.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "threshold": {
           "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level threshold applies.",
@@ -148,8 +161,7 @@
       },
       "required": [
         "examples",
-        "name",
-        "target"
+        "name"
       ],
       "type": "object"
     }
@@ -157,14 +169,30 @@
   "description": "Semantic-routing config: pick a target by request meaning.",
   "properties": {
     "default": {
-      "description": "Direct model alias used when no route clears its threshold.",
+      "description": "Direct model alias used when no route clears its threshold. Read only when `default_id` is absent.",
       "minLength": 1,
       "type": "string"
     },
+    "default_id": {
+      "description": "Resource id of the direct model used when no route clears its threshold. Present, it is authoritative and `default` is ignored, so renaming that model keeps this router pointing at it with no edit to this document.",
+      "minLength": 1,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "embedding_model": {
-      "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples.",
+      "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples. Read only when `embedding_model_id` is absent.",
       "minLength": 1,
       "type": "string"
+    },
+    "embedding_model_id": {
+      "description": "Resource id of the `embedding`-modality Model used to embed the request and the route examples. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this router pointing at it with no edit to this document. An id resolving to no model is an embedding model that does not exist, exactly as an `embedding_model` naming no model is — the router applies `on_embedding_failure`.",
+      "minLength": 1,
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "embedding_timeout_ms": {
       "description": "Per-call deadline for the embedding request in milliseconds. `0` or absent disables the embedding-specific deadline.",
@@ -201,8 +229,6 @@
     }
   },
   "required": [
-    "default",
-    "embedding_model",
     "match",
     "routes"
   ],

--- a/schemas/resources/cache_policy.schema.json
+++ b/schemas/resources/cache_policy.schema.json
@@ -29,10 +29,31 @@
       ]
     },
     "SemanticCacheConfig": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "embedding_model"
+              ]
+            },
+            {
+              "required": [
+                "embedding_model_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "Embedding-similarity matching for a cache policy. When present, a request that misses the exact layer is embedded and compared against stored entries; the nearest entry at or above `threshold` cosine similarity is served. Only requests whose messages are entirely text participate — requests containing images or audio never match by similarity.\n\nOn `backend: redis`, similarity matching requires a Redis server with vector search (Redis 8 or later, or the search module) in `single` or `sentinel` mode; without it — or in `cluster` mode — the policy keeps serving exact matches only and a warning is logged.",
       "properties": {
         "embedding_model": {
-          "description": "Name of the `embedding` model used to embed requests. The model must exist in the same environment and carry an `embedding` block; its `dimensions` value fixes the vector size for this policy's entries.",
+          "description": "Name of the `embedding` model used to embed requests. The model must exist in the same environment and carry an `embedding` block; its `dimensions` value fixes the vector size for this policy's entries. Read only when `embedding_model_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "embedding_model_id": {
+          "description": "Resource id of the `embedding` model used to embed requests. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this policy pointing at it with no edit to this document. An id resolving to no model leaves similarity matching off for the policy, exactly as an `embedding_model` naming no model does.",
           "minLength": 1,
           "type": "string"
         },
@@ -59,7 +80,6 @@
         }
       },
       "required": [
-        "embedding_model",
         "threshold"
       ],
       "type": "object"
@@ -69,8 +89,13 @@
   "properties": {
     "applies_to": {
       "default": "all",
-      "description": "Free-form scope. Supports `\"all\"`, `\"model:<name>\"`, and `\"api_key:<id>\"`. See `parsed_applies_to`.",
+      "description": "Free-form scope. Supports `\"all\"`, `\"model:<name>\"`, and `\"api_key:<id>\"`. Read only when `applies_to_model_id` is absent. See `parsed_applies_to`.",
       "maxLength": 255,
+      "minLength": 1,
+      "type": "string"
+    },
+    "applies_to_model_id": {
+      "description": "Scopes the policy to one model, named by resource id. Present, it is authoritative and `applies_to` is ignored entirely — the policy applies to the model this id resolves to and to nothing else. The id is resolved against the models in the current configuration, so renaming that model keeps the policy scoped to it with no edit to this document. An id resolving to no model makes the policy match nothing, exactly as `\"model:<name>\"` naming no model does.",
       "minLength": 1,
       "type": "string"
     },

--- a/schemas/resources/cache_policy.schema.json
+++ b/schemas/resources/cache_policy.schema.json
@@ -33,11 +33,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "embedding_model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "embedding_model"
               ]
             },
             {
+              "properties": {
+                "embedding_model_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "embedding_model_id"
               ]
@@ -55,7 +65,10 @@
         "embedding_model_id": {
           "description": "Resource id of the `embedding` model used to embed requests. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this policy pointing at it with no edit to this document. An id resolving to no model leaves similarity matching off for the policy, exactly as an `embedding_model` naming no model does.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "embedding_timeout_ms": {
           "description": "Per-call deadline for the embedding request in milliseconds. `0` or absent disables the embedding-specific deadline. On timeout the request proceeds to the upstream uncached.",
@@ -97,7 +110,10 @@
     "applies_to_model_id": {
       "description": "Scopes the policy to one model, named by resource id. Present, it is authoritative and `applies_to` is ignored entirely — the policy applies to the model this id resolves to and to nothing else. The id is resolved against the models in the current configuration, so renaming that model keeps the policy scoped to it with no edit to this document. An id resolving to no model makes the policy match nothing, exactly as `\"model:<name>\"` naming no model does.",
       "minLength": 1,
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "backend": {
       "allOf": [

--- a/schemas/resources/embedding.schema.json
+++ b/schemas/resources/embedding.schema.json
@@ -1,23 +1,23 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "EmbeddingConfig",
+  "additionalProperties": false,
   "description": "Embedding-modality metadata for a direct Model.",
-  "type": "object",
-  "required": [
-    "dimensions"
-  ],
   "properties": {
     "dimensions": {
       "description": "Output vector dimensionality. Used to validate vectors, key the example-vector cache, and (for endpoints that support it) request a reduced output size.",
-      "type": "integer",
       "format": "uint32",
-      "minimum": 1.0
+      "minimum": 1.0,
+      "type": "integer"
     },
     "normalize": {
-      "description": "Whether the endpoint already returns L2-normalized vectors. When `false`, the gateway normalizes before computing cosine similarity. Defaults to `true`.",
       "default": true,
+      "description": "Whether the endpoint already returns L2-normalized vectors. When `false`, the gateway normalizes before computing cosine similarity. Defaults to `true`.",
       "type": "boolean"
     }
   },
-  "additionalProperties": false
+  "required": [
+    "dimensions"
+  ],
+  "title": "EmbeddingConfig",
+  "type": "object"
 }

--- a/schemas/resources/ensemble.schema.json
+++ b/schemas/resources/ensemble.schema.json
@@ -1,123 +1,175 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "EnsembleConfig",
-  "type": "object",
-  "required": [
-    "judge",
-    "panel"
-  ],
+  "additionalProperties": false,
+  "definitions": {
+    "Judge": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "The judge model that synthesizes the panel responses into one answer. The judge model is named either by `model` (its display name) or by `model_id` (its resource id); the judge must carry at least one of the two.",
+      "properties": {
+        "model": {
+          "description": "Model alias for the direct model that synthesizes panel responses. Read only when `model_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that synthesizes panel responses. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps the judge pointing at it with no edit to this document. An id resolving to no model is a judge that does not exist, exactly as a `model` naming no model is.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "synthesis_prompt": {
+          "description": "Override for the built-in synthesis prompt template.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "PanelMember": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "One member of an ensemble panel. The member model is named either by `model` (its display name) or by `model_id` (its resource id); a member must carry at least one of the two.",
+      "properties": {
+        "model": {
+          "description": "Model alias for a direct model that receives one panel request. Read only when `model_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that receives one panel request. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this member pointing at it with no edit to this document. An id resolving to no model is a panel member that does not exist, exactly as a `model` naming no model is.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "seed": {
+          "description": "Sampling seed for this panel member.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "temperature": {
+          "description": "Sampling temperature for this panel member. Omit it to keep the request's temperature.",
+          "format": "float",
+          "minimum": 0.0,
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "weight": {
+          "description": "Reserved for a future voting/quorum strategy. AISIX currently ignores this field.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    }
+  },
   "properties": {
     "judge": {
-      "description": "Direct model that combines successful panel responses.",
       "allOf": [
         {
           "$ref": "#/definitions/Judge"
         }
-      ]
+      ],
+      "description": "Direct model that combines successful panel responses."
     },
     "min_responses": {
       "description": "Minimum successful panel responses required before judge synthesis. When omitted, the gateway requires the smaller of 2 and the panel size.",
+      "format": "uint32",
+      "minimum": 1.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint32",
-      "minimum": 1.0
+      ]
     },
     "panel": {
       "description": "Direct models called concurrently for each ensemble request.",
-      "type": "array",
       "items": {
         "$ref": "#/definitions/PanelMember"
       },
-      "minItems": 1
+      "minItems": 1,
+      "type": "array"
     },
     "timeout_ms": {
       "description": "Per-call upstream deadline applied to each panel member and the judge. Set `0` or omit it to disable the ensemble-level deadline.",
+      "format": "uint64",
+      "minimum": 0.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
+      ]
     }
   },
-  "additionalProperties": false,
-  "definitions": {
-    "Judge": {
-      "description": "The judge model that synthesizes the panel responses into one answer. The judge model is named either by `model` (its display name) or by `model_id` (its resource id); the judge must carry at least one of the two.",
-      "type": "object",
-      "properties": {
-        "model": {
-          "description": "Model alias for the direct model that synthesizes panel responses. Read only when `model_id` is absent.",
-          "type": "string",
-          "minLength": 1
-        },
-        "model_id": {
-          "description": "Resource id of the direct model that synthesizes panel responses. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps the judge pointing at it with no edit to this document. An id resolving to no model is a judge that does not exist, exactly as a `model` naming no model is.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "minLength": 1
-        },
-        "synthesis_prompt": {
-          "description": "Override for the built-in synthesis prompt template.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "minLength": 1
-        }
-      },
-      "additionalProperties": false
-    },
-    "PanelMember": {
-      "description": "One member of an ensemble panel. The member model is named either by `model` (its display name) or by `model_id` (its resource id); a member must carry at least one of the two.",
-      "type": "object",
-      "properties": {
-        "model": {
-          "description": "Model alias for a direct model that receives one panel request. Read only when `model_id` is absent.",
-          "type": "string",
-          "minLength": 1
-        },
-        "model_id": {
-          "description": "Resource id of the direct model that receives one panel request. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this member pointing at it with no edit to this document. An id resolving to no model is a panel member that does not exist, exactly as a `model` naming no model is.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "minLength": 1
-        },
-        "seed": {
-          "description": "Sampling seed for this panel member.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
-        },
-        "temperature": {
-          "description": "Sampling temperature for this panel member. Omit it to keep the request's temperature.",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "float",
-          "minimum": 0.0
-        },
-        "weight": {
-          "description": "Reserved for a future voting/quorum strategy. AISIX currently ignores this field.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint32",
-          "minimum": 0.0
-        }
-      },
-      "additionalProperties": false
-    }
-  }
+  "required": [
+    "judge",
+    "panel"
+  ],
+  "title": "EnsembleConfig",
+  "type": "object"
 }

--- a/schemas/resources/ensemble.schema.json
+++ b/schemas/resources/ensemble.schema.json
@@ -45,15 +45,20 @@
   "additionalProperties": false,
   "definitions": {
     "Judge": {
-      "description": "The judge model that synthesizes the panel responses into one answer. `model` references a direct model alias.",
+      "description": "The judge model that synthesizes the panel responses into one answer. The judge model is named either by `model` (its display name) or by `model_id` (its resource id); the judge must carry at least one of the two.",
       "type": "object",
-      "required": [
-        "model"
-      ],
       "properties": {
         "model": {
-          "description": "Model alias for the direct model that synthesizes panel responses.",
+          "description": "Model alias for the direct model that synthesizes panel responses. Read only when `model_id` is absent.",
           "type": "string",
+          "minLength": 1
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that synthesizes panel responses. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps the judge pointing at it with no edit to this document. An id resolving to no model is a judge that does not exist, exactly as a `model` naming no model is.",
+          "type": [
+            "string",
+            "null"
+          ],
           "minLength": 1
         },
         "synthesis_prompt": {
@@ -68,15 +73,20 @@
       "additionalProperties": false
     },
     "PanelMember": {
-      "description": "One member of an ensemble panel. `model` references a direct model alias.",
+      "description": "One member of an ensemble panel. The member model is named either by `model` (its display name) or by `model_id` (its resource id); a member must carry at least one of the two.",
       "type": "object",
-      "required": [
-        "model"
-      ],
       "properties": {
         "model": {
-          "description": "Model alias for a direct model that receives one panel request.",
+          "description": "Model alias for a direct model that receives one panel request. Read only when `model_id` is absent.",
           "type": "string",
+          "minLength": 1
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that receives one panel request. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this member pointing at it with no edit to this document. An id resolving to no model is a panel member that does not exist, exactly as a `model` naming no model is.",
+          "type": [
+            "string",
+            "null"
+          ],
           "minLength": 1
         },
         "seed": {

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -1414,11 +1414,24 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "embedding_model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "embedding_model"
               ]
             },
             {
+              "properties": {
+                "embedding_model_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
               "required": [
                 "embedding_model_id"
               ]
@@ -1479,7 +1492,10 @@
         "embedding_model_id": {
           "description": "Resource id of the `embedding`-kind Model used to embed both the examples and the screened text. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this row screening with it and needs no edit here. An id resolving to no model is an embedder that cannot be resolved, exactly as an `embedding_model` naming no model is — the row degrades per `fail_open`, fail-closed by default.\n\nDefaulted at the type level for the same reason `embedding_model` is: the strict write schema requires one of the two, the read path requires neither, and a screening row that fails to load is fail-OPEN.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "enabled": {
           "default": true,

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -1410,6 +1410,20 @@
               "allow_threshold"
             ]
           }
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "embedding_model"
+              ]
+            },
+            {
+              "required": [
+                "embedding_model_id"
+              ]
+            }
+          ]
         }
       ],
       "description": "Embedding-similarity screening against operator-supplied example texts. Deny examples block on a close match; an allow-list, when present, blocks everything that matches none of it. Calls an `embedding`-kind Model through the gateway's provider bridges. Detection-only — never rewrites content. Applies on input, output, or both, including buffered streaming output.",
@@ -1459,6 +1473,11 @@
         "embedding_model": {
           "default": "",
           "description": "Alias of an `embedding`-kind Model used to embed both the examples and the screened text. Must resolve in the same environment as this guardrail.\n\nDefaulted at the TYPE level and required by the strict write schema instead: a row the loader cannot deserialize is skipped whole, and a screening row that vanishes is a guardrail that stopped screening. Empty resolves to nothing, so the row degrades per `fail_open` — fail-closed by default — rather than disappearing.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "embedding_model_id": {
+          "description": "Resource id of the `embedding`-kind Model used to embed both the examples and the screened text. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this row screening with it and needs no edit here. An id resolving to no model is an embedder that cannot be resolved, exactly as an `embedding_model` naming no model is — the row degrades per `fail_open`, fail-closed by default.\n\nDefaulted at the type level for the same reason `embedding_model` is: the strict write schema requires one of the two, the read path requires neither, and a screening row that fails to load is fail-OPEN.",
           "minLength": 1,
           "type": "string"
         },
@@ -1545,8 +1564,7 @@
         }
       },
       "required": [
-        "kind",
-        "embedding_model"
+        "kind"
       ],
       "type": "object"
     },

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -1426,10 +1426,7 @@
             {
               "properties": {
                 "embedding_model_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "type": "string"
                 }
               },
               "required": [

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -298,11 +298,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model"
               ]
             },
             {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model_id"
               ]
@@ -320,7 +330,10 @@
         "model_id": {
           "description": "Resource id of the direct model that synthesizes panel responses. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps the judge pointing at it with no edit to this document. An id resolving to no model is a judge that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "synthesis_prompt": {
           "description": "Override for the built-in synthesis prompt template.",
@@ -369,11 +382,24 @@
             {
               "anyOf": [
                 {
+                  "properties": {
+                    "target": {
+                      "type": "string"
+                    }
+                  },
                   "required": [
                     "target"
                   ]
                 },
                 {
+                  "properties": {
+                    "target_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
                   "required": [
                     "target_id"
                   ]
@@ -391,7 +417,10 @@
             "target_id": {
               "description": "Resource id of the direct model to route to when embedding fails. Present, it is authoritative and `target` is ignored, so renaming that model keeps this fallback pointing at it with no edit to this document.",
               "minLength": 1,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -405,11 +434,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model"
               ]
             },
             {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model_id"
               ]
@@ -427,7 +466,10 @@
         "model_id": {
           "description": "Resource id of the direct model that receives one panel request. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this member pointing at it with no edit to this document. An id resolving to no model is a panel member that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "seed": {
           "description": "Sampling seed for this panel member.",
@@ -618,11 +660,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model"
               ]
             },
             {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "model_id"
               ]
@@ -640,7 +692,10 @@
         "model_id": {
           "description": "Resource id of the direct model that can receive routed traffic. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration and the name it resolves to is the target, so renaming that model keeps this target pointing at it with no edit to this document. An id resolving to no model is a target that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "priority": {
           "description": "Priority tier, default `0`; a higher value is preferred (the APISIX node-priority convention — give backup targets `-1`). The strategy orders targets within each tier; a lower tier is only tried when every higher-tier target failed or is unavailable.",
@@ -670,11 +725,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "embedding_model": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "embedding_model"
               ]
             },
             {
+              "properties": {
+                "embedding_model_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "embedding_model_id"
               ]
@@ -684,11 +749,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "default": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "default"
               ]
             },
             {
+              "properties": {
+                "default_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "default_id"
               ]
@@ -706,7 +781,10 @@
         "default_id": {
           "description": "Resource id of the direct model used when no route clears its threshold. Present, it is authoritative and `default` is ignored, so renaming that model keeps this router pointing at it with no edit to this document.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "embedding_model": {
           "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples. Read only when `embedding_model_id` is absent.",
@@ -716,7 +794,10 @@
         "embedding_model_id": {
           "description": "Resource id of the `embedding`-modality Model used to embed the request and the route examples. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this router pointing at it with no edit to this document. An id resolving to no model is an embedding model that does not exist, exactly as an `embedding_model` naming no model is — the router applies `on_embedding_failure`.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "embedding_timeout_ms": {
           "description": "Per-call deadline for the embedding request in milliseconds. `0` or absent disables the embedding-specific deadline.",
@@ -796,11 +877,21 @@
         {
           "anyOf": [
             {
+              "properties": {
+                "target": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "target"
               ]
             },
             {
+              "properties": {
+                "target_id": {
+                  "type": "string"
+                }
+              },
               "required": [
                 "target_id"
               ]
@@ -837,7 +928,10 @@
         "target_id": {
           "description": "Resource id of the direct model that receives traffic matching this route. Present, it is authoritative and `target` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this route pointing at it with no edit to this document. An id resolving to no model is a route target that does not exist, exactly as a `target` naming no model is.",
           "minLength": 1,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "threshold": {
           "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level threshold applies.",

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -394,10 +394,7 @@
                 {
                   "properties": {
                     "target_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     }
                   },
                   "required": [

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -294,10 +294,31 @@
     },
     "Judge": {
       "additionalProperties": false,
-      "description": "The judge model that synthesizes the panel responses into one answer. `model` references a direct model alias.",
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "The judge model that synthesizes the panel responses into one answer. The judge model is named either by `model` (its display name) or by `model_id` (its resource id); the judge must carry at least one of the two.",
       "properties": {
         "model": {
-          "description": "Model alias for the direct model that synthesizes panel responses.",
+          "description": "Model alias for the direct model that synthesizes panel responses. Read only when `model_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that synthesizes panel responses. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps the judge pointing at it with no edit to this document. An id resolving to no model is a judge that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
           "type": "string"
         },
@@ -307,9 +328,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "model"
-      ],
       "type": "object"
     },
     "ModelCost": {
@@ -347,17 +365,35 @@
         },
         {
           "additionalProperties": false,
-          "description": "`{ \"target\": \"<direct alias>\" }` — route to a specific safe model.",
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "target"
+                  ]
+                },
+                {
+                  "required": [
+                    "target_id"
+                  ]
+                }
+              ]
+            }
+          ],
+          "description": "`{ \"target\": \"<direct alias>\" }` (or `{ \"target_id\": \"<id>\" }`) — route to a specific safe model.",
           "properties": {
             "target": {
-              "description": "Direct-model alias to route to when embedding fails.",
+              "description": "Direct-model alias to route to when embedding fails. Read only when `target_id` is absent.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "target_id": {
+              "description": "Resource id of the direct model to route to when embedding fails. Present, it is authoritative and `target` is ignored, so renaming that model keeps this fallback pointing at it with no edit to this document.",
               "minLength": 1,
               "type": "string"
             }
           },
-          "required": [
-            "target"
-          ],
           "type": "object"
         }
       ],
@@ -365,10 +401,31 @@
     },
     "PanelMember": {
       "additionalProperties": false,
-      "description": "One member of an ensemble panel. `model` references a direct model alias.",
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "One member of an ensemble panel. The member model is named either by `model` (its display name) or by `model_id` (its resource id); a member must carry at least one of the two.",
       "properties": {
         "model": {
-          "description": "Model alias for a direct model that receives one panel request.",
+          "description": "Model alias for a direct model that receives one panel request. Read only when `model_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that receives one panel request. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this member pointing at it with no edit to this document. An id resolving to no model is a panel member that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
           "type": "string"
         },
@@ -391,9 +448,6 @@
           "type": "integer"
         }
       },
-      "required": [
-        "model"
-      ],
       "type": "object"
     },
     "RateLimit": {
@@ -560,10 +614,31 @@
     },
     "RoutingTarget": {
       "additionalProperties": false,
-      "description": "One destination in a routing configuration. `model` references a direct model alias.",
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "One destination in a routing configuration. The target model is named either by `model` (its display name) or by `model_id` (its resource id); a target must carry at least one of the two.",
       "properties": {
         "model": {
-          "description": "Model alias for a direct model that can receive routed traffic.",
+          "description": "Model alias for a direct model that can receive routed traffic. Read only when `model_id` is absent.\n\nDefaulted at the type level and required by the schemas instead — as one half of a \"`model` or `model_id`\" alternative, so a target naming its model by id alone validates while one naming it neither way is still rejected.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that can receive routed traffic. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration and the name it resolves to is the target, so renaming that model keeps this target pointing at it with no edit to this document. An id resolving to no model is a target that does not exist, exactly as a `model` naming no model is.",
           "minLength": 1,
           "type": "string"
         },
@@ -587,22 +662,59 @@
           "type": "integer"
         }
       },
-      "required": [
-        "model"
-      ],
       "type": "object"
     },
     "Semantic": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "embedding_model"
+              ]
+            },
+            {
+              "required": [
+                "embedding_model_id"
+              ]
+            }
+          ]
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "default"
+              ]
+            },
+            {
+              "required": [
+                "default_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "Semantic-routing config: pick a target by request meaning.",
       "properties": {
         "default": {
-          "description": "Direct model alias used when no route clears its threshold.",
+          "description": "Direct model alias used when no route clears its threshold. Read only when `default_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "default_id": {
+          "description": "Resource id of the direct model used when no route clears its threshold. Present, it is authoritative and `default` is ignored, so renaming that model keeps this router pointing at it with no edit to this document.",
           "minLength": 1,
           "type": "string"
         },
         "embedding_model": {
-          "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples.",
+          "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples. Read only when `embedding_model_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "embedding_model_id": {
+          "description": "Resource id of the `embedding`-modality Model used to embed the request and the route examples. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this router pointing at it with no edit to this document. An id resolving to no model is an embedding model that does not exist, exactly as an `embedding_model` naming no model is — the router applies `on_embedding_failure`.",
           "minLength": 1,
           "type": "string"
         },
@@ -638,8 +750,6 @@
         }
       },
       "required": [
-        "default",
-        "embedding_model",
         "match",
         "routes"
       ],
@@ -682,6 +792,22 @@
     },
     "SemanticRoute": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "target"
+              ]
+            },
+            {
+              "required": [
+                "target_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "One semantic route: a labeled set of example utterances whose embeddings define the route. A request that scores high enough against them dispatches to `target`.",
       "properties": {
         "description": {
@@ -704,7 +830,12 @@
           "type": "string"
         },
         "target": {
-          "description": "Direct model alias that receives traffic matching this route.",
+          "description": "Direct model alias that receives traffic matching this route. Read only when `target_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "target_id": {
+          "description": "Resource id of the direct model that receives traffic matching this route. Present, it is authoritative and `target` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this route pointing at it with no edit to this document. An id resolving to no model is a route target that does not exist, exactly as a `target` naming no model is.",
           "minLength": 1,
           "type": "string"
         },
@@ -718,8 +849,7 @@
       },
       "required": [
         "examples",
-        "name",
-        "target"
+        "name"
       ],
       "type": "object"
     },

--- a/schemas/resources/rate_limit.schema.json
+++ b/schemas/resources/rate_limit.schema.json
@@ -1,71 +1,71 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "RateLimit",
-  "type": "object",
+  "additionalProperties": false,
   "properties": {
     "concurrency": {
       "description": "Max concurrent in-flight requests.",
+      "format": "uint32",
+      "minimum": 0.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint32",
-      "minimum": 0.0
+      ]
     },
     "rpd": {
       "description": "Requests per 86,400-second window.",
+      "format": "uint64",
+      "minimum": 0.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
+      ]
     },
     "rph": {
       "description": "Requests per 3,600-second window. There is no per-hour token limit field.",
+      "format": "uint64",
+      "minimum": 0.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
+      ]
     },
     "rpm": {
       "description": "Requests per 60-second window.",
+      "format": "uint64",
+      "minimum": 0.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
+      ]
     },
     "rps": {
       "description": "Requests per 1-second window. There is no per-second token limit field.",
+      "format": "uint64",
+      "minimum": 0.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
+      ]
     },
     "tpd": {
       "description": "Tokens per 86,400-second window.",
+      "format": "uint64",
+      "minimum": 0.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
+      ]
     },
     "tpm": {
       "description": "Tokens per 60-second window.",
+      "format": "uint64",
+      "minimum": 0.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
+      ]
     }
   },
-  "additionalProperties": false
+  "title": "RateLimit",
+  "type": "object"
 }

--- a/schemas/resources/routing.schema.json
+++ b/schemas/resources/routing.schema.json
@@ -192,15 +192,20 @@
       ]
     },
     "RoutingTarget": {
-      "description": "One destination in a routing configuration. `model` references a direct model alias.",
+      "description": "One destination in a routing configuration. The target model is named either by `model` (its display name) or by `model_id` (its resource id); a target must carry at least one of the two.",
       "type": "object",
-      "required": [
-        "model"
-      ],
       "properties": {
         "model": {
-          "description": "Model alias for a direct model that can receive routed traffic.",
+          "description": "Model alias for a direct model that can receive routed traffic. Read only when `model_id` is absent.\n\nDefaulted at the type level and required by the schemas instead — as one half of a \"`model` or `model_id`\" alternative, so a target naming its model by id alone validates while one naming it neither way is still rejected.",
           "type": "string",
+          "minLength": 1
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that can receive routed traffic. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration and the name it resolves to is the target, so renaming that model keeps this target pointing at it with no edit to this document. An id resolving to no model is a target that does not exist, exactly as a `model` naming no model is.",
+          "type": [
+            "string",
+            "null"
+          ],
           "minLength": 1
         },
         "priority": {

--- a/schemas/resources/routing.schema.json
+++ b/schemas/resources/routing.schema.json
@@ -1,52 +1,248 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Routing",
-  "type": "object",
-  "required": [
-    "targets"
-  ],
+  "additionalProperties": false,
+  "definitions": {
+    "HashOnSource": {
+      "additionalProperties": false,
+      "description": "One source for the `consistent_hash` hash key. Sources are tried in order; the first one that yields a non-empty value wins.",
+      "properties": {
+        "name": {
+          "description": "The header or cookie name to read. Required for `header` and `cookie` sources; not accepted for `api_key` or `client_ip`.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/HashOnType"
+            }
+          ],
+          "description": "Which request attribute supplies the hash key."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "HashOnType": {
+      "description": "Which request attribute a [`HashOnSource`] reads the hash key from.",
+      "oneOf": [
+        {
+          "description": "A request header, named by `name`.",
+          "enum": [
+            "header"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "A cookie from the request's `Cookie` header, named by `name`.",
+          "enum": [
+            "cookie"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "The caller's API key id.",
+          "enum": [
+            "api_key"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "The caller's resolved client IP (honouring the trusted-proxy configuration).",
+          "enum": [
+            "client_ip"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "RoutingStrategy": {
+      "oneOf": [
+        {
+          "description": "Smooth weighted round-robin over target `weight`s. Equal (or absent) weights degrade to a plain declaration-order cycle.",
+          "enum": [
+            "round_robin"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Ketama-style consistent hashing of the request's hash key (see `hash_on`) over the targets, `weight` scaling each target's share of the ring. The same key keeps landing on the same target while it is healthy; on failure the walk follows the ring so only the failed target's keys move.",
+          "enum": [
+            "consistent_hash"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Always start with the first target and move to later targets only after failure.",
+          "enum": [
+            "failover"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Rank targets cheapest-first by the target model's `cost` (combined input+output per-1K price), then fall forward. Targets without a configured `cost` rank last.",
+          "enum": [
+            "least_cost"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Rank targets fastest-first by a moving average of recent observed upstream latency (time-to-first-token for streaming), then fall forward. Targets with no samples yet rank first so they get probed.",
+          "enum": [
+            "least_latency"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Rank targets least-loaded-first by in-flight requests divided by target `weight` (the APISIX least_conn score), then fall forward.",
+          "enum": [
+            "least_busy"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "RoutingTarget": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "properties": {
+                "model": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model"
+              ]
+            },
+            {
+              "properties": {
+                "model_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "model_id"
+              ]
+            }
+          ]
+        }
+      ],
+      "description": "One destination in a routing configuration. The target model is named either by `model` (its display name) or by `model_id` (its resource id); a target must carry at least one of the two.",
+      "properties": {
+        "model": {
+          "description": "Model alias for a direct model that can receive routed traffic. Read only when `model_id` is absent.\n\nDefaulted at the type level and required by the schemas instead — as one half of a \"`model` or `model_id`\" alternative, so a target naming its model by id alone validates while one naming it neither way is still rejected.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "model_id": {
+          "description": "Resource id of the direct model that can receive routed traffic. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration and the name it resolves to is the target, so renaming that model keeps this target pointing at it with no edit to this document. An id resolving to no model is a target that does not exist, exactly as a `model` naming no model is.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "priority": {
+          "description": "Priority tier, default `0`; a higher value is preferred (the APISIX node-priority convention — give backup targets `-1`). The strategy orders targets within each tier; a lower tier is only tried when every higher-tier target failed or is unavailable.",
+          "format": "int32",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tags": {
+          "description": "Tags for tag/metadata-conditional routing. When a request carries routing tags, only targets whose tags intersect the request's are eligible; a target tagged `\"default\"` is the fallback used when nothing matches and for untagged requests. Absent/empty means the target opts out of tag filtering (eligible only via the default fallback once any sibling target is tagged). The configured strategy then orders whatever set survives.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "weight": {
+          "description": "Target weight, default `1`. Used by `round_robin` (rotation share), `consistent_hash` (share of the hash ring), and `least_busy` (in-flight divided by weight). `failover`, `least_cost`, and `least_latency` accept the field but do not use it.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "WhenAllUnavailablePolicy": {
+      "description": "Behavior when every routing target is unavailable because of runtime health or cooldown state.",
+      "oneOf": [
+        {
+          "description": "Return `503` with a fixed `Retry-After` hint.",
+          "enum": [
+            "fail"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Try every target in declaration order even when all of them are currently unavailable because of health or cooldown status. Use only when maintaining availability is preferred over avoiding recently unhealthy targets.",
+          "enum": [
+            "try_anyway"
+          ],
+          "type": "string"
+        }
+      ]
+    }
+  },
   "properties": {
     "fallback_on_statuses": {
       "description": "Additional upstream HTTP status codes that participate in retries and failover. By default a non-429 4xx response is treated as a caller error and returned as-is; providers that use 4xx codes for transient conditions (model overload, queue full, quota exhaustion) can be listed here, for example `[408, 409]`. 5xx codes are already retryable, so listing them changes nothing. Authentication (`401`/`403`) and validation (`400`) codes should only be listed when the provider is known to use them for transient failures.",
+      "items": {
+        "format": "uint16",
+        "maximum": 599.0,
+        "minimum": 400.0,
+        "type": "integer"
+      },
       "type": [
         "array",
         "null"
-      ],
-      "items": {
-        "type": "integer",
-        "format": "uint16",
-        "maximum": 599.0,
-        "minimum": 400.0
-      }
+      ]
     },
     "hash_on": {
       "description": "Where the `consistent_hash` hash key comes from: an ordered chain of sources, the first non-empty value winning. Defaults to the `x-aisix-routing-key` request header, falling back to the caller's API key id. Only valid with `strategy: consistent_hash`.",
-      "type": [
-        "array",
-        "null"
-      ],
       "items": {
         "$ref": "#/definitions/HashOnSource"
       },
-      "minItems": 1
+      "minItems": 1,
+      "type": [
+        "array",
+        "null"
+      ]
     },
     "max_fallbacks": {
       "description": "Max number of later targets to attempt after the initial target fails permanently. When omitted, all later targets may be attempted.",
+      "format": "uint32",
+      "minimum": 0.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint32",
-      "minimum": 0.0
+      ]
     },
     "retries": {
       "description": "Retry attempts on the current target before failing over, applied to every target that does not set its own `retries`. Absent falls back to the deployment-wide `upstream.retries` default.",
+      "format": "uint32",
+      "minimum": 0.0,
       "type": [
         "integer",
         "null"
-      ],
-      "format": "uint32",
-      "minimum": 0.0
+      ]
     },
     "retry_on_429": {
       "description": "Whether upstream 429 participates in retries and failover.",
@@ -56,24 +252,23 @@
       ]
     },
     "strategy": {
-      "description": "Strategy used to select a target for each request.",
-      "default": "failover",
       "allOf": [
         {
           "$ref": "#/definitions/RoutingStrategy"
         }
-      ]
+      ],
+      "default": "failover",
+      "description": "Strategy used to select a target for each request."
     },
     "targets": {
       "description": "Ordered set of direct models available to this routing model.",
-      "type": "array",
       "items": {
         "$ref": "#/definitions/RoutingTarget"
       },
-      "minItems": 1
+      "minItems": 1,
+      "type": "array"
     },
     "when_all_unavailable": {
-      "description": "Policy to apply when every target is unavailable because of runtime health or cooldown state.",
       "anyOf": [
         {
           "$ref": "#/definitions/WhenAllUnavailablePolicy"
@@ -81,182 +276,13 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Policy to apply when every target is unavailable because of runtime health or cooldown state."
     }
   },
-  "additionalProperties": false,
-  "definitions": {
-    "HashOnSource": {
-      "description": "One source for the `consistent_hash` hash key. Sources are tried in order; the first one that yields a non-empty value wins.",
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "name": {
-          "description": "The header or cookie name to read. Required for `header` and `cookie` sources; not accepted for `api_key` or `client_ip`.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "minLength": 1
-        },
-        "type": {
-          "description": "Which request attribute supplies the hash key.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/HashOnType"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "HashOnType": {
-      "description": "Which request attribute a [`HashOnSource`] reads the hash key from.",
-      "oneOf": [
-        {
-          "description": "A request header, named by `name`.",
-          "type": "string",
-          "enum": [
-            "header"
-          ]
-        },
-        {
-          "description": "A cookie from the request's `Cookie` header, named by `name`.",
-          "type": "string",
-          "enum": [
-            "cookie"
-          ]
-        },
-        {
-          "description": "The caller's API key id.",
-          "type": "string",
-          "enum": [
-            "api_key"
-          ]
-        },
-        {
-          "description": "The caller's resolved client IP (honouring the trusted-proxy configuration).",
-          "type": "string",
-          "enum": [
-            "client_ip"
-          ]
-        }
-      ]
-    },
-    "RoutingStrategy": {
-      "oneOf": [
-        {
-          "description": "Smooth weighted round-robin over target `weight`s. Equal (or absent) weights degrade to a plain declaration-order cycle.",
-          "type": "string",
-          "enum": [
-            "round_robin"
-          ]
-        },
-        {
-          "description": "Ketama-style consistent hashing of the request's hash key (see `hash_on`) over the targets, `weight` scaling each target's share of the ring. The same key keeps landing on the same target while it is healthy; on failure the walk follows the ring so only the failed target's keys move.",
-          "type": "string",
-          "enum": [
-            "consistent_hash"
-          ]
-        },
-        {
-          "description": "Always start with the first target and move to later targets only after failure.",
-          "type": "string",
-          "enum": [
-            "failover"
-          ]
-        },
-        {
-          "description": "Rank targets cheapest-first by the target model's `cost` (combined input+output per-1K price), then fall forward. Targets without a configured `cost` rank last.",
-          "type": "string",
-          "enum": [
-            "least_cost"
-          ]
-        },
-        {
-          "description": "Rank targets fastest-first by a moving average of recent observed upstream latency (time-to-first-token for streaming), then fall forward. Targets with no samples yet rank first so they get probed.",
-          "type": "string",
-          "enum": [
-            "least_latency"
-          ]
-        },
-        {
-          "description": "Rank targets least-loaded-first by in-flight requests divided by target `weight` (the APISIX least_conn score), then fall forward.",
-          "type": "string",
-          "enum": [
-            "least_busy"
-          ]
-        }
-      ]
-    },
-    "RoutingTarget": {
-      "description": "One destination in a routing configuration. The target model is named either by `model` (its display name) or by `model_id` (its resource id); a target must carry at least one of the two.",
-      "type": "object",
-      "properties": {
-        "model": {
-          "description": "Model alias for a direct model that can receive routed traffic. Read only when `model_id` is absent.\n\nDefaulted at the type level and required by the schemas instead — as one half of a \"`model` or `model_id`\" alternative, so a target naming its model by id alone validates while one naming it neither way is still rejected.",
-          "type": "string",
-          "minLength": 1
-        },
-        "model_id": {
-          "description": "Resource id of the direct model that can receive routed traffic. Present, it is authoritative and `model` is ignored: the id is resolved against the models in the current configuration and the name it resolves to is the target, so renaming that model keeps this target pointing at it with no edit to this document. An id resolving to no model is a target that does not exist, exactly as a `model` naming no model is.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "minLength": 1
-        },
-        "priority": {
-          "description": "Priority tier, default `0`; a higher value is preferred (the APISIX node-priority convention — give backup targets `-1`). The strategy orders targets within each tier; a lower tier is only tried when every higher-tier target failed or is unavailable.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "int32"
-        },
-        "tags": {
-          "description": "Tags for tag/metadata-conditional routing. When a request carries routing tags, only targets whose tags intersect the request's are eligible; a target tagged `\"default\"` is the fallback used when nothing matches and for untagged requests. Absent/empty means the target opts out of tag filtering (eligible only via the default fallback once any sibling target is tagged). The configured strategy then orders whatever set survives.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "weight": {
-          "description": "Target weight, default `1`. Used by `round_robin` (rotation share), `consistent_hash` (share of the hash ring), and `least_busy` (in-flight divided by weight). `failover`, `least_cost`, and `least_latency` accept the field but do not use it.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint32",
-          "minimum": 0.0
-        }
-      },
-      "additionalProperties": false
-    },
-    "WhenAllUnavailablePolicy": {
-      "description": "Behavior when every routing target is unavailable because of runtime health or cooldown state.",
-      "oneOf": [
-        {
-          "description": "Return `503` with a fixed `Retry-After` hint.",
-          "type": "string",
-          "enum": [
-            "fail"
-          ]
-        },
-        {
-          "description": "Try every target in declaration order even when all of them are currently unavailable because of health or cooldown status. Use only when maintaining availability is preferred over avoiding recently unhealthy targets.",
-          "type": "string",
-          "enum": [
-            "try_anyway"
-          ]
-        }
-      ]
-    }
-  }
+  "required": [
+    "targets"
+  ],
+  "title": "Routing",
+  "type": "object"
 }

--- a/schemas/resources/semantic.schema.json
+++ b/schemas/resources/semantic.schema.json
@@ -1,84 +1,66 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Semantic",
-  "description": "Semantic-routing config: pick a target by request meaning.",
-  "type": "object",
-  "required": [
-    "match",
-    "routes"
-  ],
-  "properties": {
-    "default": {
-      "description": "Direct model alias used when no route clears its threshold. Read only when `default_id` is absent.",
-      "type": "string",
-      "minLength": 1
-    },
-    "default_id": {
-      "description": "Resource id of the direct model used when no route clears its threshold. Present, it is authoritative and `default` is ignored, so renaming that model keeps this router pointing at it with no edit to this document.",
-      "type": [
-        "string",
-        "null"
-      ],
-      "minLength": 1
-    },
-    "embedding_model": {
-      "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples. Read only when `embedding_model_id` is absent.",
-      "type": "string",
-      "minLength": 1
-    },
-    "embedding_model_id": {
-      "description": "Resource id of the `embedding`-modality Model used to embed the request and the route examples. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this router pointing at it with no edit to this document. An id resolving to no model is an embedding model that does not exist, exactly as an `embedding_model` naming no model is — the router applies `on_embedding_failure`.",
-      "type": [
-        "string",
-        "null"
-      ],
-      "minLength": 1
-    },
-    "embedding_timeout_ms": {
-      "description": "Per-call deadline for the embedding request in milliseconds. `0` or absent disables the embedding-specific deadline.",
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
-    },
-    "match": {
-      "description": "Shared matching parameters (metric, aggregation, default threshold).",
-      "allOf": [
-        {
-          "$ref": "#/definitions/SemanticMatch"
-        }
-      ]
-    },
-    "on_embedding_failure": {
-      "description": "Behavior when the embedding call fails or times out. Defaults to routing to `default`.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/OnEmbeddingFailure"
-        }
-      ]
-    },
-    "routes": {
-      "description": "Routes evaluated for each request. At least one is required.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/SemanticRoute"
-      },
-      "minItems": 1
-    }
-  },
   "additionalProperties": false,
+  "allOf": [
+    {
+      "anyOf": [
+        {
+          "properties": {
+            "embedding_model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "embedding_model"
+          ]
+        },
+        {
+          "properties": {
+            "embedding_model_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "embedding_model_id"
+          ]
+        }
+      ]
+    },
+    {
+      "anyOf": [
+        {
+          "properties": {
+            "default": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "default"
+          ]
+        },
+        {
+          "properties": {
+            "default_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "default_id"
+          ]
+        }
+      ]
+    }
+  ],
   "definitions": {
     "Aggregation": {
       "description": "How a request's per-example similarity scores collapse into one score for the route. v1 uses `max` (the single best-matching example), chosen for explainability — the UI surfaces \"the top matching example\" — over semantic-router's default sum/mean-over-top_k.",
       "oneOf": [
         {
           "description": "Route score = the highest cosine across its examples.",
-          "type": "string",
           "enum": [
             "max"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
@@ -87,10 +69,10 @@
       "oneOf": [
         {
           "description": "Cosine similarity — higher is more similar.",
-          "type": "string",
           "enum": [
             "cosine"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
@@ -99,143 +81,237 @@
       "oneOf": [
         {
           "description": "Route to the semantic router's `default` model.",
-          "type": "string",
           "enum": [
             "default"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "Reject the request with `503`.",
-          "type": "string",
           "enum": [
             "fail"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
     "OnEmbeddingFailure": {
-      "description": "What the router does when the embedding call errors or times out. Use `\"default\"` to route to the router's default model, `\"fail\"` to reject the request with `503`, or `{ \"target\": \"<direct alias>\" }` to route to a specific fallback model.",
       "anyOf": [
         {
-          "description": "`\"default\"` or `\"fail\"`.",
           "allOf": [
             {
               "$ref": "#/definitions/EmbeddingFailureMode"
             }
-          ]
+          ],
+          "description": "`\"default\"` or `\"fail\"`."
         },
         {
+          "additionalProperties": false,
           "description": "`{ \"target\": \"<direct alias>\" }` (or `{ \"target_id\": \"<id>\" }`) — route to a specific safe model.",
-          "type": "object",
           "properties": {
             "target": {
               "description": "Direct-model alias to route to when embedding fails. Read only when `target_id` is absent.",
-              "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "type": "string"
             },
             "target_id": {
               "description": "Resource id of the direct model to route to when embedding fails. Present, it is authoritative and `target` is ignored, so renaming that model keeps this fallback pointing at it with no edit to this document.",
+              "minLength": 1,
               "type": [
                 "string",
                 "null"
-              ],
-              "minLength": 1
+              ]
             }
           },
-          "additionalProperties": false
+          "type": "object"
         }
-      ]
+      ],
+      "description": "What the router does when the embedding call errors or times out. Use `\"default\"` to route to the router's default model, `\"fail\"` to reject the request with `503`, or `{ \"target\": \"<direct alias>\" }` to route to a specific fallback model."
     },
     "SemanticMatch": {
+      "additionalProperties": false,
       "description": "Matching parameters shared across every route in a semantic router.",
-      "type": "object",
-      "required": [
-        "threshold"
-      ],
       "properties": {
         "aggregation": {
-          "description": "Per-example score aggregation. v1: max.",
-          "default": "max",
           "allOf": [
             {
               "$ref": "#/definitions/Aggregation"
             }
-          ]
+          ],
+          "default": "max",
+          "description": "Per-example score aggregation. v1: max."
         },
         "distance_metric": {
-          "description": "Similarity metric. v1: cosine.",
-          "default": "cosine",
           "allOf": [
             {
               "$ref": "#/definitions/DistanceMetric"
             }
-          ]
+          ],
+          "default": "cosine",
+          "description": "Similarity metric. v1: cosine."
         },
         "threshold": {
           "description": "Default similarity threshold for routes that do not set their own `threshold`. Higher is stricter.",
-          "type": "number",
           "format": "float",
           "maximum": 1.0,
-          "minimum": 0.0
+          "minimum": 0.0,
+          "type": "number"
         }
       },
-      "additionalProperties": false
+      "required": [
+        "threshold"
+      ],
+      "type": "object"
     },
     "SemanticRoute": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "properties": {
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target"
+              ]
+            },
+            {
+              "properties": {
+                "target_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target_id"
+              ]
+            }
+          ]
+        }
+      ],
       "description": "One semantic route: a labeled set of example utterances whose embeddings define the route. A request that scores high enough against them dispatches to `target`.",
-      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Human-facing description. Documentation only — v1 matches on `examples`, not on this field.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "examples": {
+          "description": "Example utterances that define this route. AISIX embeds each example when applying the configuration and caches the vector. A request is matched against these examples. At least one example is required.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "name": {
+          "description": "Operator-facing route label. Surfaced in the `x-aisix-route` response header and access logs (e.g. `prod-chat -> route:legal`).",
+          "minLength": 1,
+          "type": "string"
+        },
+        "target": {
+          "description": "Direct model alias that receives traffic matching this route. Read only when `target_id` is absent.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "target_id": {
+          "description": "Resource id of the direct model that receives traffic matching this route. Present, it is authoritative and `target` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this route pointing at it with no edit to this document. An id resolving to no model is a route target that does not exist, exactly as a `target` naming no model is.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "threshold": {
+          "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level threshold applies.",
+          "format": "float",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
       "required": [
         "examples",
         "name"
       ],
-      "properties": {
-        "description": {
-          "description": "Human-facing description. Documentation only — v1 matches on `examples`, not on this field.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "minLength": 1
-        },
-        "examples": {
-          "description": "Example utterances that define this route. AISIX embeds each example when applying the configuration and caches the vector. A request is matched against these examples. At least one example is required.",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "minItems": 1
-        },
-        "name": {
-          "description": "Operator-facing route label. Surfaced in the `x-aisix-route` response header and access logs (e.g. `prod-chat -> route:legal`).",
-          "type": "string",
-          "minLength": 1
-        },
-        "target": {
-          "description": "Direct model alias that receives traffic matching this route. Read only when `target_id` is absent.",
-          "type": "string",
-          "minLength": 1
-        },
-        "target_id": {
-          "description": "Resource id of the direct model that receives traffic matching this route. Present, it is authoritative and `target` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this route pointing at it with no edit to this document. An id resolving to no model is a route target that does not exist, exactly as a `target` naming no model is.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "minLength": 1
-        },
-        "threshold": {
-          "description": "Per-route similarity threshold. A request matches this route only when its aggregated score is `>=` this value. When omitted, the router-level threshold applies.",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "float",
-          "maximum": 1.0,
-          "minimum": 0.0
-        }
-      },
-      "additionalProperties": false
+      "type": "object"
     }
-  }
+  },
+  "description": "Semantic-routing config: pick a target by request meaning.",
+  "properties": {
+    "default": {
+      "description": "Direct model alias used when no route clears its threshold. Read only when `default_id` is absent.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "default_id": {
+      "description": "Resource id of the direct model used when no route clears its threshold. Present, it is authoritative and `default` is ignored, so renaming that model keeps this router pointing at it with no edit to this document.",
+      "minLength": 1,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "embedding_model": {
+      "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples. Read only when `embedding_model_id` is absent.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "embedding_model_id": {
+      "description": "Resource id of the `embedding`-modality Model used to embed the request and the route examples. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this router pointing at it with no edit to this document. An id resolving to no model is an embedding model that does not exist, exactly as an `embedding_model` naming no model is — the router applies `on_embedding_failure`.",
+      "minLength": 1,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "embedding_timeout_ms": {
+      "description": "Per-call deadline for the embedding request in milliseconds. `0` or absent disables the embedding-specific deadline.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "match": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SemanticMatch"
+        }
+      ],
+      "description": "Shared matching parameters (metric, aggregation, default threshold)."
+    },
+    "on_embedding_failure": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/OnEmbeddingFailure"
+        }
+      ],
+      "description": "Behavior when the embedding call fails or times out. Defaults to routing to `default`."
+    },
+    "routes": {
+      "description": "Routes evaluated for each request. At least one is required.",
+      "items": {
+        "$ref": "#/definitions/SemanticRoute"
+      },
+      "minItems": 1,
+      "type": "array"
+    }
+  },
+  "required": [
+    "match",
+    "routes"
+  ],
+  "title": "Semantic",
+  "type": "object"
 }

--- a/schemas/resources/semantic.schema.json
+++ b/schemas/resources/semantic.schema.json
@@ -4,20 +4,34 @@
   "description": "Semantic-routing config: pick a target by request meaning.",
   "type": "object",
   "required": [
-    "default",
-    "embedding_model",
     "match",
     "routes"
   ],
   "properties": {
     "default": {
-      "description": "Direct model alias used when no route clears its threshold.",
+      "description": "Direct model alias used when no route clears its threshold. Read only when `default_id` is absent.",
       "type": "string",
       "minLength": 1
     },
+    "default_id": {
+      "description": "Resource id of the direct model used when no route clears its threshold. Present, it is authoritative and `default` is ignored, so renaming that model keeps this router pointing at it with no edit to this document.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    },
     "embedding_model": {
-      "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples.",
+      "description": "Alias of an `embedding`-modality Model used to embed the request and (at apply time) the route examples. Read only when `embedding_model_id` is absent.",
       "type": "string",
+      "minLength": 1
+    },
+    "embedding_model_id": {
+      "description": "Resource id of the `embedding`-modality Model used to embed the request and the route examples. Present, it is authoritative and `embedding_model` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this router pointing at it with no edit to this document. An id resolving to no model is an embedding model that does not exist, exactly as an `embedding_model` naming no model is — the router applies `on_embedding_failure`.",
+      "type": [
+        "string",
+        "null"
+      ],
       "minLength": 1
     },
     "embedding_timeout_ms": {
@@ -111,15 +125,20 @@
           ]
         },
         {
-          "description": "`{ \"target\": \"<direct alias>\" }` — route to a specific safe model.",
+          "description": "`{ \"target\": \"<direct alias>\" }` (or `{ \"target_id\": \"<id>\" }`) — route to a specific safe model.",
           "type": "object",
-          "required": [
-            "target"
-          ],
           "properties": {
             "target": {
-              "description": "Direct-model alias to route to when embedding fails.",
+              "description": "Direct-model alias to route to when embedding fails. Read only when `target_id` is absent.",
               "type": "string",
+              "minLength": 1
+            },
+            "target_id": {
+              "description": "Resource id of the direct model to route to when embedding fails. Present, it is authoritative and `target` is ignored, so renaming that model keeps this fallback pointing at it with no edit to this document.",
+              "type": [
+                "string",
+                "null"
+              ],
               "minLength": 1
             }
           },
@@ -167,8 +186,7 @@
       "type": "object",
       "required": [
         "examples",
-        "name",
-        "target"
+        "name"
       ],
       "properties": {
         "description": {
@@ -194,8 +212,16 @@
           "minLength": 1
         },
         "target": {
-          "description": "Direct model alias that receives traffic matching this route.",
+          "description": "Direct model alias that receives traffic matching this route. Read only when `target_id` is absent.",
           "type": "string",
+          "minLength": 1
+        },
+        "target_id": {
+          "description": "Resource id of the direct model that receives traffic matching this route. Present, it is authoritative and `target` is ignored: the id is resolved against the models in the current configuration, so renaming that model keeps this route pointing at it with no edit to this document. An id resolving to no model is a route target that does not exist, exactly as a `target` naming no model is.",
+          "type": [
+            "string",
+            "null"
+          ],
           "minLength": 1
         },
         "threshold": {

--- a/tests/e2e/src/cases/model-reference-ids-e2e.test.ts
+++ b/tests/e2e/src/cases/model-reference-ids-e2e.test.ts
@@ -736,7 +736,13 @@ describe("model references by resource id", () => {
       200,
     );
 
-    // …and the guardrail document is never rewritten across it.
+    // …and only the EMBEDDING MODEL's row is rewritten across it —
+    // neither the guardrail nor its attachment is touched. That is the
+    // point of the case, not incidental setup: the guardrail chain is
+    // cached and rebuilt only when the guardrail or attachment tables
+    // change, so a build-time resolution would survive this rename and
+    // the case would pass for the wrong reason. Do not "fix" a future
+    // failure here by also rewriting the guardrail row.
     await seed.update("models", ids["mr-embed-guard-renamed"], {
       display_name: "mr-embed-guard-renamed-v2",
       provider: "openai",

--- a/tests/e2e/src/cases/model-reference-ids-e2e.test.ts
+++ b/tests/e2e/src/cases/model-reference-ids-e2e.test.ts
@@ -1,0 +1,838 @@
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  ProxyClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+import { pickFreePort } from "../harness/ports.js";
+
+const execFileP = promisify(execFile);
+
+// E2E: every place a document points at a Model may name it by resource
+// id (`<field>_id`) instead of by display name. The id decides when
+// present, resolves against whatever name the model currently carries,
+// and — when it names no model — degrades exactly the way a dangling
+// name already does at that site.
+//
+// The five sites, and what each case observes:
+//   routing target          `x-aisix-served-by`
+//   ensemble panel + judge  the upstream model each sub-call asked for
+//   semantic router         `x-aisix-served-by` / `x-aisix-route`
+//   cache policy scope      `x-aisix-cache`
+//   semantic guardrail      the 422 a fail-closed screen produces
+//
+// Reference: OpenAI Chat Completions API spec
+// (https://platform.openai.com/docs/api-reference/chat/create).
+
+const CALLER = "sk-model-ref-ids-e2e";
+/**
+ * A resource id no model carries. Used as BOTH an id and a name in the
+ * paired "names no model" cases, so the two spellings produce the same
+ * reference string and their errors are comparable byte for byte.
+ */
+const DANGLING = "11111111-2222-3333-4444-555555555555";
+const CALLER_HASH = createHash("sha256").update(CALLER).digest("hex");
+
+/** Deterministic one-hot vectors, so every similarity is exactly 0 or 1. */
+function keywordVector(text: string): number[] {
+  const t = text.toLowerCase();
+  if (t.includes("jailbreak")) return [1, 0, 0, 0];
+  if (t.includes("contract")) return [0, 1, 0, 0];
+  if (t.includes("weather")) return [0, 0, 1, 0];
+  return [0, 0, 0, 1];
+}
+
+interface EmbeddingMock {
+  baseUrl: string;
+  close(): Promise<void>;
+}
+
+async function startEmbeddingMock(
+  opts: { fail?: boolean } = {},
+): Promise<EmbeddingMock> {
+  const server: Server = createServer((req, res) => {
+    res.on("error", () => {});
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString("utf8")));
+    req.on("end", () => {
+      if (!req.url?.includes("/embeddings")) {
+        res.statusCode = 404;
+        res.end("{}");
+        return;
+      }
+      if (opts.fail) {
+        res.statusCode = 500;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ error: { message: "embedding upstream down" } }));
+        return;
+      }
+      let body: { input?: string | string[] };
+      try {
+        body = JSON.parse(raw || "{}") as { input?: string | string[] };
+      } catch {
+        res.statusCode = 400;
+        res.end("{}");
+        return;
+      }
+      const inputs = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          object: "list",
+          model: "embed-mock",
+          data: inputs.map((text, index) => ({
+            object: "embedding",
+            index,
+            embedding: keywordVector(text),
+          })),
+          usage: { prompt_tokens: inputs.length, total_tokens: inputs.length },
+        }),
+      );
+    });
+  });
+  const port = await pickFreePort();
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+describe("model references by resource id", () => {
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let chatUp: OpenAiUpstream | undefined;
+  let embedMock: EmbeddingMock | undefined;
+  let failingEmbedMock: EmbeddingMock | undefined;
+  let etcdReachable = false;
+
+  /** Model display name → resource id, for every model this suite seeds. */
+  const ids: Record<string, string> = {};
+  /** Model display name → the upstream model name its provider sees. */
+  const upstreamNames: Record<string, string> = {};
+  let chatPkId = "";
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    chatUp = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "cmpl-mr",
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "answered" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    });
+    embedMock = await startEmbeddingMock();
+    failingEmbedMock = await startEmbeddingMock({ fail: true });
+
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const chatPk = await seed.createProviderKey({
+      display_name: "mr-chat-pk",
+      secret: "sk-mock",
+      api_base: `${chatUp.baseUrl}/v1`,
+    });
+    chatPkId = chatPk.id;
+    const embedPk = await seed.createProviderKey({
+      display_name: "mr-embed-pk",
+      secret: "sk-mock",
+      api_base: `${embedMock.baseUrl}/v1`,
+    });
+    const failPk = await seed.createProviderKey({
+      display_name: "mr-embed-fail-pk",
+      secret: "sk-mock",
+      api_base: `${failingEmbedMock.baseUrl}/v1`,
+    });
+
+    // Each direct model asks its upstream for a DIFFERENT model name, so
+    // the recorded request bodies say which target actually served —
+    // the ensemble sub-calls carry no response header to read.
+    const direct = async (name: string) => {
+      const upstreamName = `up-${name}`;
+      const created = await seed!.createModel({
+        display_name: name,
+        provider: "openai",
+        model_name: upstreamName,
+        provider_key_id: chatPkId,
+      });
+      ids[name] = created.id;
+      upstreamNames[name] = upstreamName;
+    };
+    const embedding = async (name: string, pkId: string) => {
+      const created = await seed!.createModel({
+        display_name: name,
+        provider: "openai",
+        model_name: `embed-${name}`,
+        provider_key_id: pkId,
+        embedding: { dimensions: 4, normalize: true },
+      });
+      ids[name] = created.id;
+    };
+
+    for (const name of [
+      "mr-alpha",
+      "mr-beta",
+      "mr-judge",
+      "mr-panelist",
+      "mr-rename-route",
+      "mr-rename-ensemble",
+      "mr-rename-semantic",
+      "mr-cache-scoped",
+      "mr-cache-other",
+      "mr-cache-renamed",
+      "mr-guarded",
+      "mr-sentinel",
+    ]) {
+      await direct(name);
+    }
+    await embedding("mr-embed", embedPk.id);
+    await embedding("mr-embed-renamed", embedPk.id);
+    await embedding("mr-embed-fail", failPk.id);
+
+    // ---- routing groups ----
+    await seed.createModel({
+      display_name: "mr-group-by-id",
+      routing: { strategy: "failover", targets: [{ model_id: ids["mr-alpha"] }] },
+    });
+    await seed.createModel({
+      display_name: "mr-group-conflict",
+      routing: {
+        strategy: "failover",
+        targets: [{ model: "mr-beta", model_id: ids["mr-alpha"] }],
+      },
+    });
+    await seed.createModel({
+      display_name: "mr-group-rename",
+      routing: {
+        strategy: "failover",
+        targets: [{ model_id: ids["mr-rename-route"] }],
+      },
+    });
+    await seed.createModel({
+      display_name: "mr-group-dangling-id",
+      routing: { strategy: "failover", targets: [{ model_id: DANGLING }] },
+    });
+    await seed.createModel({
+      display_name: "mr-group-dangling-name",
+      routing: { strategy: "failover", targets: [{ model: DANGLING }] },
+    });
+
+    // ---- ensembles (single-member panels: min_responses clamps to 1) ----
+    await seed.createModel({
+      display_name: "mr-ensemble-by-id",
+      ensemble: {
+        panel: [{ model_id: ids["mr-panelist"] }],
+        judge: { model_id: ids["mr-judge"] },
+      },
+    });
+    await seed.createModel({
+      display_name: "mr-ensemble-conflict",
+      ensemble: {
+        panel: [{ model: "mr-beta", model_id: ids["mr-panelist"] }],
+        judge: { model: "mr-beta", model_id: ids["mr-judge"] },
+      },
+    });
+    await seed.createModel({
+      display_name: "mr-ensemble-rename",
+      ensemble: {
+        panel: [{ model_id: ids["mr-panelist"] }],
+        judge: { model_id: ids["mr-rename-ensemble"] },
+      },
+    });
+    await seed.createModel({
+      display_name: "mr-ensemble-dangling-id",
+      ensemble: {
+        panel: [{ model_id: ids["mr-panelist"] }],
+        judge: { model_id: DANGLING },
+      },
+    });
+    await seed.createModel({
+      display_name: "mr-ensemble-dangling-name",
+      ensemble: {
+        panel: [{ model_id: ids["mr-panelist"] }],
+        judge: { model: DANGLING },
+      },
+    });
+
+    // ---- semantic routers ----
+    await seed.createModel({
+      display_name: "mr-semantic-by-id",
+      semantic: {
+        embedding_model_id: ids["mr-embed"],
+        routes: [
+          {
+            name: "legal",
+            target_id: ids["mr-alpha"],
+            examples: ["analyze this contract"],
+            threshold: 0.5,
+          },
+        ],
+        default_id: ids["mr-beta"],
+        match: { threshold: 0.5 },
+      },
+    });
+    await seed.createModel({
+      display_name: "mr-semantic-conflict",
+      semantic: {
+        embedding_model: "mr-embed-fail",
+        embedding_model_id: ids["mr-embed"],
+        routes: [
+          {
+            name: "legal",
+            target: "mr-beta",
+            target_id: ids["mr-alpha"],
+            examples: ["analyze this contract"],
+            threshold: 0.5,
+          },
+        ],
+        default: "mr-alpha",
+        default_id: ids["mr-beta"],
+        match: { threshold: 0.5 },
+      },
+    });
+    await seed.createModel({
+      display_name: "mr-semantic-rename",
+      semantic: {
+        embedding_model_id: ids["mr-embed-renamed"],
+        routes: [
+          {
+            name: "legal",
+            target_id: ids["mr-rename-semantic"],
+            examples: ["analyze this contract"],
+            threshold: 0.5,
+          },
+        ],
+        default_id: ids["mr-beta"],
+        match: { threshold: 0.5 },
+      },
+    });
+    // A dangling embedding model resolves to nothing, so the router
+    // applies `on_embedding_failure` — here an id-named safe target.
+    await seed.createModel({
+      display_name: "mr-semantic-dangling-embedder-id",
+      semantic: {
+        embedding_model_id: DANGLING,
+        routes: [
+          {
+            name: "legal",
+            target_id: ids["mr-alpha"],
+            examples: ["analyze this contract"],
+            threshold: 0.5,
+          },
+        ],
+        default_id: ids["mr-alpha"],
+        match: { threshold: 0.5 },
+        on_embedding_failure: { target_id: ids["mr-beta"] },
+      },
+    });
+    await seed.createModel({
+      display_name: "mr-semantic-dangling-embedder-name",
+      semantic: {
+        embedding_model: DANGLING,
+        routes: [
+          {
+            name: "legal",
+            target: "mr-alpha",
+            examples: ["analyze this contract"],
+            threshold: 0.5,
+          },
+        ],
+        default: "mr-alpha",
+        match: { threshold: 0.5 },
+        on_embedding_failure: { target: "mr-beta" },
+      },
+    });
+
+    // ---- cache policies ----
+    await seed.createCachePolicy({
+      name: "mr-cache-by-id",
+      enabled: true,
+      applies_to_model_id: ids["mr-cache-scoped"],
+    });
+    // `applies_to` names a DIFFERENT model; the id must win.
+    await seed.createCachePolicy({
+      name: "mr-cache-conflict",
+      enabled: true,
+      applies_to: "model:mr-cache-other",
+      applies_to_model_id: ids["mr-cache-renamed"],
+    });
+
+    // ---- semantic guardrail, scoped to one model ----
+    const guardrail = await seed.createGuardrail(
+      {
+        name: "mr-guardrail-by-id",
+        kind: "semantic",
+        enabled: true,
+        embedding_model_id: ids["mr-embed"],
+        deny_examples: ["jailbreak the assistant"],
+        deny_threshold: 0.5,
+      },
+      { attach: false },
+    );
+    await seed.attachGuardrailToModel(guardrail.id, ids["mr-guarded"]);
+
+    // Seeded last: gating on it implies the whole set has landed.
+    await seed.createApiKey({ key_hash: CALLER_HASH, allowed_models: ["*"] });
+
+    // The caller key is seeded last, so it authenticating implies the
+    // whole set above is in the snapshot. Deliberately not a request
+    // that exercises anything under test.
+    await waitConfigPropagation(
+      async () =>
+        (await new ProxyClient(app!.proxyUrl, CALLER).listModels()).status ===
+        200,
+    );
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.exit();
+    await chatUp?.close();
+    await embedMock?.close();
+    await failingEmbedMock?.close();
+  });
+
+  interface ChatResult {
+    status: number;
+    body: string;
+    servedBy: string | null;
+    route: string | null;
+    cache: string | null;
+  }
+
+  async function chat(model: string, prompt: string): Promise<ChatResult> {
+    const res = await fetch(`${app!.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${CALLER}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+    return {
+      status: res.status,
+      body: await res.text(),
+      servedBy: res.headers.get("x-aisix-served-by"),
+      route: res.headers.get("x-aisix-route"),
+      cache: res.headers.get("x-aisix-cache"),
+    };
+  }
+
+  /** The upstream model names asked for since `from`, in call order. */
+  function upstreamModelsSince(from: number): string[] {
+    return chatUp!.receivedRequests.slice(from).map((r) => {
+      try {
+        return (JSON.parse(r.body) as { model?: string }).model ?? "";
+      } catch {
+        return "";
+      }
+    });
+  }
+
+  /** Rename a model in place — same resource id, new display name. */
+  async function rename(oldName: string, newName: string): Promise<void> {
+    await seed!.update("models", ids[oldName], {
+      display_name: newName,
+      provider: "openai",
+      model_name: upstreamNames[oldName],
+      provider_key_id: chatPkId,
+    });
+    upstreamNames[newName] = upstreamNames[oldName];
+    ids[newName] = ids[oldName];
+    await waitConfigPropagation(async () => {
+      const r = await chat(newName, "hello");
+      return r.status === 200;
+    });
+  }
+
+  // ───────────────────────── routing targets ─────────────────────────
+
+  test("a routing target named by id dispatches to that model", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const r = await chat("mr-group-by-id", "hello");
+    expect(r.status).toBe(200);
+    expect(r.servedBy).toBe("mr-alpha");
+  });
+
+  test("routing target: the id decides and the name beside it is ignored", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const r = await chat("mr-group-conflict", "hello");
+    expect(r.status).toBe(200);
+    expect(r.servedBy).toBe("mr-alpha");
+  });
+
+  test("routing target: an id naming no model fails exactly as a name naming no model does", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const byId = await chat("mr-group-dangling-id", "hello");
+    const byName = await chat("mr-group-dangling-name", "hello");
+    expect(byId.status).toBe(byName.status);
+    expect(byId.body).toBe(byName.body);
+    // Not a 5xx and not a dropped row: the group still resolves as a
+    // model, it just has no target to dispatch to.
+    expect(byId.status).toBeLessThan(500);
+  });
+
+  // ───────────────────────── ensemble members ────────────────────────
+
+  test("an ensemble panel member and judge named by id are the ones called", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const before = chatUp!.receivedRequests.length;
+    const r = await chat("mr-ensemble-by-id", "hello");
+    expect(r.status).toBe(200);
+    const called = upstreamModelsSince(before);
+    expect(called).toContain(upstreamNames["mr-panelist"]);
+    expect(called).toContain(upstreamNames["mr-judge"]);
+    expect(called).not.toContain(upstreamNames["mr-beta"]);
+  });
+
+  test("ensemble: the ids decide and the names beside them are ignored", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const before = chatUp!.receivedRequests.length;
+    const r = await chat("mr-ensemble-conflict", "hello");
+    expect(r.status).toBe(200);
+    const called = upstreamModelsSince(before);
+    expect(called).toContain(upstreamNames["mr-panelist"]);
+    expect(called).toContain(upstreamNames["mr-judge"]);
+    expect(called).not.toContain(upstreamNames["mr-beta"]);
+  });
+
+  test("ensemble: a judge id naming no model fails as a judge name naming no model does", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const byId = await chat("mr-ensemble-dangling-id", "hello");
+    const byName = await chat("mr-ensemble-dangling-name", "hello");
+    expect(byId.status).toBe(byName.status);
+    expect(byId.body).toBe(byName.body);
+    expect(byId.status).not.toBe(200);
+  });
+
+  // ───────────────────────── semantic routers ────────────────────────
+
+  test("a semantic router named entirely by ids embeds, routes and falls through", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const matched = await chat("mr-semantic-by-id", "review this contract");
+    expect(matched.status).toBe(200);
+    expect(matched.route).toBe("legal");
+    expect(matched.servedBy).toBe("mr-alpha");
+
+    // Orthogonal prompt: no route clears its threshold → `default_id`.
+    const fellThrough = await chat("mr-semantic-by-id", "hello there");
+    expect(fellThrough.status).toBe(200);
+    expect(fellThrough.route).toBeNull();
+    expect(fellThrough.servedBy).toBe("mr-beta");
+  });
+
+  test("semantic: every id decides over the name beside it", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    // `embedding_model` names the FAILING embedder and `target` names
+    // the wrong model; both are ignored, so the route still matches and
+    // dispatches to the id-named target.
+    const matched = await chat("mr-semantic-conflict", "review this contract");
+    expect(matched.status).toBe(200);
+    expect(matched.route).toBe("legal");
+    expect(matched.servedBy).toBe("mr-alpha");
+    // `default` names mr-alpha, `default_id` names mr-beta.
+    const fellThrough = await chat("mr-semantic-conflict", "hello there");
+    expect(fellThrough.status).toBe(200);
+    expect(fellThrough.servedBy).toBe("mr-beta");
+  });
+
+  test("semantic: an embedding model id naming nothing degrades as a dangling name does", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const byId = await chat("mr-semantic-dangling-embedder-id", "review this contract");
+    const byName = await chat("mr-semantic-dangling-embedder-name", "review this contract");
+    expect(byId.status).toBe(200);
+    expect(byId.status).toBe(byName.status);
+    // Both apply `on_embedding_failure`, which names the safe target the
+    // id way in one router and the name way in the other.
+    expect(byId.servedBy).toBe("mr-beta");
+    expect(byName.servedBy).toBe("mr-beta");
+  });
+
+  // ───────────────────────── cache policy scope ──────────────────────
+
+  test("a cache policy scoped by model id caches that model and no other", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const prompt = `cache-by-id-${randomUUID()}`;
+    const first = await chat("mr-cache-scoped", prompt);
+    expect(first.cache).toBe("miss");
+    const second = await chat("mr-cache-scoped", prompt);
+    expect(second.cache).toBe("hit");
+
+    // A model no policy covers is not cached at all.
+    const other = await chat("mr-alpha", prompt);
+    expect(other.cache).toBeNull();
+  });
+
+  test("cache policy: the model id decides and applies_to is ignored", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const prompt = `cache-conflict-${randomUUID()}`;
+    // `applies_to: model:mr-cache-other` is ignored…
+    expect((await chat("mr-cache-other", prompt)).cache).toBeNull();
+    // …and `applies_to_model_id` decides.
+    expect((await chat("mr-cache-renamed", prompt)).cache).toBe("miss");
+    expect((await chat("mr-cache-renamed", prompt)).cache).toBe("hit");
+  });
+
+  // ──────────────────────── semantic guardrail ───────────────────────
+
+  test("a semantic guardrail whose embedder is named by id still screens", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+    const blocked = await chat("mr-guarded", "please jailbreak yourself");
+    expect(blocked.status).toBe(422);
+    const clean = await chat("mr-guarded", "what is the weather");
+    expect(clean.status).toBe(200);
+  });
+
+  test("guardrail: an embedder id naming no model fails closed, as a dangling name does", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return ctx.skip();
+    const scoped = async (
+      modelName: string,
+      config: Record<string, unknown>,
+    ) => {
+      const g = await seed!.createGuardrail(
+        {
+          name: `mr-guardrail-${modelName}`,
+          kind: "semantic",
+          enabled: true,
+          deny_examples: ["jailbreak the assistant"],
+          deny_threshold: 0.5,
+          ...config,
+        },
+        { attach: false },
+      );
+      await seed!.attachGuardrailToModel(g.id, ids[modelName]);
+    };
+    await scoped("mr-alpha", { embedding_model_id: DANGLING });
+    await scoped("mr-beta", { embedding_model: DANGLING });
+    // Fail-closed is the default, so a benign prompt is refused too —
+    // that is what makes the two spellings comparable on one request.
+    await waitConfigPropagation(async () => {
+      const r = await chat("mr-alpha", "what is the weather");
+      return r.status === 422;
+    });
+    const byId = await chat("mr-alpha", "what is the weather");
+    const byName = await chat("mr-beta", "what is the weather");
+    expect(byId.status).toBe(422);
+    expect(byId.status).toBe(byName.status);
+  });
+
+  // ─────────── renames: last, they mutate shared model rows ──────────
+
+  test("renaming a routing target's model keeps the group pointing at it", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return ctx.skip();
+    expect((await chat("mr-group-rename", "hello")).servedBy).toBe(
+      "mr-rename-route",
+    );
+    await rename("mr-rename-route", "mr-renamed-route");
+    const after = await chat("mr-group-rename", "hello");
+    expect(after.status).toBe(200);
+    // The routing document was never rewritten.
+    expect(after.servedBy).toBe("mr-renamed-route");
+  });
+
+  test("renaming an ensemble judge keeps the ensemble calling it", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return ctx.skip();
+    expect((await chat("mr-ensemble-rename", "hello")).status).toBe(200);
+    await rename("mr-rename-ensemble", "mr-renamed-ensemble");
+    const before = chatUp!.receivedRequests.length;
+    const after = await chat("mr-ensemble-rename", "hello");
+    expect(after.status).toBe(200);
+    expect(upstreamModelsSince(before)).toContain(
+      upstreamNames["mr-renamed-ensemble"],
+    );
+  });
+
+  test("renaming a semantic route target and its embedder keeps the router working", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return ctx.skip();
+    expect(
+      (await chat("mr-semantic-rename", "review this contract")).servedBy,
+    ).toBe("mr-rename-semantic");
+
+    await rename("mr-rename-semantic", "mr-renamed-semantic");
+    // The embedding model is renamed through the raw document, since it
+    // carries an `embedding` block the direct-model helper does not.
+    await seed.update("models", ids["mr-embed-renamed"], {
+      display_name: "mr-embed-renamed-v2",
+      provider: "openai",
+      model_name: "embed-mr-embed-renamed",
+      provider_key_id: (await seed.createProviderKey({
+        display_name: `mr-embed-pk-${randomUUID()}`,
+        secret: "sk-mock",
+        api_base: `${embedMock!.baseUrl}/v1`,
+      })).id,
+      embedding: { dimensions: 4, normalize: true },
+    });
+
+    await waitConfigPropagation(async () => {
+      const r = await chat("mr-semantic-rename", "review this contract");
+      return r.status === 200 && r.servedBy === "mr-renamed-semantic";
+    });
+    const after = await chat("mr-semantic-rename", "review this contract");
+    expect(after.status).toBe(200);
+    expect(after.route).toBe("legal");
+    expect(after.servedBy).toBe("mr-renamed-semantic");
+  });
+
+  test("renaming a cache policy's scoped model keeps the policy on it", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return ctx.skip();
+    await rename("mr-cache-renamed", "mr-cache-renamed-v2");
+    const prompt = `cache-rename-${randomUUID()}`;
+    expect((await chat("mr-cache-renamed-v2", prompt)).cache).toBe("miss");
+    expect((await chat("mr-cache-renamed-v2", prompt)).cache).toBe("hit");
+  });
+});
+
+// The id spelling is a control-plane projection: a resources file derives
+// its ids from its own entry names, so an id written there could never
+// resolve. `aisix validate` refuses each of them by name rather than
+// loading a file whose references silently point at nothing.
+describe("resources file: every model-reference id spelling is refused", () => {
+  const BIN_PATH =
+    process.env.AISIX_BIN ??
+    join(process.cwd(), "..", "..", "target", "debug", "aisix");
+
+  const PRELUDE = [
+    '_format_version: "1"',
+    "provider_keys:",
+    "  - display_name: pk",
+    "    api_key: sk-x",
+    "models:",
+    "  - display_name: m",
+    "    provider: openai",
+    "    model_name: gpt-4o",
+    "    provider_key: pk",
+    "  - display_name: e",
+    "    provider: openai",
+    "    model_name: embed",
+    "    provider_key: pk",
+    "    embedding:",
+    "      dimensions: 4",
+  ].join("\n");
+
+  const ID = "11111111-1111-1111-1111-111111111111";
+
+  const CASES: { label: string; field: string; withId: string; without: string }[] =
+    [
+      {
+        label: "routing target",
+        field: "model_id",
+        withId: `\n  - display_name: g\n    routing:\n      targets:\n        - model: m\n          model_id: ${ID}\n`,
+        without: `\n  - display_name: g\n    routing:\n      targets:\n        - model: m\n`,
+      },
+      {
+        label: "ensemble panel member",
+        field: "model_id",
+        withId: `\n  - display_name: p\n    ensemble:\n      panel:\n        - model: m\n          model_id: ${ID}\n      judge:\n        model: m\n`,
+        without: `\n  - display_name: p\n    ensemble:\n      panel:\n        - model: m\n      judge:\n        model: m\n`,
+      },
+      {
+        label: "ensemble judge",
+        field: "model_id",
+        withId: `\n  - display_name: j\n    ensemble:\n      panel:\n        - model: m\n      judge:\n        model: m\n        model_id: ${ID}\n`,
+        without: `\n  - display_name: j\n    ensemble:\n      panel:\n        - model: m\n      judge:\n        model: m\n`,
+      },
+      {
+        label: "semantic embedding model",
+        field: "embedding_model_id",
+        withId: `\n  - display_name: s\n    semantic:\n      embedding_model: e\n      embedding_model_id: ${ID}\n      routes:\n        - name: r\n          target: m\n          examples: ["hi"]\n      default: m\n      match:\n        threshold: 0.5\n`,
+        without: `\n  - display_name: s\n    semantic:\n      embedding_model: e\n      routes:\n        - name: r\n          target: m\n          examples: ["hi"]\n      default: m\n      match:\n        threshold: 0.5\n`,
+      },
+      {
+        label: "semantic default",
+        field: "default_id",
+        withId: `\n  - display_name: s\n    semantic:\n      embedding_model: e\n      routes:\n        - name: r\n          target: m\n          examples: ["hi"]\n      default: m\n      default_id: ${ID}\n      match:\n        threshold: 0.5\n`,
+        without: `\n  - display_name: s\n    semantic:\n      embedding_model: e\n      routes:\n        - name: r\n          target: m\n          examples: ["hi"]\n      default: m\n      match:\n        threshold: 0.5\n`,
+      },
+      {
+        label: "semantic route target",
+        field: "target_id",
+        withId: `\n  - display_name: s\n    semantic:\n      embedding_model: e\n      routes:\n        - name: r\n          target: m\n          target_id: ${ID}\n          examples: ["hi"]\n      default: m\n      match:\n        threshold: 0.5\n`,
+        without: `\n  - display_name: s\n    semantic:\n      embedding_model: e\n      routes:\n        - name: r\n          target: m\n          examples: ["hi"]\n      default: m\n      match:\n        threshold: 0.5\n`,
+      },
+      {
+        label: "semantic on_embedding_failure target",
+        field: "target_id",
+        withId: `\n  - display_name: s\n    semantic:\n      embedding_model: e\n      routes:\n        - name: r\n          target: m\n          examples: ["hi"]\n      default: m\n      match:\n        threshold: 0.5\n      on_embedding_failure:\n        target: m\n        target_id: ${ID}\n`,
+        without: `\n  - display_name: s\n    semantic:\n      embedding_model: e\n      routes:\n        - name: r\n          target: m\n          examples: ["hi"]\n      default: m\n      match:\n        threshold: 0.5\n      on_embedding_failure:\n        target: m\n`,
+      },
+      {
+        label: "cache policy model scope",
+        field: "applies_to_model_id",
+        withId: `\ncache_policies:\n  - name: c\n    applies_to: all\n    applies_to_model_id: ${ID}\n`,
+        without: `\ncache_policies:\n  - name: c\n    applies_to: all\n`,
+      },
+      {
+        label: "cache policy similarity embedder",
+        field: "embedding_model_id",
+        withId: `\ncache_policies:\n  - name: c\n    semantic:\n      embedding_model: e\n      embedding_model_id: ${ID}\n      threshold: 0.9\n`,
+        without: `\ncache_policies:\n  - name: c\n    semantic:\n      embedding_model: e\n      threshold: 0.9\n`,
+      },
+      {
+        label: "semantic guardrail embedder",
+        field: "embedding_model_id",
+        withId: `\nguardrails:\n  - name: g\n    kind: semantic\n    embedding_model: e\n    embedding_model_id: ${ID}\n    deny_examples: ["x"]\n    deny_threshold: 0.8\n`,
+        without: `\nguardrails:\n  - name: g\n    kind: semantic\n    embedding_model: e\n    deny_examples: ["x"]\n    deny_threshold: 0.8\n`,
+      },
+    ];
+
+  test("each id field is rejected by name, and the same file without it validates", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "aisix-model-ref-ids-"));
+    try {
+      for (const { label, field, withId, without } of CASES) {
+        const bad = join(dir, `bad-${label.replace(/\W+/g, "-")}.yaml`);
+        await writeFile(bad, PRELUDE + withId, "utf8");
+        let failure: (Error & { code?: number; stderr?: string }) | undefined;
+        try {
+          await execFileP(BIN_PATH, ["validate", "--resources", bad]);
+        } catch (e) {
+          failure = e as Error & { code?: number; stderr?: string };
+        }
+        if (!failure) throw new Error(`${label}: expected \`aisix validate\` to fail`);
+        expect(failure.code, label).toBe(1);
+        expect(String(failure.stderr), label).toContain(
+          `does not accept \`${field}\``,
+        );
+
+        // The same file with the id field removed validates, so the
+        // refusal is that field and not anything else in the fixture.
+        const good = join(dir, `good-${label.replace(/\W+/g, "-")}.yaml`);
+        await writeFile(good, PRELUDE + without, "utf8");
+        const ok = await execFileP(BIN_PATH, ["validate", "--resources", good]);
+        expect(ok.stdout, label).toContain("OK:");
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/tests/e2e/src/cases/model-reference-ids-e2e.test.ts
+++ b/tests/e2e/src/cases/model-reference-ids-e2e.test.ts
@@ -128,6 +128,7 @@ describe("model references by resource id", () => {
   /** Model display name → the upstream model name its provider sees. */
   const upstreamNames: Record<string, string> = {};
   let chatPkId = "";
+  let embedPkId = "";
 
   beforeAll(async () => {
     const etcd = new EtcdClient();
@@ -210,13 +211,16 @@ describe("model references by resource id", () => {
       "mr-cache-other",
       "mr-cache-renamed",
       "mr-guarded",
+      "mr-guarded-rename",
       "mr-sentinel",
     ]) {
       await direct(name);
     }
     await embedding("mr-embed", embedPk.id);
     await embedding("mr-embed-renamed", embedPk.id);
+    await embedding("mr-embed-guard-renamed", embedPk.id);
     await embedding("mr-embed-fail", failPk.id);
+    embedPkId = embedPk.id;
 
     // ---- routing groups ----
     await seed.createModel({
@@ -399,6 +403,24 @@ describe("model references by resource id", () => {
       { attach: false },
     );
     await seed.attachGuardrailToModel(guardrail.id, ids["mr-guarded"]);
+
+    // A second guarded model whose guardrail names its embedder by id, so
+    // the embedder can be renamed without disturbing the case above.
+    const renameGuardrail = await seed.createGuardrail(
+      {
+        name: "mr-guardrail-embedder-rename",
+        kind: "semantic",
+        enabled: true,
+        embedding_model_id: ids["mr-embed-guard-renamed"],
+        deny_examples: ["jailbreak the assistant"],
+        deny_threshold: 0.5,
+      },
+      { attach: false },
+    );
+    await seed.attachGuardrailToModel(
+      renameGuardrail.id,
+      ids["mr-guarded-rename"],
+    );
 
     // Seeded last: gating on it implies the whole set has landed.
     await seed.createApiKey({ key_hash: CALLER_HASH, allowed_models: ["*"] });
@@ -702,6 +724,43 @@ describe("model references by resource id", () => {
     expect(after.status).toBe(200);
     expect(after.route).toBe("legal");
     expect(after.servedBy).toBe("mr-renamed-semantic");
+  });
+
+  test("renaming a semantic guardrail's embedder keeps the row screening", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return ctx.skip();
+    // Screening works before the rename…
+    expect(
+      (await chat("mr-guarded-rename", "please jailbreak yourself")).status,
+    ).toBe(422);
+    expect((await chat("mr-guarded-rename", "what is the weather")).status).toBe(
+      200,
+    );
+
+    // …and the guardrail document is never rewritten across it.
+    await seed.update("models", ids["mr-embed-guard-renamed"], {
+      display_name: "mr-embed-guard-renamed-v2",
+      provider: "openai",
+      model_name: "embed-mr-embed-guard-renamed",
+      provider_key_id: embedPkId,
+      embedding: { dimensions: 4, normalize: true },
+    });
+    await waitConfigPropagation(async () => {
+      const listed = await new ProxyClient(app!.proxyUrl, CALLER).listModels();
+      if (listed.status !== 200) return false;
+      const names = (listed.body as { data: { id: string }[] }).data.map(
+        (m) => m.id,
+      );
+      return names.includes("mr-embed-guard-renamed-v2");
+    });
+
+    expect(
+      (await chat("mr-guarded-rename", "please jailbreak yourself")).status,
+    ).toBe(422);
+    // Still screening rather than merely failing closed on everything —
+    // an embedder that stopped resolving would refuse this one too.
+    expect((await chat("mr-guarded-rename", "what is the weather")).status).toBe(
+      200,
+    );
   });
 
   test("renaming a cache policy's scoped model keeps the policy on it", async (ctx) => {

--- a/tests/e2e/src/cases/model-reference-ids-e2e.test.ts
+++ b/tests/e2e/src/cases/model-reference-ids-e2e.test.ts
@@ -396,6 +396,11 @@ describe("model references by resource id", () => {
         name: "mr-guardrail-by-id",
         kind: "semantic",
         enabled: true,
+        // BOTH spellings, and the name is the FAILING embedder — the
+        // shape a control plane writes while its support floor still
+        // holds gateways that need the name to load the row at all. The
+        // id has to win, or every request in scope is refused.
+        embedding_model: "mr-embed-fail",
         embedding_model_id: ids["mr-embed"],
         deny_examples: ["jailbreak the assistant"],
         deny_threshold: 0.5,
@@ -628,10 +633,13 @@ describe("model references by resource id", () => {
 
   // ──────────────────────── semantic guardrail ───────────────────────
 
-  test("a semantic guardrail whose embedder is named by id still screens", async (ctx) => {
+  test("a semantic guardrail's embedder id decides over the name beside it", async (ctx) => {
     if (!etcdReachable || !app) return ctx.skip();
     const blocked = await chat("mr-guarded", "please jailbreak yourself");
     expect(blocked.status).toBe(422);
+    // The row's `embedding_model` names an embedder whose upstream
+    // always 500s, and this guardrail is fail-CLOSED: a 200 here is only
+    // reachable if the id decided which embedder to call.
     const clean = await chat("mr-guarded", "what is the weather");
     expect(clean.status).toBe(200);
   });


### PR DESCRIPTION
Every place a projected document points at a Model named it by display name, so renaming that model silently broke the reference — it resolved to nothing and the site degraded, with the referencing document untouched and looking fine. #1148 fixed that for `api_key.allowed_models`; this does the same for the remaining sites.

## The reference shape

Each site gains an optional `<field>_id` sibling holding the referenced model's resource id (the id of its `models/<id>` entry):

| site | name field | new id field |
| --- | --- | --- |
| `routing.targets[]` | `model` | `model_id` |
| `ensemble.panel[]` | `model` | `model_id` |
| `ensemble.judge` | `model` | `model_id` |
| `semantic` | `embedding_model` | `embedding_model_id` |
| `semantic` | `default` | `default_id` |
| `semantic.routes[]` | `target` | `target_id` |
| `semantic.on_embedding_failure` | `target` | `target_id` |
| `cache_policy` | `applies_to` (`model:<name>`) | `applies_to_model_id` |
| `cache_policy.semantic` | `embedding_model` | `embedding_model_id` |
| guardrail `kind: semantic` | `embedding_model` | `embedding_model_id` |

The last two are not new sites so much as the rest of the same class: a cache policy's similarity embedder and a semantic guardrail's embedder are model references written exactly like the others, and leaving either on names alone would have left the rename bug half-fixed.

Semantics are uniform, and identical to #1148's:

- **The id decides when present**, and the name beside it is not read at all.
- Resolution is per request against the live models table, so **renaming the referenced model takes effect on the next request with no change to the referencing document**. Nothing derived from an unrelated resource can hold a stale answer — the models table is the only input.
- **An id that resolves to no model behaves exactly as a dangling name does at that site**: a routing/ensemble target that does not exist, a semantic embedding model that does not exist, a guardrail embedder that cannot be resolved (fail-closed by default, as before), a cache policy that matches nothing. No new failure mode, and never a dropped row.
- **Absent/null id is today's name path, unchanged.**

`resolve_model_ref` is the single resolver; the routing walk and the ensemble fan-out normalize their references once, up front, rather than at each of the places that read a target name, so a reference resolved in only some of them cannot dispatch to one model and bill another.

## Schemas

The id fields are optional on both the strict and the lenient contracts. Where the name field was required, requiredness moves onto a `name`-or-`id` alternative, so a document naming the model by id alone validates while one naming it neither way is rejected exactly as a missing name was. That relaxation is applied to the read contract too, deliberately: leaving the lenient schema requiring the name would make a stored id-only reference drop its whole row.

The guardrail's `semantic` embedder keeps its existing strict/lenient split — the write path demands one of the two spellings, the read path neither, because a screening row that fails to load is fail-open.

## Compatibility

Free on this side: optional fields, plus a loosened read contract. The constraint is on the writer, and it matters — **a document that carries only the id is dropped whole by any data plane released before this change**, whose read schema still requires the name: `routing.targets[].model`, `ensemble.panel[].model`, `ensemble.judge.model`, `semantic.embedding_model` / `default` / `routes[].target` / `on_embedding_failure.target`, and `cache_policy.semantic.embedding_model`. So the control plane should write **both** spellings for as long as its support floor is below this release: the id is what the current gateway acts on, the name is what keeps an older one loading the row at all.

Two of the ten sites do not fail that way, and both are worse than a dropped row rather than better:

- **The `kind: semantic` guardrail's embedder.** Its read schema already required neither spelling, so an id-only row LOADS on an older gateway, resolves its embedder to nothing, and — `fail_open` being false by default — refuses every request in the guardrail's attachment scope. It is also the one site where an older gateway's published read schema accepts the shape, so a save-time compatibility check that validates the projection against that schema cannot catch it. This one needs the writer to be told, not the schema.
- **`cache_policy.applies_to_model_id`.** An older gateway ignores it as an unknown field and falls back to `applies_to`, so a model-scoped policy silently widens to whatever that string says. Its `applies_to: "model:<name>"` has to be written as well.

An explicit `null` is accepted for every id field, on both contracts, and means exactly what omitting the key means — the reference falls back to its name. Worth stating because it was the other half of the same hazard: these resources render `Option` without the null type, so a `null` the schema rejected would have skipped the whole row rather than ignoring the field, while `api_key.allowed_model_ids` has accepted `null` since #1148.

## Resources file and export

The file source refuses every id spelling by name, at every nesting site, with the same rule and message style as #1148: a file derives its ids from its own entry names, so no id written there could ever resolve, and accepting one would leave the reference pointing at nothing while the name spelling was ignored on top. `aisix export` rewrites each id back to the name form; an id no exported model answers to is emitted under the name field as itself — the dangling reference the gateway already sees — blocking for a model, whose references the loader cross-checks, and a warning where it does not.

## Behavior changes

- A `kind: semantic` guardrail's `guardrail_scores[].embedding_model` now reports the display name the embedder **resolved for that call**, rather than the spelling the row was configured with. A score is not interpretable without knowing which model produced it, and the row's own alias is not reliably that model: under an id-form reference it is ignored, it may be stale after a rename, and it may be absent. For a row that names its embedder by name and has not been renamed, the value is unchanged.
- Two routing targets that resolve to the same model now count as one candidate. Previously the second attempt took the first target's `weight` and `priority` and consumed a second fallback slot on the same upstream. The write path rejects duplicate targets but can only compare the spelling each entry used, so a name beside an id naming the same model reaches the gateway intact.
- Nothing else changes for a document that carries no id field.

Drive-by: the `allowed_model_ids` refusal message added in #1148 carried the source literal's line padding, so it reached operators with runs of spaces inside it. It is generated now, along with the rest of the family.

## Tests

A DP e2e spec drives every site through its id spelling for the four properties the form has to have: it dispatches to the model it names, it decides over the name written beside it, a rename of that model needs no edit to the referencing document, and an id naming no model produces the same observable outcome as a name naming no model. Plus `aisix validate` over each id spelling in a resources file, each paired with the same file minus that field. Unit coverage sits alongside for the resolver, the schema alternatives, the file-source refusal and the export rewrite; every case was checked against its own fix by mutation.

There is no comparable mechanism in the mainstream gateways to compare against — they configure models by name in a single file with no separate control plane assigning resource ids, so there is no upstream baseline for a stable-id reference form. The baseline here is this repository's own #1148.

Ref api7/AISIX-Cloud#1546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resources can reference models by stable IDs across routing, ensembles, semantic routing, cache policies, and guardrails.
  * ID references take precedence over names, follow model renames, and support ID-only configurations.
  * Exports convert resolvable model IDs back to readable model names, with warnings or blocking errors for unresolved references.
  * Guardrail results now report the resolved embedding model.

* **Validation**
  * Schemas and validation now accept supported model ID fields while rejecting invalid or missing references.

* **Documentation**
  * Updated schema descriptions to explain ID-based model references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->