### PR TITLE
feat(pricing): resolve model prices from shared pricing documents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,10 @@ This repo reads its config from etcd, but users never write etcd directly — th
 - Exactly four divergence axes are registered as intentional and allowed: reference style (names here vs UUIDs in the CP), tenancy scoping (flat here vs org/environment there), credential custody (`key_hash` in documents here vs server-generated plaintext-once there), and CP-derived fields (`cost`, `telemetry_tags`). Anything else that diverges from cp-admin.yaml is drift — the planned cross-plane contract check will fail it.
 - Why the CP spec and not this repo's schemas: the CP is spec-first behind a closed validator (its spec already is the authoritative field shape on that side), the spec renders into the customer-facing API reference, and this repo's schemas are generated from the implementation — a schema that follows the implementation cannot lead it. Naming drift has already cost real churn: #644 (the generated schema advertised `rps`/`rph` the validator rejected) and #657 (a wire-breaking rename because the field was named DP-first).
 
+## A Reference, Not a Copy
+
+**A document references another resource by id and never carries a copy of another resource's mutable data.** The gateway resolves the reference on the read path, through an index keyed on the referenced table's `generation` — never on the snapshot version. Data with its own lifecycle is its own resource kind, under the environment prefix or the global one, never a field inlined into its consumers, even while it has a single reader.
+
 ## Model Kinds Stay in Lockstep — Two Identities, and the Sub-Dispatch Bypasses
 
 **A Model is one table but five kinds (`direct` / `routing` / `ensemble` / `semantic` / `embedding`, plus wildcard display-name aliases), and every request carries TWO model identities: the caller-addressed entry (may be a virtual parent) and the dispatched target. For direct models they coincide, so a mechanism built and tested against direct models silently never decides the composite case — the most-repeated silent-bug class here (#962, #1087, #1237, #1267, #786).**

--- a/crates/aisix-admin/tests/etcd_integration.rs
+++ b/crates/aisix-admin/tests/etcd_integration.rs
@@ -577,7 +577,8 @@ async fn loader_picks_up_every_direct_write() {
         })
         .collect();
 
-    let (snap, stats) = aisix_etcd::build_snapshot(&prefix, &raw_entries);
+    let (snap, stats) =
+        aisix_etcd::build_snapshot(&aisix_etcd::PrefixSet::single(&prefix), &raw_entries);
     assert_eq!(
         stats.schema_rejected, 0,
         "loader rejected a canonical document: {stats:?}"

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -441,6 +441,21 @@ impl EtcdConfig {
             format!("{trimmed}/{}/", self.env_id)
         }
     }
+
+    /// The cross-environment key prefix: `<prefix>/global/`.
+    ///
+    /// Holds the shared pricing catalog and nothing else. Not derived
+    /// from `env_id` — every gateway reads the same one — and not
+    /// configurable, since it is one half of a contract with the control
+    /// plane rather than a deployment choice.
+    ///
+    /// Trailing slash for the same reason as [`Self::effective_prefix`]:
+    /// it is what the kine auth interceptor matches the Range key
+    /// against.
+    pub fn global_prefix(&self) -> String {
+        let trimmed = self.prefix.trim_end_matches('/');
+        format!("{trimmed}/global/")
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -239,6 +239,20 @@ pub fn load_from_str(
             )));
             continue;
         };
+        // Named ahead of the generic unknown-key error: `pricing` is a
+        // real collection the gateway loads from etcd, so "unknown
+        // top-level key" would read as a typo rather than as the answer
+        // it is. Pricing documents are a control-plane projection —
+        // shared across environments and keyed by control-plane id — and
+        // a file that declared its own could not be the same document any
+        // other environment reads. Set `cost` on the model instead.
+        if key == "pricing" {
+            errors.push(file_error(
+                "the resources file does not accept a `pricing` collection — pricing documents                  are written by the control plane and shared across environments, which a file                  cannot express; set `cost` on each model instead"
+                    .to_string(),
+            ));
+            continue;
+        }
         if key != "_format_version" && !KINDS.iter().any(|(k, _)| k == key) {
             let known: Vec<&str> = KINDS.iter().map(|(k, _)| *k).collect();
             errors.push(file_error(format!(
@@ -397,6 +411,20 @@ pub fn load_from_str(
         // there an id that resolves to no model simply grants nothing and
         // must never fail the row, because a rejected api_key stops
         // authenticating entirely.)
+        // `pricing_key` is the same class of control-plane projection as
+        // `allowed_model_ids` below: it names a pricing document a file
+        // has no way to declare, so a file that carried it would leave the
+        // model with no price at all — silently, and with `cost` the only
+        // thing that could have supplied one.
+        if entry.kind == "models" && entry.doc.get("pricing_key").is_some() {
+            errors.push(LoadError {
+                scope,
+                message: "the resources file does not accept `pricing_key` — it names a                           pricing document written by the control plane, which a file cannot                           declare; set the price inline with `cost`"
+                    .into(),
+            });
+            continue;
+        }
+
         if entry.kind == "api_keys" && entry.doc.get("allowed_model_ids").is_some() {
             errors.push(LoadError {
                 scope,

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -248,7 +248,10 @@ pub fn load_from_str(
         // other environment reads. Set `cost` on the model instead.
         if key == "pricing" {
             errors.push(file_error(
-                "the resources file does not accept a `pricing` collection — pricing documents                  are written by the control plane and shared across environments, which a file                  cannot express; set `cost` on each model instead"
+                "the resources file does not accept a `pricing` collection — pricing \
+                 documents are written by the control plane and shared across \
+                 environments, which a file cannot express; set `cost` on each model \
+                 instead"
                     .to_string(),
             ));
             continue;
@@ -419,7 +422,9 @@ pub fn load_from_str(
         if entry.kind == "models" && entry.doc.get("pricing_key").is_some() {
             errors.push(LoadError {
                 scope,
-                message: "the resources file does not accept `pricing_key` — it names a                           pricing document written by the control plane, which a file cannot                           declare; set the price inline with `cost`"
+                message: "the resources file does not accept `pricing_key` — it names a \
+                          pricing document written by the control plane, which a file \
+                          cannot declare; set the price inline with `cost`"
                     .into(),
             });
             continue;
@@ -428,7 +433,9 @@ pub fn load_from_str(
         if entry.kind == "api_keys" && entry.doc.get("allowed_model_ids").is_some() {
             errors.push(LoadError {
                 scope,
-                message: "the resources file does not accept `allowed_model_ids` — it names                           models by control-plane id, which a file cannot resolve; grant                           models by name with `allowed_models`"
+                message: "the resources file does not accept `allowed_model_ids` — it \
+                          names models by control-plane id, which a file cannot resolve; \
+                          grant models by name with `allowed_models`"
                     .into(),
             });
             continue;

--- a/crates/aisix-core/src/filesource/tests.rs
+++ b/crates/aisix-core/src/filesource/tests.rs
@@ -444,6 +444,63 @@ models:
 }
 
 #[test]
+fn pricing_key_is_rejected_by_the_file_source() {
+    // The reference names a document only the control plane writes, and
+    // the shared catalog is not even under the prefix a standalone
+    // gateway reads. A file that carried it would leave the model with no
+    // price at all — silently, with `cost` the only thing that could have
+    // supplied one.
+    let contents = r#"
+_format_version: "1"
+models:
+  - display_name: m
+    provider: openai
+    model_name: x
+    provider_key: pk
+    pricing_key: openai/x
+provider_keys:
+  - display_name: pk
+    api_key: sk-x
+"#;
+    let env = env_of(&[]);
+    let errs = errors_of(load(contents, &env));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].contains("does not accept `pricing_key`") && errs[0].contains("cost"),
+        "{errs:?}"
+    );
+
+    // The same file without the field loads, so the rejection is the
+    // field and not anything else in the fixture.
+    let ok = contents.replace("    pricing_key: openai/x\n", "");
+    load(&ok, &env).expect("the same file without the field loads");
+}
+
+#[test]
+fn a_pricing_collection_is_rejected_by_the_file_source() {
+    // Named rather than swept into the generic unknown-key error: it is a
+    // real collection the gateway loads from etcd, so "unknown top-level
+    // key" would read as a typo rather than as the answer it is.
+    let contents = r#"
+_format_version: "1"
+pricing:
+  - key: openai/x
+    input_per_1k: 1.0
+    output_per_1k: 2.0
+provider_keys:
+  - display_name: pk
+    api_key: sk-x
+"#;
+    let env = env_of(&[]);
+    let errs = errors_of(load(contents, &env));
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(
+        errs[0].contains("does not accept a `pricing` collection") && errs[0].contains("cost"),
+        "{errs:?}"
+    );
+}
+
+#[test]
 fn allowed_model_ids_is_rejected_by_the_file_source() {
     // A file's ids are derived from entry names, so no id written here
     // resolves to a model — the key would silently grant nothing, with

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -31,6 +31,7 @@ pub mod observability_exporter;
 pub mod oidc_provider;
 pub mod passthrough_route;
 pub mod policy_conditions;
+pub mod pricing;
 pub mod provider_key;
 pub mod rate_limit;
 pub mod rate_limit_policy;
@@ -71,6 +72,7 @@ pub use policy_conditions::{
     ConditionNode, ConditionOperator, ConditionValue, GroupByDimension, PolicyAction,
     PolicyCondition, PolicyDimension,
 };
+pub use pricing::{LivePricingIndex, Pricing, PricingIndex};
 pub use provider_key::{
     ApiEndpoint, ApiSurface, ParamConstraints, ProviderApis, ProviderKey, RequestOverrides,
     ResponseOverrides, StreamDoneMarker, TelemetryKind, TelemetryTags,
@@ -91,8 +93,9 @@ pub use schema::{
     validate_mcp_server_lenient, validate_model, validate_model_lenient,
     validate_observability_exporter, validate_observability_exporter_lenient,
     validate_oidc_provider, validate_oidc_provider_lenient, validate_passthrough_route,
-    validate_passthrough_route_lenient, validate_provider_key, validate_provider_key_lenient,
-    validate_rate_limit_policy, validate_rate_limit_policy_lenient, SchemaError,
+    validate_passthrough_route_lenient, validate_pricing, validate_pricing_lenient,
+    validate_provider_key, validate_provider_key_lenient, validate_rate_limit_policy,
+    validate_rate_limit_policy_lenient, SchemaError,
 };
 pub use semantic::{
     Aggregation, DistanceMetric, EmbeddingFailureMode, OnEmbeddingFailure, Semantic, SemanticMatch,

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -539,7 +539,12 @@ fn model_one_of_variant(strict: bool) -> Value {
         // stay direct-only.
         extend(
             &mut arr[3],
-            &["auto_prompt_caching", "cost", "pricing_key", "effort_mapping"],
+            &[
+                "auto_prompt_caching",
+                "cost",
+                "pricing_key",
+                "effort_mapping",
+            ],
         );
     }
     variants

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -305,6 +305,10 @@ pub struct Model {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost: Option<ModelCost>,
 
+    /// Name of a shared `pricing` document to take the per-token cost from, instead of setting `cost` on this model. The environment's own pricing documents are searched first and the shared catalog second; when the key matches neither, `cost` applies. Editing the pricing document repricies every model naming it, with no change to the models themselves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing_key: Option<String>,
+
     /// Direct-model-only background health-check configuration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub background_model_check: Option<BackgroundModelCheck>,
@@ -383,6 +387,9 @@ impl Model {
         }
         if self.effort_mapping.take().is_some() {
             stripped.push("effort_mapping");
+        }
+        if self.pricing_key.take().is_some() {
+            stripped.push("pricing_key");
         }
         if (self.is_routing() || self.is_ensemble()) && self.retries.take().is_some() {
             stripped.push("retries");
@@ -477,7 +484,8 @@ pub fn model_one_of() -> Value {
 /// [`Model::strip_kind_inapplicable`]). Kind policy (project decision):
 /// generic call knobs (`timeout`/`stream_timeout`/`retries`) resolve
 /// member → group → deployment default wherever a group slot exists;
-/// model-specific knobs (`auto_prompt_caching`, `cost`) are direct-only.
+/// model-specific knobs (`auto_prompt_caching`, `cost`, `pricing_key`) are
+/// direct-only.
 pub fn model_one_of_strict() -> Value {
     model_one_of_variant(true)
 }
@@ -497,7 +505,13 @@ fn model_one_of_variant(strict: bool) -> Value {
         // top-level value is dead — as are the model-specific knobs.
         extend(
             &mut arr[0],
-            &["retries", "auto_prompt_caching", "cost", "effort_mapping"],
+            &[
+                "retries",
+                "auto_prompt_caching",
+                "cost",
+                "pricing_key",
+                "effort_mapping",
+            ],
         );
         // The direct-shaped branch also carries embedding models. They do
         // not accept generation effort, so forbid the mapping only when the
@@ -516,6 +530,7 @@ fn model_one_of_variant(strict: bool) -> Value {
                 "retries",
                 "auto_prompt_caching",
                 "cost",
+                "pricing_key",
                 "effort_mapping",
             ],
         );
@@ -524,7 +539,7 @@ fn model_one_of_variant(strict: bool) -> Value {
         // stay direct-only.
         extend(
             &mut arr[3],
-            &["auto_prompt_caching", "cost", "effort_mapping"],
+            &["auto_prompt_caching", "cost", "pricing_key", "effort_mapping"],
         );
     }
     variants

--- a/crates/aisix-core/src/models/model.rs
+++ b/crates/aisix-core/src/models/model.rs
@@ -307,6 +307,7 @@ pub struct Model {
 
     /// Name of a shared `pricing` document to take the per-token cost from, instead of setting `cost` on this model. The environment's own pricing documents are searched first and the shared catalog second; when the key matches neither, `cost` applies. Editing the pricing document repricies every model naming it, with no change to the models themselves.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1, max = 255))]
     pub pricing_key: Option<String>,
 
     /// Direct-model-only background health-check configuration.

--- a/crates/aisix-core/src/models/pricing.rs
+++ b/crates/aisix-core/src/models/pricing.rs
@@ -192,4 +192,137 @@ mod tests {
     fn resource_kind_matches_kine_path_segment() {
         assert_eq!(<Pricing as Resource>::kind(), "pricing");
     }
+
+    use crate::resource::ResourceEntry;
+
+    fn price(key: &str, input: f64, output: f64) -> Pricing {
+        Pricing {
+            key: key.into(),
+            input_per_1k: input,
+            output_per_1k: output,
+            runtime_id: String::new(),
+        }
+    }
+
+    fn model(json: &str) -> Model {
+        serde_json::from_str(json).unwrap()
+    }
+
+    fn direct(extra: &str) -> Model {
+        model(&format!(
+            r#"{{"display_name":"m","provider":"openai","model_name":"gpt-4o",
+                "provider_key_id":"11111111-1111-1111-1111-111111111111"{extra}}}"#
+        ))
+    }
+
+    #[test]
+    fn an_environment_document_wins_over_the_global_one() {
+        let snap = AisixSnapshot::new();
+        snap.global_pricing
+            .insert(ResourceEntry::new("g", price("k", 1.0, 1.0), 1));
+        snap.pricing
+            .insert(ResourceEntry::new("e", price("k", 9.0, 9.0), 2));
+
+        let index = PricingIndex::build(&snap);
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.get("k").unwrap().input_per_1k, 9.0);
+    }
+
+    #[test]
+    fn a_global_document_applies_where_the_environment_has_none() {
+        let snap = AisixSnapshot::new();
+        snap.global_pricing
+            .insert(ResourceEntry::new("g", price("k", 1.0, 2.0), 1));
+        snap.pricing
+            .insert(ResourceEntry::new("e", price("other", 9.0, 9.0), 2));
+
+        let index = PricingIndex::build(&snap);
+        assert_eq!(index.get("k").unwrap().output_per_1k, 2.0);
+    }
+
+    #[test]
+    fn resolution_falls_through_pricing_key_then_inline_cost() {
+        let snap = AisixSnapshot::new();
+        snap.global_pricing
+            .insert(ResourceEntry::new("g", price("k", 1.0, 1.0), 1));
+        let index = PricingIndex::build(&snap);
+
+        // A resolving key wins over the inline cost sitting next to it,
+        // which is what makes the reference authoritative rather than
+        // advisory.
+        let keyed =
+            direct(r#","pricing_key":"k","cost":{"input_per_1k":50.0,"output_per_1k":50.0}"#);
+        assert_eq!(index.resolve(&keyed).unwrap().input_per_1k, 1.0);
+
+        // A key naming no document falls through to the inline cost.
+        let missing =
+            direct(r#","pricing_key":"absent","cost":{"input_per_1k":7.0,"output_per_1k":7.0}"#);
+        assert_eq!(index.resolve(&missing).unwrap().input_per_1k, 7.0);
+
+        // No key at all: unchanged behaviour for every model written
+        // before this feature existed.
+        let inline = direct(r#","cost":{"input_per_1k":3.0,"output_per_1k":3.0}"#);
+        assert_eq!(index.resolve(&inline).unwrap().input_per_1k, 3.0);
+
+        // Neither: no price, which ranks last rather than free.
+        let none = direct(r#","pricing_key":"absent""#);
+        assert!(index.resolve(&none).is_none());
+        assert!(index.resolve(&direct("")).is_none());
+    }
+
+    #[test]
+    fn the_live_index_rebuilds_when_a_pricing_table_changes() {
+        let snap = AisixSnapshot::new();
+        snap.global_pricing
+            .insert(ResourceEntry::new("g", price("k", 1.0, 1.0), 1));
+        let live = LivePricingIndex::new();
+
+        let first = live.for_snapshot(&snap);
+        assert!(Arc::ptr_eq(&first, &live.for_snapshot(&snap)));
+
+        // A write to an unrelated table must NOT invalidate: that is the
+        // difference between keying on the table generation and keying on
+        // the snapshot version (AISIX-Cloud#1542).
+        snap.apikeys.insert(ResourceEntry::new(
+            "k-1",
+            serde_json::from_str::<crate::models::ApiKey>(
+                r#"{"key_hash":"91ed2dbc407561556f3e7be98ba0bd2a57986d6a868c482d867d19c6d40d201c"}"#,
+            )
+            .unwrap(),
+            1,
+        ));
+        assert!(Arc::ptr_eq(&first, &live.for_snapshot(&snap)));
+
+        // A price edit does invalidate, and the new price is what the
+        // next reader sees — with no model document involved.
+        snap.global_pricing
+            .insert(ResourceEntry::new("g", price("k", 5.0, 5.0), 2));
+        let second = live.for_snapshot(&snap);
+        assert!(!Arc::ptr_eq(&first, &second));
+        assert_eq!(second.get("k").unwrap().input_per_1k, 5.0);
+
+        // The environment table is the other half of the invalidation
+        // key; a write there must invalidate too.
+        snap.pricing
+            .insert(ResourceEntry::new("e", price("k", 8.0, 8.0), 3));
+        let third = live.for_snapshot(&snap);
+        assert!(!Arc::ptr_eq(&second, &third));
+        assert_eq!(third.get("k").unwrap().input_per_1k, 8.0);
+    }
+
+    #[test]
+    fn pricing_key_is_direct_only_like_cost() {
+        // `pricing_key` and `cost` are two spellings of the same knob, so
+        // a kind that strips one must strip the other — otherwise a
+        // routing group could carry a price the runtime never reads.
+        let mut group: Model = serde_json::from_str(
+            r#"{"display_name":"g","routing":{"targets":[{"model":"a"}]},
+                "cost":{"input_per_1k":1.0,"output_per_1k":1.0},"pricing_key":"k"}"#,
+        )
+        .unwrap();
+        let stripped = group.strip_kind_inapplicable();
+        assert!(stripped.contains(&"pricing_key"), "{stripped:?}");
+        assert!(stripped.contains(&"cost"), "{stripped:?}");
+        assert!(group.pricing_key.is_none() && group.cost.is_none());
+    }
 }

--- a/crates/aisix-core/src/models/pricing.rs
+++ b/crates/aisix-core/src/models/pricing.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use crate::models::model::{Model, ModelCost};
 use crate::models::snapshot::AisixSnapshot;
 use crate::resource::Resource;
+use crate::snapshot::ResourceTable;
 
 /// A per-1,000-token price shared by every model that names it.
 ///
@@ -81,13 +82,10 @@ impl PricingIndex {
     /// Flatten both tables, environment documents last so one of them
     /// replaces the global document carrying the same `key`.
     pub fn build(snap: &AisixSnapshot) -> Self {
-        let mut by_key = HashMap::new();
-        for entry in snap.global_pricing.entries() {
-            by_key.insert(entry.value.key.clone(), cost_of(&entry.value));
-        }
-        for entry in snap.pricing.entries() {
-            by_key.insert(entry.value.key.clone(), cost_of(&entry.value));
-        }
+        let global = flatten(&snap.global_pricing);
+        let mut by_key: HashMap<String, ModelCost> =
+            global.into_iter().map(|(k, v)| (k, v.2)).collect();
+        by_key.extend(flatten(&snap.pricing).into_iter().map(|(k, v)| (k, v.2)));
         Self { by_key }
     }
 
@@ -117,6 +115,30 @@ impl PricingIndex {
     pub fn is_empty(&self) -> bool {
         self.by_key.is_empty()
     }
+}
+
+/// One table's prices by `key`, carrying the revision and id that won.
+///
+/// Nothing constrains `key` to be unique within a table, and the control
+/// plane writes a replacement before deleting the row it replaces — so
+/// two documents can carry one key for a window. Picking by highest
+/// revision, then by id, makes the effective price the later write
+/// rather than whichever row the table happened to iterate first: an
+/// order that is not stable across rebuilds would otherwise let the
+/// price flip back and forth while the window is open, changing both
+/// `least_cost` ordering and the cost on emitted usage events.
+fn flatten(table: &ResourceTable<Pricing>) -> HashMap<String, (i64, String, ModelCost)> {
+    let mut out: HashMap<String, (i64, String, ModelCost)> = HashMap::new();
+    for entry in table.entries() {
+        let candidate = (entry.revision, entry.id.clone(), cost_of(&entry.value));
+        match out.get(&entry.value.key) {
+            Some(current) if (current.0, &current.1) >= (candidate.0, &candidate.1) => {}
+            _ => {
+                out.insert(entry.value.key.clone(), candidate);
+            }
+        }
+    }
+    out
 }
 
 fn cost_of(p: &Pricing) -> ModelCost {
@@ -226,6 +248,26 @@ mod tests {
         let index = PricingIndex::build(&snap);
         assert_eq!(index.len(), 1);
         assert_eq!(index.get("k").unwrap().input_per_1k, 9.0);
+    }
+
+    #[test]
+    fn two_documents_with_one_key_resolve_to_the_later_write() {
+        // The control plane writes a replacement before deleting the row
+        // it replaces, so one key can name two documents for a window.
+        // Whichever the table iterates first is not stable across
+        // rebuilds; the price must not flip while the window is open.
+        let snap = AisixSnapshot::new();
+        snap.global_pricing
+            .insert(ResourceEntry::new("old", price("k", 1.0, 1.0), 4));
+        snap.global_pricing
+            .insert(ResourceEntry::new("new", price("k", 9.0, 9.0), 7));
+
+        for _ in 0..20 {
+            assert_eq!(
+                PricingIndex::build(&snap).get("k").unwrap().input_per_1k,
+                9.0
+            );
+        }
     }
 
     #[test]

--- a/crates/aisix-core/src/models/pricing.rs
+++ b/crates/aisix-core/src/models/pricing.rs
@@ -1,0 +1,195 @@
+//! `Pricing` entity — a per-1,000-token price a model refers to by
+//! `pricing_key` instead of carrying inline.
+//!
+//! Pricing documents have their own lifecycle: a price changes far more
+//! often than the models priced by it, and one price is usually shared by
+//! many models. Two prefixes carry them. The environment prefix
+//! (`<prefix>/<env>/pricing/<uuid>`) holds an organization's own
+//! overrides; the global prefix (`<prefix>/global/pricing/<uuid>`) holds
+//! the catalog every environment reads. An environment document wins over
+//! a global one with the same `key`.
+//!
+//! The gateway resolves the reference on the read path, so a price edit
+//! takes effect on the next request without any model document being
+//! rewritten.
+
+use arc_swap::ArcSwapOption;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::models::model::{Model, ModelCost};
+use crate::models::snapshot::AisixSnapshot;
+use crate::resource::Resource;
+
+/// A per-1,000-token price shared by every model that names it.
+///
+/// A model refers to one of these with `pricing_key`. The gateway looks
+/// the price up in the environment's own pricing documents first and in
+/// the global catalog second; a model with no `pricing_key`, or one whose
+/// key matches no document, falls back to its inline `cost`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Pricing {
+    /// Value a model's `pricing_key` is matched against, compared as an
+    /// exact string. Conventionally `<provider>/<model_name>`, but the
+    /// gateway attaches no meaning to its parts.
+    #[schemars(length(min = 1, max = 255))]
+    pub key: String,
+
+    /// Prompt token price in USD per 1,000 tokens.
+    #[schemars(range(min = 0.0))]
+    pub input_per_1k: f64,
+
+    /// Completion token price in USD per 1,000 tokens.
+    #[schemars(range(min = 0.0))]
+    pub output_per_1k: f64,
+
+    /// Set by the loader from the kine path's UUID segment. Not part of
+    /// the wire shape.
+    #[serde(skip)]
+    pub(crate) runtime_id: String,
+}
+
+impl Resource for Pricing {
+    fn id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    /// The lookup `key`, not a display name: the name index is what
+    /// `pricing_key` resolution reads.
+    fn name(&self) -> &str {
+        &self.key
+    }
+
+    fn kind() -> &'static str {
+        "pricing"
+    }
+}
+
+/// Prices by lookup key, flattened from the two pricing tables.
+///
+/// Derived state, so it is rebuilt only when the rows behind it change:
+/// [`LivePricingIndex`] keys the cached copy on the two tables'
+/// generations rather than on the snapshot version, which moves on every
+/// published write of any kind (AISIX-Cloud#1542).
+#[derive(Debug, Default)]
+pub struct PricingIndex {
+    by_key: HashMap<String, ModelCost>,
+}
+
+impl PricingIndex {
+    /// Flatten both tables, environment documents last so one of them
+    /// replaces the global document carrying the same `key`.
+    pub fn build(snap: &AisixSnapshot) -> Self {
+        let mut by_key = HashMap::new();
+        for entry in snap.global_pricing.entries() {
+            by_key.insert(entry.value.key.clone(), cost_of(&entry.value));
+        }
+        for entry in snap.pricing.entries() {
+            by_key.insert(entry.value.key.clone(), cost_of(&entry.value));
+        }
+        Self { by_key }
+    }
+
+    /// The price a `pricing_key` names, environment documents winning
+    /// over global ones. `None` when no document carries the key.
+    pub fn get(&self, key: &str) -> Option<&ModelCost> {
+        self.by_key.get(key)
+    }
+
+    /// The price to charge `model` by: the document its `pricing_key`
+    /// names, then the model's own inline `cost`, then nothing.
+    ///
+    /// Every reader of a model's price goes through here, so ranking and
+    /// the usage events cannot disagree about what a model costs.
+    pub fn resolve<'a>(&'a self, model: &'a Model) -> Option<&'a ModelCost> {
+        model
+            .pricing_key
+            .as_deref()
+            .and_then(|key| self.get(key))
+            .or(model.cost.as_ref())
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_key.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_key.is_empty()
+    }
+}
+
+fn cost_of(p: &Pricing) -> ModelCost {
+    ModelCost {
+        input_per_1k: p.input_per_1k,
+        output_per_1k: p.output_per_1k,
+    }
+}
+
+/// The generations of exactly the tables [`PricingIndex::build`] reads.
+fn index_key(snap: &AisixSnapshot) -> (u64, u64) {
+    (snap.pricing.generation(), snap.global_pricing.generation())
+}
+
+#[derive(Debug)]
+struct Cached {
+    key: (u64, u64),
+    index: Arc<PricingIndex>,
+}
+
+/// Lazily-rebuilt [`PricingIndex`] shared by every reader of a model's
+/// price. Cheap on the request path: a hit is one atomic load.
+///
+/// A racing rebuild produces two equal indexes and one of them is
+/// discarded — the same benign duplication the guardrail index accepts,
+/// and cheaper than holding a lock across the build.
+#[derive(Debug, Default)]
+pub struct LivePricingIndex {
+    cached: ArcSwapOption<Cached>,
+}
+
+impl LivePricingIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The index for `snap`, rebuilt only if a pricing table changed
+    /// since the cached copy was built. Takes the caller's snapshot
+    /// rather than loading its own, so a request ranks and bills against
+    /// the same published configuration it resolved its models from.
+    pub fn for_snapshot(&self, snap: &AisixSnapshot) -> Arc<PricingIndex> {
+        let key = index_key(snap);
+        if let Some(cached) = self.cached.load_full() {
+            if cached.key == key {
+                return Arc::clone(&cached.index);
+            }
+        }
+        let index = Arc::new(PricingIndex::build(snap));
+        self.cached.store(Some(Arc::new(Cached {
+            key,
+            index: Arc::clone(&index),
+        })));
+        index
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_name_is_the_lookup_key() {
+        let p: Pricing = serde_json::from_str(
+            r#"{"key":"openai/gpt-4o","input_per_1k":0.005,"output_per_1k":0.015}"#,
+        )
+        .unwrap();
+        assert_eq!(p.name(), "openai/gpt-4o");
+        assert_eq!(p.input_per_1k, 0.005);
+        assert_eq!(p.output_per_1k, 0.015);
+    }
+
+    #[test]
+    fn resource_kind_matches_kine_path_segment() {
+        assert_eq!(<Pricing as Resource>::kind(), "pricing");
+    }
+}

--- a/crates/aisix-core/src/models/routing.rs
+++ b/crates/aisix-core/src/models/routing.rs
@@ -27,9 +27,10 @@
 //!
 //! Metric-ordered strategies rank targets by a runtime signal within each
 //! tier and attempt them best-first, falling forward down the ranked order:
-//! - `least_cost`: cheapest target first, by the target model's `cost`
-//!   (combined input+output per-1K price). Targets without a `cost` rank
-//!   last.
+//! - `least_cost`: cheapest target first, by the target model's resolved
+//!   price (combined input+output per-1K) — the `pricing` document its
+//!   `pricing_key` names, or its inline `cost`. Targets with no price at
+//!   all rank last.
 //! - `least_latency`: fastest target first, by a moving average of recent
 //!   observed upstream latency (time-to-first-token for streaming). Targets
 //!   with no latency samples yet rank first so they get probed.
@@ -58,9 +59,11 @@ pub enum RoutingStrategy {
     /// after failure.
     #[default]
     Failover,
-    /// Rank targets cheapest-first by the target model's `cost` (combined
-    /// input+output per-1K price), then fall forward. Targets without a
-    /// configured `cost` rank last.
+    /// Rank targets cheapest-first by the target model's resolved price
+    /// (combined input+output per-1K), then fall forward. A target is
+    /// priced by the `pricing` document its `pricing_key` names, or by
+    /// its inline `cost` when it names none; a target with no price at
+    /// all ranks last.
     LeastCost,
     /// Rank targets fastest-first by a moving average of recent observed
     /// upstream latency (time-to-first-token for streaming), then fall

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -71,6 +71,7 @@ pub struct Schemas {
     pub claim_mapping: Validator,
     pub passthrough_route: Validator,
     pub mcp_auth_settings: Validator,
+    pub pricing: Validator,
 }
 
 pub static SCHEMAS: Lazy<Arc<Schemas>> = Lazy::new(|| Arc::new(Schemas::compile(true)));
@@ -84,7 +85,7 @@ pub static LENIENT_SCHEMAS: Lazy<Arc<Schemas>> = Lazy::new(|| Arc::new(Schemas::
 /// [`resource_root_schema`] takes. The published schema files and the
 /// validator sets are built from this list, so a new resource cannot reach
 /// one without reaching the other.
-pub const RESOURCES: [&str; 15] = [
+pub const RESOURCES: [&str; 16] = [
     "model",
     "api_key",
     "provider_key",
@@ -100,6 +101,7 @@ pub const RESOURCES: [&str; 15] = [
     "claim_mapping",
     "passthrough_route",
     "mcp_auth_settings",
+    "pricing",
 ];
 
 /// Whether a resource's write contract closes unknown top-level fields.
@@ -137,6 +139,7 @@ pub fn resource_root_schema(resource: &str, strict: bool) -> Value {
         "claim_mapping" => claim_mapping_root_schema(),
         "passthrough_route" => passthrough_route_root_schema(),
         "mcp_auth_settings" => mcp_auth_settings_root_schema(),
+        "pricing" => pricing_root_schema(),
         other => panic!("unknown resource {other:?}"),
     };
     if strict {
@@ -172,6 +175,7 @@ impl Schemas {
             claim_mapping: build("claim_mapping"),
             passthrough_route: build("passthrough_route"),
             mcp_auth_settings: build("mcp_auth_settings"),
+            pricing: build("pricing"),
         }
     }
 }
@@ -603,6 +607,10 @@ pub fn validate_cache_policy(value: &Value) -> Result<(), SchemaError> {
     validate(&SCHEMAS.cache_policy, value)
 }
 
+pub fn validate_pricing(value: &Value) -> Result<(), SchemaError> {
+    validate(&SCHEMAS.pricing, value)
+}
+
 pub fn validate_observability_exporter(value: &Value) -> Result<(), SchemaError> {
     match validate(&SCHEMAS.observability_exporter, value) {
         Ok(()) => Ok(()),
@@ -741,6 +749,10 @@ pub fn validate_guardrail_lenient(value: &Value) -> Result<(), SchemaError> {
 
 pub fn validate_cache_policy_lenient(value: &Value) -> Result<(), SchemaError> {
     validate(&LENIENT_SCHEMAS.cache_policy, value)
+}
+
+pub fn validate_pricing_lenient(value: &Value) -> Result<(), SchemaError> {
+    validate(&LENIENT_SCHEMAS.pricing, value)
 }
 
 pub fn validate_observability_exporter_lenient(value: &Value) -> Result<(), SchemaError> {
@@ -1747,6 +1759,14 @@ fn set_property_additional_properties_description(
 /// (i.e. `true`) — forward-compat fields from a newer cp-api are tolerated.
 pub fn cache_policy_root_schema() -> Value {
     struct_root_schema::<crate::models::CachePolicy>(false)
+}
+
+/// Canonical JSON Schema for the `pricing` resource, derived from the
+/// [`Pricing`](crate::models::Pricing) struct. All three fields are the
+/// document — a row missing one prices nothing — so they are required on
+/// both the write and the read path.
+pub fn pricing_root_schema() -> Value {
+    struct_root_schema::<crate::models::Pricing>(false)
 }
 
 /// Canonical JSON Schema for the `observability_exporter` resource, derived

--- a/crates/aisix-core/src/models/snapshot.rs
+++ b/crates/aisix-core/src/models/snapshot.rs
@@ -16,6 +16,7 @@ use super::model::Model;
 use super::observability_exporter::ObservabilityExporter;
 use super::oidc_provider::OidcProvider;
 use super::passthrough_route::PassthroughRoute;
+use super::pricing::Pricing;
 use super::provider_key::ProviderKey;
 use super::rate_limit_policy::RateLimitPolicy;
 use crate::snapshot::ResourceTable;
@@ -76,6 +77,15 @@ pub struct AisixSnapshot {
     /// one enabled `oidc_providers` row it activates the `/mcp`
     /// RFC 9728 discovery surface (AISIX-Cloud#1143).
     pub mcp_auth_settings: ResourceTable<McpAuthSettings>,
+    /// The environment's own pricing documents:
+    /// `/aisix/<env>/pricing/<uuid>`. Indexed by `key`, and consulted
+    /// before [`AisixSnapshot::global_pricing`] so an organization can
+    /// override a catalog price.
+    pub pricing: ResourceTable<Pricing>,
+    /// The shared pricing catalog: `/aisix/global/pricing/<uuid>` — the
+    /// one collection the gateway reads from outside its own environment
+    /// prefix, and the only kind accepted there.
+    pub global_pricing: ResourceTable<Pricing>,
 }
 
 impl AisixSnapshot {
@@ -101,6 +111,8 @@ impl AisixSnapshot {
             + self.claim_mappings.len()
             + self.passthrough_routes.len()
             + self.mcp_auth_settings.len()
+            + self.pricing.len()
+            + self.global_pricing.len()
     }
 }
 

--- a/crates/aisix-core/tests/resource_schema_characterization.rs
+++ b/crates/aisix-core/tests/resource_schema_characterization.rs
@@ -1248,6 +1248,15 @@ const UNKNOWN_FIELD_TOLERANCE: &[Probe] = &[
                    "provider_key_id": "pk-1"})
         },
     },
+    // A pricing document is closed on write at its root: the three
+    // fields ARE the document, so anything else there is a mistake the
+    // control plane should hear about. The loader still takes the row —
+    // a price it can read is worth more than a field it cannot.
+    Probe {
+        resource: "pricing",
+        pointer: "",
+        document: || json!({"key": "openai/gpt-4o", "input_per_1k": 0.005, "output_per_1k": 0.015}),
+    },
 ];
 
 /// The two resources whose write contract closes NOTHING — not the root, not

--- a/crates/aisix-etcd/src/key.rs
+++ b/crates/aisix-etcd/src/key.rs
@@ -279,6 +279,93 @@ mod tests {
         assert!(matches!(err, KeyError::EmptySegment(_)));
     }
 
+    fn set(env: &str, global: &str) -> PrefixSet {
+        PrefixSet::new(vec![
+            WatchedPrefix::environment(env),
+            WatchedPrefix::global(global),
+        ])
+    }
+
+    #[test]
+    fn a_key_resolves_to_the_prefix_that_holds_it() {
+        let s = set("/aisix/env-1/", "/aisix/global/");
+        let env = s.resolve("/aisix/env-1/models/m-1").unwrap();
+        assert_eq!(env.scope, PrefixScope::Environment);
+        assert_eq!((env.kind, env.id), ("models", "m-1"));
+
+        let global = s.resolve("/aisix/global/pricing/p-1").unwrap();
+        assert_eq!(global.scope, PrefixScope::Global);
+        assert_eq!((global.kind, global.id), ("pricing", "p-1"));
+    }
+
+    #[test]
+    fn the_global_prefix_wins_when_it_nests_inside_a_bare_environment_prefix() {
+        // The pre-`env_id` shape a self-managed deployment still uses:
+        // the environment prefix is the bare base, so `<base>/global/`
+        // sits INSIDE it. Resolved against the outer prefix the key would
+        // parse as kind `global` and be rejected, silently costing every
+        // model its catalog price.
+        let s = set("/aisix", "/aisix/global/");
+        let k = s.resolve("/aisix/global/pricing/p-1").unwrap();
+        assert_eq!(k.scope, PrefixScope::Global);
+        assert_eq!((k.kind, k.id), ("pricing", "p-1"));
+
+        // A sibling of `global` under the same base is still the
+        // environment's.
+        let m = s.resolve("/aisix/models/m-1").unwrap();
+        assert_eq!(m.scope, PrefixScope::Environment);
+        assert_eq!(m.kind, "models");
+    }
+
+    #[test]
+    fn a_key_under_no_watched_prefix_is_a_mismatch() {
+        let s = set("/aisix/env-1/", "/aisix/global/");
+        let err = s.resolve("/aisix/env-2/models/m-1").unwrap_err();
+        assert!(matches!(err, KeyError::PrefixMismatch { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn a_malformed_suffix_under_a_watched_prefix_is_not_retried_elsewhere() {
+        let s = set("/aisix/env-1/", "/aisix/global/");
+        assert!(matches!(
+            s.resolve("/aisix/env-1/models").unwrap_err(),
+            KeyError::MissingSuffix(_)
+        ));
+        assert!(matches!(
+            s.resolve("/aisix/global/pricing/").unwrap_err(),
+            KeyError::EmptySegment(_)
+        ));
+    }
+
+    #[test]
+    fn only_global_pricing_takes_a_different_table_than_its_kind() {
+        let s = set("/aisix/env-1/", "/aisix/global/");
+        assert_eq!(
+            s.resolve("/aisix/global/pricing/p-1").unwrap().table_kind(),
+            "global_pricing"
+        );
+        // The same kind under the environment keeps its own table, which
+        // is what lets an environment document override a catalog one.
+        assert_eq!(
+            s.resolve("/aisix/env-1/pricing/p-1").unwrap().table_kind(),
+            "pricing"
+        );
+        assert_eq!(
+            s.resolve("/aisix/env-1/models/m-1").unwrap().table_kind(),
+            "models"
+        );
+    }
+
+    #[test]
+    fn a_single_prefix_set_is_environment_scoped() {
+        let s = PrefixSet::single("/aisix");
+        assert_eq!(s.len(), 1);
+        assert_eq!(
+            s.resolve("/aisix/models/m-1").unwrap().scope,
+            PrefixScope::Environment
+        );
+    }
+
     #[test]
     fn display_is_kind_slash_id() {
         let k = ResourceKey {

--- a/crates/aisix-etcd/src/key.rs
+++ b/crates/aisix-etcd/src/key.rs
@@ -4,6 +4,13 @@
 //! demultiplexes incoming events by the `kind` segment (`models`, `api_keys`,
 //! `provider_keys`, `guardrails`, …) so each typed table can be updated
 //! independently.
+//!
+//! The supervisor watches more than one prefix — its environment's, plus
+//! the shared `<base>/global/` catalog — over one snapshot, so a key is
+//! resolved against a [`PrefixSet`] rather than a single string. Which
+//! prefix a key came from is part of its identity: the same `pricing`
+//! kind means two different tables depending on the prefix it was
+//! written under.
 
 use std::fmt;
 
@@ -59,6 +66,149 @@ pub fn parse<'a>(prefix: &str, key: &'a str) -> Result<ResourceKey<'a>, KeyError
     }
 
     Ok(ResourceKey { kind, id })
+}
+
+/// Which of the supervisor's prefixes a key was written under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrefixScope {
+    /// The gateway's own environment: `<base>/<env_id>/`. Carries every
+    /// resource kind.
+    Environment,
+    /// The shared catalog: `<base>/global/`. Carries `pricing` and
+    /// nothing else — see [`crate::loader::build_snapshot`].
+    Global,
+}
+
+impl PrefixScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Environment => "environment",
+            Self::Global => "global",
+        }
+    }
+}
+
+/// One prefix the supervisor watches, with what it is allowed to carry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WatchedPrefix {
+    pub prefix: String,
+    pub scope: PrefixScope,
+}
+
+impl WatchedPrefix {
+    pub fn environment(prefix: impl Into<String>) -> Self {
+        Self {
+            prefix: prefix.into(),
+            scope: PrefixScope::Environment,
+        }
+    }
+
+    pub fn global(prefix: impl Into<String>) -> Self {
+        Self {
+            prefix: prefix.into(),
+            scope: PrefixScope::Global,
+        }
+    }
+}
+
+/// The prefixes one supervisor resolves keys against.
+///
+/// Ordered longest-first, so a key is attributed to the most specific
+/// prefix that contains it. That matters when the environment prefix is
+/// the bare base — the pre-`env_id` shape a self-managed deployment still
+/// uses — because `<base>/global/` then nests inside it, and a global
+/// document resolved against the outer prefix would parse as kind
+/// `global` and be rejected.
+#[derive(Debug, Clone)]
+pub struct PrefixSet {
+    prefixes: Vec<WatchedPrefix>,
+}
+
+impl PrefixSet {
+    pub fn new(mut prefixes: Vec<WatchedPrefix>) -> Self {
+        prefixes.sort_by_key(|p| std::cmp::Reverse(p.prefix.trim_end_matches('/').len()));
+        Self { prefixes }
+    }
+
+    /// A set holding one environment prefix — the shape every caller that
+    /// does not read the shared catalog uses.
+    pub fn single(prefix: impl Into<String>) -> Self {
+        Self::new(vec![WatchedPrefix::environment(prefix)])
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &WatchedPrefix> {
+        self.prefixes.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.prefixes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.prefixes.is_empty()
+    }
+
+    /// Split `key` into scope, kind and id. Reports the mismatch against
+    /// the first (longest) prefix, which is the one an operator is most
+    /// likely to have meant.
+    pub fn resolve<'a>(&self, key: &'a str) -> Result<ScopedKey<'a>, KeyError> {
+        let mut first_err = None;
+        for watched in &self.prefixes {
+            match parse(&watched.prefix, key) {
+                Ok(parsed) => {
+                    return Ok(ScopedKey {
+                        scope: watched.scope,
+                        kind: parsed.kind,
+                        id: parsed.id,
+                    })
+                }
+                // A key under this prefix with a malformed suffix is a bad
+                // key, not a reason to try the next prefix: no other
+                // prefix contains it either.
+                Err(err @ (KeyError::MissingSuffix(_) | KeyError::EmptySegment(_))) => {
+                    return Err(err)
+                }
+                Err(err) => first_err.get_or_insert(err),
+            };
+        }
+        Err(first_err.unwrap_or_else(|| KeyError::PrefixMismatch {
+            key: key.to_string(),
+            prefix: String::new(),
+        }))
+    }
+}
+
+/// A parsed key plus the prefix scope it came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScopedKey<'a> {
+    pub scope: PrefixScope,
+    /// The `kind` segment exactly as written in the key. This is what
+    /// rejection and compatibility reports quote, so the control plane
+    /// sees the name it wrote.
+    pub kind: &'a str,
+    pub id: &'a str,
+}
+
+impl<'a> ScopedKey<'a> {
+    /// The snapshot table this row belongs in.
+    ///
+    /// Differs from [`ScopedKey::kind`] for exactly one pair: a `pricing`
+    /// document under the global prefix belongs in `global_pricing`, so
+    /// an environment document carrying the same `key` can win over it.
+    /// Every snapshot-shaped operation — insert, remove, presence probe,
+    /// per-kind counts — keys on this, never on the raw kind.
+    pub fn table_kind(&self) -> &'a str {
+        match (self.scope, self.kind) {
+            (PrefixScope::Global, "pricing") => "global_pricing",
+            _ => self.kind,
+        }
+    }
+}
+
+impl fmt::Display for ScopedKey<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.kind, self.id)
+    }
 }
 
 impl fmt::Display for ResourceKey<'_> {

--- a/crates/aisix-etcd/src/lib.rs
+++ b/crates/aisix-etcd/src/lib.rs
@@ -37,7 +37,9 @@ pub use etcd_provider::{
     ConnectPolicy, EtcdConfigProvider, EtcdWatchStream, CONNECT_MAX_ATTEMPTS,
     CONNECT_RETRY_INTERVAL,
 };
-pub use key::{parse as parse_key, KeyError, ResourceKey};
+pub use key::{
+    parse as parse_key, KeyError, PrefixScope, PrefixSet, ResourceKey, ScopedKey, WatchedPrefix,
+};
 pub use loader::{build_snapshot, BuildStats};
 pub use provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 pub use snapshot_cache::SnapshotCache;

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -34,13 +34,14 @@ use aisix_core::models::{
     McpServer, Model, ObservabilityExporter, OidcProvider, PassthroughRoute, ProviderKey,
     RateLimitPolicy, SchemaError,
 };
+use aisix_core::models::{validate_pricing_lenient, Pricing};
 use aisix_core::resource::ResourceEntry;
 use aisix_core::AisixSnapshot;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::key::{self, ResourceKey};
+use crate::key::{PrefixScope, PrefixSet, ScopedKey};
 use crate::provider::RawEntry;
 
 /// Why the loader skipped an entry. Surfaced in [`RejectedEntry`] so
@@ -202,14 +203,15 @@ pub struct BuildStats {
 }
 
 /// Build a fresh snapshot from raw entries. Never fails — bad rows are
-/// counted in [`BuildStats`] and skipped. The prefix lets us strip it
-/// before key parsing.
-pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, BuildStats) {
+/// counted in [`BuildStats`] and skipped. The prefix set both strips the
+/// prefix before key parsing and decides which prefix a key came from,
+/// which is what selects the table a `pricing` row lands in.
+pub fn build_snapshot(prefixes: &PrefixSet, entries: &[RawEntry]) -> (AisixSnapshot, BuildStats) {
     let snapshot = AisixSnapshot::new();
     let mut stats = BuildStats::default();
 
     for raw in entries {
-        let parsed = match key::parse(prefix, &raw.key) {
+        let parsed = match prefixes.resolve(&raw.key) {
             Ok(k) => k,
             Err(err) => {
                 tracing::warn!(key = %raw.key, error = %err, "skipping etcd entry with bad key");
@@ -236,6 +238,30 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
                 continue;
             }
         };
+
+        // The shared catalog carries prices and nothing else. Anything
+        // else written there is refused outright rather than loaded into
+        // the environment's tables: the global prefix is written by a
+        // different authority, and every other kind is environment-scoped
+        // by definition.
+        if parsed.scope == PrefixScope::Global && parsed.kind != "pricing" {
+            tracing::warn!(
+                key = %raw.key,
+                kind = %parsed.kind,
+                "rejecting etcd entry: the global prefix carries `pricing` documents only",
+            );
+            stats.unknown_kind += 1;
+            stats.rejections.push(RejectedEntry::new(
+                raw.key.clone(),
+                RejectionKind::UnknownKind,
+                format!(
+                    "kind {:?} is not accepted under the global prefix, which carries \
+                     `pricing` documents only",
+                    parsed.kind
+                ),
+            ));
+            continue;
+        }
 
         match parsed.kind {
             "models" => {
@@ -448,6 +474,24 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
                     snapshot.mcp_auth_settings.insert(entry);
                 }
             }
+            "pricing" => {
+                if let Some(entry) = validate_and_parse::<Pricing>(
+                    &raw.key,
+                    raw.revision,
+                    parsed,
+                    &value,
+                    validate_pricing_lenient,
+                    &mut stats,
+                ) {
+                    // Which table follows from the prefix, not the kind:
+                    // an environment document overrides the catalog entry
+                    // carrying the same `key`.
+                    match parsed.scope {
+                        PrefixScope::Environment => snapshot.pricing.insert(entry),
+                        PrefixScope::Global => snapshot.global_pricing.insert(entry),
+                    }
+                }
+            }
             other => {
                 tracing::debug!(key = %raw.key, kind = %other, "unknown etcd kind; skipping");
                 stats.unknown_kind += 1;
@@ -467,7 +511,7 @@ pub fn build_snapshot(prefix: &str, entries: &[RawEntry]) -> (AisixSnapshot, Bui
 fn validate_and_parse<T>(
     key: &str,
     revision: i64,
-    parsed: ResourceKey<'_>,
+    parsed: ScopedKey<'_>,
     value: &Value,
     validate: fn(&Value) -> Result<(), SchemaError>,
     stats: &mut BuildStats,
@@ -488,7 +532,7 @@ where
 fn validate_and_parse_with_semantics<T>(
     key: &str,
     revision: i64,
-    parsed: ResourceKey<'_>,
+    parsed: ScopedKey<'_>,
     value: &Value,
     validate: fn(&Value) -> Result<(), SchemaError>,
     semantic: fn(&T) -> Result<(), String>,

--- a/crates/aisix-etcd/src/loader.rs
+++ b/crates/aisix-etcd/src/loader.rs
@@ -749,6 +749,21 @@ fn warn_partial_compat_deduped(key: &str, kind: &str, fields: &[String]) {
 mod tests {
     use super::*;
 
+    /// The environment prefix alone — what every case below that says
+    /// nothing about scopes is built on.
+    fn env_prefixes() -> PrefixSet {
+        PrefixSet::single("/aisix")
+    }
+
+    /// Environment `/aisix/<env>/` plus the shared catalog
+    /// `/aisix/global/`, the shape a managed gateway watches.
+    fn scoped_prefixes() -> PrefixSet {
+        PrefixSet::new(vec![
+            crate::key::WatchedPrefix::environment("/aisix/env-1/"),
+            crate::key::WatchedPrefix::global("/aisix/global/"),
+        ])
+    }
+
     fn raw(key: &str, value: &[u8], rev: i64) -> RawEntry {
         RawEntry {
             key: key.into(),
@@ -775,7 +790,7 @@ mod tests {
             raw("/aisix/models/m-1", VALID_MODEL, 2),
             raw("/aisix/api_keys/k-1", VALID_APIKEY, 3),
         ];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
 
         assert_eq!(stats.accepted, 2);
         assert_eq!(snap.models.len(), 1);
@@ -797,7 +812,7 @@ mod tests {
             raw("/aisix/models/bad", b"not-json", 1),
             raw("/aisix/models/good", VALID_MODEL, 2),
         ];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.parse_rejected, 1);
         assert_eq!(stats.accepted, 1);
         assert_eq!(snap.models.len(), 1);
@@ -813,15 +828,101 @@ mod tests {
             br#"{"display_name":"","provider":"openai","model_name":"large","provider_key_id":"pk-1"}"#,
             1,
         )];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.schema_rejected, 1);
         assert_eq!(stats.accepted, 0);
+    }
+
+    const PRICE: &[u8] = br#"{"key":"openai/gpt-4o","input_per_1k":0.005,"output_per_1k":0.015}"#;
+
+    #[test]
+    fn a_pricing_document_lands_in_the_table_its_prefix_selects() {
+        let entries = vec![
+            raw("/aisix/env-1/pricing/env-p", PRICE, 1),
+            raw("/aisix/global/pricing/global-p", PRICE, 2),
+        ];
+        let (snap, stats) = build_snapshot(&scoped_prefixes(), &entries);
+        assert_eq!(stats.accepted, 2);
+        assert!(stats.rejections.is_empty(), "{:?}", stats.rejections);
+        // Two tables, not one: the whole point of the split is that an
+        // environment document can win over the catalog document carrying
+        // the same `key`.
+        assert_eq!(snap.pricing.len(), 1);
+        assert_eq!(snap.global_pricing.len(), 1);
+        assert!(snap.pricing.get_by_id("env-p").is_some());
+        assert!(snap.global_pricing.get_by_id("global-p").is_some());
+        // Indexed by `key`, which is what `pricing_key` resolves through.
+        assert_eq!(
+            snap.global_pricing.get_by_name("openai/gpt-4o").unwrap().id,
+            "global-p"
+        );
+    }
+
+    #[test]
+    fn the_global_prefix_refuses_every_kind_but_pricing() {
+        // A well-formed model document — it would load without complaint
+        // under the environment prefix. Written under the global one it
+        // must not reach the snapshot at all: that prefix is written by a
+        // different authority, and every other kind is environment-scoped.
+        let model = br#"{"display_name":"m","provider":"openai","model_name":"gpt-4o","provider_key_id":"11111111-1111-1111-1111-111111111111"}"#;
+        let entries = vec![
+            raw("/aisix/global/models/smuggled", model, 1),
+            raw("/aisix/global/api_keys/smuggled-key", br#"{"key_hash":"91ed2dbc407561556f3e7be98ba0bd2a57986d6a868c482d867d19c6d40d201c"}"#, 2),
+            raw("/aisix/global/pricing/ok", PRICE, 3),
+        ];
+        let (snap, stats) = build_snapshot(&scoped_prefixes(), &entries);
+        assert_eq!(snap.models.len(), 0);
+        assert_eq!(snap.apikeys.len(), 0);
+        assert_eq!(snap.global_pricing.len(), 1);
+        assert_eq!(stats.accepted, 1);
+        assert_eq!(stats.unknown_kind, 2);
+        assert_eq!(stats.rejections.len(), 2);
+        for r in &stats.rejections {
+            assert_eq!(r.kind, RejectionKind::UnknownKind);
+            assert!(
+                r.error.contains("global prefix"),
+                "rejection should say why, got {:?}",
+                r.error
+            );
+        }
+    }
+
+    #[test]
+    fn the_same_kinds_still_load_under_the_environment_prefix() {
+        // The mirror of the case above: the gate is scoped to the global
+        // prefix and must not have narrowed the environment's kinds.
+        let model = br#"{"display_name":"m","provider":"openai","model_name":"gpt-4o","provider_key_id":"11111111-1111-1111-1111-111111111111"}"#;
+        let entries = vec![raw("/aisix/env-1/models/m-1", model, 1)];
+        let (snap, stats) = build_snapshot(&scoped_prefixes(), &entries);
+        assert_eq!(stats.accepted, 1);
+        assert_eq!(snap.models.len(), 1);
+    }
+
+    #[test]
+    fn a_pricing_document_missing_a_price_is_rejected() {
+        // All three fields ARE the document; a row missing one prices
+        // nothing, so the read path refuses it rather than defaulting.
+        let entries = vec![
+            raw(
+                "/aisix/global/pricing/no-out",
+                br#"{"key":"k","input_per_1k":1.0}"#,
+                1,
+            ),
+            raw(
+                "/aisix/global/pricing/no-key",
+                br#"{"input_per_1k":1.0,"output_per_1k":2.0}"#,
+                2,
+            ),
+        ];
+        let (snap, stats) = build_snapshot(&scoped_prefixes(), &entries);
+        assert_eq!(snap.global_pricing.len(), 0);
+        assert_eq!(stats.schema_rejected, 2);
     }
 
     #[test]
     fn unknown_kinds_are_skipped() {
         let entries = vec![raw("/aisix/unknown_kind/x-1", b"{}", 1)];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.unknown_kind, 1);
         assert!(snap.models.is_empty());
         assert!(snap.apikeys.is_empty());
@@ -830,7 +931,7 @@ mod tests {
     #[test]
     fn bad_key_shape_is_counted_separately() {
         let entries = vec![raw("/other/models/a", VALID_MODEL, 1)];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.key_rejected, 1);
     }
 
@@ -844,7 +945,7 @@ mod tests {
     #[test]
     fn rejection_records_bad_key_with_kind_and_error_message() {
         let entries = vec![raw("/wrong/models/x", VALID_MODEL, 1)];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.rejections.len(), 1);
         assert_eq!(stats.rejections[0].kind, RejectionKind::BadKey);
         assert_eq!(stats.rejections[0].key, "/wrong/models/x");
@@ -854,7 +955,7 @@ mod tests {
     #[test]
     fn rejection_records_non_json_payload() {
         let entries = vec![raw("/aisix/models/m1", b"not-json", 1)];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.rejections.len(), 1);
         assert_eq!(stats.rejections[0].kind, RejectionKind::NonJson);
     }
@@ -866,7 +967,7 @@ mod tests {
             br#"{"display_name":"","provider":"openai","model_name":"l","provider_key_id":"pk"}"#,
             1,
         )];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.rejections.len(), 1);
         assert_eq!(stats.rejections[0].kind, RejectionKind::SchemaFailed);
     }
@@ -874,7 +975,7 @@ mod tests {
     #[test]
     fn rejection_records_unknown_kind() {
         let entries = vec![raw("/aisix/unknown_kind/x-1", b"{}", 1)];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.rejections.len(), 1);
         assert_eq!(stats.rejections[0].kind, RejectionKind::UnknownKind);
     }
@@ -882,7 +983,7 @@ mod tests {
     #[test]
     fn happy_entries_have_no_rejections() {
         let entries = vec![raw("/aisix/models/m-1", VALID_MODEL, 1)];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert!(stats.rejections.is_empty());
     }
 
@@ -905,7 +1006,7 @@ mod tests {
     #[test]
     fn provider_key_happy_path_accepts() {
         let entries = vec![raw("/aisix/provider_keys/pk-1", VALID_PROVIDER_KEY, 1)];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1);
         assert_eq!(snap.provider_keys.len(), 1);
         assert!(stats.rejections.is_empty());
@@ -928,7 +1029,7 @@ mod tests {
             br#"{"display_name":"bedrock-pk","secret":"x","provider":"amazon-bedrock","aws_region":"us-east-1"}"#,
             1,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
         assert!(stats.rejections.is_empty());
         assert!(snap.provider_keys.get_by_id("pk-bedrock").is_some());
@@ -953,7 +1054,7 @@ mod tests {
             br#"{"display_name":"vertex-pk","secret":"x","provider":"google-vertex","gcp_project":"my-proj","gcp_region":"us-central1"}"#,
             1,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
         assert!(snap.provider_keys.get_by_id("pk-vertex").is_some());
         assert_eq!(
@@ -984,7 +1085,7 @@ mod tests {
             br#"{"display_name":"azure-pk","secret":"x","provider":"azure","azure_resource_name":"my-azure","api_version":"2024-02-01"}"#,
             1,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
         assert!(snap.provider_keys.get_by_id("pk-azure").is_some());
         assert_eq!(
@@ -1024,7 +1125,7 @@ mod tests {
             }"#,
             1,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
 
         // YELLOW: the row loads and serves with the unknown field ignored.
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
@@ -1070,7 +1171,7 @@ mod tests {
             }"#,
             1,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
 
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
         assert!(stats.rejections.is_empty());
@@ -1104,7 +1205,7 @@ mod tests {
             }"#,
             1,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
 
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
         assert_eq!(snap.observability_exporters.len(), 1);
@@ -1135,7 +1236,7 @@ mod tests {
             }"#,
             1,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
         assert_eq!(
             stats.partially_compatible,
@@ -1162,7 +1263,7 @@ mod tests {
             }"#,
             1,
         )];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
         assert_eq!(
             stats.partially_compatible,
@@ -1183,7 +1284,7 @@ mod tests {
             br#"{"display_name":"r","routing":{"strategy":"quantum","targets":[{"model":"a"}]}}"#,
             1,
         )];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 0);
         assert_eq!(stats.schema_rejected, 1);
         assert_eq!(stats.rejections[0].kind, RejectionKind::SchemaFailed);
@@ -1201,7 +1302,7 @@ mod tests {
             raw("/aisix/api_keys/k-1", doc, 1),
             raw("/aisix/api_keys/k-2", doc, 2),
         ];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 2);
         assert_eq!(
             stats.partially_compatible,
@@ -1237,7 +1338,7 @@ mod tests {
             }"#,
             1,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
         assert_eq!(snap.guardrail_attachments.len(), 1);
         assert!(
@@ -1261,7 +1362,7 @@ mod tests {
             }"#,
             1,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
         let m = snap.models.get_by_name("grp").expect("row loaded");
         assert!(m.value.retries.is_none(), "dead knob stripped from struct");
@@ -1286,7 +1387,7 @@ mod tests {
             }"#,
             1,
         )];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
         let rows: Vec<_> = stats
             .partial_rows
@@ -1323,7 +1424,7 @@ mod tests {
             doc.to_string().as_bytes(),
             1,
         )];
-        let (_snap, stats) = build_snapshot("/aisix", &entries);
+        let (_snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1);
         let fields = &stats.partial_rows[0].fields;
         assert_eq!(fields.len(), 65, "64 fields + the truncation sentinel");
@@ -1353,7 +1454,7 @@ mod tests {
                 2,
             ),
         ];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 2, "rejections: {:?}", stats.rejections);
         assert_eq!(snap.provider_keys.len(), 2);
         // Both spellings land on the same typed field.
@@ -1381,7 +1482,7 @@ mod tests {
                 2,
             ),
         ];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.schema_rejected, 0);
         assert_eq!(stats.parse_rejected, 1);
         assert_eq!(stats.accepted, 1);
@@ -1415,7 +1516,7 @@ mod tests {
                 4,
             ),
         ];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 4, "rejections: {:?}", stats.rejections);
         // The name index is fed by the renamed field for both spellings.
         assert!(snap.mcp_servers.get_by_name("gh-former").is_some());
@@ -1432,7 +1533,7 @@ mod tests {
             raw("/aisix/models/m-2", VALID_MODEL, 3), // same name -> update in place
             raw("/aisix/api_keys/k-1", VALID_APIKEY, 4),
         ];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 3);
         assert_eq!(stats.parse_rejected, 1);
         // m-1 and m-2 share the same name; the second insert rebinds the
@@ -1456,7 +1557,7 @@ mod tests {
             VALID_RATE_LIMIT_POLICY,
             5,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1);
         assert_eq!(snap.rate_limit_policies.len(), 1);
         let entry = snap.rate_limit_policies.get_by_id("rlp-1").unwrap();
@@ -1487,7 +1588,7 @@ mod tests {
             }"#,
             6,
         )];
-        let (snap, stats) = build_snapshot("/aisix", &entries);
+        let (snap, stats) = build_snapshot(&env_prefixes(), &entries);
         assert_eq!(stats.accepted, 1);
         let entry = snap.rate_limit_policies.get_by_id("rlp-2").unwrap();
         assert!(entry.value.is_conditional());
@@ -1514,7 +1615,7 @@ mod tests {
             }"#,
             7,
         );
-        let (snap, stats) = build_snapshot("/aisix", std::slice::from_ref(&bad));
+        let (snap, stats) = build_snapshot(&env_prefixes(), std::slice::from_ref(&bad));
         assert_eq!(stats.accepted, 0);
         assert_eq!(stats.schema_rejected, 1);
         assert_eq!(snap.rate_limit_policies.len(), 0);

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -31,10 +31,11 @@ use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 
 use crate::backoff::ExpBackoff;
-use crate::key;
+use crate::key::{PrefixScope, PrefixSet, WatchedPrefix};
 use crate::loader::{self, BuildStats, PartialCompatEntry, PartialCompatRow, RejectedEntry};
 use crate::provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
 use crate::snapshot_cache::SnapshotCache;
+use std::sync::atomic::AtomicBool;
 
 /// Cheap clonable handle for the watch supervisor's freshness state —
 /// the etcd revision the snapshot reflects, and how long ago the
@@ -187,8 +188,14 @@ impl StateEntry {
 /// One supervisor instance. Consumers call [`Supervisor::run`] once and
 /// drop the returned handle on shutdown.
 pub struct Supervisor<P: ConfigProvider> {
-    provider: Arc<P>,
-    prefix: String,
+    /// One source per watched prefix: the environment's, and — in a
+    /// managed deployment — the shared `<base>/global/` catalog. Each is
+    /// range-read and watched separately; all of them land in the ONE
+    /// snapshot this supervisor publishes, so a request never sees half
+    /// a configuration.
+    sources: Vec<PrefixSource<P>>,
+    /// The same prefixes, in the form key parsing resolves against.
+    prefixes: PrefixSet,
     handle: SnapshotHandle<AisixSnapshot>,
 
     // Last-known etcd state, kept in `key → RawEntry` form so deltas
@@ -265,6 +272,51 @@ pub struct Supervisor<P: ConfigProvider> {
     pending_writes: Mutex<Vec<JoinHandle<()>>>,
 }
 
+/// One watched prefix and the provider that reads it.
+struct PrefixSource<P: ConfigProvider> {
+    prefix: WatchedPrefix,
+    provider: Arc<P>,
+    /// Set once the tolerated refusal below has been logged, cleared the
+    /// next time the prefix reads successfully — so an old control plane
+    /// produces one WARN, not one per reconnect.
+    refusal_logged: AtomicBool,
+}
+
+impl<P: ConfigProvider> PrefixSource<P> {
+    /// Whether this prefix may be treated as empty when etcd answers
+    /// `err`, instead of failing the cycle.
+    ///
+    /// Only the shared catalog, and only for a refusal. A control plane
+    /// older than the catalog denies reads outside the environment's own
+    /// prefix, and a gateway that failed its cycle over that would serve
+    /// nothing at all rather than serve without prices. Every other
+    /// error, and every error on the environment prefix, is handled as
+    /// before: the cycle fails and the backoff loop retries.
+    ///
+    /// A refusal that is really about credentials cannot hide here — it
+    /// refuses the environment prefix too, which is not tolerated.
+    fn tolerates(&self, err: &ProviderError) -> bool {
+        self.prefix.scope == PrefixScope::Global && matches!(err, ProviderError::Rejected(_))
+    }
+
+    fn log_refusal(&self, err: &ProviderError) {
+        if self.refusal_logged.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        tracing::warn!(
+            prefix = %self.prefix.prefix,
+            error = %err,
+            "etcd refused the shared pricing catalog; serving without it — a model with \
+             `pricing_key` falls back to its inline `cost` until the control plane grants \
+             read access to this prefix",
+        );
+    }
+
+    fn clear_refusal(&self) {
+        self.refusal_logged.store(false, Ordering::Relaxed);
+    }
+}
+
 impl<P: ConfigProvider> Supervisor<P> {
     /// Construct without on-disk persistence. Equivalent to
     /// [`Self::with_cache(provider, prefix, SnapshotCache::disabled())`].
@@ -276,10 +328,33 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// resync / put / delete the supervisor flushes the current entry
     /// set to the cache so a restart that can't reach etcd still has
     /// configuration to serve from.
+    ///
+    /// Watches the environment prefix alone. Use [`Self::with_sources`]
+    /// to add the shared catalog.
     pub fn with_cache(provider: Arc<P>, prefix: impl Into<String>, cache: SnapshotCache) -> Self {
+        Self::with_sources(vec![(WatchedPrefix::environment(prefix), provider)], cache)
+    }
+
+    /// Construct over several prefixes, each with its own provider.
+    ///
+    /// All of them feed ONE snapshot and one revision floor: kine
+    /// revisions are cluster-global, so the applied revision is the
+    /// maximum across prefixes, and readiness waits for every prefix's
+    /// initial range read (a tolerated refusal on the shared catalog
+    /// counts as read-and-empty — see [`PrefixSource::tolerates`]).
+    pub fn with_sources(sources: Vec<(WatchedPrefix, Arc<P>)>, cache: SnapshotCache) -> Self {
+        let prefixes = PrefixSet::new(sources.iter().map(|(p, _)| p.clone()).collect());
+        let sources = sources
+            .into_iter()
+            .map(|(prefix, provider)| PrefixSource {
+                prefix,
+                provider,
+                refusal_logged: AtomicBool::new(false),
+            })
+            .collect();
         Self {
-            provider,
-            prefix: prefix.into(),
+            sources,
+            prefixes,
             handle: SnapshotHandle::new(AisixSnapshot::new()),
             state: Mutex::new(BTreeMap::new()),
             revision: Mutex::new(0),
@@ -362,7 +437,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             self.partial_compat_observation();
         let mut stale_served_rows_by_kind: BTreeMap<String, usize> = BTreeMap::new();
         for key_str in stale.keys() {
-            if let Ok(parsed) = key::parse(&self.prefix, key_str) {
+            if let Ok(parsed) = self.prefixes.resolve(key_str) {
                 *stale_served_rows_by_kind
                     .entry(parsed.kind.to_string())
                     .or_insert(0) += 1;
@@ -399,7 +474,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         r: &RejectedEntry,
         stale: &HashMap<String, StaleServing>,
     ) -> IncomingRejection {
-        let (kind, id) = match key::parse(&self.prefix, &r.key) {
+        let (kind, id) = match self.prefixes.resolve(&r.key) {
             Ok(parsed) => (parsed.kind.to_string(), parsed.id.to_string()),
             Err(_) => (String::new(), String::new()),
         };
@@ -649,7 +724,7 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// Stops after the first watch error — the outer [`Self::run`] loop
     /// decides whether to backoff and retry.
     pub async fn load_once(&self) -> Result<BuildStats, ProviderError> {
-        let (entries, revision) = self.provider.load_all().await?;
+        let (entries, revision) = self.load_all_prefixes().await?;
         let stats = self.apply_resync(&entries);
         // apply_resync uses max(entry revisions); bump to the etcd
         // load_all revision so the cache file records the true "as
@@ -662,6 +737,33 @@ impl<P: ConfigProvider> Supervisor<P> {
             "initial snapshot built",
         );
         Ok(stats)
+    }
+
+    /// Range-read every watched prefix and return the union of their
+    /// entries with the highest revision any of them reported.
+    ///
+    /// Kine revisions are cluster-global, so the maximum is the point the
+    /// whole read is consistent as of, and it is what the heartbeat
+    /// reports as `applied_revision`.
+    async fn load_all_prefixes(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
+        let mut all = Vec::new();
+        let mut revision = 0i64;
+        for source in &self.sources {
+            match source.provider.load_all().await {
+                Ok((entries, rev)) => {
+                    source.clear_refusal();
+                    all.extend(entries);
+                    revision = revision.max(rev);
+                }
+                Err(err) if source.tolerates(&err) => {
+                    // Read as empty: the prefix contributes no rows and no
+                    // revision, and readiness is not held back.
+                    source.log_refusal(&err);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Ok((all, revision))
     }
 
     /// Bump the recorded revision floor. Used by the cycle path to
@@ -700,14 +802,14 @@ impl<P: ConfigProvider> Supervisor<P> {
         if self.stale_serving.lock().unwrap().contains_key(key_str) {
             return;
         }
-        let Ok(parsed) = key::parse(&self.prefix, key_str) else {
+        let Ok(parsed) = self.prefixes.resolve(key_str) else {
             return;
         };
         // The presence probe reads through the batch's own staged
         // mutations: within one coalesced apply a row put earlier in the
         // batch is serving as far as this decision is concerned, even
         // though the snapshot carrying it has not been published yet.
-        if !view.present(base, parsed.kind, parsed.id) {
+        if !view.present(base, parsed.table_kind(), parsed.id) {
             return;
         }
         let Some(good) = self
@@ -839,7 +941,8 @@ impl<P: ConfigProvider> Supervisor<P> {
         dirty: &mut Dirty,
     ) -> bool {
         // Build a tiny snapshot out of just the new entry, then merge.
-        let (tiny, mut stats) = loader::build_snapshot(&self.prefix, std::slice::from_ref(entry));
+        let (tiny, mut stats) =
+            loader::build_snapshot(&self.prefixes, std::slice::from_ref(entry));
         if stats.accepted == 0 {
             // The previous good value keeps serving. Pin it now (#871):
             // the next resync rebuilds from the rejected etcd bytes and
@@ -873,7 +976,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             return false;
         }
 
-        view.record_put(&self.prefix, &entry.key);
+        view.record_put(&self.prefixes, &entry.key);
         // Fold a run of puts into ONE staged snapshot rather than keeping a
         // `Box<AisixSnapshot>` per event alive until the commit: the loader
         // hands back a full fifteen-table snapshot for the single row it
@@ -923,7 +1026,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         apply_stamp: &mut Option<i64>,
         dirty: &mut Dirty,
     ) -> bool {
-        let parsed = match key::parse(&self.prefix, key_str) {
+        let parsed = match self.prefixes.resolve(key_str) {
             Ok(k) => k,
             Err(err) => {
                 tracing::warn!(key = %key_str, error = %err, "ignoring delete with bad key");
@@ -937,7 +1040,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         // reads through the batch's staged mutations as well as the
         // published snapshot, so a delete that follows a put of the same
         // key inside one batch sees the row the put staged.
-        let present = view.present(base, parsed.kind, parsed.id);
+        let present = view.present(base, parsed.table_kind(), parsed.id);
         let removed_rejection = self.remove_rejection_for_key(key_str);
         // A deleted key no longer serves, so its partially-compatible
         // signal (if any) goes with it — and so does its last-known-good
@@ -964,9 +1067,9 @@ impl<P: ConfigProvider> Supervisor<P> {
             return removed_rejection;
         }
 
-        view.record_delete(parsed.kind, parsed.id);
+        view.record_delete(parsed.table_kind(), parsed.id);
         mutations.push(SnapshotMutation::Remove {
-            kind: parsed.kind.to_string(),
+            kind: parsed.table_kind().to_string(),
             id: parsed.id.to_string(),
         });
         stamp_max(apply_stamp, *self.revision.lock().unwrap());
@@ -1023,7 +1126,7 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// write that broke it. Retention ends when the key loads cleanly
     /// again or leaves etcd.
     pub fn apply_resync(&self, entries: &[RawEntry]) -> BuildStats {
-        let (snap, mut stats) = loader::build_snapshot(&self.prefix, entries);
+        let (snap, mut stats) = loader::build_snapshot(&self.prefixes, entries);
 
         // Reconcile the last-known-good state against this build, then
         // inject the retained values into the fresh snapshot.
@@ -1056,10 +1159,10 @@ impl<P: ConfigProvider> Supervisor<P> {
                 if stale.contains_key(&r.key) {
                     continue;
                 }
-                let Ok(parsed) = key::parse(&self.prefix, &r.key) else {
+                let Ok(parsed) = self.prefixes.resolve(&r.key) else {
                     continue;
                 };
-                if !snapshot_has(&prev_snap, parsed.kind, parsed.id) {
+                if !snapshot_has(&prev_snap, parsed.table_kind(), parsed.id) {
                     continue;
                 }
                 if let Some(good) = prev_state.get(&r.key) {
@@ -1082,7 +1185,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         // build can no longer parse (e.g. after a DP downgrade) drops
         // its retention with an ERROR — same contract as any RED row.
         if !injected.is_empty() {
-            let (lkg_snap, lkg_stats) = loader::build_snapshot(&self.prefix, &injected);
+            let (lkg_snap, lkg_stats) = loader::build_snapshot(&self.prefixes, &injected);
             if !lkg_stats.rejections.is_empty() {
                 let mut stale = self.stale_serving.lock().unwrap();
                 for r in &lkg_stats.rejections {
@@ -1277,19 +1380,32 @@ impl<P: ConfigProvider> Supervisor<P> {
         cancel: &tokio::sync::watch::Receiver<bool>,
     ) -> Result<(), SupervisorError> {
         let (entries, revision) = self
-            .provider
-            .load_all()
+            .load_all_prefixes()
             .await
             .map_err(SupervisorError::Provider)?;
 
+        // ONE resync over the union: the snapshot is published only after
+        // every prefix has been read, so readiness means every prefix's
+        // initial load completed and no request can observe the
+        // environment loaded and the catalog not.
         self.apply_resync(&entries);
         self.set_revision_floor(revision);
 
-        let mut stream = self
-            .provider
-            .watch(revision + 1)
-            .await
-            .map_err(SupervisorError::Provider)?;
+        let mut streams = Vec::with_capacity(self.sources.len());
+        for source in &self.sources {
+            match source.provider.watch(revision + 1).await {
+                Ok(stream) => streams.push(stream),
+                Err(err) if source.tolerates(&err) => {
+                    // No stream for this prefix this cycle. It is retried
+                    // whenever the cycle restarts — which is what a
+                    // control-plane upgrade causes, since it takes the
+                    // kine connections behind the surviving watch with it.
+                    source.log_refusal(&err);
+                }
+                Err(err) => return Err(SupervisorError::Provider(err)),
+            }
+        }
+        let mut stream = futures::stream::select_all(streams);
 
         // An event the drain below pulled off the stream but could not
         // add to its batch (a resync, a stream error, the end of the
@@ -1524,11 +1640,11 @@ struct BatchView {
 }
 
 impl BatchView {
-    fn record_put(&mut self, prefix: &str, key_str: &str) {
-        let Ok(parsed) = key::parse(prefix, key_str) else {
+    fn record_put(&mut self, prefixes: &PrefixSet, key_str: &str) {
+        let Ok(parsed) = prefixes.resolve(key_str) else {
             return;
         };
-        let id = (parsed.kind.to_string(), parsed.id.to_string());
+        let id = (parsed.table_kind().to_string(), parsed.id.to_string());
         self.removed.remove(&id);
         self.added.insert(id);
     }
@@ -1646,6 +1762,8 @@ fn merge_snapshot(dst: &AisixSnapshot, src: &AisixSnapshot) {
         claim_mappings,
         passthrough_routes,
         mcp_auth_settings,
+        pricing,
+        global_pricing,
     } = src;
     for e in models.entries() {
         dst.models.insert_arc(e);
@@ -1692,6 +1810,12 @@ fn merge_snapshot(dst: &AisixSnapshot, src: &AisixSnapshot) {
     for e in mcp_auth_settings.entries() {
         dst.mcp_auth_settings.insert_arc(e);
     }
+    for e in pricing.entries() {
+        dst.pricing.insert_arc(e);
+    }
+    for e in global_pricing.entries() {
+        dst.global_pricing.insert_arc(e);
+    }
 }
 
 /// Remove `(kind, id)` from `snap`.
@@ -1717,6 +1841,8 @@ fn remove_from_snapshot(snap: &AisixSnapshot, kind: &str, id: &str) {
         claim_mappings,
         passthrough_routes,
         mcp_auth_settings,
+        pricing,
+        global_pricing,
     } = snap;
     match kind {
         "models" => {
@@ -1764,6 +1890,15 @@ fn remove_from_snapshot(snap: &AisixSnapshot, kind: &str, id: &str) {
         "mcp_auth_settings" => {
             mcp_auth_settings.remove(id);
         }
+        // Not the `pricing` kind but the table selector — a global-prefix
+        // pricing row arrives here as `global_pricing`. See
+        // [`crate::key::ScopedKey::table_kind`].
+        "pricing" => {
+            pricing.remove(id);
+        }
+        "global_pricing" => {
+            global_pricing.remove(id);
+        }
         _ => {}
     }
 }
@@ -1789,6 +1924,8 @@ fn snapshot_has(snap: &AisixSnapshot, kind: &str, id: &str) -> bool {
         claim_mappings,
         passthrough_routes,
         mcp_auth_settings,
+        pricing,
+        global_pricing,
     } = snap;
     match kind {
         "models" => models.get_by_id(id).is_some(),
@@ -1806,6 +1943,8 @@ fn snapshot_has(snap: &AisixSnapshot, kind: &str, id: &str) -> bool {
         "claim_mappings" => claim_mappings.get_by_id(id).is_some(),
         "passthrough_routes" => passthrough_routes.get_by_id(id).is_some(),
         "mcp_auth_settings" => mcp_auth_settings.get_by_id(id).is_some(),
+        "pricing" => pricing.get_by_id(id).is_some(),
+        "global_pricing" => global_pricing.get_by_id(id).is_some(),
         _ => false,
     }
 }
@@ -1842,6 +1981,8 @@ fn resource_counts(snap: &AisixSnapshot) -> BTreeMap<String, usize> {
         ("claim_mappings", snap.claim_mappings.len()),
         ("passthrough_routes", snap.passthrough_routes.len()),
         ("mcp_auth_settings", snap.mcp_auth_settings.len()),
+        ("pricing", snap.pricing.len()),
+        ("global_pricing", snap.global_pricing.len()),
     ] {
         if n > 0 {
             counts.insert(kind.to_string(), n);

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -342,7 +342,18 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// maximum across prefixes, and readiness waits for every prefix's
     /// initial range read (a tolerated refusal on the shared catalog
     /// counts as read-and-empty — see [`PrefixSource::tolerates`]).
-    pub fn with_sources(sources: Vec<(WatchedPrefix, Arc<P>)>, cache: SnapshotCache) -> Self {
+    pub fn with_sources(mut sources: Vec<(WatchedPrefix, Arc<P>)>, cache: SnapshotCache) -> Self {
+        // Environment prefixes are read FIRST, and that ordering is load
+        // bearing rather than cosmetic: [`PrefixSource::tolerates`] is
+        // only safe because credentials etcd genuinely refuses are
+        // refused for the environment prefix too, and that refusal has
+        // to be the one that surfaces. Reading the tolerant prefix first
+        // would let a wrong password come back as a tolerated catalog
+        // refusal followed by a second, redundant failure.
+        sources.sort_by_key(|(p, _)| match p.scope {
+            PrefixScope::Environment => 0,
+            PrefixScope::Global => 1,
+        });
         let prefixes = PrefixSet::new(sources.iter().map(|(p, _)| p.clone()).collect());
         let sources = sources
             .into_iter()
@@ -1440,13 +1451,18 @@ impl<P: ConfigProvider> Supervisor<P> {
                 Err(err) => return Err(SupervisorError::Provider(err)),
             }
         }
-        let mut stream = futures::stream::select_all(streams);
+        // Each stream is tagged so its END is delivered as an item
+        // rather than absorbed by `select_all`. See [`Watched`].
+        let mut stream = futures::stream::select_all(streams.into_iter().map(|s| {
+            s.map(Watched::Event)
+                .chain(futures::stream::iter([Watched::Ended]))
+        }));
 
         // An event the drain below pulled off the stream but could not
         // add to its batch (a resync, a stream error, the end of the
         // stream). Held here so the next loop iteration handles it
         // exactly as if it had just arrived.
-        let mut pushed_back: Option<Option<Result<WatchEvent, ProviderError>>> = None;
+        let mut pushed_back: Option<Option<Watched>> = None;
 
         loop {
             if *cancel.borrow() {
@@ -1464,16 +1480,19 @@ impl<P: ConfigProvider> Supervisor<P> {
             };
 
             match next {
-                None => return Ok(()),
-                Some(Err(ProviderError::Compacted)) => {
+                // Every stream exhausted, or any ONE of them ended:
+                // either way this cycle is over and the next one re-reads
+                // and re-watches every prefix.
+                None | Some(Watched::Ended) => return Ok(()),
+                Some(Watched::Event(Err(ProviderError::Compacted))) => {
                     tracing::warn!("etcd compaction detected — resyncing");
                     // Break out so `run` re-enters `cycle` cleanly; the
                     // next iteration re-loads from scratch. We don't want
                     // to treat compaction as a backoff-worthy failure.
                     return Ok(());
                 }
-                Some(Err(err)) => return Err(SupervisorError::Provider(err)),
-                Some(Ok(WatchEvent::Resync { entries, revision })) => {
+                Some(Watched::Event(Err(err))) => return Err(SupervisorError::Provider(err)),
+                Some(Watched::Event(Ok(WatchEvent::Resync { entries, revision }))) => {
                     self.apply_resync(&entries);
                     // The resync's header revision is the "consistent as
                     // of" point even when the entry set is empty or only
@@ -1483,7 +1502,9 @@ impl<P: ConfigProvider> Supervisor<P> {
                 // Explicit over the two batchable variants rather than a
                 // catch-all: a new `WatchEvent` must fail to compile here
                 // instead of falling into a batch that cannot carry it.
-                Some(Ok(first @ (WatchEvent::Put(_) | WatchEvent::Delete { .. }))) => {
+                Some(Watched::Event(Ok(
+                    first @ (WatchEvent::Put(_) | WatchEvent::Delete { .. }),
+                ))) => {
                     // Coalesce: hold the batch open for a short bounded
                     // window and apply the whole run as one
                     // copy-on-write cycle. The window closes on the first
@@ -1532,9 +1553,9 @@ impl<P: ConfigProvider> Supervisor<P> {
                             _ = tokio::time::sleep(COALESCE_QUIET_PERIOD) => break,
                         };
                         match item {
-                            Some(Ok(event @ (WatchEvent::Put(_) | WatchEvent::Delete { .. }))) => {
-                                batch.push(event)
-                            }
+                            Some(Watched::Event(Ok(
+                                event @ (WatchEvent::Put(_) | WatchEvent::Delete { .. }),
+                            ))) => batch.push(event),
                             other => {
                                 pushed_back = Some(other);
                                 break;
@@ -1593,6 +1614,23 @@ impl PrefixLoad {
     fn max_revision(&self) -> i64 {
         self.revisions.iter().flatten().copied().max().unwrap_or(0)
     }
+}
+
+/// One item off the merged watch.
+///
+/// `select_all` drops an exhausted stream and keeps polling the
+/// survivors, so a stream that ends cleanly is otherwise invisible — and
+/// a cleanly ended watch is precisely the signal [`Supervisor::cycle`]
+/// runs on: it returns, and `watch_loop` re-reads and re-opens both
+/// prefixes. With one stream that came for free. With two, on two
+/// connections, swallowing it would leave the cycle polling the
+/// survivor while the ended prefix's configuration froze for the life
+/// of the process — no resync, no error, and `/status/config` still
+/// reporting connected.
+enum Watched {
+    Event(Result<WatchEvent, ProviderError>),
+    /// The stream this item came from has ended.
+    Ended,
 }
 
 #[derive(Debug)]
@@ -2139,6 +2177,9 @@ mod tests {
         refuse: bool,
         /// The `start_revision` this provider's watch was opened with.
         watched_from: Mutex<Option<i64>>,
+        /// Hand back a stream that never ends and never yields, the way
+        /// a healthy watch on a prefix nobody is writing behaves.
+        never_ends: bool,
     }
 
     impl ScopedProvider {
@@ -2148,6 +2189,20 @@ mod tests {
                 revision,
                 refuse: false,
                 watched_from: Mutex::new(None),
+                never_ends: false,
+            })
+        }
+
+        /// Serves its rows, then holds a watch open forever — the
+        /// catalog's normal steady state, since nobody writes prices
+        /// most of the time.
+        fn quiet(entries: Vec<RawEntry>, revision: i64) -> Arc<Self> {
+            Arc::new(Self {
+                entries,
+                revision,
+                refuse: false,
+                watched_from: Mutex::new(None),
+                never_ends: true,
             })
         }
 
@@ -2157,6 +2212,7 @@ mod tests {
                 revision: 0,
                 refuse: true,
                 watched_from: Mutex::new(None),
+                never_ends: false,
             })
         }
     }
@@ -2184,6 +2240,9 @@ mod tests {
                 return Err(ProviderError::Rejected(
                     "etcdserver: permission denied: outside env env-1 prefix".into(),
                 ));
+            }
+            if self.never_ends {
+                return Ok(Box::new(stream::pending()));
             }
             Ok(Box::new(stream::iter(Vec::new())))
         }
@@ -2325,6 +2384,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn one_watch_ending_ends_the_cycle() {
+        // The reconnect trigger is a watch stream ending; `watch_loop`
+        // re-enters `cycle`, which re-reads and re-opens every prefix.
+        // `select_all` drops an exhausted stream and keeps polling the
+        // survivors, so without the end being delivered as an item the
+        // cycle would sit on the catalog's idle stream forever while the
+        // environment's configuration froze — no resync, no error, and
+        // nothing in `/status/config` to show it.
+        //
+        // The catalog stream here never yields and never ends, which is
+        // its normal state: nobody writes prices most of the time. That
+        // is what makes the bug reachable rather than theoretical.
+        let sup = scoped_supervisor(
+            ScopedProvider::serving(vec![entry("/aisix/env-1/models/m-1", VALID_MODEL, 1)], 7),
+            ScopedProvider::quiet(vec![entry("/aisix/global/pricing/g", VALID_PRICE, 1)], 7),
+        );
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+
+        let cycle = tokio::time::timeout(Duration::from_secs(5), sup.cycle(&rx)).await;
+        assert!(
+            matches!(cycle, Ok(Ok(()))),
+            "the environment watch ended, so the cycle must return and let \
+             watch_loop reconnect; got {cycle:?}",
+        );
+        // Both prefixes did load before the cycle ended.
+        let snap = sup.handle().load();
+        assert_eq!(snap.models.len(), 1);
+        assert_eq!(snap.global_pricing.len(), 1);
+    }
+
+    #[tokio::test]
     async fn each_prefix_resumes_from_its_own_read() {
         // The range reads run in sequence, so the later prefix reports a
         // higher revision. Resuming BOTH watches from the maximum would
@@ -2367,6 +2457,32 @@ mod tests {
         // as SupervisorError::Provider.
         sup.cycle(&rx).await.expect("cycle survives the refusal");
         assert_eq!(sup.handle().load().models.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn the_environment_prefix_is_always_read_first() {
+        // `tolerates` swallows a refusal on the catalog, so a refusal
+        // that is really about credentials must reach the environment
+        // prefix first — that one is not tolerated and is what fails the
+        // cycle. Constructed catalog-first to prove the supervisor
+        // reorders rather than trusting its caller.
+        let sup = Arc::new(Supervisor::with_sources(
+            vec![
+                (
+                    WatchedPrefix::global(GLOBAL_PREFIX),
+                    ScopedProvider::refusing(),
+                ),
+                (
+                    WatchedPrefix::environment(ENV_PREFIX),
+                    ScopedProvider::refusing(),
+                ),
+            ],
+            SnapshotCache::disabled(),
+        ));
+        assert!(
+            matches!(sup.load_once().await, Err(ProviderError::Rejected(_))),
+            "a refusal on both prefixes must surface as the environment's",
+        );
     }
 
     #[tokio::test]

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -746,13 +746,33 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// whole read is consistent as of, and it is what the heartbeat
     /// reports as `applied_revision`.
     async fn load_all_prefixes(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
-        let mut all = Vec::new();
+        // Deduplicated by key, because the prefixes can nest: when the
+        // gateway has no `env_id` the environment prefix is the bare base
+        // and `<base>/global/` sits inside it, so both range reads return
+        // the catalog's rows. The snapshot and the observed-state map are
+        // both keyed and would absorb the repeat, but the BuildStats are
+        // not — `accepted` and the per-field partially-compatible row
+        // counts are sums, and those numbers are reported.
+        let mut all: BTreeMap<String, RawEntry> = BTreeMap::new();
         let mut revision = 0i64;
         for source in &self.sources {
             match source.provider.load_all().await {
                 Ok((entries, rev)) => {
                     source.clear_refusal();
-                    all.extend(entries);
+                    for entry in entries {
+                        match all.entry(entry.key.clone()) {
+                            std::collections::btree_map::Entry::Occupied(mut slot) => {
+                                // Two reads of one key are two points in
+                                // time; keep the later write.
+                                if entry.revision > slot.get().revision {
+                                    slot.insert(entry);
+                                }
+                            }
+                            std::collections::btree_map::Entry::Vacant(slot) => {
+                                slot.insert(entry);
+                            }
+                        }
+                    }
                     revision = revision.max(rev);
                 }
                 Err(err) if source.tolerates(&err) => {
@@ -763,7 +783,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                 Err(err) => return Err(err),
             }
         }
-        Ok((all, revision))
+        Ok((all.into_values().collect(), revision))
     }
 
     /// Bump the recorded revision floor. Used by the cycle path to
@@ -2163,6 +2183,44 @@ mod tests {
         assert_eq!(snap.models.len(), 1);
         assert_eq!(snap.pricing.len(), 1);
         assert_eq!(snap.global_pricing.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_row_both_prefixes_return_is_counted_once() {
+        // The nesting case: with no `env_id` the environment prefix is
+        // the bare base, so `<base>/global/` is inside it and the
+        // catalog's rows come back from BOTH range reads. The snapshot
+        // absorbs the repeat because it is keyed; `accepted` is a sum and
+        // would report two rows where etcd holds one.
+        let shared = entry("/aisix/global/pricing/p-1", VALID_PRICE, 4);
+        let sup = Arc::new(Supervisor::with_sources(
+            vec![
+                (
+                    WatchedPrefix::environment("/aisix"),
+                    ScopedProvider::serving(
+                        vec![entry("/aisix/models/m-1", VALID_MODEL, 3), shared.clone()],
+                        4,
+                    ),
+                ),
+                (
+                    WatchedPrefix::global("/aisix/global/"),
+                    ScopedProvider::serving(vec![shared], 4),
+                ),
+            ],
+            SnapshotCache::disabled(),
+        ));
+
+        let stats = sup.load_once().await.unwrap();
+        assert_eq!(
+            stats.accepted, 2,
+            "one model and one price, counted once each"
+        );
+        let snap = sup.handle().load();
+        assert_eq!(snap.models.len(), 1);
+        // Resolved to the catalog table by the longer prefix, not to the
+        // environment's, even though the outer prefix also returned it.
+        assert_eq!(snap.global_pricing.len(), 1);
+        assert_eq!(snap.pricing.len(), 0);
     }
 
     #[tokio::test]

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -941,8 +941,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         dirty: &mut Dirty,
     ) -> bool {
         // Build a tiny snapshot out of just the new entry, then merge.
-        let (tiny, mut stats) =
-            loader::build_snapshot(&self.prefixes, std::slice::from_ref(entry));
+        let (tiny, mut stats) = loader::build_snapshot(&self.prefixes, std::slice::from_ref(entry));
         if stats.accepted == 0 {
             // The previous good value keeps serving. Pin it now (#871):
             // the next resync rebuilds from the rejected etcd bytes and
@@ -2067,6 +2066,196 @@ mod tests {
         "kind": "keyword",
         "patterns": [{"kind": "literal", "value": "AKIA"}]
     }"#;
+
+    // ── multi-prefix supervision (AISIX-Cloud#1546) ───────────────
+
+    const ENV_PREFIX: &str = "/aisix/env-1/";
+    const GLOBAL_PREFIX: &str = "/aisix/global/";
+    const VALID_PRICE: &[u8] =
+        br#"{"key":"openai/gpt-4o","input_per_1k":0.005,"output_per_1k":0.015}"#;
+
+    /// A provider that either serves entries or refuses every call the
+    /// way a control plane predating the shared catalog does — its kine
+    /// ACL answers `PermissionDenied` for a Range outside the
+    /// environment's own prefix, which reaches the supervisor as
+    /// [`ProviderError::Rejected`].
+    struct ScopedProvider {
+        entries: Vec<RawEntry>,
+        revision: i64,
+        refuse: bool,
+    }
+
+    impl ScopedProvider {
+        fn serving(entries: Vec<RawEntry>, revision: i64) -> Arc<Self> {
+            Arc::new(Self {
+                entries,
+                revision,
+                refuse: false,
+            })
+        }
+
+        fn refusing() -> Arc<Self> {
+            Arc::new(Self {
+                entries: Vec::new(),
+                revision: 0,
+                refuse: true,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl ConfigProvider for ScopedProvider {
+        async fn load_all(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
+            if self.refuse {
+                return Err(ProviderError::Rejected(
+                    "etcdserver: permission denied: outside env env-1 prefix".into(),
+                ));
+            }
+            Ok((self.entries.clone(), self.revision))
+        }
+
+        async fn watch(
+            &self,
+            _start_revision: i64,
+        ) -> Result<
+            Box<dyn futures::Stream<Item = Result<WatchEvent, ProviderError>> + Send + Unpin>,
+            ProviderError,
+        > {
+            if self.refuse {
+                return Err(ProviderError::Rejected(
+                    "etcdserver: permission denied: outside env env-1 prefix".into(),
+                ));
+            }
+            Ok(Box::new(stream::iter(Vec::new())))
+        }
+    }
+
+    fn scoped_supervisor(
+        env: Arc<ScopedProvider>,
+        global: Arc<ScopedProvider>,
+    ) -> Arc<Supervisor<ScopedProvider>> {
+        Arc::new(Supervisor::with_sources(
+            vec![
+                (WatchedPrefix::environment(ENV_PREFIX), env),
+                (WatchedPrefix::global(GLOBAL_PREFIX), global),
+            ],
+            SnapshotCache::disabled(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn both_prefixes_land_in_one_snapshot() {
+        let sup = scoped_supervisor(
+            ScopedProvider::serving(
+                vec![
+                    entry("/aisix/env-1/models/m-1", VALID_MODEL, 7),
+                    entry("/aisix/env-1/pricing/env-p", VALID_PRICE, 8),
+                ],
+                8,
+            ),
+            ScopedProvider::serving(
+                vec![entry("/aisix/global/pricing/global-p", VALID_PRICE, 5)],
+                5,
+            ),
+        );
+        sup.load_once().await.unwrap();
+        let snap = sup.handle().load();
+        assert_eq!(snap.models.len(), 1);
+        assert_eq!(snap.pricing.len(), 1);
+        assert_eq!(snap.global_pricing.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn applied_revision_is_the_maximum_across_prefixes() {
+        // kine revisions are cluster-global, so the point the whole read
+        // is consistent as of is the highest either prefix reported —
+        // whichever one that is. Both orders, because taking the LAST
+        // prefix's revision (or the FIRST, or the environment's) passes
+        // one of them by accident.
+        //
+        // Every entry is written at revision 1 so the header revisions
+        // are the only thing that can produce the expected value: the
+        // resync raises the floor to the highest entry revision first,
+        // and entries at 7 / 42 / 99 would supply the answer by
+        // themselves — which is how the first version of this case
+        // stayed green against a last-prefix-wins mutation.
+        let global_ahead = scoped_supervisor(
+            ScopedProvider::serving(vec![entry("/aisix/env-1/models/m-1", VALID_MODEL, 1)], 7),
+            ScopedProvider::serving(vec![entry("/aisix/global/pricing/g", VALID_PRICE, 1)], 42),
+        );
+        global_ahead.load_once().await.unwrap();
+        assert_eq!(global_ahead.watch_status().snapshot().revision, 42);
+
+        let env_ahead = scoped_supervisor(
+            ScopedProvider::serving(vec![entry("/aisix/env-1/models/m-1", VALID_MODEL, 1)], 99),
+            ScopedProvider::serving(vec![entry("/aisix/global/pricing/g", VALID_PRICE, 1)], 5),
+        );
+        env_ahead.load_once().await.unwrap();
+        assert_eq!(env_ahead.watch_status().snapshot().revision, 99);
+    }
+
+    #[tokio::test]
+    async fn a_refused_catalog_leaves_the_environment_serving() {
+        // The old-control-plane case: the catalog prefix is denied, the
+        // environment's is not. The gateway must come up on the
+        // environment's configuration rather than fail its cycle — the
+        // alternative is serving nothing at all instead of serving
+        // without prices.
+        let sup = scoped_supervisor(
+            ScopedProvider::serving(
+                vec![
+                    entry("/aisix/env-1/models/m-1", VALID_MODEL, 11),
+                    entry("/aisix/env-1/api_keys/k-1", VALID_APIKEY, 12),
+                ],
+                12,
+            ),
+            ScopedProvider::refusing(),
+        );
+
+        // Completes rather than erroring — readiness is not held back by
+        // the refused prefix.
+        let stats = sup.load_once().await.expect("environment load succeeds");
+        assert_eq!(stats.accepted, 2);
+        let snap = sup.handle().load();
+        assert_eq!(snap.models.len(), 1);
+        assert_eq!(snap.apikeys.len(), 1);
+        // Read as empty, not as an error: no rejection is reported for a
+        // prefix the gateway was never allowed to read.
+        assert_eq!(snap.global_pricing.len(), 0);
+        assert!(sup.recent_rejections().is_empty());
+        // The revision floor comes from the prefix that did answer.
+        assert_eq!(sup.watch_status().snapshot().revision, 12);
+    }
+
+    #[tokio::test]
+    async fn a_refused_catalog_does_not_stop_the_watch_cycle() {
+        // The watch half of the case above: the catalog's watch create is
+        // refused too, and the cycle still runs to a clean end on the
+        // environment's stream alone.
+        let sup = scoped_supervisor(
+            ScopedProvider::serving(vec![entry("/aisix/env-1/models/m-1", VALID_MODEL, 3)], 3),
+            ScopedProvider::refusing(),
+        );
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        // The environment stream is empty, so the cycle drains it and
+        // returns Ok — a refusal on the catalog would have surfaced here
+        // as SupervisorError::Provider.
+        sup.cycle(&rx).await.expect("cycle survives the refusal");
+        assert_eq!(sup.handle().load().models.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_refused_environment_prefix_still_fails_the_cycle() {
+        // The tolerance is scoped to the catalog. Credentials etcd
+        // refuses outright must still stop the cycle and reach the
+        // backoff loop's error path, or a misconfigured gateway would
+        // quietly serve an empty configuration forever.
+        let sup = scoped_supervisor(ScopedProvider::refusing(), ScopedProvider::refusing());
+        assert!(matches!(
+            sup.load_once().await,
+            Err(ProviderError::Rejected(_))
+        ));
+    }
 
     /// The two config digests must stay byte-identical to what the
     /// unchanged `hash_entries` produces over the same served set: cp-api

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -724,8 +724,9 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// Stops after the first watch error — the outer [`Self::run`] loop
     /// decides whether to backoff and retry.
     pub async fn load_once(&self) -> Result<BuildStats, ProviderError> {
-        let (entries, revision) = self.load_all_prefixes().await?;
-        let stats = self.apply_resync(&entries);
+        let load = self.load_all_prefixes().await?;
+        let revision = load.max_revision();
+        let stats = self.apply_resync(&load.entries);
         // apply_resync uses max(entry revisions); bump to the etcd
         // load_all revision so the cache file records the true "as
         // of" point, not just the max entry write.
@@ -745,7 +746,7 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// Kine revisions are cluster-global, so the maximum is the point the
     /// whole read is consistent as of, and it is what the heartbeat
     /// reports as `applied_revision`.
-    async fn load_all_prefixes(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
+    async fn load_all_prefixes(&self) -> Result<PrefixLoad, ProviderError> {
         // Deduplicated by key, because the prefixes can nest: when the
         // gateway has no `env_id` the environment prefix is the bare base
         // and `<base>/global/` sits inside it, so both range reads return
@@ -754,7 +755,13 @@ impl<P: ConfigProvider> Supervisor<P> {
         // not — `accepted` and the per-field partially-compatible row
         // counts are sums, and those numbers are reported.
         let mut all: BTreeMap<String, RawEntry> = BTreeMap::new();
-        let mut revision = 0i64;
+        // Per source, and not just the maximum: each prefix's watch has
+        // to start from the revision ITS OWN range read was consistent
+        // as of. The reads run in sequence, so a later prefix reports a
+        // higher revision, and starting an earlier prefix's watch there
+        // would skip every write to it in between — absent from that
+        // read and never delivered to that watch.
+        let mut revisions: Vec<Option<i64>> = Vec::with_capacity(self.sources.len());
         for source in &self.sources {
             match source.provider.load_all().await {
                 Ok((entries, rev)) => {
@@ -773,17 +780,21 @@ impl<P: ConfigProvider> Supervisor<P> {
                             }
                         }
                     }
-                    revision = revision.max(rev);
+                    revisions.push(Some(rev));
                 }
                 Err(err) if source.tolerates(&err) => {
                     // Read as empty: the prefix contributes no rows and no
                     // revision, and readiness is not held back.
                     source.log_refusal(&err);
+                    revisions.push(None);
                 }
                 Err(err) => return Err(err),
             }
         }
-        Ok((all.into_values().collect(), revision))
+        Ok(PrefixLoad {
+            entries: all.into_values().collect(),
+            revisions,
+        })
     }
 
     /// Bump the recorded revision floor. Used by the cycle path to
@@ -1398,21 +1409,26 @@ impl<P: ConfigProvider> Supervisor<P> {
         &self,
         cancel: &tokio::sync::watch::Receiver<bool>,
     ) -> Result<(), SupervisorError> {
-        let (entries, revision) = self
+        let load = self
             .load_all_prefixes()
             .await
             .map_err(SupervisorError::Provider)?;
+        let revision = load.max_revision();
 
         // ONE resync over the union: the snapshot is published only after
         // every prefix has been read, so readiness means every prefix's
         // initial load completed and no request can observe the
         // environment loaded and the catalog not.
-        self.apply_resync(&entries);
+        self.apply_resync(&load.entries);
         self.set_revision_floor(revision);
 
         let mut streams = Vec::with_capacity(self.sources.len());
-        for source in &self.sources {
-            match source.provider.watch(revision + 1).await {
+        for (source, from) in self.sources.iter().zip(&load.revisions) {
+            // Each prefix resumes from its own read, never from the
+            // maximum across prefixes. A prefix whose read was refused
+            // has no revision to resume from and no stream this cycle.
+            let Some(from) = *from else { continue };
+            match source.provider.watch(from + 1).await {
                 Ok(stream) => streams.push(stream),
                 Err(err) if source.tolerates(&err) => {
                     // No stream for this prefix this cycle. It is retried
@@ -1558,6 +1574,24 @@ impl<P: ConfigProvider> Supervisor<P> {
                 }
             }
         }
+    }
+}
+
+/// One pass of [`Supervisor::load_all_prefixes`]: the union of every
+/// watched prefix's rows, plus the revision each prefix's own read was
+/// consistent as of (`None` for a refusal that was tolerated).
+struct PrefixLoad {
+    entries: Vec<RawEntry>,
+    revisions: Vec<Option<i64>>,
+}
+
+impl PrefixLoad {
+    /// The revision the snapshot as a whole reflects. kine revisions are
+    /// cluster-global, so the highest any prefix reported is the point
+    /// the combined read is consistent as of, and it is what the
+    /// heartbeat reports as `applied_revision`.
+    fn max_revision(&self) -> i64 {
+        self.revisions.iter().flatten().copied().max().unwrap_or(0)
     }
 }
 
@@ -2103,6 +2137,8 @@ mod tests {
         entries: Vec<RawEntry>,
         revision: i64,
         refuse: bool,
+        /// The `start_revision` this provider's watch was opened with.
+        watched_from: Mutex<Option<i64>>,
     }
 
     impl ScopedProvider {
@@ -2111,6 +2147,7 @@ mod tests {
                 entries,
                 revision,
                 refuse: false,
+                watched_from: Mutex::new(None),
             })
         }
 
@@ -2119,6 +2156,7 @@ mod tests {
                 entries: Vec::new(),
                 revision: 0,
                 refuse: true,
+                watched_from: Mutex::new(None),
             })
         }
     }
@@ -2136,11 +2174,12 @@ mod tests {
 
         async fn watch(
             &self,
-            _start_revision: i64,
+            start_revision: i64,
         ) -> Result<
             Box<dyn futures::Stream<Item = Result<WatchEvent, ProviderError>> + Send + Unpin>,
             ProviderError,
         > {
+            *self.watched_from.lock().unwrap() = Some(start_revision);
             if self.refuse {
                 return Err(ProviderError::Rejected(
                     "etcdserver: permission denied: outside env env-1 prefix".into(),
@@ -2283,6 +2322,34 @@ mod tests {
         assert!(sup.recent_rejections().is_empty());
         // The revision floor comes from the prefix that did answer.
         assert_eq!(sup.watch_status().snapshot().revision, 12);
+    }
+
+    #[tokio::test]
+    async fn each_prefix_resumes_from_its_own_read() {
+        // The range reads run in sequence, so the later prefix reports a
+        // higher revision. Resuming BOTH watches from the maximum would
+        // skip every write to the earlier prefix made in between: absent
+        // from its read, and before the point its watch begins. The
+        // window is one range read wide and the loss is silent until the
+        // next resync.
+        let env =
+            ScopedProvider::serving(vec![entry("/aisix/env-1/models/m-1", VALID_MODEL, 1)], 7);
+        let global =
+            ScopedProvider::serving(vec![entry("/aisix/global/pricing/g", VALID_PRICE, 1)], 42);
+        let sup = scoped_supervisor(Arc::clone(&env), Arc::clone(&global));
+
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        sup.cycle(&rx).await.expect("cycle completes");
+
+        assert_eq!(
+            *env.watched_from.lock().unwrap(),
+            Some(8),
+            "the environment watch must resume from its OWN read (7), not from the maximum (42)",
+        );
+        assert_eq!(*global.watched_from.lock().unwrap(), Some(43));
+        // The reported applied revision is still the maximum: it is what
+        // the whole combined read is consistent as of.
+        assert_eq!(sup.watch_status().snapshot().revision, 42);
     }
 
     #[tokio::test]

--- a/crates/aisix-proxy/src/chat.rs
+++ b/crates/aisix-proxy/src/chat.rs
@@ -1492,6 +1492,7 @@ async fn dispatch(
             let attempts = resolve_attempt_models(
                 &state.routing,
                 &state.runtime_status,
+                &state.pricing,
                 snapshot,
                 &req.model,
                 &virtual_entry.id,

--- a/crates/aisix-proxy/src/count_tokens.rs
+++ b/crates/aisix-proxy/src/count_tokens.rs
@@ -426,6 +426,7 @@ async fn dispatch(
     let attempt_models = crate::routing::resolve_attempt_models(
         &state.routing,
         &state.runtime_status,
+        &state.pricing,
         snapshot,
         &model_name,
         &model_entry.id,

--- a/crates/aisix-proxy/src/jobs.rs
+++ b/crates/aisix-proxy/src/jobs.rs
@@ -1877,7 +1877,17 @@ fn maybe_attribute_batch(
     let jwt = auth.jwt.clone();
     let model_id = target.model_entry.id.clone();
     let display_name = target.display_name().to_string();
-    let cost = target.model_entry.value.cost.clone();
+    // Resolved before the spawn, off the live snapshot, through the same
+    // index `least_cost` ranks with: `pricing_key` first, inline `cost`
+    // second. The completed batch is priced at what the model costs when
+    // its output is collected.
+    let snap = state.snapshot.load();
+    let cost = state
+        .pricing
+        .for_snapshot(&snap)
+        .resolve(&target.model_entry.value)
+        .cloned();
+    drop(snap);
     let pk_id = target.pk_entry.id.to_string();
     let secret = target.secret.clone();
     let adapter = target.adapter;

--- a/crates/aisix-proxy/src/messages.rs
+++ b/crates/aisix-proxy/src/messages.rs
@@ -775,6 +775,7 @@ async fn dispatch(
     let attempt_models = crate::routing::resolve_attempt_models(
         &state.routing,
         &state.runtime_status,
+        &state.pricing,
         snapshot,
         &model_name,
         &model_entry.id,

--- a/crates/aisix-proxy/src/realtime.rs
+++ b/crates/aisix-proxy/src/realtime.rs
@@ -963,6 +963,10 @@ async fn run_session(
     // usage event and `record_usage` below, where each used to do its own.
     let snap = state.snapshot.load();
     let pk = crate::usage_attr::ResolvedPk::resolve(&snap, &pk_id);
+    // Priced off the same fresh snapshot, through the index every other
+    // reader of a model's price uses: `pricing_key` first, inline `cost`
+    // second.
+    let pricing = state.pricing.for_snapshot(&snap);
     crate::request_metrics::record(
         &state,
         "/v1/realtime",
@@ -994,10 +998,8 @@ async fn run_session(
         // the upstream figure and what the caller waited for coincide.
         upstream_latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
         downstream_latency_ms: elapsed.as_millis().min(u32::MAX as u128) as u32,
-        cost_usd: model_entry
-            .value
-            .cost
-            .as_ref()
+        cost_usd: pricing
+            .resolve(&model_entry.value)
             .map(|c| c.calculate(usage.input_tokens, usage.output_tokens))
             .unwrap_or(0.0),
         inbound_protocol: "realtime".to_string(),

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -663,6 +663,7 @@ async fn dispatch(
     let attempt_models = crate::routing::resolve_attempt_models(
         &state.routing,
         &state.runtime_status,
+        &state.pricing,
         snapshot,
         &model_name,
         &model_entry.id,

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -2526,11 +2526,11 @@ mod tests {
     fn no_one_reads_a_models_price_off_the_field() {
         use std::path::Path;
 
-        fn walk(dir: &Path, out: &mut Vec<(String, usize, String)>) {
+        fn walk(dir: &Path, needle: &str, out: &mut Vec<(String, usize, String)>) {
             for e in std::fs::read_dir(dir).expect("crate src is readable") {
                 let path = e.expect("dir entry").path();
                 if path.is_dir() {
-                    walk(&path, out);
+                    walk(&path, needle, out);
                 } else if path.extension().is_some_and(|x| x == "rs") {
                     let name = path.file_name().unwrap().to_string_lossy().into_owned();
                     let src = std::fs::read_to_string(&path).expect("source is utf-8");
@@ -2543,8 +2543,8 @@ mod tests {
                             continue;
                         }
                         let mut rest = line;
-                        while let Some(at) = rest.find(".cost") {
-                            let after = &rest[at + 5..];
+                        while let Some(at) = rest.find(&needle) {
+                            let after = &rest[at + needle.len()..];
                             let boundary = after
                                 .chars()
                                 .next()
@@ -2560,13 +2560,17 @@ mod tests {
             }
         }
 
+        // Assembled rather than written out, so this file is scanned
+        // like every other one: excluding it to stop the census matching
+        // its own text would also stop it covering `cost_key`, which
+        // lives here and is the reader most likely to regress.
+        let needle = format!(".{}", "cost");
         let mut hits = Vec::new();
         walk(
             Path::new(env!("CARGO_MANIFEST_DIR")).join("src").as_path(),
+            &needle,
             &mut hits,
         );
-        // The census itself quotes the pattern it looks for.
-        hits.retain(|(file, _, _)| file != "routing.rs");
         assert!(
             hits.is_empty(),
             "these read a model's price off the field instead of through \

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -2526,13 +2526,31 @@ mod tests {
     fn no_one_reads_a_models_price_off_the_field() {
         use std::path::Path;
 
+        /// The two places allowed to touch the field, by PATH rather
+        /// than by file name: excluding a bare name would also excuse a
+        /// same-named file in another crate, and excluding a whole file
+        /// is how the first version of this census stopped covering
+        /// `cost_key`.
+        const AUTHORIZED: [&str; 2] = [
+            // Defines `ModelCost` and clears it in strip_kind_inapplicable.
+            "aisix-core/src/models/model.rs",
+            // The resolver every other reader must go through.
+            "aisix-core/src/models/pricing.rs",
+        ];
+
         fn walk(dir: &Path, needle: &str, out: &mut Vec<(String, usize, String)>) {
-            for e in std::fs::read_dir(dir).expect("crate src is readable") {
+            for e in std::fs::read_dir(dir).expect("crates dir is readable") {
                 let path = e.expect("dir entry").path();
                 if path.is_dir() {
+                    if path.file_name().is_some_and(|n| n == "target") {
+                        continue;
+                    }
                     walk(&path, needle, out);
                 } else if path.extension().is_some_and(|x| x == "rs") {
-                    let name = path.file_name().unwrap().to_string_lossy().into_owned();
+                    let name = path.to_string_lossy().replace('\\', "/");
+                    if AUTHORIZED.iter().any(|ok| name.ends_with(ok)) {
+                        continue;
+                    }
                     let src = std::fs::read_to_string(&path).expect("source is utf-8");
                     for (i, line) in src.lines().enumerate() {
                         // `.cost` as a field access, not `cost_usd` /
@@ -2566,15 +2584,25 @@ mod tests {
         // lives here and is the reader most likely to regress.
         let needle = format!(".{}", "cost");
         let mut hits = Vec::new();
-        walk(
-            Path::new(env!("CARGO_MANIFEST_DIR")).join("src").as_path(),
-            &needle,
-            &mut hits,
-        );
+        // The whole workspace, not just this crate: a usage event is
+        // assembled in more than one of them, and a direct read added
+        // anywhere else would be just as silent.
+        let crates = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("the crate lives under crates/")
+            .to_path_buf();
+        walk(&crates, &needle, &mut hits);
         assert!(
             hits.is_empty(),
             "these read a model's price off the field instead of through \
              PricingIndex::resolve, so `pricing_key` is ignored there: {hits:#?}",
+        );
+        // The census is worthless if it scans nothing; prove it reached
+        // the crates it is meant to cover.
+        assert!(
+            crates.join("aisix-server/src").is_dir() && crates.join("aisix-obs/src").is_dir(),
+            "the census did not reach the other crates: {}",
+            crates.display(),
         );
     }
 

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -34,6 +34,7 @@
 //! - **least_busy**: least-loaded target first, by in-flight requests
 //!   divided by target `weight` (the APISIX least_conn score).
 
+use aisix_core::models::{LivePricingIndex, PricingIndex};
 use aisix_core::{
     AisixSnapshot, HashOnType, Model, Routing, RoutingStrategy, RoutingTarget,
     WhenAllUnavailablePolicy,
@@ -909,12 +910,12 @@ fn cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
 }
 
 /// Combined per-1K unit price used to rank `least_cost` targets. A target
-/// Model without a configured `cost` sorts last (treated as +∞) so a
-/// misconfigured target is deprioritised rather than silently preferred.
-fn cost_key(model: &Model) -> f64 {
-    model
-        .cost
-        .as_ref()
+/// Model with no price at all — no `pricing_key` that resolves, and no
+/// inline `cost` — sorts last (treated as +∞) so a misconfigured target
+/// is deprioritised rather than silently preferred.
+fn cost_key(pricing: &PricingIndex, model: &Model) -> f64 {
+    pricing
+        .resolve(model)
         .map(|c| c.input_per_1k + c.output_per_1k)
         .unwrap_or(f64::INFINITY)
 }
@@ -936,10 +937,18 @@ fn order_attempts_by_metric(
     strategy: RoutingStrategy,
     attempts: &mut [AttemptModel],
     runtime_status: &crate::ModelRuntimeStatusTracker,
+    snapshot: &AisixSnapshot,
+    pricing: &LivePricingIndex,
 ) {
     match strategy {
         RoutingStrategy::LeastCost => {
-            attempts.sort_by(|a, b| cost_key(&a.model).total_cmp(&cost_key(&b.model)));
+            // Built here rather than per comparison: the sort calls the
+            // key function O(n log n) times, and the index is shared with
+            // whatever else prices this snapshot.
+            let pricing = pricing.for_snapshot(snapshot);
+            attempts.sort_by(|a, b| {
+                cost_key(&pricing, &a.model).total_cmp(&cost_key(&pricing, &b.model))
+            });
         }
         RoutingStrategy::LeastLatency => {
             attempts.sort_by(|a, b| {
@@ -1161,6 +1170,7 @@ fn targets_allowed_for_ip(
 pub(crate) fn resolve_attempt_models(
     routing_registry: &RoutingRegistry,
     runtime_status: &crate::ModelRuntimeStatusTracker,
+    pricing: &LivePricingIndex,
     snapshot: &AisixSnapshot,
     virtual_name: &str,
     virtual_id: &str,
@@ -1243,7 +1253,13 @@ pub(crate) fn resolve_attempt_models(
     // metric sort runs first, then a stable sort on priority — so tiers
     // concatenate highest-first with the metric order preserved inside each.
     if routing.strategy.is_metric_based() {
-        order_attempts_by_metric(routing.strategy, &mut resolved, runtime_status);
+        order_attempts_by_metric(
+            routing.strategy,
+            &mut resolved,
+            runtime_status,
+            snapshot,
+            pricing,
+        );
         resolved.sort_by_key(|a| std::cmp::Reverse(a.priority));
         resolved.truncate(routing.max_fallbacks_or_default() + 1);
     }

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -2543,7 +2543,7 @@ mod tests {
                             continue;
                         }
                         let mut rest = line;
-                        while let Some(at) = rest.find(&needle) {
+                        while let Some(at) = rest.find(needle) {
                             let after = &rest[at + needle.len()..];
                             let boundary = after
                                 .chars()

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -1167,6 +1167,7 @@ fn targets_allowed_for_ip(
 ///
 /// Shared by `/v1/chat/completions` and `/v1/messages` so both endpoints
 /// dispatch Model Groups identically (ai-gateway#471).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn resolve_attempt_models(
     routing_registry: &RoutingRegistry,
     runtime_status: &crate::ModelRuntimeStatusTracker,
@@ -2467,6 +2468,92 @@ mod tests {
     }
 
     // ── order_attempts_by_metric (least_cost) ─────────────────────
+
+    /// A snapshot with no pricing documents — the cases below rank by
+    /// the models' own inline `cost`, which is what every deployment
+    /// written before pricing documents existed still does.
+    fn unpriced() -> AisixSnapshot {
+        AisixSnapshot::new()
+    }
+
+    /// A snapshot whose shared catalog prices `key` at `input`/`output`.
+    fn priced(key: &str, input: f64, output: f64) -> AisixSnapshot {
+        let snap = AisixSnapshot::new();
+        snap.global_pricing.insert(aisix_core::ResourceEntry::new(
+            "p-1",
+            serde_json::from_str(&format!(
+                r#"{{"key":"{key}","input_per_1k":{input},"output_per_1k":{output}}}"#
+            ))
+            .unwrap(),
+            1,
+        ));
+        snap
+    }
+
+    /// A target priced only by reference — no inline `cost` to fall back
+    /// on, so a resolution that does not happen ranks it last.
+    fn am_with_pricing_key(id: &str, key: &str) -> AttemptModel {
+        let model: Model = serde_json::from_str(&format!(
+            r#"{{
+              "display_name": "{id}",
+              "provider": "openai",
+              "model_name": "gpt-4o-mini",
+              "provider_key_id": "pk-{id}",
+              "pricing_key": "{key}"
+            }}"#
+        ))
+        .unwrap();
+        AttemptModel {
+            id: id.to_string(),
+            model,
+            priority: 0,
+            weight: 1,
+        }
+    }
+
+    #[test]
+    fn least_cost_ranks_a_referenced_price_against_an_inline_one() {
+        let t = crate::ModelRuntimeStatusTracker::new();
+        // The referenced price (2/1K) undercuts the inline one (6/1K).
+        // Reversed against the same models with no catalog, below, so
+        // neither ordering can be the accidental one.
+        let snap = priced("vendor/x", 1.0, 1.0);
+        let mut attempts = vec![
+            am_with_cost("inline", 3.0, 3.0),
+            am_with_pricing_key("referenced", "vendor/x"),
+        ];
+        order_attempts_by_metric(
+            RoutingStrategy::LeastCost,
+            &mut attempts,
+            &t,
+            &snap,
+            &LivePricingIndex::new(),
+        );
+        let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, vec!["referenced", "inline"]);
+    }
+
+    #[test]
+    fn least_cost_ranks_an_unresolved_reference_last() {
+        let t = crate::ModelRuntimeStatusTracker::new();
+        // Same two targets, no catalog: the reference resolves to
+        // nothing and the model carries no inline cost, so it is +∞ and
+        // sorts behind the priced one.
+        let mut attempts = vec![
+            am_with_pricing_key("referenced", "vendor/x"),
+            am_with_cost("inline", 3.0, 3.0),
+        ];
+        order_attempts_by_metric(
+            RoutingStrategy::LeastCost,
+            &mut attempts,
+            &t,
+            &unpriced(),
+            &LivePricingIndex::new(),
+        );
+        let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, vec!["inline", "referenced"]);
+    }
+
     fn am_with_cost(id: &str, input_per_1k: f64, output_per_1k: f64) -> AttemptModel {
         let model: Model = serde_json::from_str(&format!(
             r#"{{
@@ -2494,7 +2581,13 @@ mod tests {
             am_with_cost("cheap", 1.0, 2.0),    // 3 / 1K
             am_with_cost("mid", 5.0, 5.0),      // 10 / 1K
         ];
-        order_attempts_by_metric(RoutingStrategy::LeastCost, &mut attempts, &t);
+        order_attempts_by_metric(
+            RoutingStrategy::LeastCost,
+            &mut attempts,
+            &t,
+            &unpriced(),
+            &LivePricingIndex::new(),
+        );
         let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
         assert_eq!(ids, vec!["cheap", "mid", "pricey"]);
     }
@@ -2507,7 +2600,13 @@ mod tests {
             am_with_cost("cheap", 1.0, 1.0), // 2 / 1K
             am("no-cost-b"),                 // +∞
         ];
-        order_attempts_by_metric(RoutingStrategy::LeastCost, &mut attempts, &t);
+        order_attempts_by_metric(
+            RoutingStrategy::LeastCost,
+            &mut attempts,
+            &t,
+            &unpriced(),
+            &LivePricingIndex::new(),
+        );
         let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
         // Priced target first; equal (missing-cost) targets keep their
         // declaration order thanks to the stable sort.
@@ -2518,7 +2617,13 @@ mod tests {
     fn non_metric_strategy_leaves_order_untouched() {
         let t = crate::ModelRuntimeStatusTracker::new();
         let mut attempts = vec![am_with_cost("b", 9.0, 9.0), am_with_cost("a", 1.0, 1.0)];
-        order_attempts_by_metric(RoutingStrategy::Failover, &mut attempts, &t);
+        order_attempts_by_metric(
+            RoutingStrategy::Failover,
+            &mut attempts,
+            &t,
+            &unpriced(),
+            &LivePricingIndex::new(),
+        );
         let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
         assert_eq!(ids, vec!["b", "a"]);
     }
@@ -2531,7 +2636,13 @@ mod tests {
         t.record_latency("fast", 50);
         t.record_latency("mid", 300);
         let mut attempts = vec![am("slow"), am("fast"), am("mid")];
-        order_attempts_by_metric(RoutingStrategy::LeastLatency, &mut attempts, &t);
+        order_attempts_by_metric(
+            RoutingStrategy::LeastLatency,
+            &mut attempts,
+            &t,
+            &unpriced(),
+            &LivePricingIndex::new(),
+        );
         let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
         assert_eq!(ids, vec!["fast", "mid", "slow"]);
     }
@@ -2543,7 +2654,13 @@ mod tests {
         // "unseen-a"/"unseen-b" have no samples → rank first (−∞), keeping
         // their declaration order via the stable sort.
         let mut attempts = vec![am("measured"), am("unseen-a"), am("unseen-b")];
-        order_attempts_by_metric(RoutingStrategy::LeastLatency, &mut attempts, &t);
+        order_attempts_by_metric(
+            RoutingStrategy::LeastLatency,
+            &mut attempts,
+            &t,
+            &unpriced(),
+            &LivePricingIndex::new(),
+        );
         let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
         assert_eq!(ids, vec!["unseen-a", "unseen-b", "measured"]);
     }
@@ -2568,7 +2685,13 @@ mod tests {
         let _m1 = t.begin_in_flight("mid"); // 1 in-flight
                                             // "idle" has 0 in-flight.
         let mut attempts = vec![am("busy"), am("idle"), am("mid")];
-        order_attempts_by_metric(RoutingStrategy::LeastBusy, &mut attempts, &t);
+        order_attempts_by_metric(
+            RoutingStrategy::LeastBusy,
+            &mut attempts,
+            &t,
+            &unpriced(),
+            &LivePricingIndex::new(),
+        );
         let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
         assert_eq!(ids, vec!["idle", "mid", "busy"]);
     }
@@ -2578,7 +2701,13 @@ mod tests {
         let t = crate::ModelRuntimeStatusTracker::new();
         // All idle (0 in-flight) → stable sort preserves declaration order.
         let mut attempts = vec![am("a"), am("b"), am("c")];
-        order_attempts_by_metric(RoutingStrategy::LeastBusy, &mut attempts, &t);
+        order_attempts_by_metric(
+            RoutingStrategy::LeastBusy,
+            &mut attempts,
+            &t,
+            &unpriced(),
+            &LivePricingIndex::new(),
+        );
         let ids: Vec<&str> = attempts.iter().map(|a| a.id.as_str()).collect();
         assert_eq!(ids, vec!["a", "b", "c"]);
     }

--- a/crates/aisix-proxy/src/routing.rs
+++ b/crates/aisix-proxy/src/routing.rs
@@ -2511,6 +2511,69 @@ mod tests {
         }
     }
 
+    /// Every reader of a model's price must go through
+    /// [`PricingIndex::resolve`], so ranking and billing cannot disagree
+    /// about what a model costs.
+    ///
+    /// A census rather than a list of the three known sites, for the
+    /// reason `guardrail_coverage.rs` gives: the readers here come in a
+    /// family (`least_cost` ordering, the realtime session's `cost_usd`,
+    /// the batch attribution's), a fourth is added by writing one more
+    /// `.cost`, and a hand-written list agrees with itself forever. The
+    /// symptom of missing one is silent — a model priced by reference
+    /// bills zero on the site that still reads the field.
+    #[test]
+    fn no_one_reads_a_models_price_off_the_field() {
+        use std::path::Path;
+
+        fn walk(dir: &Path, out: &mut Vec<(String, usize, String)>) {
+            for e in std::fs::read_dir(dir).expect("crate src is readable") {
+                let path = e.expect("dir entry").path();
+                if path.is_dir() {
+                    walk(&path, out);
+                } else if path.extension().is_some_and(|x| x == "rs") {
+                    let name = path.file_name().unwrap().to_string_lossy().into_owned();
+                    let src = std::fs::read_to_string(&path).expect("source is utf-8");
+                    for (i, line) in src.lines().enumerate() {
+                        // `.cost` as a field access, not `cost_usd` /
+                        // `cost_saved_usd` / a local named `*_cost`, and
+                        // not a comment.
+                        let trimmed = line.trim_start();
+                        if trimmed.starts_with("//") || trimmed.starts_with("///") {
+                            continue;
+                        }
+                        let mut rest = line;
+                        while let Some(at) = rest.find(".cost") {
+                            let after = &rest[at + 5..];
+                            let boundary = after
+                                .chars()
+                                .next()
+                                .is_none_or(|c| !c.is_alphanumeric() && c != '_');
+                            if boundary {
+                                out.push((name.clone(), i + 1, line.trim().to_string()));
+                                break;
+                            }
+                            rest = after;
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut hits = Vec::new();
+        walk(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("src").as_path(),
+            &mut hits,
+        );
+        // The census itself quotes the pattern it looks for.
+        hits.retain(|(file, _, _)| file != "routing.rs");
+        assert!(
+            hits.is_empty(),
+            "these read a model's price off the field instead of through \
+             PricingIndex::resolve, so `pricing_key` is ignored there: {hits:#?}",
+        );
+    }
+
     #[test]
     fn least_cost_ranks_a_referenced_price_against_an_inline_one() {
         let t = crate::ModelRuntimeStatusTracker::new();

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -19,6 +19,7 @@ use aisix_core::models::CacheBackend;
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, ProxyConfig};
 use aisix_gateway::Hub;
+use aisix_core::models::LivePricingIndex;
 use aisix_guardrails::LiveGuardrailIndex;
 use aisix_obs::{ClientTypeClassifier, Metrics, OtlpHttpFanOut, UsageSink};
 use aisix_ratelimit::Limiter;
@@ -182,6 +183,12 @@ pub struct ProxyStateInner {
     /// when the snapshot version changes. Default is an empty index
     /// (no-op); the server bootstrap wires a live handle at startup.
     pub guardrail_index: Arc<LiveGuardrailIndex>,
+    /// Prices by `pricing_key`, derived from the two pricing tables and
+    /// rebuilt only when one of them changes. Every reader of a model's
+    /// price goes through it — `least_cost` ranking and the `cost_usd` on
+    /// the usage events — so ranking and billing cannot disagree about
+    /// what a model costs.
+    pub pricing: Arc<LivePricingIndex>,
     /// Per-request budget gate. Asks cp-api whether the api_key may
     /// proceed; cached for 5s with sticky fallback on cp-api outage.
     pub budgets: Arc<BudgetClient>,
@@ -322,6 +329,7 @@ impl ProxyState {
             routing: Arc::new(RoutingRegistry::new()),
             semantic_cache,
             guardrail_index,
+            pricing: Arc::new(LivePricingIndex::new()),
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
             livez: Arc::new(LivezState::new()),
@@ -370,6 +378,7 @@ impl ProxyState {
             routing: Arc::new(RoutingRegistry::new()),
             semantic_cache,
             guardrail_index,
+            pricing: Arc::new(LivePricingIndex::new()),
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
             livez: Arc::new(LivezState::new()),
@@ -432,6 +441,7 @@ impl ProxyState {
             routing: Arc::new(RoutingRegistry::new()),
             semantic_cache,
             guardrail_index,
+            pricing: Arc::new(LivePricingIndex::new()),
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::with_flags(bookkeeping_flags)),
             livez: Arc::new(LivezState::new()),

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -16,10 +16,10 @@
 
 use aisix_cache::{Cache, MemoryCache, MemorySemanticCache, SemanticCacheStore};
 use aisix_core::models::CacheBackend;
+use aisix_core::models::LivePricingIndex;
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, ProxyConfig};
 use aisix_gateway::Hub;
-use aisix_core::models::LivePricingIndex;
 use aisix_guardrails::LiveGuardrailIndex;
 use aisix_obs::{ClientTypeClassifier, Metrics, OtlpHttpFanOut, UsageSink};
 use aisix_ratelimit::Limiter;

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -672,9 +672,13 @@ fn resugar_provider_key(
 /// A pricing document lives in a collection the resources file does not
 /// have, and the shared catalog lives outside the exported prefix
 /// entirely, so the reference cannot be resugared into anything a file
-/// can resolve. Dropping it costs the model its price unless it also
-/// carries an inline `cost`, which is worth saying: the exported model
-/// then ranks last under `least_cost` rather than at its real price.
+/// can resolve.
+///
+/// Dropping it always changes what the model costs, so it is always
+/// reported. A model carrying an inline `cost` too is NOT safe to pass
+/// over: the document wins at runtime, so the exported file prices that
+/// model at its `cost` instead — silently, and by a different number
+/// whenever the two disagree.
 fn drop_pricing_key(doc: &mut Value, model: &str, diag: &mut Diagnostics) {
     let Some(map) = doc.as_object_mut() else {
         return;
@@ -683,6 +687,11 @@ fn drop_pricing_key(doc: &mut Value, model: &str, diag: &mut Diagnostics) {
         return;
     };
     if map.contains_key("cost") {
+        diag.warnings.push(format!(
+            "model {model:?} is priced by the pricing document {key:?}, which a resources file \
+             cannot express — the exported model falls back to its inline `cost`, which is a \
+             different price whenever the two disagree"
+        ));
         return;
     }
     diag.warnings.push(format!(

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -134,7 +134,10 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
             |m| m.display_name.clone(),
             "models",
             &mut diag,
-            |doc, identity, diag| resugar_provider_key(doc, identity, &provider_key_names, diag),
+            |doc, identity, diag| {
+                resugar_provider_key(doc, identity, &provider_key_names, diag);
+                drop_pricing_key(doc, identity, diag);
+            },
             |_, _| {},
         ),
     );
@@ -648,6 +651,32 @@ fn resugar_provider_key(
              will not load until it is resolved)"
         )),
     }
+}
+
+/// Drop `model.pricing_key` — a control-plane projection with no file
+/// form.
+///
+/// A pricing document lives in a collection the resources file does not
+/// have, and the shared catalog lives outside the exported prefix
+/// entirely, so the reference cannot be resugared into anything a file
+/// can resolve. Dropping it costs the model its price unless it also
+/// carries an inline `cost`, which is worth saying: the exported model
+/// then ranks last under `least_cost` rather than at its real price.
+fn drop_pricing_key(doc: &mut Value, model: &str, diag: &mut Diagnostics) {
+    let Some(map) = doc.as_object_mut() else {
+        return;
+    };
+    let Some(Value::String(key)) = map.remove("pricing_key") else {
+        return;
+    };
+    if map.contains_key("cost") {
+        return;
+    }
+    diag.warnings.push(format!(
+        "model {model:?} takes its price from the pricing document {key:?}, which a resources \
+         file cannot express — the exported model carries no price and will rank last under \
+         `least_cost`; set `cost` on it if the price matters"
+    ));
 }
 
 /// `api_key.allowed_model_ids` (etcd ids) → `allowed_models` names.

--- a/crates/aisix-server/src/export/document_tests.rs
+++ b/crates/aisix-server/src/export/document_tests.rs
@@ -672,6 +672,53 @@ fn a_team_scope_is_carried_through_verbatim() {
 }
 
 #[test]
+fn model_pricing_key_is_dropped_from_the_export() {
+    let snap = AisixSnapshot::new();
+    snap.provider_keys
+        .insert(ResourceEntry::new("pk", provider_key("pk", "sk"), 1));
+    snap.models.insert(ResourceEntry::new(
+        "m-1",
+        model_value(json!({
+            "display_name": "priced-by-catalog",
+            "provider": "openai",
+            "model_name": "x",
+            "provider_key_id": "pk",
+            "pricing_key": "openai/x"
+        })),
+        1,
+    ));
+    snap.models.insert(ResourceEntry::new(
+        "m-2",
+        model_value(json!({
+            "display_name": "priced-inline-too",
+            "provider": "openai",
+            "model_name": "x",
+            "provider_key_id": "pk",
+            "pricing_key": "openai/x",
+            "cost": {"input_per_1k": 1.0, "output_per_1k": 2.0}
+        })),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    let models = find(&doc, "models");
+    // The reference has no file form, so neither model keeps it — the
+    // file source rejects the field outright.
+    for m in models {
+        assert!(m.get("pricing_key").is_none(), "{m:?}");
+    }
+    // Losing it costs the first model its price entirely, which is worth
+    // saying; the second still carries `cost`, so nothing is lost there.
+    assert_eq!(doc.warnings.len(), 1, "{:?}", doc.warnings);
+    assert!(
+        doc.warnings[0].contains("priced-by-catalog") && doc.warnings[0].contains("least_cost"),
+        "{:?}",
+        doc.warnings
+    );
+    assert!(doc.blocking.is_empty(), "{:?}", doc.blocking);
+}
+
+#[test]
 fn api_key_allowed_model_ids_resugar_to_names() {
     let snap = AisixSnapshot::new();
     snap.provider_keys

--- a/crates/aisix-server/src/export/document_tests.rs
+++ b/crates/aisix-server/src/export/document_tests.rs
@@ -732,14 +732,22 @@ fn model_pricing_key_is_dropped_from_the_export() {
     for m in models {
         assert!(m.get("pricing_key").is_none(), "{m:?}");
     }
-    // Losing it costs the first model its price entirely, which is worth
-    // saying; the second still carries `cost`, so nothing is lost there.
-    assert_eq!(doc.warnings.len(), 1, "{:?}", doc.warnings);
-    assert!(
-        doc.warnings[0].contains("priced-by-catalog") && doc.warnings[0].contains("least_cost"),
-        "{:?}",
-        doc.warnings
-    );
+    // BOTH are reported. The first loses its price outright. The second
+    // keeps a number, but a DIFFERENT one — the document outranks the
+    // inline `cost` at runtime, so exporting silently reprices it.
+    assert_eq!(doc.warnings.len(), 2, "{:?}", doc.warnings);
+    let by_catalog = doc
+        .warnings
+        .iter()
+        .find(|w| w.contains("priced-by-catalog"))
+        .expect("the model with no inline cost is reported");
+    assert!(by_catalog.contains("least_cost"), "{by_catalog:?}");
+    let inline_too = doc
+        .warnings
+        .iter()
+        .find(|w| w.contains("priced-inline-too"))
+        .expect("the model that falls back to a different price is reported");
+    assert!(inline_too.contains("`cost`"), "{inline_too:?}");
     assert!(doc.blocking.is_empty(), "{:?}", doc.blocking);
 }
 

--- a/crates/aisix-server/src/export/mod.rs
+++ b/crates/aisix-server/src/export/mod.rs
@@ -26,7 +26,7 @@ mod yaml_emit;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use aisix_etcd::{build_snapshot, ConfigProvider, ConnectPolicy, EtcdConfigProvider};
+use aisix_etcd::{build_snapshot, ConfigProvider, ConnectPolicy, EtcdConfigProvider, PrefixSet};
 
 use document::build_export_document;
 use yaml_emit::emit_yaml;
@@ -77,7 +77,7 @@ pub async fn run(args: ExportArgs) -> anyhow::Result<()> {
 
     // Decode through the identical loader path the gateway uses, so the
     // exported set is exactly what the running gateway would serve.
-    let (snapshot, stats) = build_snapshot(&args.prefix, &entries);
+    let (snapshot, stats) = build_snapshot(&PrefixSet::single(&args.prefix), &entries);
 
     let document = build_export_document(&snapshot, args.reveal_secrets);
     let yaml = emit_yaml(&document).map_err(|e| anyhow::anyhow!(e))?;

--- a/crates/aisix-server/src/export/mod.rs
+++ b/crates/aisix-server/src/export/mod.rs
@@ -26,7 +26,9 @@ mod yaml_emit;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use aisix_etcd::{build_snapshot, ConfigProvider, ConnectPolicy, EtcdConfigProvider, PrefixSet};
+use aisix_etcd::{
+    build_snapshot, ConfigProvider, ConnectPolicy, EtcdConfigProvider, PrefixSet, WatchedPrefix,
+};
 
 use document::build_export_document;
 use yaml_emit::emit_yaml;
@@ -77,7 +79,19 @@ pub async fn run(args: ExportArgs) -> anyhow::Result<()> {
 
     // Decode through the identical loader path the gateway uses, so the
     // exported set is exactly what the running gateway would serve.
-    let (snapshot, stats) = build_snapshot(&PrefixSet::single(&args.prefix), &entries);
+    // The catalog prefix is declared alongside the exported one even
+    // though export never emits a pricing document. When `--prefix` is
+    // the bare base — the pre-`env_id` shape — the range read also
+    // returns `<base>/global/pricing/*`, and resolved against the base
+    // alone those keys parse as kind `global` and are reported as
+    // rejected rows the operator did nothing wrong to produce. Declaring
+    // the prefix resolves them as the prices they are; they simply have
+    // no file form to be emitted into.
+    let prefixes = PrefixSet::new(vec![
+        WatchedPrefix::environment(&args.prefix),
+        WatchedPrefix::global(format!("{}/global/", args.prefix.trim_end_matches('/'))),
+    ]);
+    let (snapshot, stats) = build_snapshot(&prefixes, &entries);
 
     let document = build_export_document(&snapshot, args.reveal_secrets);
     let yaml = emit_yaml(&document).map_err(|e| anyhow::anyhow!(e))?;

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -74,7 +74,7 @@ use aisix_core::{
     AisixSnapshot, CacheBackend, Config, ConfigStatus, EtcdConfig, EtcdTlsConfig, RateLimitBackend,
     SourceKind,
 };
-use aisix_etcd::{EtcdConfigProvider, SnapshotCache, Supervisor};
+use aisix_etcd::{EtcdConfigProvider, SnapshotCache, Supervisor, WatchedPrefix};
 use aisix_gateway::{Hub, UpstreamHttpConfig};
 use aisix_obs::{init_tracing, Metrics};
 use aisix_provider_anthropic::AnthropicBridge;
@@ -738,6 +738,12 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
             // (env_id populated from the register response above), bare
             // `<prefix>` in self-hosted dev where env_id is empty.
             let etcd_prefix = cfg.etcd.effective_prefix();
+            // The shared pricing catalog, watched alongside the
+            // environment's own prefix and folded into the same snapshot.
+            // A control plane that does not grant read access to it is
+            // tolerated: the supervisor serves without prices rather than
+            // without configuration.
+            let global_prefix = cfg.etcd.global_prefix();
             // Only a refusal ends the boot here: an etcd that cannot be
             // reached leaves the connection pending and the supervisor
             // dials it again, so the gateway waits for its source instead
@@ -746,6 +752,21 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 EtcdConfigProvider::connect(
                     &cfg.etcd.endpoints,
                     etcd_prefix.clone(),
+                    connect_options.clone(),
+                    cfg.etcd.request_timeout(),
+                    cfg.etcd.dial_timeout(),
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?,
+            );
+            // Its own connection, for the same reason the admin surface
+            // has one: the catalog's range read and watch never queue
+            // behind the environment's, and a refusal on one channel does
+            // not disturb the other.
+            let global_provider = Arc::new(
+                EtcdConfigProvider::connect(
+                    &cfg.etcd.endpoints,
+                    global_prefix.clone(),
                     connect_options.clone(),
                     cfg.etcd.request_timeout(),
                     cfg.etcd.dial_timeout(),
@@ -784,9 +805,11 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                 Some(path) => SnapshotCache::new(path),
                 None => SnapshotCache::disabled(),
             };
-            let supervisor = Arc::new(Supervisor::with_cache(
-                provider,
-                etcd_prefix,
+            let supervisor = Arc::new(Supervisor::with_sources(
+                vec![
+                    (WatchedPrefix::environment(etcd_prefix), provider),
+                    (WatchedPrefix::global(global_prefix), global_provider),
+                ],
                 snapshot_cache,
             ));
             // Seed the snapshot from disk before the etcd cycle starts so the

--- a/crates/aisix-server/tests/guardrail_read_path_forward_compat.rs
+++ b/crates/aisix-server/tests/guardrail_read_path_forward_compat.rs
@@ -37,7 +37,7 @@ fn guardrail_with_an_unknown_nested_field_loads_and_still_masks() {
         value: GUARDRAIL_FROM_A_NEWER_CP.to_vec(),
         revision: 1,
     }];
-    let (snapshot, stats) = build_snapshot("/aisix", &entries);
+    let (snapshot, stats) = build_snapshot(&aisix_etcd::PrefixSet::single("/aisix"), &entries);
 
     assert_eq!(stats.accepted, 1, "rejections: {:?}", stats.rejections);
     assert_eq!(snapshot.guardrails.len(), 1);

--- a/schemas/resources-lenient/model.schema.json
+++ b/schemas/resources-lenient/model.schema.json
@@ -616,7 +616,7 @@
           "type": "string"
         },
         {
-          "description": "Rank targets cheapest-first by the target model's `cost` (combined input+output per-1K price), then fall forward. Targets without a configured `cost` rank last.",
+          "description": "Rank targets cheapest-first by the target model's resolved price (combined input+output per-1K), then fall forward. A target is priced by the `pricing` document its `pricing_key` names, or by its inline `cost` when it names none; a target with no price at all ranks last.",
           "enum": [
             "least_cost"
           ],
@@ -1198,6 +1198,8 @@
     },
     "pricing_key": {
       "description": "Name of a shared `pricing` document to take the per-token cost from, instead of setting `cost` on this model. The environment's own pricing documents are searched first and the shared catalog second; when the key matches neither, `cost` applies. Editing the pricing document repricies every model naming it, with no change to the models themselves.",
+      "maxLength": 255,
+      "minLength": 1,
       "type": "string"
     },
     "provider": {

--- a/schemas/resources-lenient/model.schema.json
+++ b/schemas/resources-lenient/model.schema.json
@@ -975,6 +975,10 @@
       "minLength": 1,
       "type": "string"
     },
+    "pricing_key": {
+      "description": "Name of a shared `pricing` document to take the per-token cost from, instead of setting `cost` on this model. The environment's own pricing documents are searched first and the shared catalog second; when the key matches neither, `cost` applies. Editing the pricing document repricies every model naming it, with no change to the models themselves.",
+      "type": "string"
+    },
     "provider": {
       "description": "Upstream vendor identity used for dispatch, compatibility checks, telemetry, and access logs. Routing and ensemble models leave this field unset.",
       "maxLength": 64,

--- a/schemas/resources-lenient/pricing.schema.json
+++ b/schemas/resources-lenient/pricing.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "A per-1,000-token price shared by every model that names it.\n\nA model refers to one of these with `pricing_key`. The gateway looks the price up in the environment's own pricing documents first and in the global catalog second; a model with no `pricing_key`, or one whose key matches no document, falls back to its inline `cost`.",
+  "properties": {
+    "input_per_1k": {
+      "description": "Prompt token price in USD per 1,000 tokens.",
+      "format": "double",
+      "minimum": 0.0,
+      "type": "number"
+    },
+    "key": {
+      "description": "Value a model's `pricing_key` is matched against, compared as an exact string. Conventionally `<provider>/<model_name>`, but the gateway attaches no meaning to its parts.",
+      "maxLength": 255,
+      "minLength": 1,
+      "type": "string"
+    },
+    "output_per_1k": {
+      "description": "Completion token price in USD per 1,000 tokens.",
+      "format": "double",
+      "minimum": 0.0,
+      "type": "number"
+    }
+  },
+  "required": [
+    "input_per_1k",
+    "key",
+    "output_per_1k"
+  ],
+  "title": "Pricing",
+  "type": "object"
+}

--- a/schemas/resources-lenient/routing.schema.json
+++ b/schemas/resources-lenient/routing.schema.json
@@ -83,7 +83,7 @@
           "type": "string"
         },
         {
-          "description": "Rank targets cheapest-first by the target model's `cost` (combined input+output per-1K price), then fall forward. Targets without a configured `cost` rank last.",
+          "description": "Rank targets cheapest-first by the target model's resolved price (combined input+output per-1K), then fall forward. A target is priced by the `pricing` document its `pricing_key` names, or by its inline `cost` when it names none; a target with no price at all ranks last.",
           "enum": [
             "least_cost"
           ],

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -804,6 +804,11 @@
           },
           {
             "required": [
+              "pricing_key"
+            ]
+          },
+          {
+            "required": [
               "effort_mapping"
             ]
           }
@@ -915,6 +920,11 @@
           },
           {
             "required": [
+              "pricing_key"
+            ]
+          },
+          {
+            "required": [
               "effort_mapping"
             ]
           }
@@ -975,6 +985,11 @@
           {
             "required": [
               "cost"
+            ]
+          },
+          {
+            "required": [
+              "pricing_key"
             ]
           },
           {
@@ -1061,6 +1076,10 @@
     "model_name": {
       "description": "Upstream model identifier sent in provider requests. Routing and ensemble models leave this field unset.",
       "minLength": 1,
+      "type": "string"
+    },
+    "pricing_key": {
+      "description": "Name of a shared `pricing` document to take the per-token cost from, instead of setting `cost` on this model. The environment's own pricing documents are searched first and the shared catalog second; when the key matches neither, `cost` applies. Editing the pricing document repricies every model naming it, with no change to the models themselves.",
       "type": "string"
     },
     "provider": {

--- a/schemas/resources/model.schema.json
+++ b/schemas/resources/model.schema.json
@@ -629,7 +629,7 @@
           "type": "string"
         },
         {
-          "description": "Rank targets cheapest-first by the target model's `cost` (combined input+output per-1K price), then fall forward. Targets without a configured `cost` rank last.",
+          "description": "Rank targets cheapest-first by the target model's resolved price (combined input+output per-1K), then fall forward. A target is priced by the `pricing` document its `pricing_key` names, or by its inline `cost` when it names none; a target with no price at all ranks last.",
           "enum": [
             "least_cost"
           ],
@@ -1301,6 +1301,8 @@
     },
     "pricing_key": {
       "description": "Name of a shared `pricing` document to take the per-token cost from, instead of setting `cost` on this model. The environment's own pricing documents are searched first and the shared catalog second; when the key matches neither, `cost` applies. Editing the pricing document repricies every model naming it, with no change to the models themselves.",
+      "maxLength": 255,
+      "minLength": 1,
       "type": "string"
     },
     "provider": {

--- a/schemas/resources/pricing.schema.json
+++ b/schemas/resources/pricing.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "description": "A per-1,000-token price shared by every model that names it.\n\nA model refers to one of these with `pricing_key`. The gateway looks the price up in the environment's own pricing documents first and in the global catalog second; a model with no `pricing_key`, or one whose key matches no document, falls back to its inline `cost`.",
+  "properties": {
+    "input_per_1k": {
+      "description": "Prompt token price in USD per 1,000 tokens.",
+      "format": "double",
+      "minimum": 0.0,
+      "type": "number"
+    },
+    "key": {
+      "description": "Value a model's `pricing_key` is matched against, compared as an exact string. Conventionally `<provider>/<model_name>`, but the gateway attaches no meaning to its parts.",
+      "maxLength": 255,
+      "minLength": 1,
+      "type": "string"
+    },
+    "output_per_1k": {
+      "description": "Completion token price in USD per 1,000 tokens.",
+      "format": "double",
+      "minimum": 0.0,
+      "type": "number"
+    }
+  },
+  "required": [
+    "input_per_1k",
+    "key",
+    "output_per_1k"
+  ],
+  "title": "Pricing",
+  "type": "object"
+}

--- a/schemas/resources/routing.schema.json
+++ b/schemas/resources/routing.schema.json
@@ -85,7 +85,7 @@
           "type": "string"
         },
         {
-          "description": "Rank targets cheapest-first by the target model's `cost` (combined input+output per-1K price), then fall forward. Targets without a configured `cost` rank last.",
+          "description": "Rank targets cheapest-first by the target model's resolved price (combined input+output per-1K), then fall forward. A target is priced by the `pricing` document its `pricing_key` names, or by its inline `cost` when it names none; a target with no price at all ranks last.",
           "enum": [
             "least_cost"
           ],

--- a/tests/e2e/src/cases/global-pricing-e2e.test.ts
+++ b/tests/e2e/src/cases/global-pricing-e2e.test.ts
@@ -109,6 +109,25 @@ describe("global pricing e2e: pricing documents drive least_cost", () => {
     });
   }
 
+  /**
+   * Wait until the two pricing tables together hold `total` rows.
+   *
+   * `waitForModels` cannot stand in for this: the catalog is a separate
+   * prefix on its own watch, so a model can be listed while the price
+   * that ranks it has not landed. Counting rows is the only signal the
+   * gateway exposes for the catalog, and it is upstream-neutral.
+   */
+  async function waitForPricingRows(total: number): Promise<void> {
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.metricsUrl}/status/config`);
+      if (!res.ok) return false;
+      const counts =
+        ((await res.json()) as { applied?: { resource_counts?: Record<string, number> } }).applied
+          ?.resource_counts ?? {};
+      return (counts.pricing ?? 0) + (counts.global_pricing ?? 0) >= total;
+    });
+  }
+
   /** Which upstream served, by the content the mock answers with. */
   async function ask(model: string, prompt: string): Promise<string | null | undefined> {
     const completion = await client().chat.completions.create({
@@ -128,9 +147,11 @@ describe("global pricing e2e: pricing documents drive least_cost", () => {
     const pricey = await startOpenAiUpstream({ nonStreamBody: okBody("g-pricey-served") });
     upstreams.push(cheap, pricey);
 
-    // Neither target carries `cost`. Everything ranking them comes from
-    // the catalog, so a test that passes with the documents removed is
-    // not testing anything.
+    // The catalog says cheap < pricey. The inline `cost` on each model
+    // says the OPPOSITE, so a resolver that consulted `cost` first would
+    // serve the other upstream and fail this case — without the
+    // conflicting values, omitting `cost` entirely would let such a
+    // resolver pass.
     await global.createPricing({ key: "vendor/g-cheap", input_per_1k: 0.1, output_per_1k: 0.1 });
     await global.createPricing({ key: "vendor/g-pricey", input_per_1k: 10, output_per_1k: 10 });
 
@@ -142,9 +163,16 @@ describe("global pricing e2e: pricing documents drive least_cost", () => {
         targets: [{ model: "g-pricey" }, { model: "g-cheap" }],
       },
     });
-    await createOpenAiModel("g-cheap", cheap, { pricing_key: "vendor/g-cheap" });
-    await createOpenAiModel("g-pricey", pricey, { pricing_key: "vendor/g-pricey" });
+    await createOpenAiModel("g-cheap", cheap, {
+      pricing_key: "vendor/g-cheap",
+      cost: { input_per_1k: 50, output_per_1k: 50 },
+    });
+    await createOpenAiModel("g-pricey", pricey, {
+      pricing_key: "vendor/g-pricey",
+      cost: { input_per_1k: 0.01, output_per_1k: 0.01 },
+    });
     await waitForModels("g-cheap", "g-pricey");
+    await waitForPricingRows(2);
 
     const cheapBaseline = cheap.receivedRequests.length;
     const priceyBaseline = pricey.receivedRequests.length;
@@ -181,6 +209,8 @@ describe("global pricing e2e: pricing documents drive least_cost", () => {
     await createOpenAiModel("env-a", a, { pricing_key: "vendor/env-a" });
     await createOpenAiModel("env-b", b, { pricing_key: "vendor/env-b" });
     await waitForModels("env-a", "env-b");
+    // Three more rows than the previous case left behind.
+    await waitForPricingRows(5);
 
     const aBaseline = a.receivedRequests.length;
     const bBaseline = b.receivedRequests.length;
@@ -254,6 +284,7 @@ describe("global pricing e2e: pricing documents drive least_cost", () => {
     const modelA = await createOpenAiModel("flip-a", a, { pricing_key: "vendor/flip-a" });
     await createOpenAiModel("flip-b", b, { pricing_key: "vendor/flip-b" });
     await waitForModels("flip-a", "flip-b");
+    await waitForPricingRows(7);
 
     const before = await seed.raw("models", modelA.id);
     expect(await ask("flip-virtual", "a is cheaper")).toBe("flip-a-served");

--- a/tests/e2e/src/cases/global-pricing-e2e.test.ts
+++ b/tests/e2e/src/cases/global-pricing-e2e.test.ts
@@ -1,0 +1,508 @@
+import { createHash } from "node:crypto";
+import OpenAI from "openai";
+import { WebSocketServer, type WebSocket as WsSocket } from "ws";
+import { WebSocket } from "undici";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  scrapeMetrics,
+  spawnApp,
+  startOpenAiUpstream,
+  sumMetric,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: shared pricing documents (AISIX-Cloud#1546) against a real `aisix`
+// binary, a real etcd and mock upstreams.
+//
+// A model can take its per-token price from a `pricing` document instead
+// of carrying `cost` inline. The gateway watches two prefixes for these:
+// its own environment's, and the shared `<base>/global/` catalog. What
+// the cases below pin is the resolution order and its consequences —
+// environment over global over inline, a price edit taking effect with no
+// model document rewritten, the catalog carrying nothing but prices, and
+// the same chain pricing the usage events.
+
+const CALLER_PLAINTEXT = "sk-global-pricing-e2e-caller";
+const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("hex");
+
+function okBody(content: string) {
+  return {
+    id: `cmpl-${content}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "gpt-4o-mini",
+    choices: [
+      { index: 0, message: { role: "assistant", content }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe("global pricing e2e: pricing documents drive least_cost", () => {
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let global: SeedClient | undefined;
+  let etcd: EtcdClient | undefined;
+  let etcdReachable = false;
+  const upstreams: OpenAiUpstream[] = [];
+
+  beforeAll(async () => {
+    etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+    // The shared catalog: `<base>/global/`, the one collection the
+    // gateway reads from outside its own environment prefix.
+    global = new SeedClient(etcd, `${app.etcdPrefix}/global`);
+    await seed.createApiKey({ key_hash: CALLER_KEY_HASH, allowed_models: ["*"] });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await Promise.all(upstreams.map((u) => u.close()));
+  });
+
+  async function createOpenAiModel(
+    displayName: string,
+    upstream: OpenAiUpstream,
+    extra: Record<string, unknown> = {},
+  ): Promise<{ id: string }> {
+    if (!seed) throw new Error("seed client not initialized");
+    const providerKey = await seed.createProviderKey({
+      display_name: `${displayName}-pk`,
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+    return seed.createModel({
+      display_name: displayName,
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: providerKey.id,
+      ...extra,
+    });
+  }
+
+  function client(): OpenAI {
+    return new OpenAI({
+      apiKey: CALLER_PLAINTEXT,
+      baseURL: `${app?.proxyUrl}/v1`,
+      maxRetries: 0,
+    });
+  }
+
+  /** Upstream-neutral readiness: `/v1/models` lists the named rows. */
+  async function waitForModels(...names: string[]): Promise<void> {
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+      });
+      if (res.status !== 200) return false;
+      const ids =
+        ((await res.json()) as { data?: Array<{ id?: string }> }).data?.map((m) => m.id) ?? [];
+      return names.every((n) => ids.includes(n));
+    });
+  }
+
+  /** Which upstream served, by the content the mock answers with. */
+  async function ask(model: string, prompt: string): Promise<string | null | undefined> {
+    const completion = await client().chat.completions.create({
+      model,
+      messages: [{ role: "user", content: prompt }],
+    });
+    return completion.choices[0]?.message.content;
+  }
+
+  test("a global pricing document orders least_cost between two targets", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !global) {
+      ctx.skip();
+      return;
+    }
+
+    const cheap = await startOpenAiUpstream({ nonStreamBody: okBody("g-cheap-served") });
+    const pricey = await startOpenAiUpstream({ nonStreamBody: okBody("g-pricey-served") });
+    upstreams.push(cheap, pricey);
+
+    // Neither target carries `cost`. Everything ranking them comes from
+    // the catalog, so a test that passes with the documents removed is
+    // not testing anything.
+    await global.createPricing({ key: "vendor/g-cheap", input_per_1k: 0.1, output_per_1k: 0.1 });
+    await global.createPricing({ key: "vendor/g-pricey", input_per_1k: 10, output_per_1k: 10 });
+
+    // Expensive target declared FIRST: the price has to reorder it.
+    await seed.createModel({
+      display_name: "g-virtual",
+      routing: {
+        strategy: "least_cost",
+        targets: [{ model: "g-pricey" }, { model: "g-cheap" }],
+      },
+    });
+    await createOpenAiModel("g-cheap", cheap, { pricing_key: "vendor/g-cheap" });
+    await createOpenAiModel("g-pricey", pricey, { pricing_key: "vendor/g-pricey" });
+    await waitForModels("g-cheap", "g-pricey");
+
+    const cheapBaseline = cheap.receivedRequests.length;
+    const priceyBaseline = pricey.receivedRequests.length;
+
+    expect(await ask("g-virtual", "cheapest please")).toBe("g-cheap-served");
+    expect(cheap.receivedRequests.length - cheapBaseline).toBe(1);
+    expect(pricey.receivedRequests.length - priceyBaseline).toBe(0);
+  });
+
+  test("an environment pricing document wins over the global one with the same key", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !global) {
+      ctx.skip();
+      return;
+    }
+
+    const a = await startOpenAiUpstream({ nonStreamBody: okBody("env-a-served") });
+    const b = await startOpenAiUpstream({ nonStreamBody: okBody("env-b-served") });
+    upstreams.push(a, b);
+
+    // Globally, A is the cheap one. The environment overrides A's price
+    // upward, which must flip the order — so the assertion below is the
+    // OPPOSITE of what the catalog alone would produce.
+    await global.createPricing({ key: "vendor/env-a", input_per_1k: 0.1, output_per_1k: 0.1 });
+    await global.createPricing({ key: "vendor/env-b", input_per_1k: 1, output_per_1k: 1 });
+    await seed.createPricing({ key: "vendor/env-a", input_per_1k: 50, output_per_1k: 50 });
+
+    await seed.createModel({
+      display_name: "env-virtual",
+      routing: {
+        strategy: "least_cost",
+        targets: [{ model: "env-a" }, { model: "env-b" }],
+      },
+    });
+    await createOpenAiModel("env-a", a, { pricing_key: "vendor/env-a" });
+    await createOpenAiModel("env-b", b, { pricing_key: "vendor/env-b" });
+    await waitForModels("env-a", "env-b");
+
+    const aBaseline = a.receivedRequests.length;
+    const bBaseline = b.receivedRequests.length;
+
+    expect(await ask("env-virtual", "override applies")).toBe("env-b-served");
+    expect(b.receivedRequests.length - bBaseline).toBe(1);
+    expect(a.receivedRequests.length - aBaseline).toBe(0);
+  });
+
+  test("with no pricing document the model's inline cost still ranks it", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+
+    const cheap = await startOpenAiUpstream({ nonStreamBody: okBody("inline-cheap-served") });
+    const pricey = await startOpenAiUpstream({ nonStreamBody: okBody("inline-pricey-served") });
+    upstreams.push(cheap, pricey);
+
+    // `pricing_key` names a document neither prefix carries, so the chain
+    // has to fall all the way through to `cost`.
+    await seed.createModel({
+      display_name: "inline-virtual",
+      routing: {
+        strategy: "least_cost",
+        targets: [{ model: "inline-pricey" }, { model: "inline-cheap" }],
+      },
+    });
+    await createOpenAiModel("inline-cheap", cheap, {
+      pricing_key: "vendor/never-written",
+      cost: { input_per_1k: 0.1, output_per_1k: 0.1 },
+    });
+    await createOpenAiModel("inline-pricey", pricey, {
+      pricing_key: "vendor/never-written-either",
+      cost: { input_per_1k: 10, output_per_1k: 10 },
+    });
+    await waitForModels("inline-cheap", "inline-pricey");
+
+    const cheapBaseline = cheap.receivedRequests.length;
+    const priceyBaseline = pricey.receivedRequests.length;
+
+    expect(await ask("inline-virtual", "inline fallback")).toBe("inline-cheap-served");
+    expect(cheap.receivedRequests.length - cheapBaseline).toBe(1);
+    expect(pricey.receivedRequests.length - priceyBaseline).toBe(0);
+  });
+
+  test("editing the global price flips the order without rewriting a model", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !global || !etcd) {
+      ctx.skip();
+      return;
+    }
+
+    const a = await startOpenAiUpstream({ nonStreamBody: okBody("flip-a-served") });
+    const b = await startOpenAiUpstream({ nonStreamBody: okBody("flip-b-served") });
+    upstreams.push(a, b);
+
+    const priceA = await global.createPricing({
+      key: "vendor/flip-a",
+      input_per_1k: 0.1,
+      output_per_1k: 0.1,
+    });
+    await global.createPricing({ key: "vendor/flip-b", input_per_1k: 1, output_per_1k: 1 });
+
+    await seed.createModel({
+      display_name: "flip-virtual",
+      routing: {
+        strategy: "least_cost",
+        targets: [{ model: "flip-a" }, { model: "flip-b" }],
+      },
+    });
+    const modelA = await createOpenAiModel("flip-a", a, { pricing_key: "vendor/flip-a" });
+    await createOpenAiModel("flip-b", b, { pricing_key: "vendor/flip-b" });
+    await waitForModels("flip-a", "flip-b");
+
+    const before = await seed.raw("models", modelA.id);
+    expect(await ask("flip-virtual", "a is cheaper")).toBe("flip-a-served");
+
+    // One write, to the pricing document alone.
+    await etcd!.put(
+      `${app.etcdPrefix}/global/pricing/${priceA.id}`,
+      JSON.stringify({ key: "vendor/flip-a", input_per_1k: 100, output_per_1k: 100 }),
+    );
+
+    // The order flips on a later request; poll because the write reaches
+    // the snapshot through the watch stream.
+    await waitConfigPropagation(async () => (await ask("flip-virtual", "b now")) === "flip-b-served");
+
+    // The model document is byte-identical: nothing repriced it but the
+    // pricing row, which is the point of the reference.
+    expect(await seed.raw("models", modelA.id)).toBe(before);
+  });
+
+  test("the global prefix carries prices only — another kind there is never served", async (ctx) => {
+    if (!etcdReachable || !app || !seed || !global) {
+      ctx.skip();
+      return;
+    }
+
+    const upstream = await startOpenAiUpstream({ nonStreamBody: okBody("legit-served") });
+    upstreams.push(upstream);
+
+    // Model rows already in the snapshot from the cases above — this
+    // describe shares one gateway, so the assertion below has to be a
+    // delta rather than an absolute count.
+    async function modelCount(): Promise<number> {
+      const res = await fetch(`${app!.metricsUrl}/status/config`);
+      const body = (await res.json()) as {
+        applied?: { resource_counts?: Record<string, number> };
+      };
+      return body.applied?.resource_counts?.models ?? 0;
+    }
+    const modelsBefore = await modelCount();
+
+    // A price alongside the smuggled row, so this case proves BOTH
+    // halves. Without it, "the model is not served" is equally true of a
+    // gateway that never reads the global prefix at all, and the case
+    // survives deleting the whole feature.
+    await global.createPricing({
+      key: "vendor/allowlist-probe",
+      input_per_1k: 1,
+      output_per_1k: 1,
+    });
+
+    // A well-formed model document, written under the global prefix. If
+    // the gateway loaded kinds other than `pricing` from there, this
+    // model would be servable — by a writer outside the environment.
+    await global.createModel({
+      display_name: "smuggled-global-model",
+      provider: "openai",
+      model_name: "gpt-4o-mini",
+      provider_key_id: "11111111-1111-1111-1111-111111111111",
+    });
+    await createOpenAiModel("legit-env-model", upstream);
+    // Gating on the environment model written AFTER the smuggled one:
+    // watch events apply in revision order, so once this is visible the
+    // global write has been processed too.
+    await waitForModels("legit-env-model");
+
+    // The prefix IS being read: its pricing document reached the
+    // snapshot, under its own table.
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.metricsUrl}/status/config`);
+      if (!res.ok) return false;
+      const body = (await res.json()) as {
+        applied?: { resource_counts?: Record<string, number> };
+      };
+      return (body.applied?.resource_counts?.global_pricing ?? 0) >= 1;
+    });
+
+    // …and the model written beside it did not: exactly one model row
+    // was added, the environment one.
+    expect((await modelCount()) - modelsBefore).toBe(1);
+
+    const res = await fetch(`${app.proxyUrl}/v1/models`, {
+      headers: { authorization: `Bearer ${CALLER_PLAINTEXT}` },
+    });
+    const ids =
+      ((await res.json()) as { data?: Array<{ id?: string }> }).data?.map((m) => m.id) ?? [];
+    expect(ids).not.toContain("smuggled-global-model");
+
+    const refused = await fetch(`${app.proxyUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CALLER_PLAINTEXT}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "smuggled-global-model",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(refused.status).toBeGreaterThanOrEqual(400);
+  });
+});
+
+/** Mock OpenAI Realtime upstream answering one usage-bearing frame. */
+async function startRealtimeUpstream(input: number, output: number) {
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  wss.on("connection", (socket: WsSocket) => {
+    socket.on("message", () => {
+      socket.send(
+        JSON.stringify({
+          type: "response.done",
+          response: {
+            usage: {
+              input_tokens: input,
+              output_tokens: output,
+              input_token_details: { cached_tokens: 0 },
+            },
+          },
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve) => wss.on("listening", resolve));
+  const addr = wss.address();
+  if (addr === null || typeof addr === "string") throw new Error("no port");
+  return {
+    port: addr.port,
+    close: () =>
+      new Promise<void>((resolve, reject) => wss.close((e) => (e ? reject(e) : resolve()))),
+  };
+}
+
+describe("global pricing e2e: usage events price through the same chain", () => {
+  // The realtime session is one of the two paths that compute `cost_usd`
+  // on the data plane rather than leaving it to the control plane, so it
+  // is where a divergence between "what least_cost ranks by" and "what
+  // the usage event bills" would show up. Nine input and four output
+  // tokens against 1.0/2.0 per 1K is 0.017 USD — 17000 micro-USD.
+  const INPUT_TOKENS = 9;
+  const OUTPUT_TOKENS = 4;
+  const CALLER = "sk-global-pricing-realtime-caller";
+  const CALLER_HASH = createHash("sha256").update(CALLER).digest("hex");
+
+  let app: SpawnedApp | undefined;
+  let seed: SeedClient | undefined;
+  let global: SeedClient | undefined;
+  let upstream: Awaited<ReturnType<typeof startRealtimeUpstream>> | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startRealtimeUpstream(INPUT_TOKENS, OUTPUT_TOKENS);
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+    global = new SeedClient(etcd, `${app.etcdPrefix}/global`);
+
+    await global.createPricing({ key: "vendor/rt", input_per_1k: 1.0, output_per_1k: 2.0 });
+    const pk = await seed.createProviderKey({
+      display_name: "rt-pk",
+      secret: "sk-mock",
+      api_base: `http://127.0.0.1:${upstream.port}/v1`,
+    });
+    // Priced by the catalog. The inline `cost` is deliberately absent, so
+    // a spend counter that moves at all proves the reference resolved.
+    await seed.createModel({
+      display_name: "rt-catalog",
+      provider: "openai",
+      model_name: "gpt-realtime-mock",
+      provider_key_id: pk.id,
+      pricing_key: "vendor/rt",
+    });
+    // Same session shape, priced inline instead — the fallback half.
+    await seed.createModel({
+      display_name: "rt-inline",
+      provider: "openai",
+      model_name: "gpt-realtime-mock",
+      provider_key_id: pk.id,
+      pricing_key: "vendor/not-written",
+      cost: { input_per_1k: 1.0, output_per_1k: 2.0 },
+    });
+    await seed.createApiKey({ key_hash: CALLER_HASH, allowed_models: ["*"] });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  /** One realtime session against `model`; resolves when it closes. */
+  async function runSession(model: string): Promise<void> {
+    const ws = new WebSocket(`${app!.proxyUrl.replace("http", "ws")}/v1/realtime?model=${model}`, [
+      "realtime",
+      `openai-insecure-api-key.${CALLER}`,
+    ]);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("realtime session timed out")), 15000);
+      ws.addEventListener("open", () => ws.send(JSON.stringify({ type: "response.create" })));
+      ws.addEventListener("message", () => {
+        clearTimeout(timer);
+        ws.close();
+        resolve();
+      });
+      ws.addEventListener("error", (e) => {
+        clearTimeout(timer);
+        reject(new Error(`realtime session errored: ${String(e)}`));
+      });
+    });
+  }
+
+  async function spendFor(model: string): Promise<number> {
+    return sumMetric(
+      await scrapeMetrics(app!.metricsUrl),
+      "aisix_llm_spend_micro_usd_total",
+      (labels) => labels.model === model,
+    );
+  }
+
+  test("a realtime session bills at the pricing document's rate", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${CALLER}` },
+      });
+      if (res.status !== 200) return false;
+      const ids =
+        ((await res.json()) as { data?: Array<{ id?: string }> }).data?.map((m) => m.id) ?? [];
+      return ids.includes("rt-catalog") && ids.includes("rt-inline");
+    });
+
+    const before = await spendFor("rt-catalog");
+    await runSession("rt-catalog");
+    // The usage event is emitted as the session tears down.
+    await waitConfigPropagation(async () => (await spendFor("rt-catalog")) > before);
+    expect(Math.round((await spendFor("rt-catalog")) - before)).toBe(17000);
+  });
+
+  test("without a pricing document the session bills at the model's inline cost", async (ctx) => {
+    if (!etcdReachable || !app || !seed) {
+      ctx.skip();
+      return;
+    }
+    const before = await spendFor("rt-inline");
+    await runSession("rt-inline");
+    await waitConfigPropagation(async () => (await spendFor("rt-inline")) > before);
+    expect(Math.round((await spendFor("rt-inline")) - before)).toBe(17000);
+  });
+});

--- a/tests/e2e/src/harness/seed.ts
+++ b/tests/e2e/src/harness/seed.ts
@@ -47,6 +47,25 @@ export class SeedClient {
     return this.put("provider_keys", { provider: "openai", adapter: "openai", ...pk });
   }
 
+  /**
+   * Seeds a `pricing` document under this client's prefix.
+   *
+   * Which prefix the client was built with is the whole point: an
+   * environment-prefix client writes the environment's own price, a
+   * client built on `<prefix>/global` writes the shared catalog entry.
+   * The gateway prefers the former.
+   */
+  async createPricing(
+    pricing: Record<string, unknown>,
+  ): Promise<{ id: string; value: Record<string, unknown> }> {
+    return this.put("pricing", pricing);
+  }
+
+  /** The raw etcd bytes of a seeded document, for round-trip checks. */
+  async raw(kind: string, id: string): Promise<string | undefined> {
+    return this.etcd.get(`${this.prefix}/${kind}/${id}`);
+  }
+
   async createObservabilityExporter(
     exporter: Record<string, unknown>,
   ): Promise<{ id: string; value: Record<string, unknown> }> {


### PR DESCRIPTION
A model can now take its per-token price from a shared `pricing` document
instead of carrying `cost` inline, so repricing a model is one write to
the price rather than a rewrite of every model that charges it.

Ref api7/AISIX-Cloud#1546

## A second watched prefix

The watch supervisor used to hold one prefix and one provider. It now
holds a list: the environment's `<base>/<env_id>/` as before, plus
`<base>/global/`, the shared catalog every environment reads. There is no
new configuration — the global prefix is derived from the same configured
etcd prefix, because it is one half of a contract with the control plane
rather than a deployment choice.

Both prefixes feed **one** snapshot. Each is range-read and watched on its
own connection, each watch resumes from the revision its own range read
was consistent as of (the reads run in sequence, so resuming them all at
the highest revision would skip the earlier prefix's writes made in
between), the initial reads are merged into a single resync, and
readiness waits for all of them — so no request can observe the
environment loaded and the catalog not. `applied_revision` is the maximum
across prefixes, since kine revisions are cluster-global.

Only `pricing` is accepted under the global prefix. Any other kind written
there is rejected with the usual bookkeeping and never reaches the
snapshot: that prefix is written by a different authority, and every other
kind is environment-scoped by definition. `pricing` is *also* an
environment kind, which is how an organization overrides a catalog price.

## Resolving a price

`Model` gains an optional `pricing_key`. Every reader of a model's price
resolves the same chain — the environment's pricing document with that
key, then the global one, then the model's inline `cost`, then nothing
(which ranks last under `least_cost`, as an unpriced model always has).

The lookup goes through an index derived from the two pricing tables and
rebuilt only when one of them changes, keyed on their table generations
rather than on the snapshot version. A price edit therefore takes effect
on the next request with no model document touched, and an unrelated
config write does not rebuild it.

Three readers share that chain, so ranking and billing cannot disagree
about what a model costs: `least_cost` ordering, and the two paths that
compute `cost_usd` on the gateway rather than leaving it to the control
plane (the realtime session and the batch-completion attribution).

## Behaviour changes

- **Nothing an existing deployment bills changes.** With no `pricing_key`
  and no pricing documents the chain resolves to the model's inline
  `cost`, which is what those paths read before. In managed mode the
  control plane overwrites `cost_usd` from its own pricing lookup anyway;
  in standalone mode there are no pricing documents at all, because the
  resources file rejects the kind.
- **A model with `pricing_key` but no inline `cost` has no price on a
  gateway that cannot read the catalog** — it ranks last under
  `least_cost` and reports no spend. That is the fallback the refusal
  handling below produces, and the reason the control plane keeps writing
  `cost` alongside `pricing_key` until every gateway can read the catalog.
- `aisix export` drops `pricing_key`, which has no file form, and reports
  every model it drops one from — including a model that also carries an
  inline `cost`, because the document outranks that `cost` at runtime, so
  the exported file prices the model differently whenever the two
  disagree.
- The resources file rejects a `pricing` collection and the `pricing_key`
  field, each with a message saying to set `cost` instead.

## An older control plane

A control plane predating the catalog denies reads outside the
environment's own prefix. That refusal is tolerated on the global prefix
alone: the catalog reads as empty, readiness is not held back, one WARN
says prices fell back to inline `cost`, and the prefix is retried whenever
the cycle restarts — which a control-plane upgrade causes, since it takes
the kine connections behind the surviving watch with it. A refusal on the
environment prefix still fails the cycle exactly as before, so credentials
etcd genuinely refuses cannot hide here.

## Compatibility

Free under the upgrade-floor rule: `pricing` is a new resource collection
and `pricing_key` a new optional field on an existing one. Neither can
stop an older gateway loading anything it loads today.

Two details worth having on the record, because neither is silent. A
gateway below this release does not watch the global prefix at all, so
the catalog is invisible to it — but an *environment* pricing document
sits under the prefix it does watch, and it will skip that row as an
unknown kind and report it as a rejected resource until it is upgraded.
That is the accepted cost of a new collection, not a regression. A model
carrying `pricing_key` still loads on an older gateway: the field is
reported through the partial-compat channel and ignored, so the model
prices from its inline `cost` — which is why the control plane keeps
writing both during the window.

## Not in this pull request

- The control-plane half — writing pricing documents, the `cp-admin.yaml`
  field descriptions and their per-kind statement, the dashboard, and the
  `pricing_key` / `cost` coexistence window — is a separate change. Until
  it lands, no user can create a pricing document.
- No admin read surface for the table. The existing pattern would take a
  store-trait method pair across three implementations plus hand-written
  OpenAPI, and in standalone mode the table is always empty, so it would
  be a public surface that can never have content.

## Tests

End-to-end against a real binary, a real etcd and mock upstreams: a global
pricing document orders `least_cost`; an environment document with the
same key wins over it; with neither, the inline `cost` still ranks; a
price edit flips the order with the model document byte-identical before
and after; the global prefix serves its price while a model written beside
it is never loaded; and a realtime session bills at the pricing document's
rate, then at the inline `cost` when no document matches.

Unit coverage for longest-prefix key resolution (the global prefix nests
inside the environment prefix in the pre-`env_id` shape, where a naive
resolution would parse a price as kind `global` and reject it), the
global-prefix kind allowlist, index precedence and its generation-keyed
invalidation, `applied_revision` as the maximum across prefixes, the
tolerated and untolerated refusals, and the file-source and export
rejections.

Every case was mutation-checked. Two were worthless as first written and
are fixed here: the revision case passed against a last-prefix-wins
mutation because the entry revisions supplied the expected value on their
own, and the allowlist case passed with the whole second prefix removed,
because "not served" is equally true of a prefix that is never read.
