### PR TITLE
feat(mcp): reference MCP servers by resource id, so a rename keeps the grant

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1512,6 +1512,28 @@ const OPENAPI_JSON_BASE: &str = r##"{
         },
         "description": "Admin API error response envelope."
       },
+      "McpToolRef": {
+        "type": "object",
+        "required": [
+          "server_id",
+          "tool"
+        ],
+        "properties": {
+          "server_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Resource id of the registered MCP server this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
+            "example": "9b1b6d9c-1f5e-4c1e-9f8f-2f5f5b9d1c11"
+          },
+          "tool": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Tool on that server, matched as a single-`*` glob against the bare tool name \u2014 the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
+            "example": "create_issue"
+          }
+        },
+        "description": "One tool on one MCP server, the server named by its resource id and the tool by name. The server half is compared as an exact id, never glob-matched."
+      },
       "PublicApiKey": {
         "type": "object",
         "required": [
@@ -1561,20 +1583,40 @@ const OPENAPI_JSON_BASE: &str = r##"{
                 "items": {
                   "type": "string"
                 },
-                "description": "Namespaced `<server>__<tool>` glob patterns this key allows, intersected with the environment and team layers."
+                "description": "Namespaced `<server>__<tool>` glob patterns this key allows, intersected with the environment and team layers. Read only when `allow_ids` is omitted or null; an array there, `[]` included, takes over entirely."
+              },
+              "allow_ids": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/McpToolRef"
+                },
+                "description": "The same allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the key may reach. An array here, `[]` included, is authoritative and `allow` is ignored. Omitted or null falls back to `allow`."
               },
               "deny": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 },
-                "description": "Namespaced `<server>__<tool>` glob patterns subtracted from this key's effective grant. Deny always wins."
+                "description": "Namespaced `<server>__<tool>` glob patterns subtracted from this key's effective grant. Deny always wins. Read only when `deny_ids` is omitted or null."
+              },
+              "deny_ids": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/McpToolRef"
+                },
+                "description": "The same deny side written by MCP server resource id instead of by server name. An array here, `[]` included, is authoritative and `deny` is ignored. Omitted or null falls back to `deny`."
               }
             },
             "required": [
               "allow"
             ],
-            "description": "This key's own layer of the MCP tool ACL, as namespaced `<server>__<tool>` glob patterns. Intersected with the environment and team MCP access policies: every present layer must allow a tool and no layer may deny it. When omitted the key adds no constraint of its own; with no layer present anywhere the grant is empty."
+            "description": "This key's own layer of the MCP tool ACL, as namespaced `<server>__<tool>` glob patterns or as `allow_ids` / `deny_ids` entries naming the server by resource id. Intersected with the environment and team MCP access policies: every present layer must allow a tool and no layer may deny it. When omitted the key adds no constraint of its own; with no layer present anywhere the grant is empty."
           },
           "allowed_agents": {
             "type": [

--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -1593,7 +1593,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
                 "items": {
                   "$ref": "#/components/schemas/McpToolRef"
                 },
-                "description": "The same allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the key may reach. An array here, `[]` included, is authoritative and `allow` is ignored. Omitted or null falls back to `allow`."
+                "description": "The same allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the key may reach. An array here, `[]` included, is authoritative and `allow` is ignored. Omitted or null falls back to `allow`. Cannot express \"every server\": each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow — to cover every server, present and future, omit this and use the name form's `\"*\"`."
               },
               "deny": {
                 "type": "array",
@@ -1610,7 +1610,7 @@ const OPENAPI_JSON_BASE: &str = r##"{
                 "items": {
                   "$ref": "#/components/schemas/McpToolRef"
                 },
-                "description": "The same deny side written by MCP server resource id instead of by server name. An array here, `[]` included, is authoritative and `deny` is ignored. Omitted or null falls back to `deny`."
+                "description": "The same deny side written by MCP server resource id instead of by server name. An array here, `[]` included, is authoritative and `deny` is ignored. Omitted or null falls back to `deny`. Writing it requires `deny` beside it, so a gateway one release behind the control plane still reads the denial. Cannot express \"every server\": each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow — to cover every server, present and future, omit this and use the name form's `\"*\"`."
               }
             },
             "required": [

--- a/crates/aisix-core/src/filesource/mod.rs
+++ b/crates/aisix-core/src/filesource/mod.rs
@@ -221,6 +221,80 @@ pub fn model_ref_id_fields(kind: &str) -> &'static [ModelRefIdField] {
     }
 }
 
+/// One id-form MCP server reference a document can carry: where it sits,
+/// the field, and the name-form field that replaces it.
+///
+/// The name form spells the server as the `<server>` half of a namespaced
+/// `<server>__<tool>` pattern (an ACL side) or as a map key (the per-server
+/// rate limits); either way the file names the server, and the id form is
+/// what a file cannot express.
+pub struct McpRefIdField {
+    /// Object path from the document root to the object carrying `field`.
+    pub path: &'static [&'static str],
+    pub field: &'static str,
+    pub name_field: &'static str,
+}
+
+impl McpRefIdField {
+    /// Dotted path an operator sees in the error, e.g. `mcp_access.allow_ids`.
+    fn display_path(&self) -> String {
+        let mut out = String::new();
+        for segment in self.path {
+            out.push_str(segment);
+            out.push('.');
+        }
+        out.push_str(self.field);
+        out
+    }
+}
+
+/// The id-form MCP server references a document of `kind` can carry.
+///
+/// Same contract as [`model_ref_id_fields`], for the other reference that
+/// has an id spelling: the resources file refuses it (see [`load_from_str`])
+/// and `aisix export` rewrites it back to the name form, and a field one of
+/// them knows about and the other does not is a silent round-trip loss.
+///
+/// `mcp_policies` is deliberately absent — the file source carries no such
+/// collection, so there is no document of that kind for a file to reject.
+pub fn mcp_ref_id_fields(kind: &str) -> &'static [McpRefIdField] {
+    const API_KEYS: [McpRefIdField; 3] = [
+        McpRefIdField {
+            path: &[],
+            field: "mcp_rate_limits_by_id",
+            name_field: "mcp_rate_limits",
+        },
+        McpRefIdField {
+            path: &["mcp_access"],
+            field: "allow_ids",
+            name_field: "allow",
+        },
+        McpRefIdField {
+            path: &["mcp_access"],
+            field: "deny_ids",
+            name_field: "deny",
+        },
+    ];
+    match kind {
+        "api_keys" => &API_KEYS,
+        _ => &[],
+    }
+}
+
+/// The first id-form MCP reference `doc` carries, if any.
+fn mcp_ref_id_field(kind: &str, doc: &Value) -> Option<&'static McpRefIdField> {
+    mcp_ref_id_fields(kind).iter().find(|f| {
+        let mut node = doc;
+        for segment in f.path {
+            match node.get(segment) {
+                Some(next) => node = next,
+                None => return false,
+            }
+        }
+        node.get(f.field).is_some()
+    })
+}
+
 /// Call `f` on every object in `doc` that may carry one of
 /// [`model_ref_id_fields`]'s fields, for a document of `kind`.
 ///
@@ -572,6 +646,25 @@ pub fn load_from_str(
                     "the resources file does not accept `{field}` — it names a model by \
                      control-plane id, which a file cannot resolve; name the model with \
                      `{hint}` instead"
+                ),
+            });
+            continue;
+        }
+
+        // The same rule for the other reference with an id spelling: an
+        // MCP server named by the id the control plane assigned it. A file
+        // registers its servers by name and derives their ids from those
+        // names, so an id a file carries resolves to nothing — the grant
+        // would silently cover no tool, or the limit bind to no server,
+        // with the name spelling ignored on top.
+        if let Some(reference) = mcp_ref_id_field(entry.kind, &entry.doc) {
+            let (path, name_field) = (reference.display_path(), reference.name_field);
+            errors.push(LoadError {
+                scope,
+                message: format!(
+                    "the resources file does not accept `{path}` — it names an MCP server by \
+                     control-plane id, which a file cannot resolve; name the server with \
+                     `{name_field}` instead"
                 ),
             });
             continue;

--- a/crates/aisix-core/src/filesource/tests.rs
+++ b/crates/aisix-core/src/filesource/tests.rs
@@ -539,6 +539,55 @@ api_keys:
     load(&ok, &env).expect("the same file without the field loads");
 }
 
+/// The MCP server references with an id spelling are refused the same way,
+/// each at the nesting site it appears at. Each is asserted twice: once
+/// with the id field (one error naming it and the name-form field that
+/// replaces it) and once without (the file loads), so the rejection is
+/// pinned to the field rather than to anything else in the fixture.
+#[test]
+fn mcp_server_reference_ids_are_rejected_by_the_file_source() {
+    const PRELUDE: &str = r#"
+_format_version: "1"
+mcp_servers:
+  - name: github
+    url: https://example.test/mcp
+api_keys:
+  - display_name: k
+    key_env: CALLER_KEY
+    allowed_models: []
+"#;
+    // (id-form line, the dotted path the error names, the name-form field)
+    let cases = [
+        (
+            "    mcp_rate_limits_by_id:\n      \"11111111-1111-1111-1111-111111111111\": {rpm: 1}\n",
+            "mcp_rate_limits_by_id",
+            "mcp_rate_limits",
+        ),
+        (
+            "    mcp_access:\n      allow: []\n      allow_ids: [{server_id: \"s-1\", tool: \"*\"}]\n",
+            "mcp_access.allow_ids",
+            "allow",
+        ),
+        (
+            "    mcp_access:\n      allow: [\"*\"]\n      deny_ids: [{server_id: \"s-1\", tool: \"x\"}]\n",
+            "mcp_access.deny_ids",
+            "deny",
+        ),
+    ];
+    let env = env_of(&[("CALLER_KEY", "sk-caller")]);
+    for (line, path, name_field) in cases {
+        let contents = format!("{PRELUDE}{line}");
+        let errs = errors_of(load(&contents, &env));
+        assert_eq!(errs.len(), 1, "{path}: {errs:?}");
+        assert!(
+            errs[0].contains(&format!("does not accept `{path}`")) && errs[0].contains(name_field),
+            "{path}: {errs:?}"
+        );
+
+        load(PRELUDE, &env).expect("the same file without the field loads");
+    }
+}
+
 /// Every other id-form model reference is refused the same way, at every
 /// nesting site it can appear. Each fixture is asserted twice: once with
 /// the id field (one error naming it and the name-form field that

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -99,7 +99,8 @@ pub struct ApiKey {
     pub jwt_provider: Option<String>,
 
     /// This key's own layer of the MCP tool ACL, as namespaced
-    /// `<server>__<tool>` glob patterns. It is intersected with the
+    /// `<server>__<tool>` glob patterns, or as `allow_ids` / `deny_ids`
+    /// entries naming the server by resource id. It is intersected with the
     /// environment and team MCP access policies: every present layer must
     /// allow a tool and no layer may deny it. When omitted the key adds no
     /// constraint of its own — but with no layer present anywhere the grant
@@ -114,8 +115,24 @@ pub struct ApiKey {
     /// a burst against one server never consumes another's budget. A server
     /// with no entry here is bounded by `rate_limit` alone. Only tool calls
     /// are metered; the `initialize` / `tools/list` handshake is not.
+    ///
+    /// Read only when `mcp_rate_limits_by_id` is absent; ignored entirely
+    /// when it is present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_rate_limits: Option<BTreeMap<String, McpRateLimit>>,
+
+    /// The same per-server limits, keyed by the MCP server's resource id
+    /// (`mcp_servers/<id>`) rather than by its name, so renaming a server
+    /// does not detach the limit that was set for it.
+    ///
+    /// Present — including as an empty object — it is authoritative and
+    /// `mcp_rate_limits` is ignored; an empty object therefore leaves every
+    /// server bounded by `rate_limit` alone. A key naming no registered
+    /// server imposes nothing, and the other entries are unaffected. Set to
+    /// `null` it means the same as omitted: the key falls back to
+    /// `mcp_rate_limits`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_rate_limits_by_id: Option<BTreeMap<String, McpRateLimit>>,
 
     /// A2A agents this key may reach, named by their registered names. Entries
     /// are matched as single-`*` globs, mirroring `allowed_models`: `"*"` grants
@@ -213,8 +230,30 @@ impl ApiKey {
     /// The limits this key carries for one MCP server, named as it is
     /// registered (the `<server>` namespace of a `<server>__<tool>` call).
     /// `None` when the key sets no limit for that server.
-    pub fn mcp_rate_limit(&self, server: &str) -> Option<&McpRateLimit> {
-        self.mcp_rate_limits.as_ref()?.get(server)
+    ///
+    /// **The single chokepoint for the key→MCP-server limit.** The key
+    /// carries the limits one of two ways and this decides between them, so
+    /// no caller can read one shape and miss the other:
+    ///
+    /// - `mcp_rate_limits_by_id` present (an empty object included): the
+    ///   server's registered name is resolved to the resource id it is
+    ///   stored under and the limit is looked up by that id, so a rename
+    ///   keeps the limit attached. `mcp_rate_limits` is not read at all.
+    /// - `mcp_rate_limits_by_id` absent: `mcp_rate_limits` is looked up by
+    ///   the server's name, as before.
+    ///
+    /// Resolution is done per request against the live table rather than
+    /// cached, so a server rename takes effect on the next request with no
+    /// rewrite of any key document.
+    pub fn mcp_rate_limit(
+        &self,
+        servers: &super::McpServerIndex,
+        server: &str,
+    ) -> Option<&McpRateLimit> {
+        match &self.mcp_rate_limits_by_id {
+            Some(by_id) => by_id.get(servers.id_of(server)?),
+            None => self.mcp_rate_limits.as_ref()?.get(server),
+        }
     }
 
     /// True if this key may reach the given A2A agent, named by its registered
@@ -364,6 +403,7 @@ mod tests {
             mcp_access: None,
             allowed_routes: None,
             mcp_rate_limits: None,
+            mcp_rate_limits_by_id: None,
             allowed_agents: None,
             expires_at: None,
             disabled: false,
@@ -709,6 +749,110 @@ mod tests {
             serde_json::from_str(r#"{"key_hash":"h","allowed_model_ids":["m-1"]}"#).unwrap();
         let v = serde_json::to_value(&k).unwrap();
         assert_eq!(v["allowed_model_ids"], serde_json::json!(["m-1"]));
+    }
+
+    /// A registered-server index over one `(id, name)` pair per server.
+    fn server_index(servers: &[(&str, &str)]) -> super::super::McpServerIndex {
+        let snap = super::super::AisixSnapshot::default();
+        for (id, name) in servers {
+            let server: crate::models::McpServer = serde_json::from_str(&format!(
+                r#"{{"name":"{name}","url":"https://example.test/mcp"}}"#
+            ))
+            .unwrap();
+            snap.mcp_servers
+                .insert(crate::resource::ResourceEntry::new(*id, server, 1));
+        }
+        super::super::McpServerIndex::build(&snap.mcp_servers)
+    }
+
+    const ONE_RPM: &str = r#"{"rpm":1}"#;
+
+    #[test]
+    fn mcp_rate_limits_are_looked_up_by_server_name_by_default() {
+        let servers = server_index(&[("s-github", "github")]);
+        let k: ApiKey = serde_json::from_str(&format!(
+            r#"{{"key_hash":"h","mcp_rate_limits":{{"github":{ONE_RPM}}}}}"#
+        ))
+        .unwrap();
+        assert!(k.mcp_rate_limit(&servers, "github").is_some());
+        assert!(k.mcp_rate_limit(&servers, "slack").is_none());
+    }
+
+    #[test]
+    fn mcp_rate_limits_by_id_are_looked_up_through_the_server_index() {
+        let servers = server_index(&[("s-github", "github"), ("s-slack", "slack")]);
+        let k: ApiKey = serde_json::from_str(&format!(
+            r#"{{"key_hash":"h","mcp_rate_limits_by_id":{{"s-github":{ONE_RPM}}}}}"#
+        ))
+        .unwrap();
+        assert!(k.mcp_rate_limit(&servers, "github").is_some());
+        assert!(k.mcp_rate_limit(&servers, "slack").is_none());
+    }
+
+    #[test]
+    fn mcp_rate_limits_by_id_follow_a_rename() {
+        let k: ApiKey = serde_json::from_str(&format!(
+            r#"{{"key_hash":"h","mcp_rate_limits_by_id":{{"s-github":{ONE_RPM}}}}}"#
+        ))
+        .unwrap();
+        assert!(k
+            .mcp_rate_limit(&server_index(&[("s-github", "github")]), "github")
+            .is_some());
+
+        // Same id, new name: the key document is untouched.
+        let renamed = server_index(&[("s-github", "github-v2")]);
+        assert!(k.mcp_rate_limit(&renamed, "github-v2").is_some());
+        assert!(k.mcp_rate_limit(&renamed, "github").is_none());
+    }
+
+    #[test]
+    fn mcp_rate_limits_by_id_win_over_the_name_form() {
+        let servers = server_index(&[("s-github", "github"), ("s-slack", "slack")]);
+        let k: ApiKey = serde_json::from_str(&format!(
+            r#"{{"key_hash":"h",
+                 "mcp_rate_limits":{{"slack":{ONE_RPM}}},
+                 "mcp_rate_limits_by_id":{{"s-github":{ONE_RPM}}}}}"#
+        ))
+        .unwrap();
+        assert!(k.mcp_rate_limit(&servers, "github").is_some());
+        assert!(
+            k.mcp_rate_limit(&servers, "slack").is_none(),
+            "the name form is not read at all once the id form is present"
+        );
+
+        // An empty object is authoritative too: every server is bounded by
+        // `rate_limit` alone.
+        let emptied: ApiKey = serde_json::from_str(&format!(
+            r#"{{"key_hash":"h",
+                 "mcp_rate_limits":{{"github":{ONE_RPM}}},
+                 "mcp_rate_limits_by_id":{{}}}}"#
+        ))
+        .unwrap();
+        assert!(emptied.mcp_rate_limit(&servers, "github").is_none());
+    }
+
+    #[test]
+    fn an_unresolvable_server_id_imposes_no_limit_and_spares_its_neighbours() {
+        let servers = server_index(&[("s-slack", "slack")]);
+        let k: ApiKey = serde_json::from_str(&format!(
+            r#"{{"key_hash":"h","mcp_rate_limits_by_id":{{"s-gone":{ONE_RPM},"s-slack":{ONE_RPM}}}}}"#
+        ))
+        .unwrap();
+        assert!(k.mcp_rate_limit(&servers, "slack").is_some());
+        assert!(k.mcp_rate_limit(&servers, "s-gone").is_none());
+    }
+
+    #[test]
+    fn mcp_rate_limits_by_id_stays_off_the_wire_when_absent() {
+        let v = serde_json::to_value(sample()).unwrap();
+        assert!(v.get("mcp_rate_limits_by_id").is_none());
+
+        let k: ApiKey = serde_json::from_str(&format!(
+            r#"{{"key_hash":"h","mcp_rate_limits_by_id":{{"s-1":{ONE_RPM}}}}}"#
+        ))
+        .unwrap();
+        let v = serde_json::to_value(&k).unwrap();
+        assert!(v["mcp_rate_limits_by_id"]["s-1"].is_object());
     }
 
     #[test]

--- a/crates/aisix-core/src/models/apikey.rs
+++ b/crates/aisix-core/src/models/apikey.rs
@@ -131,6 +131,10 @@ pub struct ApiKey {
     /// server imposes nothing, and the other entries are unaffected. Set to
     /// `null` it means the same as omitted: the key falls back to
     /// `mcp_rate_limits`.
+    ///
+    /// Each key names one server exactly; there is no "every server" key,
+    /// which is the same as today — a server with no entry is bounded by
+    /// `rate_limit` alone.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_rate_limits_by_id: Option<BTreeMap<String, McpRateLimit>>,
 
@@ -245,14 +249,30 @@ impl ApiKey {
     /// Resolution is done per request against the live table rather than
     /// cached, so a server rename takes effect on the next request with no
     /// rewrite of any key document.
-    pub fn mcp_rate_limit(
-        &self,
-        servers: &super::McpServerIndex,
-        server: &str,
-    ) -> Option<&McpRateLimit> {
+    pub fn mcp_rate_limit<'a>(
+        &'a self,
+        servers: &'a super::McpServerIndex,
+        server: &'a str,
+    ) -> Option<McpServerLimit<'a>> {
         match &self.mcp_rate_limits_by_id {
-            Some(by_id) => by_id.get(servers.id_of(server)?),
-            None => self.mcp_rate_limits.as_ref()?.get(server),
+            Some(by_id) => {
+                // Bucketed on the id, not the name: a rename must not hand
+                // the key a fresh window, which is the whole reason the
+                // limit was attached by id.
+                let id = servers.id_of(server)?;
+                Some(McpServerLimit {
+                    bucket: id,
+                    limits: by_id.get(id)?,
+                })
+            }
+            // Bucketed on the name, which is also what selected it: a
+            // rename detaches a name-keyed limit outright, so there is no
+            // window to carry over, and keying these on the id instead
+            // would reset every counter in the fleet at upgrade.
+            None => Some(McpServerLimit {
+                bucket: server,
+                limits: self.mcp_rate_limits.as_ref()?.get(server)?,
+            }),
         }
     }
 
@@ -301,6 +321,17 @@ impl ApiKey {
             .filter(|name| self.can_access(snapshot, name))
             .collect()
     }
+}
+
+/// One key's limits for one MCP server, with the identity its counter is
+/// bucketed on — the server's resource id when the limit was attached by
+/// id, its name when it was attached by name.
+///
+/// The two must not be confused: a counter that changes bucket resets the
+/// window it was in the middle of.
+pub struct McpServerLimit<'a> {
+    pub bucket: &'a str,
+    pub limits: &'a McpRateLimit,
 }
 
 impl Resource for ApiKey {
@@ -840,6 +871,39 @@ mod tests {
         .unwrap();
         assert!(k.mcp_rate_limit(&servers, "slack").is_some());
         assert!(k.mcp_rate_limit(&servers, "s-gone").is_none());
+    }
+
+    #[test]
+    fn the_counter_bucket_is_whichever_identity_selected_the_limit() {
+        // A rename detaches a name-keyed limit outright, so its counter has
+        // no window to carry over — but an id-keyed limit survives the
+        // rename, and bucketing it on the name would hand the key a fresh
+        // window at the exact moment the feature exists to be transparent.
+        let servers = server_index(&[("s-github", "github")]);
+
+        let by_name: ApiKey = serde_json::from_str(&format!(
+            r#"{{"key_hash":"h","mcp_rate_limits":{{"github":{ONE_RPM}}}}}"#
+        ))
+        .unwrap();
+        assert_eq!(
+            by_name.mcp_rate_limit(&servers, "github").unwrap().bucket,
+            "github"
+        );
+
+        let by_id: ApiKey = serde_json::from_str(&format!(
+            r#"{{"key_hash":"h","mcp_rate_limits_by_id":{{"s-github":{ONE_RPM}}}}}"#
+        ))
+        .unwrap();
+        assert_eq!(
+            by_id.mcp_rate_limit(&servers, "github").unwrap().bucket,
+            "s-github"
+        );
+        // And it stays that bucket across the rename.
+        let renamed = server_index(&[("s-github", "github-v2")]);
+        assert_eq!(
+            by_id.mcp_rate_limit(&renamed, "github-v2").unwrap().bucket,
+            "s-github"
+        );
     }
 
     #[test]

--- a/crates/aisix-core/src/models/mcp_policy.rs
+++ b/crates/aisix-core/src/models/mcp_policy.rs
@@ -71,6 +71,12 @@ pub struct McpPolicy {
     /// Present — including as an empty array — it is authoritative and
     /// `allow` is ignored; an empty array therefore allows nothing. Set to
     /// `null` it means the same as omitted: the layer falls back to `allow`.
+    ///
+    /// It cannot express "every server": each entry names one server
+    /// exactly and `server_id` is never a glob, so an enumeration of the
+    /// servers registered today silently fails to cover one registered
+    /// tomorrow. To allow (or deny) every server, present and future,
+    /// leave this absent and use the name form's `"*"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_ids: Option<Vec<McpToolRef>>,
 
@@ -88,6 +94,12 @@ pub struct McpPolicy {
     /// by server name. Present — including as an empty array — it is
     /// authoritative and `deny` is ignored; an empty array subtracts
     /// nothing. Absent or `null`, the layer falls back to `deny`.
+    ///
+    /// It cannot express "every server": each entry names one server
+    /// exactly and `server_id` is never a glob, so an enumeration of the
+    /// servers registered today silently fails to cover one registered
+    /// tomorrow. To allow (or deny) every server, present and future,
+    /// leave this absent and use the name form's `"*"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deny_ids: Option<Vec<McpToolRef>>,
 
@@ -129,6 +141,12 @@ pub struct McpAccess {
     /// reach. Present — including as an empty array — it is authoritative
     /// and `allow` is ignored; an empty array therefore allows nothing.
     /// Absent or `null`, the key falls back to `allow`.
+    ///
+    /// It cannot express "every server": each entry names one server
+    /// exactly and `server_id` is never a glob, so an enumeration of the
+    /// servers registered today silently fails to cover one registered
+    /// tomorrow. To allow (or deny) every server, present and future,
+    /// leave this absent and use the name form's `"*"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_ids: Option<Vec<McpToolRef>>,
 
@@ -142,6 +160,12 @@ pub struct McpAccess {
     /// server name. Present — including as an empty array — it is
     /// authoritative and `deny` is ignored; an empty array subtracts
     /// nothing. Absent or `null`, the key falls back to `deny`.
+    ///
+    /// It cannot express "every server": each entry names one server
+    /// exactly and `server_id` is never a glob, so an enumeration of the
+    /// servers registered today silently fails to cover one registered
+    /// tomorrow. To allow (or deny) every server, present and future,
+    /// leave this absent and use the name form's `"*"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deny_ids: Option<Vec<McpToolRef>>,
 }

--- a/crates/aisix-core/src/models/mcp_policy.rs
+++ b/crates/aisix-core/src/models/mcp_policy.rs
@@ -17,6 +17,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::mcp_ref::McpToolRef;
 use crate::resource::Resource;
 
 /// Which API keys an MCP access policy applies to.
@@ -55,15 +56,40 @@ pub struct McpPolicy {
     /// a document written before the layered shape would otherwise fail
     /// to deserialize, and a skipped `api_key` row stops authenticating
     /// altogether rather than merely losing MCP access.
+    ///
+    /// Read only when `allow_ids` is absent; ignored entirely when it is
+    /// present.
     #[serde(default)]
     pub allow: Vec<String>,
+
+    /// This layer's allow side written by MCP server resource id instead of
+    /// by server name, so renaming a server does not change what the layer
+    /// allows. Each entry names one MCP server by the id it is registered
+    /// under and one tool by name, the tool matched as a single-`*` glob
+    /// against the bare tool name.
+    ///
+    /// Present — including as an empty array — it is authoritative and
+    /// `allow` is ignored; an empty array therefore allows nothing. Set to
+    /// `null` it means the same as omitted: the layer falls back to `allow`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_ids: Option<Vec<McpToolRef>>,
 
     /// Namespaced `<server>__<tool>` patterns subtracted from the effective
     /// grant of every key the policy applies to, using the same single-`*`
     /// glob matching as `allow`. Deny always wins: a tool matched here stays
     /// unavailable however the other layers allow it.
+    ///
+    /// Read only when `deny_ids` is absent; ignored entirely when it is
+    /// present.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deny: Vec<String>,
+
+    /// This layer's deny side written by MCP server resource id instead of
+    /// by server name. Present — including as an empty array — it is
+    /// authoritative and `deny` is ignored; an empty array subtracts
+    /// nothing. Absent or `null`, the layer falls back to `deny`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deny_ids: Option<Vec<McpToolRef>>,
 
     /// Whether the policy is applied. A disabled policy is kept but
     /// contributes neither its allow nor its deny side. Treated as `true`
@@ -93,14 +119,31 @@ pub struct McpAccess {
     /// and `["*"]` narrows nothing (useful with `deny` alone).
     ///
     /// Required on the write path and defaulted by the runtime loader,
-    /// for the reason given on [`McpPolicy::allow`].
+    /// for the reason given on [`McpPolicy::allow`]. Read only when
+    /// `allow_ids` is absent; ignored entirely when it is present.
     #[serde(default)]
     pub allow: Vec<String>,
 
+    /// This key's allow side written by MCP server resource id instead of by
+    /// server name, so renaming a server does not change what the key may
+    /// reach. Present — including as an empty array — it is authoritative
+    /// and `allow` is ignored; an empty array therefore allows nothing.
+    /// Absent or `null`, the key falls back to `allow`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_ids: Option<Vec<McpToolRef>>,
+
     /// Namespaced `<server>__<tool>` patterns subtracted from this key's
     /// effective grant, using the same single-`*` glob matching as `allow`.
+    /// Read only when `deny_ids` is absent.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deny: Vec<String>,
+
+    /// This key's deny side written by MCP server resource id instead of by
+    /// server name. Present — including as an empty array — it is
+    /// authoritative and `deny` is ignored; an empty array subtracts
+    /// nothing. Absent or `null`, the key falls back to `deny`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deny_ids: Option<Vec<McpToolRef>>,
 }
 
 impl Resource for McpPolicy {

--- a/crates/aisix-core/src/models/mcp_ref.rs
+++ b/crates/aisix-core/src/models/mcp_ref.rs
@@ -31,19 +31,29 @@ use crate::snapshot::ResourceTable;
 /// is an exact id: it is compared against the id of the server the addressed
 /// tool actually belongs to, never glob-matched, so a server whose *name*
 /// happens to contain a `*` cannot widen a grant.
+///
+/// Both halves are required on the WRITE path and defaulted by the runtime
+/// loader — the strict schemas add them to this definition's `required`,
+/// the types do not. An entry these were required of at the type level
+/// would fail to deserialize, and the loader skips a row it cannot
+/// deserialize whole: one malformed entry in one `allow_ids` array would
+/// stop the entire `api_key` from authenticating any traffic at all, not
+/// merely lose it MCP access. Defaulted, the malformed entry matches
+/// nothing instead — an empty `server_id` names no registered server, and
+/// an empty `tool` glob covers no tool name the gateway exposes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct McpToolRef {
     /// Resource id of the registered MCP server (`mcp_servers/<id>`) this
     /// entry refers to. An id matching no registered server refers to
     /// nothing: the entry never matches, and the other entries are
     /// unaffected.
-    #[schemars(length(min = 1))]
+    #[serde(default)]
     pub server_id: String,
 
     /// Tool on that server, matched as a single-`*` glob against the bare
     /// tool name — the part after the `<server>__` namespace prefix. `"*"`
     /// covers every tool the server exposes.
-    #[schemars(length(min = 1))]
+    #[serde(default)]
     pub tool: String,
 }
 

--- a/crates/aisix-core/src/models/mcp_ref.rs
+++ b/crates/aisix-core/src/models/mcp_ref.rs
@@ -1,0 +1,237 @@
+//! Referring to an MCP server by its resource id instead of by its name.
+//!
+//! Every MCP grant a key or a policy carries used to name its server
+//! literally, as the `<server>` half of the namespaced `<server>__<tool>`
+//! form the gateway exposes: an `mcp_access` / `mcp_policies` allow or deny
+//! pattern, and a per-key MCP rate-limit entry. Renaming a registered server
+//! therefore invalidated every document that named it, and the control plane
+//! had to rewrite each of them.
+//!
+//! Each of those sites now also accepts the server's resource id, with the
+//! tool still named. The id survives a rename, so the referencing document
+//! never has to be rewritten — and because the client-facing namespace is
+//! still the server's CURRENT name, a rename changes what callers type and
+//! nothing else.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arc_swap::ArcSwapOption;
+use serde::{Deserialize, Serialize};
+
+use super::mcp_server::McpServer;
+use super::AisixSnapshot;
+use crate::snapshot::ResourceTable;
+
+/// One tool on one MCP server, the server named by its resource id and the
+/// tool by name.
+///
+/// The tool half is matched with the same single-`*` glob rule the name form
+/// uses, so `tool: "*"` is the id spelling of `<server>__*`. The server half
+/// is an exact id: it is compared against the id of the server the addressed
+/// tool actually belongs to, never glob-matched, so a server whose *name*
+/// happens to contain a `*` cannot widen a grant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct McpToolRef {
+    /// Resource id of the registered MCP server (`mcp_servers/<id>`) this
+    /// entry refers to. An id matching no registered server refers to
+    /// nothing: the entry never matches, and the other entries are
+    /// unaffected.
+    #[schemars(length(min = 1))]
+    pub server_id: String,
+
+    /// Tool on that server, matched as a single-`*` glob against the bare
+    /// tool name — the part after the `<server>__` namespace prefix. `"*"`
+    /// covers every tool the server exposes.
+    #[schemars(length(min = 1))]
+    pub tool: String,
+}
+
+/// The registered MCP servers' names, mapped to the resource ids they are
+/// stored under — the direction an ACL check needs, because the tool name a
+/// client sends carries the server's NAME.
+///
+/// Derived from one table, so it is rebuilt exactly when that table changes
+/// (see [`LiveMcpServerIndex`]).
+#[derive(Debug, Default)]
+pub struct McpServerIndex {
+    by_name: HashMap<String, String>,
+}
+
+/// The namespace separator between a server name and a tool name in the
+/// client-facing `<server>__<tool>` form. Duplicated from `aisix-mcp`, which
+/// depends on this crate rather than the other way round; a server name may
+/// not contain it (`McpServer::name`'s pattern), so the split below is exact.
+const TOOL_NAMESPACE_SEPARATOR: &str = "__";
+
+impl McpServerIndex {
+    /// Build from the `mcp_servers` table. A name is mapped to whichever id
+    /// the table's own name index says owns it, so a window in which two
+    /// rows carry one name resolves here exactly as `get_by_name` does.
+    pub fn build(servers: &ResourceTable<McpServer>) -> Self {
+        let mut by_name = HashMap::new();
+        for entry in servers.entries() {
+            let name = entry.value.name.clone();
+            if let Some(owner) = servers.get_by_name(&name) {
+                by_name.insert(name, owner.id.clone());
+            }
+        }
+        Self { by_name }
+    }
+
+    /// Split a client-facing `<server>__<tool>` name into the id of the
+    /// server it addresses and the bare tool name.
+    ///
+    /// `None` when the name carries no namespace prefix or names a server
+    /// that is not registered — in either case no id-form entry can match
+    /// it, which is the fail-closed answer.
+    pub fn address<'a>(&self, namespaced_tool: &'a str) -> Option<(&str, &'a str)> {
+        let (server, tool) = namespaced_tool.split_once(TOOL_NAMESPACE_SEPARATOR)?;
+        Some((self.by_name.get(server)?.as_str(), tool))
+    }
+
+    /// The resource id the registered server `name` is stored under.
+    pub fn id_of(&self, name: &str) -> Option<&str> {
+        self.by_name.get(name).map(String::as_str)
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_name.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+}
+
+#[derive(Debug)]
+struct Cached {
+    generation: u64,
+    index: Arc<McpServerIndex>,
+}
+
+/// Lazily-rebuilt [`McpServerIndex`] shared by every reader that has to turn
+/// an addressed tool into the id its server is stored under. A hit is one
+/// atomic load.
+///
+/// Keyed on the `mcp_servers` table's own generation, never the snapshot
+/// version: registering an API key must not make the next MCP request
+/// rebuild this (AISIX-Cloud#1542). A racing rebuild produces two equal
+/// indexes and one is discarded, the same benign duplication the pricing
+/// index accepts.
+#[derive(Debug, Default)]
+pub struct LiveMcpServerIndex {
+    cached: ArcSwapOption<Cached>,
+}
+
+impl LiveMcpServerIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The index for `snap`, rebuilt only if the `mcp_servers` table changed
+    /// since the cached copy was built. Takes the caller's snapshot rather
+    /// than loading its own, so one request resolves its ACL and its
+    /// per-server limits against the same published configuration.
+    pub fn for_snapshot(&self, snap: &AisixSnapshot) -> Arc<McpServerIndex> {
+        let generation = snap.mcp_servers.generation();
+        if let Some(cached) = self.cached.load_full() {
+            if cached.generation == generation {
+                return Arc::clone(&cached.index);
+            }
+        }
+        let index = Arc::new(McpServerIndex::build(&snap.mcp_servers));
+        self.cached.store(Some(Arc::new(Cached {
+            generation,
+            index: Arc::clone(&index),
+        })));
+        index
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::ResourceEntry;
+
+    fn snapshot_with(servers: &[(&str, &str)]) -> AisixSnapshot {
+        let snap = AisixSnapshot::default();
+        for (id, name) in servers {
+            let server: McpServer = serde_json::from_str(&format!(
+                r#"{{"name":"{name}","url":"https://example.test/mcp"}}"#
+            ))
+            .unwrap();
+            snap.mcp_servers.insert(ResourceEntry::new(*id, server, 1));
+        }
+        snap
+    }
+
+    #[test]
+    fn addresses_a_namespaced_tool_to_its_server_id() {
+        let snap = snapshot_with(&[("s-1", "github"), ("s-2", "slack")]);
+        let index = McpServerIndex::build(&snap.mcp_servers);
+        assert_eq!(
+            index.address("github__create_issue"),
+            Some(("s-1", "create_issue"))
+        );
+        assert_eq!(
+            index.address("slack__post_message"),
+            Some(("s-2", "post_message"))
+        );
+    }
+
+    #[test]
+    fn a_tool_name_may_itself_contain_the_separator() {
+        // The split takes the FIRST separator: server names may not contain
+        // one, so everything after it is the tool.
+        let snap = snapshot_with(&[("s-1", "github")]);
+        let index = McpServerIndex::build(&snap.mcp_servers);
+        assert_eq!(index.address("github__a__b"), Some(("s-1", "a__b")));
+    }
+
+    #[test]
+    fn an_unregistered_or_bare_name_addresses_nothing() {
+        let snap = snapshot_with(&[("s-1", "github")]);
+        let index = McpServerIndex::build(&snap.mcp_servers);
+        assert!(index.address("gitlab__create_issue").is_none());
+        assert!(index.address("create_issue").is_none());
+    }
+
+    #[test]
+    fn the_index_follows_a_rename() {
+        let before = snapshot_with(&[("s-1", "github")]);
+        assert_eq!(
+            McpServerIndex::build(&before.mcp_servers).id_of("github"),
+            Some("s-1")
+        );
+
+        let after = snapshot_with(&[("s-1", "github-v2")]);
+        let index = McpServerIndex::build(&after.mcp_servers);
+        assert_eq!(index.id_of("github-v2"), Some("s-1"));
+        assert!(index.id_of("github").is_none());
+    }
+
+    #[test]
+    fn the_live_index_rebuilds_only_when_the_server_table_changes() {
+        let live = LiveMcpServerIndex::new();
+        let snap = snapshot_with(&[("s-1", "github")]);
+
+        let first = live.for_snapshot(&snap);
+        assert!(Arc::ptr_eq(&first, &live.for_snapshot(&snap)));
+
+        // An unrelated table moving does not invalidate it.
+        let key: crate::models::ApiKey =
+            serde_json::from_str(r#"{"key_hash":"h","allowed_models":[]}"#).unwrap();
+        snap.apikeys.insert(ResourceEntry::new("k-1", key, 1));
+        assert!(Arc::ptr_eq(&first, &live.for_snapshot(&snap)));
+
+        // Registering a server does.
+        let server: McpServer =
+            serde_json::from_str(r#"{"name":"slack","url":"https://example.test/mcp"}"#).unwrap();
+        snap.mcp_servers
+            .insert(ResourceEntry::new("s-2", server, 1));
+        let second = live.for_snapshot(&snap);
+        assert!(!Arc::ptr_eq(&first, &second));
+        assert_eq!(second.id_of("slack"), Some("s-2"));
+    }
+}

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -43,7 +43,7 @@ pub mod semantic;
 pub mod snapshot;
 
 pub use a2a_agent::{A2aAgent, A2aAuthType, A2aProtocolVersion};
-pub use apikey::ApiKey;
+pub use apikey::{ApiKey, McpServerLimit};
 pub use cache_policy::{AppliesTo, CacheBackend, CachePolicy, CacheScope, SemanticCacheConfig};
 pub use claim_mapping::{ClaimMapping, ClaimMatch, ClaimMatchOp, ClaimResolve};
 pub use embedding::EmbeddingConfig;

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -25,6 +25,7 @@ pub mod ensemble;
 pub mod guardrail;
 pub mod mcp_auth_settings;
 pub mod mcp_policy;
+pub mod mcp_ref;
 pub mod mcp_server;
 pub mod model;
 pub mod model_ref;
@@ -58,6 +59,7 @@ pub use guardrail::{
 };
 pub use mcp_auth_settings::McpAuthSettings;
 pub use mcp_policy::{McpAccess, McpPolicy, McpPolicyScope};
+pub use mcp_ref::{LiveMcpServerIndex, McpServerIndex, McpToolRef};
 pub use mcp_server::{McpAuthType, McpProtocolVersion, McpServer, McpServerType, McpTransport};
 pub use model::{
     Adapter, BackgroundModelCheck, CooldownConfig, Model, DEFAULT_COOLDOWN_TRIGGER_STATUSES,

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -995,14 +995,84 @@ pub fn apply_model_ref_alternatives(schema: &mut Value) {
 pub fn apikey_root_schema(strict: bool) -> Value {
     let mut schema = struct_root_schema::<crate::models::ApiKey>(true);
     if strict {
-        require_property(
-            schema
-                .pointer_mut("/definitions/McpAccess")
-                .expect("api_key schema defines McpAccess"),
-            "allow",
+        require_mcp_tool_ref(&mut schema);
+        let access = schema
+            .pointer_mut("/definitions/McpAccess")
+            .expect("api_key schema defines McpAccess");
+        require_property(access, "allow");
+        insert_all_of(access, vec![require_name_form_beside_ids("deny", "array")]);
+        insert_all_of(
+            &mut schema,
+            vec![require_name_form_beside_ids("mcp_rate_limits", "object")],
         );
     }
     schema
+}
+
+/// The write-path shape of one [`McpToolRef`](crate::models::McpToolRef)
+/// entry: both halves present and non-empty.
+///
+/// It lives here rather than on the type because the runtime loader must
+/// keep DESERIALIZING a malformed entry — a row it cannot deserialize is
+/// skipped whole, and for an `api_key` that means the key stops
+/// authenticating every kind of traffic rather than merely losing MCP
+/// access. The write path still refuses to guess.
+fn require_mcp_tool_ref(schema: &mut Value) {
+    let Some(def) = schema.pointer_mut("/definitions/McpToolRef") else {
+        return;
+    };
+    for field in ["server_id", "tool"] {
+        require_property(def, field);
+        if let Some(property) = def.pointer_mut(&format!("/properties/{field}")) {
+            property
+                .as_object_mut()
+                .expect("McpToolRef property is a JSON object")
+                .insert("minLength".to_string(), json!(1));
+        }
+    }
+}
+
+/// A subschema requiring `<name_field>` whenever the id spelling that
+/// shadows it, `<name_field>_ids` (or `<name_field>_by_id` for a map), is
+/// written as a real value.
+///
+/// The id spelling is invisible to a gateway one release behind the
+/// control plane, and the name spelling is the only thing such a gateway
+/// can read. Left optional, a control plane could write a deny — or a
+/// per-server limit — that simply does not exist on that gateway for the
+/// length of the upgrade window: a restriction failing OPEN, silently.
+/// Requiring the pair keeps the older reading conservative and unchanged,
+/// the same reason `allow` is required outright.
+///
+/// The `type` guard matters: `required` alone would also fire on an
+/// explicit `null`, which means the same as omitting the field.
+fn require_name_form_beside_ids(name_field: &str, id_type: &str) -> Value {
+    let id_field = match id_type {
+        "object" => format!("{name_field}_by_id"),
+        _ => format!("{name_field}_ids"),
+    };
+    json!({
+        "if": {
+            "required": [id_field],
+            "properties": { id_field: { "type": id_type } }
+        },
+        "then": { "required": [name_field] }
+    })
+}
+
+/// Append `subschemas` to a schema node's `allOf`, creating it when absent.
+/// Never overwrites: a producer may inject more than one overlay, and
+/// `close_unknown_fields` deliberately does not descend into them.
+fn insert_all_of(schema: &mut Value, subschemas: Vec<Value>) {
+    let obj = schema
+        .as_object_mut()
+        .expect("schema fragment is a JSON object");
+    match obj.get_mut("allOf").and_then(Value::as_array_mut) {
+        Some(list) => list.extend(subschemas),
+        None => {
+            obj.insert("allOf".to_string(), Value::Array(subschemas));
+        }
+    }
 }
 
 /// Add `name` to a schema object's `required` list, creating the list
@@ -1401,24 +1471,21 @@ pub fn mcp_auth_settings_root_schema() -> Value {
 /// environment layer).
 pub fn mcp_policy_root_schema(strict: bool) -> Value {
     let mut schema = struct_root_schema::<crate::models::McpPolicy>(true);
+    let mut overlays = vec![json!({
+        "if": {
+            "properties": { "scope": { "const": "team" } }
+        },
+        "then": {
+            "required": ["scope_ref"],
+            "properties": { "scope_ref": { "type": "string", "minLength": 1 } }
+        }
+    })];
     if strict {
         require_property(&mut schema, "allow");
+        require_mcp_tool_ref(&mut schema);
+        overlays.push(require_name_form_beside_ids("deny", "array"));
     }
-    schema
-        .as_object_mut()
-        .expect("mcp_policy root schema is a JSON object")
-        .insert(
-            "allOf".to_string(),
-            json!([{
-                "if": {
-                    "properties": { "scope": { "const": "team" } }
-                },
-                "then": {
-                    "required": ["scope_ref"],
-                    "properties": { "scope_ref": { "type": "string", "minLength": 1 } }
-                }
-            }]),
-        );
+    insert_all_of(&mut schema, overlays);
     schema
 }
 
@@ -3095,13 +3162,17 @@ mod tests {
         let entry = json!({"server_id": "s-1", "tool": "create_issue"});
 
         for ids in [json!([entry.clone()]), json!([]), json!(null)] {
-            let policy = json!({"scope": "env", "allow": ["*"], "allow_ids": ids, "deny_ids": ids});
+            let policy = json!({
+                "scope": "env", "allow": ["*"], "deny": [],
+                "allow_ids": ids, "deny_ids": ids,
+            });
             validate_mcp_policy(&policy).unwrap();
             validate_mcp_policy_lenient(&policy).unwrap();
 
             let key = json!({
                 "key_hash": hash,
-                "mcp_access": {"allow": ["*"], "allow_ids": ids, "deny_ids": ids},
+                "mcp_access": {"allow": ["*"], "deny": [], "allow_ids": ids, "deny_ids": ids},
+                "mcp_rate_limits": {},
                 "mcp_rate_limits_by_id": {"s-1": {"rpm": 1}},
             });
             validate_apikey(&key).unwrap();
@@ -3119,7 +3190,7 @@ mod tests {
     }
 
     #[test]
-    fn mcp_id_form_entries_must_name_a_server_and_a_tool() {
+    fn mcp_id_form_entries_must_name_a_server_and_a_tool_on_the_write_path() {
         let bad = [
             json!({"tool": "create_issue"}),
             json!({"server_id": "s-1"}),
@@ -3134,23 +3205,92 @@ mod tests {
                     "scope": "env", "allow": ["*"], "allow_ids": [entry.clone()]
                 }))
                 .is_err(),
-                "allow_ids entry {entry} must be rejected"
+                "allow_ids entry {entry} must be rejected on the write path"
             );
         }
     }
 
     #[test]
-    fn the_write_path_still_requires_the_name_form_allow_side() {
-        // Deliberately unchanged by the id spelling. A control plane
-        // writing `allow_ids` writes `allow` beside it, and a gateway one
-        // release behind — which cannot see `allow_ids` at all — then keeps
-        // reading the grant it always did instead of losing MCP access at
-        // the moment the control plane is upgraded.
+    fn a_half_written_mcp_tool_ref_still_loads_leniently() {
+        // Pins the split, and requiredness is exactly what has to be
+        // pinned on BOTH sets: the loader deserializes what it validates,
+        // and a row it cannot deserialize is skipped whole — for an
+        // `api_key` that means the key stops authenticating every kind of
+        // traffic, not just losing MCP access. So one malformed entry in
+        // one `allow_ids` array must degrade to an entry matching nothing,
+        // never to a dead key.
+        let hash = "9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20";
+        for entry in [
+            json!({"tool": "create_issue"}),
+            json!({"server_id": "s-1"}),
+            json!({"server_id": "", "tool": ""}),
+        ] {
+            let key = json!({
+                "key_hash": hash,
+                "mcp_access": {"allow": [], "allow_ids": [entry.clone()]},
+            });
+            validate_apikey_lenient(&key).unwrap();
+            assert!(validate_apikey(&key).is_err());
+            // And it really deserializes — validating leniently is only
+            // half of what the loader does with the row.
+            let parsed: crate::models::ApiKey = serde_json::from_value(key).unwrap();
+            let refs = parsed.mcp_access.unwrap().allow_ids.unwrap();
+            assert_eq!(refs.len(), 1);
+        }
+    }
+
+    #[test]
+    fn the_write_path_requires_the_name_form_beside_every_id_form() {
+        // The id spelling is invisible to a gateway one release behind the
+        // control plane, and the name spelling is the only thing such a
+        // gateway can read. Writing a deny — or a per-server limit — in
+        // the id spelling ALONE would leave that restriction simply absent
+        // there for the length of the upgrade window: a restriction
+        // failing open, silently. `allow` is required outright for the
+        // same reason.
+        let hash = "9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20";
+        let entry = json!({"server_id": "s-1", "tool": "delete_repo"});
+
+        // allow: required outright, so the id spelling alone is refused.
         assert!(validate_mcp_policy(&json!({
-            "scope": "env",
-            "allow_ids": [{"server_id": "s-1", "tool": "*"}],
+            "scope": "env", "allow_ids": [entry],
         }))
         .is_err());
+
+        // deny, on a policy and on a key's own layer.
+        let policy = json!({"scope": "env", "allow": ["*"], "deny_ids": [entry]});
+        assert!(validate_mcp_policy(&policy).is_err());
+        validate_mcp_policy(&json!({
+            "scope": "env", "allow": ["*"], "deny": ["github__delete_repo"],
+            "deny_ids": [entry],
+        }))
+        .unwrap();
+
+        let key_only_ids =
+            json!({"key_hash": hash, "mcp_access": {"allow": ["*"], "deny_ids": [entry]}});
+        assert!(validate_apikey(&key_only_ids).is_err());
+
+        // Per-server limits.
+        let limits_only_ids =
+            json!({"key_hash": hash, "mcp_rate_limits_by_id": {"s-1": {"rpm": 1}}});
+        assert!(validate_apikey(&limits_only_ids).is_err());
+        validate_apikey(&json!({
+            "key_hash": hash,
+            "mcp_rate_limits": {"github": {"rpm": 1}},
+            "mcp_rate_limits_by_id": {"s-1": {"rpm": 1}},
+        }))
+        .unwrap();
+
+        // An explicit `null` means the same as omitted, so it demands
+        // nothing — only a real value does.
+        validate_mcp_policy(&json!({"scope": "env", "allow": ["*"], "deny_ids": null})).unwrap();
+        validate_apikey(&json!({"key_hash": hash, "mcp_rate_limits_by_id": null})).unwrap();
+
+        // The loader takes every one of these rows regardless: the guard
+        // is a write contract, never a reason to drop a stored row.
+        validate_mcp_policy_lenient(&policy).unwrap();
+        validate_apikey_lenient(&key_only_ids).unwrap();
+        validate_apikey_lenient(&limits_only_ids).unwrap();
     }
 
     #[test]

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -1024,10 +1024,17 @@ fn require_mcp_tool_ref(schema: &mut Value) {
     for field in ["server_id", "tool"] {
         require_property(def, field);
         if let Some(property) = def.pointer_mut(&format!("/properties/{field}")) {
-            property
+            let property = property
                 .as_object_mut()
-                .expect("McpToolRef property is a JSON object")
-                .insert("minLength".to_string(), json!(1));
+                .expect("McpToolRef property is a JSON object");
+            property.insert("minLength".to_string(), json!(1));
+            // The `#[serde(default)]` the loader needs renders as
+            // `default: ""`, which beside `minLength: 1` is a value this
+            // very schema refuses — a form generator that honours defaults
+            // would pre-fill a field and then fail to save it. The lenient
+            // set keeps the annotation, where it is the truth about what
+            // the loader does with an omitted half.
+            property.remove("default");
         }
     }
 }

--- a/crates/aisix-core/src/models/schema.rs
+++ b/crates/aisix-core/src/models/schema.rs
@@ -3090,6 +3090,70 @@ mod tests {
     }
 
     #[test]
+    fn mcp_id_form_sides_are_accepted_on_both_paths() {
+        let hash = "9df37f5e7cbc3c391d872742b5f286c242e733a09add9eeaa4d26a599bd90b20";
+        let entry = json!({"server_id": "s-1", "tool": "create_issue"});
+
+        for ids in [json!([entry.clone()]), json!([]), json!(null)] {
+            let policy = json!({"scope": "env", "allow": ["*"], "allow_ids": ids, "deny_ids": ids});
+            validate_mcp_policy(&policy).unwrap();
+            validate_mcp_policy_lenient(&policy).unwrap();
+
+            let key = json!({
+                "key_hash": hash,
+                "mcp_access": {"allow": ["*"], "allow_ids": ids, "deny_ids": ids},
+                "mcp_rate_limits_by_id": {"s-1": {"rpm": 1}},
+            });
+            validate_apikey(&key).unwrap();
+            validate_apikey_lenient(&key).unwrap();
+        }
+
+        // Both spellings may be written together; the runtime lets the ids
+        // decide.
+        validate_mcp_policy(&json!({
+            "scope": "env",
+            "allow": ["github__create_issue"],
+            "allow_ids": [entry],
+        }))
+        .unwrap();
+    }
+
+    #[test]
+    fn mcp_id_form_entries_must_name_a_server_and_a_tool() {
+        let bad = [
+            json!({"tool": "create_issue"}),
+            json!({"server_id": "s-1"}),
+            json!({"server_id": "", "tool": "create_issue"}),
+            json!({"server_id": "s-1", "tool": ""}),
+            json!({"server_id": "s-1", "tool": "x", "rogue": 1}),
+            json!("s-1__create_issue"),
+        ];
+        for entry in bad {
+            assert!(
+                validate_mcp_policy(&json!({
+                    "scope": "env", "allow": ["*"], "allow_ids": [entry.clone()]
+                }))
+                .is_err(),
+                "allow_ids entry {entry} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn the_write_path_still_requires_the_name_form_allow_side() {
+        // Deliberately unchanged by the id spelling. A control plane
+        // writing `allow_ids` writes `allow` beside it, and a gateway one
+        // release behind — which cannot see `allow_ids` at all — then keeps
+        // reading the grant it always did instead of losing MCP access at
+        // the moment the control plane is upgraded.
+        assert!(validate_mcp_policy(&json!({
+            "scope": "env",
+            "allow_ids": [{"server_id": "s-1", "tool": "*"}],
+        }))
+        .is_err());
+    }
+
+    #[test]
     fn mcp_policy_requires_an_explicit_allow_side() {
         assert!(validate_mcp_policy(&json!({"scope": "env"})).is_err());
         assert!(validate_mcp_policy(&json!({"scope": "env", "deny": ["github__*"]})).is_err());

--- a/crates/aisix-core/tests/resource_schema_characterization.rs
+++ b/crates/aisix-core/tests/resource_schema_characterization.rs
@@ -989,11 +989,11 @@ fn published_strict_schemas_are_what_the_write_path_compiles() {
 ///
 /// - a `required` / `minLength` / `not` change, which really does let the
 ///   loader accept a document the write path rejects (`api_key`,
-///   `mcp_policy`, `model`, and the `semantic` guardrail branch). Every
-///   `McpToolRef` path is this shape: a half-written entry has to keep
-///   deserializing, because the loader skips a row it cannot deserialize
-///   whole and for an `api_key` that costs the key every kind of traffic,
-///   not just MCP access;
+///   `mcp_policy`, `model`, and the `semantic` guardrail branch). The
+///   `McpToolRef` `required` / `minLength` paths are this shape: a
+///   half-written entry has to keep deserializing, because the loader
+///   skips a row it cannot deserialize whole and for an `api_key` that
+///   costs the key every kind of traffic, not just MCP access;
 /// - an `allOf` overlay the STRICT producer injects and the lenient one
 ///   does not. `mcp_policy`'s `/allOf` holds both the team-scope guard,
 ///   which is on both sets, and the strict-only "write the name form beside
@@ -1003,8 +1003,9 @@ fn published_strict_schemas_are_what_the_write_path_compiles() {
 ///   lenient one keeps, which changes nothing about what validates but does
 ///   feed a schema-driven form generator a value the same branch would refuse
 ///   (the `custom` guardrail's `script`, whose `default: ""` sits beside
-///   `minLength: 1`; the semantic thresholds' `default: 0.75`). `script`
-///   itself is required on BOTH sets.
+///   `minLength: 1`; both halves of `McpToolRef`, for the same reason; the
+///   semantic thresholds' `default: 0.75`). `script` itself is required on
+///   BOTH sets.
 const EXTRA_RELAXATIONS: &[(&str, &[&str])] = &[
     (
         "api_key",
@@ -1012,7 +1013,9 @@ const EXTRA_RELAXATIONS: &[(&str, &[&str])] = &[
             "/allOf",
             "/definitions/McpAccess/allOf",
             "/definitions/McpAccess/required",
+            "/definitions/McpToolRef/properties/server_id/default",
             "/definitions/McpToolRef/properties/server_id/minLength",
+            "/definitions/McpToolRef/properties/tool/default",
             "/definitions/McpToolRef/properties/tool/minLength",
             "/definitions/McpToolRef/required",
         ],
@@ -1030,7 +1033,9 @@ const EXTRA_RELAXATIONS: &[(&str, &[&str])] = &[
         "mcp_policy",
         &[
             "/allOf",
+            "/definitions/McpToolRef/properties/server_id/default",
             "/definitions/McpToolRef/properties/server_id/minLength",
+            "/definitions/McpToolRef/properties/tool/default",
             "/definitions/McpToolRef/properties/tool/minLength",
             "/definitions/McpToolRef/required",
             "/required",

--- a/crates/aisix-core/tests/resource_schema_characterization.rs
+++ b/crates/aisix-core/tests/resource_schema_characterization.rs
@@ -984,12 +984,21 @@ fn published_strict_schemas_are_what_the_write_path_compiles() {
 /// makes the table checkable — a claim that some OTHER field relaxed, or that
 /// one of these stopped relaxing, moves a path and fails.
 ///
-/// Two shapes appear here, and `schemas/README.md` must keep telling them
+/// Three shapes appear here, and `schemas/README.md` must keep telling them
 /// apart:
 ///
-/// - a `required` / `not` change, which really does let the loader accept a
-///   document the write path rejects (`api_key`, `mcp_policy`, `model`, and
-///   the `semantic` guardrail branch);
+/// - a `required` / `minLength` / `not` change, which really does let the
+///   loader accept a document the write path rejects (`api_key`,
+///   `mcp_policy`, `model`, and the `semantic` guardrail branch). Every
+///   `McpToolRef` path is this shape: a half-written entry has to keep
+///   deserializing, because the loader skips a row it cannot deserialize
+///   whole and for an `api_key` that costs the key every kind of traffic,
+///   not just MCP access;
+/// - an `allOf` overlay the STRICT producer injects and the lenient one
+///   does not. `mcp_policy`'s `/allOf` holds both the team-scope guard,
+///   which is on both sets, and the strict-only "write the name form beside
+///   the id form" guard — so the whole keyword differs even though half of
+///   its contents do not. `api_key`'s two are strict-only outright;
 /// - a `default` annotation the STRICT producer strips on purpose and the
 ///   lenient one keeps, which changes nothing about what validates but does
 ///   feed a schema-driven form generator a value the same branch would refuse
@@ -997,7 +1006,17 @@ fn published_strict_schemas_are_what_the_write_path_compiles() {
 ///   `minLength: 1`; the semantic thresholds' `default: 0.75`). `script`
 ///   itself is required on BOTH sets.
 const EXTRA_RELAXATIONS: &[(&str, &[&str])] = &[
-    ("api_key", &["/definitions/McpAccess/required"]),
+    (
+        "api_key",
+        &[
+            "/allOf",
+            "/definitions/McpAccess/allOf",
+            "/definitions/McpAccess/required",
+            "/definitions/McpToolRef/properties/server_id/minLength",
+            "/definitions/McpToolRef/properties/tool/minLength",
+            "/definitions/McpToolRef/required",
+        ],
+    ),
     (
         "guardrail",
         &[
@@ -1007,7 +1026,16 @@ const EXTRA_RELAXATIONS: &[(&str, &[&str])] = &[
             "/oneOf/11/properties/script/default",
         ],
     ),
-    ("mcp_policy", &["/required"]),
+    (
+        "mcp_policy",
+        &[
+            "/allOf",
+            "/definitions/McpToolRef/properties/server_id/minLength",
+            "/definitions/McpToolRef/properties/tool/minLength",
+            "/definitions/McpToolRef/required",
+            "/required",
+        ],
+    ),
     (
         "model",
         &[

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -96,6 +96,21 @@ impl WatchStatus {
         *self.inner.last_apply_at.lock().unwrap() = Some(Instant::now());
     }
 
+    /// [`Self::record_apply`] for a completed READ, which knows the exact
+    /// point its result is consistent as of and therefore ASSIGNS rather
+    /// than raising.
+    ///
+    /// A read of several prefixes can land below what the resync just
+    /// stamped from the entry set — a row in the later-read prefix may
+    /// have been written after the earlier prefix was read, while a write
+    /// to the earlier prefix in that interval is missing from the union
+    /// altogether. Keeping the higher number would go on claiming a write
+    /// the gateway has not seen.
+    pub(crate) fn record_read(&self, revision: i64) {
+        self.inner.revision.store(revision, Ordering::Relaxed);
+        *self.inner.last_apply_at.lock().unwrap() = Some(Instant::now());
+    }
+
     /// Snapshot the current freshness state. Returns the revision and
     /// the age (wall-clock duration since last apply); `None` for age
     /// means the supervisor has not yet successfully completed a cycle.
@@ -743,7 +758,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         // apply_resync uses max(entry revisions); bump to the etcd
         // load_all revision so the cache file records the true "as
         // of" point, not just the max entry write.
-        self.set_revision_floor(revision);
+        self.record_read_revision(revision);
         tracing::info!(
             accepted = stats.accepted,
             rejected = stats.schema_rejected + stats.parse_rejected,
@@ -775,10 +790,15 @@ impl<P: ConfigProvider> Supervisor<P> {
         // would skip every write to it in between — absent from that
         // read and never delivered to that watch.
         let mut revisions: Vec<Option<i64>> = Vec::with_capacity(self.sources.len());
+        // Retention (below) runs in a second pass so it can see the WHOLE
+        // read, not just the prefixes that came before the refusal.
+        let mut read_ok: Vec<&str> = Vec::new();
+        let mut refused: Vec<&PrefixSource<P>> = Vec::new();
         for source in &self.sources {
             match source.provider.load_all().await {
                 Ok((entries, rev)) => {
                     source.clear_refusal();
+                    read_ok.push(&source.prefix.prefix);
                     for entry in entries {
                         match all.entry(entry.key.clone()) {
                             std::collections::btree_map::Entry::Occupied(mut slot) => {
@@ -796,30 +816,40 @@ impl<P: ConfigProvider> Supervisor<P> {
                     revisions.push(Some(rev));
                 }
                 Err(err) if source.tolerates(&err) => {
-                    // A refusal is not a deletion. The rows this prefix
-                    // contributed to the last successful union are carried
-                    // into this one unchanged, and replaced only when a read
-                    // of it succeeds again — so a control plane that starts
-                    // refusing the shared catalog leaves the gateway pricing
-                    // on the last catalog it was allowed to read instead of
-                    // dropping every price at once. Losing them is not
-                    // neutral: `least_cost` stops ranking and realtime /
-                    // batch usage events lose `cost_usd`, and the WARN above
-                    // is the only sign either happened. Readiness is not held
-                    // back and the prefix has no revision to resume from, as
-                    // before; the cycle keeps retrying it at the normal
-                    // cadence.
+                    // Read as refused: the prefix contributes no revision,
+                    // has no revision to resume its watch from, and does not
+                    // hold readiness back — as before. Its rows are carried
+                    // over in the pass below.
                     source.log_refusal(&err);
-                    for entry in self.entries_last_read_from(&source.prefix) {
-                        // Never over a row this cycle DID read: the
-                        // environment prefix is the bare base on a
-                        // deployment with no `env_id`, so a fresh copy of a
-                        // catalog row can already be in `all`.
-                        all.entry(entry.key.clone()).or_insert(entry);
-                    }
+                    refused.push(source);
                     revisions.push(None);
                 }
                 Err(err) => return Err(err),
+            }
+        }
+
+        // A refusal is not a deletion. The rows a refused prefix
+        // contributed to the last successful union are carried into this
+        // one unchanged, and replaced only when a read of it succeeds
+        // again — so a control plane that starts refusing the shared
+        // catalog leaves the gateway pricing on the last catalog it was
+        // allowed to read instead of dropping every price at once. Losing
+        // them is not neutral: `least_cost` stops ranking and realtime /
+        // batch usage events lose `cost_usd`, and the WARN above is the
+        // only sign either happened.
+        for source in refused {
+            for entry in self.entries_last_read_from(&source.prefix) {
+                // Only where nothing else answered for the key. On a
+                // deployment with no `env_id` the environment prefix is the
+                // bare base, so a SUCCESSFUL read of it already covers the
+                // catalog — and that read is authoritative about the key
+                // being gone, which carrying the old row over would undo.
+                // A deleted price would come back to life, priced at
+                // whatever it used to cost.
+                if read_ok.iter().any(|p| entry.key.starts_with(p)) {
+                    continue;
+                }
+                all.entry(entry.key.clone()).or_insert(entry);
             }
         }
         Ok(PrefixLoad {
@@ -843,20 +873,26 @@ impl<P: ConfigProvider> Supervisor<P> {
             .collect()
     }
 
-    /// Bump the recorded revision floor. Used by the cycle path to
-    /// stamp the cache with the etcd `load_all` revision even when the
-    /// resulting entry set is empty (so the file still reflects when
-    /// the DP last successfully reached the CP). Also stamps
-    /// `WatchStatus.last_apply_at` so `/admin/v1/health` reflects the
-    /// successful round-trip with etcd even on an empty config.
-    fn set_revision_floor(&self, revision: i64) {
-        {
-            let mut rev = self.revision.lock().unwrap();
-            if revision > *rev {
-                *rev = revision;
-            }
-        }
-        self.status.record_apply(revision);
+    /// Record the revision a completed read was consistent as of, replacing
+    /// whatever the preceding `apply_resync` derived from the entry set.
+    /// Used by the cycle path so the cache and the heartbeat reflect when
+    /// the DP last successfully reached the CP even when the resulting
+    /// entry set is empty. Also stamps `WatchStatus.last_apply_at` so
+    /// `/admin/v1/health` reflects the successful round-trip with etcd.
+    ///
+    /// **Assigns, rather than raising a floor.** `apply_resync` stamps
+    /// `max(entry revision)`, which across several prefixes read in
+    /// sequence can exceed the point the union as a whole is consistent as
+    /// of: a row written to the later-read prefix after the earlier one was
+    /// read carries a revision above the earlier read's header, while a
+    /// write to the earlier prefix in that same interval is missing from
+    /// the union entirely. Raising a floor would keep that overstatement
+    /// and go on claiming a write the gateway has not seen — the one thing
+    /// `applied_revision` exists to answer. The caller's value is the
+    /// authoritative one and is never lower than honest.
+    fn record_read_revision(&self, revision: i64) {
+        *self.revision.lock().unwrap() = revision;
+        self.status.record_read(revision);
         // Reflect the finalised revision on the status view (the preceding
         // apply_resync synced with the entry-max revision; this corrects it to
         // the load/watch header revision). Not itself a reload event.
@@ -1088,7 +1124,7 @@ impl<P: ConfigProvider> Supervisor<P> {
     }
 
     /// Stage one Delete. `revision` carries the watch header revision the
-    /// cycle loop would otherwise pass to [`Self::set_revision_floor`]
+    /// cycle loop would otherwise pass to [`Self::record_read_revision`]
     /// immediately afterwards; `None` (the standalone
     /// [`Self::apply_delete`] entry point) leaves the floor alone.
     #[allow(clippy::too_many_arguments)]
@@ -1168,12 +1204,18 @@ impl<P: ConfigProvider> Supervisor<P> {
         }
     }
 
-    /// In-batch form of [`Self::set_revision_floor`]: bump the floor and
-    /// mark the batch as needing a status publish, deferring the single
+    /// In-batch form for the watch-event path: raise the floor and mark
+    /// the batch as needing a status publish, deferring the single
     /// `record_apply` / `sync_config_status` to the end of the batch.
     ///
+    /// A floor here, not an assignment as in [`Self::record_read_revision`]:
+    /// these are individual watch events, delivered in revision order and
+    /// each carrying only its own write's revision, so the highest seen is
+    /// the point the configuration reflects. Only a completed READ knows a
+    /// consistent-as-of point that can be lower than what came before.
+    ///
     /// Status only — the floor is not part of the observed entry set, and
-    /// `set_revision_floor` never wrote the cache file either.
+    /// `record_read_revision` never wrote the cache file either.
     fn raise_revision_floor(
         &self,
         revision: Option<i64>,
@@ -1466,7 +1508,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         // initial load completed and no request can observe the
         // environment loaded and the catalog not.
         self.apply_resync(&load.entries);
-        self.set_revision_floor(revision);
+        self.record_read_revision(revision);
 
         let mut streams = Vec::with_capacity(self.sources.len());
         for (source, from) in self.sources.iter().zip(&load.revisions) {
@@ -1532,7 +1574,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                     // The resync's header revision is the "consistent as
                     // of" point even when the entry set is empty or only
                     // contains older mod_revisions.
-                    self.set_revision_floor(revision);
+                    self.record_read_revision(revision);
                 }
                 // Explicit over the two batchable variants rather than a
                 // catch-all: a new `WatchEvent` must fail to compile here
@@ -2433,6 +2475,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_later_prefixs_newer_row_does_not_raise_the_applied_revision() {
+        // The resync stamps `max(entry revision)` from the union, and the
+        // later-read prefix can legitimately hold a row written AFTER the
+        // earlier prefix was read — while a write to the earlier prefix in
+        // that same interval is missing from the union entirely. Letting
+        // the entry-max stand would keep claiming a revision the gateway
+        // has not seen, which is exactly what taking the minimum header is
+        // for. Distinct from the case above: here the overstatement comes
+        // from an ENTRY, not from a header.
+        let sup = scoped_supervisor(
+            ScopedProvider::serving(vec![entry("/aisix/env-1/models/m-1", VALID_MODEL, 90)], 100),
+            ScopedProvider::serving(
+                vec![entry("/aisix/global/pricing/g", VALID_PRICE, 103)],
+                105,
+            ),
+        );
+        sup.load_once().await.unwrap();
+        assert_eq!(
+            sup.watch_status().snapshot().revision,
+            100,
+            "the union is consistent as of the earliest read, whatever revision \
+             a later prefix's rows carry"
+        );
+    }
+
+    #[tokio::test]
     async fn a_refused_prefix_does_not_lower_the_applied_revision() {
         // A refusal contributes no rows, so nothing in the union came
         // from that prefix and it has no earliest-read point to impose.
@@ -2490,6 +2558,48 @@ mod tests {
             "a successful read replaces the retained rows"
         );
         assert!(replaced.global_pricing.get_by_id("g-2").is_some());
+    }
+
+    #[tokio::test]
+    async fn a_broader_successful_read_still_deletes_a_retained_row() {
+        // The nesting case again: with no `env_id` the environment prefix
+        // is the bare base, so a SUCCESSFUL read of it already answers for
+        // the catalog's keys — including answering that one is gone. The
+        // catalog prefix being refused must not undo that: carrying the
+        // old row over would bring a deleted price back to life, at
+        // whatever it used to cost.
+        let priced = entry("/aisix/global/pricing/p-1", VALID_PRICE, 4);
+        let sup = Arc::new(Supervisor::with_sources(
+            vec![
+                (
+                    WatchedPrefix::environment("/aisix"),
+                    ScopedProvider::scripted(vec![
+                        Some((
+                            vec![entry("/aisix/models/m-1", VALID_MODEL, 3), priced.clone()],
+                            4,
+                        )),
+                        // The price is deleted; the environment read that
+                        // covers it comes back without it.
+                        Some((vec![entry("/aisix/models/m-1", VALID_MODEL, 3)], 9)),
+                    ]),
+                ),
+                (
+                    WatchedPrefix::global("/aisix/global/"),
+                    ScopedProvider::scripted(vec![Some((vec![priced], 4)), None]),
+                ),
+            ],
+            SnapshotCache::disabled(),
+        ));
+
+        sup.load_once().await.unwrap();
+        assert_eq!(sup.handle().load().global_pricing.len(), 1);
+
+        sup.load_once().await.unwrap();
+        assert_eq!(
+            sup.handle().load().global_pricing.len(),
+            0,
+            "a deleted price must stay deleted when a read that covers it succeeded"
+        );
     }
 
     #[tokio::test]
@@ -3903,7 +4013,7 @@ mod tests {
         ));
         let sup = Supervisor::new(provider, "/aisix");
 
-        // load_once → set_revision_floor(7) → record_apply(7)
+        // load_once → record_read_revision(7) → record_apply(7)
         sup.load_once().await.unwrap();
         let snap = sup.watch_status().snapshot();
         assert_eq!(

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -306,8 +306,9 @@ impl<P: ConfigProvider> PrefixSource<P> {
         tracing::warn!(
             prefix = %self.prefix.prefix,
             error = %err,
-            "etcd refused the shared pricing catalog; serving without it — a model with \
-             `pricing_key` falls back to its inline `cost` until the control plane grants \
+            "etcd refused the shared pricing catalog; keeping the prices last read from it, \
+             or serving without prices if it was never read — a model with `pricing_key` and \
+             no catalog entry falls back to its inline `cost` until the control plane grants \
              read access to this prefix",
         );
     }
@@ -337,11 +338,12 @@ impl<P: ConfigProvider> Supervisor<P> {
 
     /// Construct over several prefixes, each with its own provider.
     ///
-    /// All of them feed ONE snapshot and one revision floor: kine
-    /// revisions are cluster-global, so the applied revision is the
-    /// maximum across prefixes, and readiness waits for every prefix's
-    /// initial range read (a tolerated refusal on the shared catalog
-    /// counts as read-and-empty — see [`PrefixSource::tolerates`]).
+    /// All of them feed ONE snapshot and one revision floor: the applied
+    /// revision is the MINIMUM across prefixes, because sequential reads
+    /// make the union consistent only as far as the earliest of them (see
+    /// [`PrefixLoad::applied_revision`]), and readiness waits for every
+    /// prefix's initial range read (a tolerated refusal on the shared
+    /// catalog counts as read-and-kept — see [`PrefixSource::tolerates`]).
     pub fn with_sources(mut sources: Vec<(WatchedPrefix, Arc<P>)>, cache: SnapshotCache) -> Self {
         // Environment prefixes are read FIRST, and that ordering is load
         // bearing rather than cosmetic: [`PrefixSource::tolerates`] is
@@ -736,7 +738,7 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// decides whether to backoff and retry.
     pub async fn load_once(&self) -> Result<BuildStats, ProviderError> {
         let load = self.load_all_prefixes().await?;
-        let revision = load.max_revision();
+        let revision = load.applied_revision();
         let stats = self.apply_resync(&load.entries);
         // apply_resync uses max(entry revisions); bump to the etcd
         // load_all revision so the cache file records the true "as
@@ -752,11 +754,11 @@ impl<P: ConfigProvider> Supervisor<P> {
     }
 
     /// Range-read every watched prefix and return the union of their
-    /// entries with the highest revision any of them reported.
+    /// entries, plus the revision each one's own read was consistent as of.
     ///
-    /// Kine revisions are cluster-global, so the maximum is the point the
-    /// whole read is consistent as of, and it is what the heartbeat
-    /// reports as `applied_revision`.
+    /// The reads run in sequence, so the union as a whole is consistent
+    /// only as far as the EARLIEST of them — see
+    /// [`PrefixLoad::applied_revision`].
     async fn load_all_prefixes(&self) -> Result<PrefixLoad, ProviderError> {
         // Deduplicated by key, because the prefixes can nest: when the
         // gateway has no `env_id` the environment prefix is the bare base
@@ -794,9 +796,27 @@ impl<P: ConfigProvider> Supervisor<P> {
                     revisions.push(Some(rev));
                 }
                 Err(err) if source.tolerates(&err) => {
-                    // Read as empty: the prefix contributes no rows and no
-                    // revision, and readiness is not held back.
+                    // A refusal is not a deletion. The rows this prefix
+                    // contributed to the last successful union are carried
+                    // into this one unchanged, and replaced only when a read
+                    // of it succeeds again — so a control plane that starts
+                    // refusing the shared catalog leaves the gateway pricing
+                    // on the last catalog it was allowed to read instead of
+                    // dropping every price at once. Losing them is not
+                    // neutral: `least_cost` stops ranking and realtime /
+                    // batch usage events lose `cost_usd`, and the WARN above
+                    // is the only sign either happened. Readiness is not held
+                    // back and the prefix has no revision to resume from, as
+                    // before; the cycle keeps retrying it at the normal
+                    // cadence.
                     source.log_refusal(&err);
+                    for entry in self.entries_last_read_from(&source.prefix) {
+                        // Never over a row this cycle DID read: the
+                        // environment prefix is the bare base on a
+                        // deployment with no `env_id`, so a fresh copy of a
+                        // catalog row can already be in `all`.
+                        all.entry(entry.key.clone()).or_insert(entry);
+                    }
                     revisions.push(None);
                 }
                 Err(err) => return Err(err),
@@ -806,6 +826,21 @@ impl<P: ConfigProvider> Supervisor<P> {
             entries: all.into_values().collect(),
             revisions,
         })
+    }
+
+    /// The rows the last applied union carried under `prefix`.
+    ///
+    /// Attribution is by key prefix, which is exact for the only caller:
+    /// [`PrefixSource::tolerates`] admits the shared catalog alone, and the
+    /// catalog prefix is the longest one a supervisor watches, so no key
+    /// under it belongs to another source.
+    fn entries_last_read_from(&self, prefix: &WatchedPrefix) -> Vec<RawEntry> {
+        let state = self.state.lock().unwrap();
+        state
+            .iter()
+            .filter(|(key, _)| key.starts_with(&prefix.prefix))
+            .map(|(_, held)| held.entry.clone())
+            .collect()
     }
 
     /// Bump the recorded revision floor. Used by the cycle path to
@@ -1424,7 +1459,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             .load_all_prefixes()
             .await
             .map_err(SupervisorError::Provider)?;
-        let revision = load.max_revision();
+        let revision = load.applied_revision();
 
         // ONE resync over the union: the snapshot is published only after
         // every prefix has been read, so readiness means every prefix's
@@ -1607,12 +1642,25 @@ struct PrefixLoad {
 }
 
 impl PrefixLoad {
-    /// The revision the snapshot as a whole reflects. kine revisions are
-    /// cluster-global, so the highest any prefix reported is the point
-    /// the combined read is consistent as of, and it is what the
+    /// The revision the snapshot as a whole reflects, and what the
     /// heartbeat reports as `applied_revision`.
-    fn max_revision(&self) -> i64 {
-        self.revisions.iter().flatten().copied().max().unwrap_or(0)
+    ///
+    /// The LOWEST any prefix reported, not the highest. kine revisions are
+    /// cluster-global, but the range reads run in sequence: a write landing
+    /// between the first prefix's read and the last one's is below the last
+    /// read's header revision and absent from the union all the same. So
+    /// the union is consistent as of the EARLIEST point any part of it was
+    /// read at, and claiming the highest would tell the control plane the
+    /// gateway had applied a write it has not seen — the one thing
+    /// `applied_revision` exists to answer.
+    ///
+    /// A prefix whose read was refused reports no revision and does not
+    /// lower the answer: it contributed no rows this cycle, so nothing in
+    /// the union came from it. With no prefix reporting one at all the
+    /// answer is 0, which the caller treats as a floor and never lowers an
+    /// earlier one with.
+    fn applied_revision(&self) -> i64 {
+        self.revisions.iter().flatten().copied().min().unwrap_or(0)
     }
 }
 
@@ -2166,6 +2214,10 @@ mod tests {
     const VALID_PRICE: &[u8] =
         br#"{"key":"openai/gpt-4o","input_per_1k":0.005,"output_per_1k":0.015}"#;
 
+    /// One scripted `load_all` answer: `Some((rows, revision))` serves,
+    /// `None` refuses.
+    type ScriptedRead = Option<(Vec<RawEntry>, i64)>;
+
     /// A provider that either serves entries or refuses every call the
     /// way a control plane predating the shared catalog does — its kine
     /// ACL answers `PermissionDenied` for a Range outside the
@@ -2180,6 +2232,10 @@ mod tests {
         /// Hand back a stream that never ends and never yields, the way
         /// a healthy watch on a prefix nobody is writing behaves.
         never_ends: bool,
+        /// Successive `load_all` answers, one popped per call, `None`
+        /// refusing. Empty — every constructor but `scripted` — means the
+        /// provider answers the same way every time.
+        script: Mutex<std::collections::VecDeque<ScriptedRead>>,
     }
 
     impl ScopedProvider {
@@ -2190,6 +2246,7 @@ mod tests {
                 refuse: false,
                 watched_from: Mutex::new(None),
                 never_ends: false,
+                script: Mutex::new(std::collections::VecDeque::new()),
             })
         }
 
@@ -2203,6 +2260,7 @@ mod tests {
                 refuse: false,
                 watched_from: Mutex::new(None),
                 never_ends: true,
+                script: Mutex::new(std::collections::VecDeque::new()),
             })
         }
 
@@ -2213,6 +2271,21 @@ mod tests {
                 refuse: true,
                 watched_from: Mutex::new(None),
                 never_ends: false,
+                script: Mutex::new(std::collections::VecDeque::new()),
+            })
+        }
+
+        /// Answers each `load_all` from `steps` in order — `Some((rows,
+        /// revision))` serves, `None` refuses — so one test can walk a
+        /// prefix through success, refusal and success again.
+        fn scripted(steps: Vec<ScriptedRead>) -> Arc<Self> {
+            Arc::new(Self {
+                entries: Vec::new(),
+                revision: 0,
+                refuse: true,
+                watched_from: Mutex::new(None),
+                never_ends: false,
+                script: Mutex::new(steps.into()),
             })
         }
     }
@@ -2220,10 +2293,17 @@ mod tests {
     #[async_trait]
     impl ConfigProvider for ScopedProvider {
         async fn load_all(&self) -> Result<(Vec<RawEntry>, i64), ProviderError> {
-            if self.refuse {
-                return Err(ProviderError::Rejected(
+            let refusal = || {
+                ProviderError::Rejected(
                     "etcdserver: permission denied: outside env env-1 prefix".into(),
-                ));
+                )
+            };
+            let step = self.script.lock().unwrap().pop_front();
+            if let Some(step) = step {
+                return step.map(Ok).unwrap_or_else(|| Err(refusal()));
+            }
+            if self.refuse {
+                return Err(refusal());
             }
             Ok((self.entries.clone(), self.revision))
         }
@@ -2322,17 +2402,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn applied_revision_is_the_maximum_across_prefixes() {
-        // kine revisions are cluster-global, so the point the whole read
-        // is consistent as of is the highest either prefix reported —
-        // whichever one that is. Both orders, because taking the LAST
-        // prefix's revision (or the FIRST, or the environment's) passes
-        // one of them by accident.
+    async fn applied_revision_is_the_minimum_across_prefixes() {
+        // The prefixes are read in sequence, so the union is consistent
+        // only as far as the EARLIEST read: a write that landed between
+        // the two reads is missing from the union while sitting below the
+        // later read's header revision. Reporting the higher one would
+        // claim a write the gateway has not applied. Both orders, because
+        // taking the LAST prefix's revision (or the FIRST, or the
+        // environment's) passes one of them by accident.
         //
         // Every entry is written at revision 1 so the header revisions
         // are the only thing that can produce the expected value: the
         // resync raises the floor to the highest entry revision first,
-        // and entries at 7 / 42 / 99 would supply the answer by
+        // and entries at 5 / 7 / 42 / 99 would supply the answer by
         // themselves — which is how the first version of this case
         // stayed green against a last-prefix-wins mutation.
         let global_ahead = scoped_supervisor(
@@ -2340,14 +2422,74 @@ mod tests {
             ScopedProvider::serving(vec![entry("/aisix/global/pricing/g", VALID_PRICE, 1)], 42),
         );
         global_ahead.load_once().await.unwrap();
-        assert_eq!(global_ahead.watch_status().snapshot().revision, 42);
+        assert_eq!(global_ahead.watch_status().snapshot().revision, 7);
 
         let env_ahead = scoped_supervisor(
             ScopedProvider::serving(vec![entry("/aisix/env-1/models/m-1", VALID_MODEL, 1)], 99),
             ScopedProvider::serving(vec![entry("/aisix/global/pricing/g", VALID_PRICE, 1)], 5),
         );
         env_ahead.load_once().await.unwrap();
-        assert_eq!(env_ahead.watch_status().snapshot().revision, 99);
+        assert_eq!(env_ahead.watch_status().snapshot().revision, 5);
+    }
+
+    #[tokio::test]
+    async fn a_refused_prefix_does_not_lower_the_applied_revision() {
+        // A refusal contributes no rows, so nothing in the union came
+        // from that prefix and it has no earliest-read point to impose.
+        // Reading its missing revision as 0 would freeze
+        // `applied_revision` at the floor for the life of the deployment.
+        let sup = scoped_supervisor(
+            ScopedProvider::serving(vec![entry("/aisix/env-1/models/m-1", VALID_MODEL, 1)], 31),
+            ScopedProvider::refusing(),
+        );
+        sup.load_once().await.unwrap();
+        assert_eq!(sup.watch_status().snapshot().revision, 31);
+    }
+
+    #[tokio::test]
+    async fn a_refused_catalog_keeps_the_prices_it_last_read() {
+        // A denial is not a deletion. Once the catalog HAS been read, a
+        // later refusal must leave those prices in place: dropping them
+        // silently stops `least_cost` ranking and empties `cost_usd` on
+        // realtime and batch usage events, with only the WARN to show for
+        // it. A successful read replaces them; only a successful read does.
+        const OTHER_PRICE: &[u8] =
+            br#"{"key":"openai/gpt-4o","input_per_1k":0.001,"output_per_1k":0.002}"#;
+        let sup = scoped_supervisor(
+            ScopedProvider::serving(vec![entry("/aisix/env-1/models/m-1", VALID_MODEL, 1)], 5),
+            ScopedProvider::scripted(vec![
+                Some((vec![entry("/aisix/global/pricing/g-1", VALID_PRICE, 3)], 3)),
+                None,
+                Some((vec![entry("/aisix/global/pricing/g-2", OTHER_PRICE, 9)], 9)),
+            ]),
+        );
+
+        sup.load_once().await.unwrap();
+        let priced = sup.handle().load();
+        assert_eq!(priced.global_pricing.len(), 1);
+        assert!(priced.global_pricing.get_by_id("g-1").is_some());
+
+        // Denied: the rows stay, and the environment is untouched.
+        sup.load_once().await.unwrap();
+        let denied = sup.handle().load();
+        assert_eq!(
+            denied.global_pricing.len(),
+            1,
+            "a refusal must not clear the catalog"
+        );
+        assert!(denied.global_pricing.get_by_id("g-1").is_some());
+        assert_eq!(denied.models.len(), 1);
+
+        // Allowed again with different content: the retained rows are
+        // replaced by what the read returned, not merged with it.
+        sup.load_once().await.unwrap();
+        let replaced = sup.handle().load();
+        assert_eq!(replaced.global_pricing.len(), 1);
+        assert!(
+            replaced.global_pricing.get_by_id("g-1").is_none(),
+            "a successful read replaces the retained rows"
+        );
+        assert!(replaced.global_pricing.get_by_id("g-2").is_some());
     }
 
     #[tokio::test]
@@ -2437,9 +2579,11 @@ mod tests {
             "the environment watch must resume from its OWN read (7), not from the maximum (42)",
         );
         assert_eq!(*global.watched_from.lock().unwrap(), Some(43));
-        // The reported applied revision is still the maximum: it is what
-        // the whole combined read is consistent as of.
-        assert_eq!(sup.watch_status().snapshot().revision, 42);
+        // The reported applied revision is the MINIMUM, for the same
+        // reason the resume points differ: the union is only consistent
+        // as far as the earliest read (`applied_revision_is_the_minimum_
+        // across_prefixes`).
+        assert_eq!(sup.watch_status().snapshot().revision, 7);
     }
 
     #[tokio::test]

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -754,7 +754,7 @@ impl<P: ConfigProvider> Supervisor<P> {
     pub async fn load_once(&self) -> Result<BuildStats, ProviderError> {
         let load = self.load_all_prefixes().await?;
         let revision = load.applied_revision();
-        let stats = self.apply_resync(&load.entries);
+        let stats = self.apply_resync_at(&load.entries, Some(revision));
         // apply_resync uses max(entry revisions); bump to the etcd
         // load_all revision so the cache file records the true "as
         // of" point, not just the max entry write.
@@ -1244,6 +1244,22 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// write that broke it. Retention ends when the key loads cleanly
     /// again or leaves etcd.
     pub fn apply_resync(&self, entries: &[RawEntry]) -> BuildStats {
+        self.apply_resync_at(entries, None)
+    }
+
+    /// [`Self::apply_resync`] told the revision the entry set was read at.
+    ///
+    /// A completed read knows the exact point its result is consistent as
+    /// of, and that point can be BELOW the highest revision in the entry
+    /// set — see [`Self::record_read_revision`]. The caller's value has to
+    /// land BEFORE the cache flush at the end of this function, because the
+    /// cache refuses a write below the revision it has already committed:
+    /// commit the entry maximum here and every apply between the two
+    /// numbers is silently dropped from the cache — precisely the events
+    /// carrying the writes the read could not see. A restart during an etcd
+    /// outage would then serve a cache claiming a revision whose changes it
+    /// does not contain.
+    pub fn apply_resync_at(&self, entries: &[RawEntry], read_revision: Option<i64>) -> BuildStats {
         let (snap, mut stats) = loader::build_snapshot(&self.prefixes, entries);
 
         // Reconcile the last-known-good state against this build, then
@@ -1336,14 +1352,21 @@ impl<P: ConfigProvider> Supervisor<P> {
                 state.insert(e.key.clone(), StateEntry::new(e.clone()));
             }
         }
-        // Resync revision is the max of any entry; if the caller has a
-        // separate "load_all revision" they pass it via the cycle path
-        // (see `cycle`), this branch just covers the watch Resync event.
-        let max_rev = entries.iter().map(|e| e.revision).max();
-        if let Some(rev_val) = max_rev {
-            let mut rev = self.revision.lock().unwrap();
-            if rev_val > *rev {
-                *rev = rev_val;
+        match read_revision {
+            // The caller read the entry set and knows what it is
+            // consistent as of. Assigned, not raised, for the reason in
+            // this function's doc comment.
+            Some(revision) => *self.revision.lock().unwrap() = revision,
+            // No read behind this one — the standalone entry point, used
+            // by tests and by callers replaying an entry set. The max of
+            // any entry is the best available answer.
+            None => {
+                if let Some(rev_val) = entries.iter().map(|e| e.revision).max() {
+                    let mut rev = self.revision.lock().unwrap();
+                    if rev_val > *rev {
+                        *rev = rev_val;
+                    }
+                }
             }
         }
         // /admin/v1/health: stamp freshness on every resync, even when the
@@ -1507,7 +1530,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         // every prefix has been read, so readiness means every prefix's
         // initial load completed and no request can observe the
         // environment loaded and the catalog not.
-        self.apply_resync(&load.entries);
+        self.apply_resync_at(&load.entries, Some(revision));
         self.record_read_revision(revision);
 
         let mut streams = Vec::with_capacity(self.sources.len());
@@ -1570,7 +1593,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                 }
                 Some(Watched::Event(Err(err))) => return Err(SupervisorError::Provider(err)),
                 Some(Watched::Event(Ok(WatchEvent::Resync { entries, revision }))) => {
-                    self.apply_resync(&entries);
+                    self.apply_resync_at(&entries, Some(revision));
                     // The resync's header revision is the "consistent as
                     // of" point even when the entry set is empty or only
                     // contains older mod_revisions.
@@ -3845,6 +3868,75 @@ mod tests {
         assert!(
             started.elapsed() >= CACHE_WRITE_DRAIN,
             "the drain must actually wait out its bound before giving up",
+        );
+    }
+
+    #[tokio::test]
+    async fn an_event_below_a_later_prefixs_entry_still_reaches_the_cache() {
+        // The multi-prefix load reports the EARLIEST read as its revision
+        // (`applied_revision_is_the_minimum_across_prefixes`), and that can
+        // be below the highest revision in the entry set — a row in the
+        // later-read prefix may have been written after the earlier prefix
+        // was read. The resync's cache flush has to carry the read's number
+        // rather than the entry maximum, because the cache refuses a write
+        // below what it has committed: commit 103 here and every apply
+        // between 100 and 103 is silently dropped from the cache — exactly
+        // the events carrying the writes the read could not see. A restart
+        // during an etcd outage would then serve a cache claiming 103 whose
+        // changes it does not contain.
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("snap.json");
+
+        {
+            let sup = Arc::new(Supervisor::with_sources(
+                vec![
+                    (
+                        WatchedPrefix::environment(ENV_PREFIX),
+                        ScopedProvider::serving(
+                            vec![entry("/aisix/env-1/models/m-1", VALID_MODEL, 90)],
+                            100,
+                        ),
+                    ),
+                    (
+                        WatchedPrefix::global(GLOBAL_PREFIX),
+                        ScopedProvider::serving(
+                            vec![entry("/aisix/global/pricing/g", VALID_PRICE, 103)],
+                            105,
+                        ),
+                    ),
+                ],
+                SnapshotCache::new(&cache_path),
+            ));
+            sup.load_once().await.unwrap();
+            sup.await_pending_cache_writes().await;
+
+            // The watch on the environment prefix resumes at 101 and
+            // delivers a write the load could not have seen.
+            assert!(sup.apply_put(&entry("/aisix/env-1/models/m-2", VALID_MODEL, 101)));
+            sup.await_pending_cache_writes().await;
+        }
+
+        // A restart that cannot reach etcd serves the cache: both models
+        // must be there. Same prefixes, so the cached keys resolve to the
+        // same kinds they were stored under.
+        let restarted = Supervisor::with_sources(
+            vec![
+                (
+                    WatchedPrefix::environment(ENV_PREFIX),
+                    ScopedProvider::refusing(),
+                ),
+                (
+                    WatchedPrefix::global(GLOBAL_PREFIX),
+                    ScopedProvider::refusing(),
+                ),
+            ],
+            SnapshotCache::new(&cache_path),
+        );
+        restarted.restore_from_cache();
+        assert_eq!(
+            restarted.handle().load().models.len(),
+            2,
+            "the applied write at revision 101 must be in the cache"
         );
     }
 

--- a/crates/aisix-mcp/src/gateway.rs
+++ b/crates/aisix-mcp/src/gateway.rs
@@ -40,7 +40,10 @@ use rmcp::transport::streamable_http_server::session::local::LocalSessionManager
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use rmcp::{RoleServer, ServerHandler};
 
-use aisix_core::models::{ApiKey, McpPolicy, McpPolicyScope, McpServerType};
+use aisix_core::models::{
+    ApiKey, LiveMcpServerIndex, McpPolicy, McpPolicyScope, McpServerIndex, McpServerType,
+    McpToolRef,
+};
 use aisix_core::{AisixSnapshot, ResourceEntry};
 
 use crate::bridge::{
@@ -100,13 +103,25 @@ pub fn strip_server_prefix<'a>(server: &str, name: &'a str) -> Option<&'a str> {
 /// widen what another one already narrowed. A layer that is absent or
 /// disabled contributes nothing; with no allow layer at all the ACL grants
 /// nothing, so MCP access is always granted explicitly.
+///
+/// Each side of each layer is written EITHER as `<server>__<tool>` name
+/// patterns or as `{server_id, tool}` entries naming the server by resource
+/// id ([`McpToolRef`]); the id spelling wins for the side that carries it.
+/// The two decide the same question, so the ACL keeps a resolved
+/// name → id index of the registered servers and evaluates whichever
+/// spelling a layer used against the one tool name the caller addressed.
 #[derive(Clone)]
 pub struct ToolAcl {
     /// Conjunctive allow layers: a tool must match every layer.
     allow: Vec<AllowLayer>,
-    /// Deny patterns; any match rejects the tool, overriding every allow
+    /// Deny rules; any match rejects the tool, overriding every allow
     /// layer.
-    deny: Vec<String>,
+    deny: Vec<DenyRule>,
+    /// The registered servers this ACL resolves ids against, as of the
+    /// snapshot it was built from. Empty for the ACLs built without one
+    /// ([`ToolAcl::allow_all`], [`ToolAcl::from_allowed`]), which carry no
+    /// id-form entry to resolve.
+    servers: Arc<McpServerIndex>,
 }
 
 #[derive(Clone)]
@@ -115,6 +130,29 @@ enum AllowLayer {
     All,
     /// The layer admits tools matching any of these single-`*` glob patterns.
     Patterns(Vec<String>),
+    /// The layer admits tools named by server id plus a tool-name glob. An
+    /// empty list admits nothing, exactly as an empty pattern list does.
+    Refs(Vec<McpToolRef>),
+}
+
+/// One deny entry, in whichever spelling its layer used.
+#[derive(Clone)]
+enum DenyRule {
+    Pattern(String),
+    Ref(McpToolRef),
+}
+
+/// Whether `entry` names the tool the caller addressed, which
+/// [`McpServerIndex::address`] has resolved to `(server id, bare tool)`.
+///
+/// The server half is compared as an exact id, never glob-matched: a
+/// registered name may legally contain a `*`, so pasting the resolved name
+/// into a pattern would let one server's grant reach another's tools.
+fn ref_matches(entry: &McpToolRef, addressed: Option<(&str, &str)>) -> bool {
+    let Some((server_id, tool)) = addressed else {
+        return false;
+    };
+    entry.server_id == server_id && aisix_core::wildcard::wildcard_matches(&entry.tool, tool)
 }
 
 impl AllowLayer {
@@ -129,12 +167,40 @@ impl AllowLayer {
         }
     }
 
-    fn admits(&self, namespaced_tool: &str) -> bool {
+    /// The layer for one `allow` / `allow_ids` pair: the id spelling decides
+    /// whenever it is present, an empty array included.
+    fn from_sides(patterns: &[String], ids: Option<&Vec<McpToolRef>>) -> Self {
+        match ids {
+            Some(refs) => Self::Refs(refs.clone()),
+            None => Self::from_patterns(patterns),
+        }
+    }
+
+    fn admits(&self, namespaced_tool: &str, addressed: Option<(&str, &str)>) -> bool {
         match self {
             Self::All => true,
             Self::Patterns(patterns) => patterns
                 .iter()
                 .any(|p| aisix_core::wildcard::wildcard_matches(p, namespaced_tool)),
+            Self::Refs(refs) => refs.iter().any(|r| ref_matches(r, addressed)),
+        }
+    }
+}
+
+impl DenyRule {
+    /// The deny rules for one `deny` / `deny_ids` pair, in the spelling the
+    /// layer used.
+    fn from_sides(patterns: &[String], ids: Option<&Vec<McpToolRef>>) -> Vec<Self> {
+        match ids {
+            Some(refs) => refs.iter().cloned().map(Self::Ref).collect(),
+            None => patterns.iter().cloned().map(Self::Pattern).collect(),
+        }
+    }
+
+    fn matches(&self, namespaced_tool: &str, addressed: Option<(&str, &str)>) -> bool {
+        match self {
+            Self::Pattern(p) => aisix_core::wildcard::wildcard_matches(p, namespaced_tool),
+            Self::Ref(r) => ref_matches(r, addressed),
         }
     }
 }
@@ -146,6 +212,7 @@ impl ToolAcl {
         Self {
             allow: vec![AllowLayer::All],
             deny: Vec::new(),
+            servers: Arc::new(McpServerIndex::default()),
         }
     }
 
@@ -185,6 +252,7 @@ impl ToolAcl {
         Self {
             allow: vec![AllowLayer::from_patterns(allowed.unwrap_or(&[]))],
             deny: Vec::new(),
+            servers: Arc::new(McpServerIndex::default()),
         }
     }
 
@@ -198,9 +266,16 @@ impl ToolAcl {
     /// is absent — no row, a disabled row, or no `mcp_access` block —
     /// contributes neither side.
     ///
+    /// Each layer writes each of its two sides either as `<server>__<tool>`
+    /// name patterns or as `{server_id, tool}` entries; a side that carries
+    /// the id spelling is decided by it alone, an empty array included. The
+    /// two spellings mix freely across layers and across the two sides of
+    /// one layer, because every layer is resolved against the same
+    /// addressed tool.
+    ///
     /// With no allow layer at all the ACL grants nothing: MCP access is
     /// granted explicitly, never by the absence of configuration.
-    pub fn resolve(snapshot: &AisixSnapshot, key: &ApiKey) -> Self {
+    pub fn resolve(snapshot: &AisixSnapshot, servers: &LiveMcpServerIndex, key: &ApiKey) -> Self {
         // Grant side: pick the governing row per scope deterministically
         // (lowest id wins) so a duplicated row — the writer enforces
         // uniqueness — can only ever produce a stable outcome. Deny side:
@@ -209,7 +284,7 @@ impl ToolAcl {
         // tie-break.
         let mut env_policy: Option<Arc<ResourceEntry<McpPolicy>>> = None;
         let mut team_policy: Option<Arc<ResourceEntry<McpPolicy>>> = None;
-        let mut deny: Vec<String> = Vec::new();
+        let mut deny: Vec<DenyRule> = Vec::new();
         for entry in snapshot.mcp_policies.entries() {
             if !entry.value.enabled {
                 continue;
@@ -225,7 +300,10 @@ impl ToolAcl {
                     &mut team_policy
                 }
             };
-            deny.extend(entry.value.deny.iter().cloned());
+            deny.extend(DenyRule::from_sides(
+                &entry.value.deny,
+                entry.value.deny_ids.as_ref(),
+            ));
             match slot {
                 Some(current) if current.id <= entry.id => {}
                 _ => *slot = Some(entry),
@@ -237,11 +315,17 @@ impl ToolAcl {
             .into_iter()
             .flatten()
         {
-            allow.push(AllowLayer::from_patterns(&policy.value.allow));
+            allow.push(AllowLayer::from_sides(
+                &policy.value.allow,
+                policy.value.allow_ids.as_ref(),
+            ));
         }
         if let Some(access) = &key.mcp_access {
-            allow.push(AllowLayer::from_patterns(&access.allow));
-            deny.extend(access.deny.iter().cloned());
+            allow.push(AllowLayer::from_sides(
+                &access.allow,
+                access.allow_ids.as_ref(),
+            ));
+            deny.extend(DenyRule::from_sides(&access.deny, access.deny_ids.as_ref()));
         }
         // Deny-by-default: an unconfigured key in an unconfigured
         // environment has no MCP access, rather than the empty conjunction's
@@ -249,20 +333,38 @@ impl ToolAcl {
         if allow.is_empty() {
             allow.push(AllowLayer::Patterns(Vec::new()));
         }
-        Self { allow, deny }
+        Self {
+            allow,
+            deny,
+            servers: servers.for_snapshot(snapshot),
+        }
     }
 
     /// Whether `namespaced_tool` is permitted: every allow layer must admit
-    /// it and no deny pattern may match it. Patterns are single-`*` globs:
+    /// it and no deny rule may match it. Name patterns are single-`*` globs:
     /// `"<server>__*"` covers every tool on that server, a pattern without a
-    /// `*` matches exactly, and a bare `"*"` covers everything. Uses the same
-    /// matcher as `ApiKey::can_access_tool`.
+    /// `*` matches exactly, and a bare `"*"` covers everything.
+    ///
+    /// An id-form entry is decided against the server the addressed tool
+    /// actually belongs to: the `<server>__<tool>` name is split as it always
+    /// was, the server half is resolved through the registered-server index,
+    /// and the entry matches when its `server_id` equals that server's id and
+    /// its `tool` glob covers the bare tool name. A tool naming no registered
+    /// server, and an entry whose `server_id` names no registered server,
+    /// therefore match no id-form entry at all — the fail-closed answer for
+    /// an allow side, and one that leaves the layer's other entries intact.
     pub fn permits(&self, namespaced_tool: &str) -> bool {
-        self.allow.iter().all(|layer| layer.admits(namespaced_tool))
+        // Resolved once per decision and shared by both sides: with only
+        // name patterns configured nothing reads it, and `address` is one
+        // split plus one hash lookup when something does.
+        let addressed = self.servers.address(namespaced_tool);
+        self.allow
+            .iter()
+            .all(|layer| layer.admits(namespaced_tool, addressed))
             && !self
                 .deny
                 .iter()
-                .any(|p| aisix_core::wildcard::wildcard_matches(p, namespaced_tool))
+                .any(|rule| rule.matches(namespaced_tool, addressed))
     }
 }
 

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -1251,3 +1251,88 @@ fn an_id_layer_admits_nothing_for_a_tool_outside_every_namespace() {
     assert!(!acl.permits("create_issue"), "no namespace prefix at all");
     assert!(!acl.permits("unregistered__create_issue"));
 }
+
+#[test]
+fn an_env_policy_may_write_its_allow_side_by_id() {
+    // The policy layers carry the id spelling too, and nothing else in
+    // this suite exercises a policy's `allow_ids`: the key layer is where
+    // every other id case above puts it.
+    let snapshot = with_servers(
+        policy_snapshot(&[(
+            "p-env",
+            serde_json::json!({
+                "scope": "env", "allow": [],
+                "allow_ids": [{"server_id": "s-github", "tool": "create_issue"}]
+            }),
+        )]),
+        &[("s-github", "github"), ("s-slack", "slack")],
+    );
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"mcp_access":{"allow":["*"]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("github__create_issue"));
+    assert!(!acl.permits("github__delete_repo"));
+    assert!(
+        !acl.permits("slack__post_message"),
+        "the env layer's id grant narrows the key's `*`"
+    );
+}
+
+#[test]
+fn a_team_policy_may_write_its_allow_side_by_id() {
+    let snapshot = with_servers(
+        policy_snapshot(&[
+            ("p-env", serde_json::json!({"scope": "env", "allow": ["*"]})),
+            (
+                "p-team",
+                serde_json::json!({
+                    "scope": "team", "scope_ref": "team-1", "allow": [],
+                    "allow_ids": [{"server_id": "s-github", "tool": "*"}]
+                }),
+            ),
+        ]),
+        &[("s-github", "github"), ("s-slack", "slack")],
+    );
+    let member = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"team_id":"team-1",
+        "mcp_access":{"allow":["*"]}
+    }));
+    let acl = resolve_now(&snapshot, &member);
+    assert!(acl.permits("github__create_issue"));
+    assert!(!acl.permits("slack__post_message"));
+
+    // A key outside the team is not narrowed by it, so the id-spelled
+    // team layer really is what produced the result above.
+    let outsider = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"team_id":"team-2",
+        "mcp_access":{"allow":["*"]}
+    }));
+    assert!(resolve_now(&snapshot, &outsider).permits("slack__post_message"));
+}
+
+#[test]
+fn a_policy_id_grant_survives_a_server_rename() {
+    let policy_row = serde_json::json!({
+        "scope": "env", "allow": ["github__create_issue"],
+        "allow_ids": [{"server_id": "s-github", "tool": "create_issue"}]
+    });
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"mcp_access":{"allow":["*"]}
+    }));
+
+    let before = with_servers(
+        policy_snapshot(&[("p-env", policy_row.clone())]),
+        &[("s-github", "github")],
+    );
+    assert!(resolve_now(&before, &key).permits("github__create_issue"));
+
+    // Same policy document, same key document, renamed server.
+    let after = with_servers(
+        policy_snapshot(&[("p-env", policy_row)]),
+        &[("s-github", "github-v2")],
+    );
+    let acl = resolve_now(&after, &key);
+    assert!(acl.permits("github-v2__create_issue"));
+    assert!(!acl.permits("github__create_issue"));
+}

--- a/crates/aisix-mcp/tests/gateway_aggregation.rs
+++ b/crates/aisix-mcp/tests/gateway_aggregation.rs
@@ -560,7 +560,29 @@ fn policy_snapshot(rows: &[(&str, serde_json::Value)]) -> AisixSnapshot {
 }
 
 fn resolve_now(snapshot: &AisixSnapshot, key: &aisix_core::models::ApiKey) -> ToolAcl {
-    ToolAcl::resolve(snapshot, key)
+    // A fresh index per call: these tests build one snapshot each, and a
+    // shared one would hide a rebuild the generation key is meant to force.
+    ToolAcl::resolve(
+        snapshot,
+        &aisix_core::models::LiveMcpServerIndex::new(),
+        key,
+    )
+}
+
+/// Register the given `(id, name)` MCP servers on `snapshot`, so an
+/// id-form ACL entry has something to resolve against.
+fn with_servers(snapshot: AisixSnapshot, servers: &[(&str, &str)]) -> AisixSnapshot {
+    for (id, name) in servers {
+        let server: aisix_core::models::McpServer = serde_json::from_value(serde_json::json!({
+            "name": name,
+            "url": "https://example.test/mcp",
+        }))
+        .unwrap();
+        snapshot
+            .mcp_servers
+            .insert(ResourceEntry::new(*id, server, 1));
+    }
+    snapshot
 }
 
 #[test]
@@ -1024,4 +1046,208 @@ async fn policy_resolved_acl_filters_list_and_rejects_calls() {
 fn call(name: &'static str, text: &str) -> CallToolRequestParams {
     let args = serde_json::json!({ "text": text });
     CallToolRequestParams::new(name).with_arguments(args.as_object().unwrap().clone())
+}
+
+// ---- the id spelling of a layer's two sides (`allow_ids` / `deny_ids`) ----
+
+#[test]
+fn allow_ids_grant_by_server_resource_id() {
+    let snapshot = with_servers(
+        policy_snapshot(&[]),
+        &[("s-github", "github"), ("s-slack", "slack")],
+    );
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],
+        "mcp_access":{"allow":[],"allow_ids":[{"server_id":"s-github","tool":"create_issue"}]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("github__create_issue"));
+    assert!(!acl.permits("github__delete_repo"));
+    assert!(!acl.permits("slack__post_message"));
+}
+
+#[test]
+fn an_allow_id_tool_glob_covers_the_whole_server() {
+    let snapshot = with_servers(policy_snapshot(&[]), &[("s-github", "github")]);
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],
+        "mcp_access":{"allow":[],"allow_ids":[{"server_id":"s-github","tool":"*"}]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("github__create_issue"));
+    assert!(acl.permits("github__anything_at_all"));
+    assert!(!acl.permits("slack__post_message"));
+}
+
+#[test]
+fn an_id_grant_survives_a_server_rename() {
+    // The whole point: the key document is byte-identical across the
+    // rename, and the grant follows the id to the server's new namespace.
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],
+        "mcp_access":{"allow":["github__create_issue"],
+                      "allow_ids":[{"server_id":"s-github","tool":"create_issue"}]}
+    }));
+
+    let before = with_servers(policy_snapshot(&[]), &[("s-github", "github")]);
+    assert!(resolve_now(&before, &key).permits("github__create_issue"));
+
+    let after = with_servers(policy_snapshot(&[]), &[("s-github", "github-v2")]);
+    let acl = resolve_now(&after, &key);
+    assert!(
+        acl.permits("github-v2__create_issue"),
+        "the grant follows the id into the server's new namespace"
+    );
+    assert!(
+        !acl.permits("github__create_issue"),
+        "and does not linger on the old one, which now names no server"
+    );
+}
+
+#[test]
+fn allow_ids_win_over_allow_on_the_same_layer() {
+    let snapshot = with_servers(
+        policy_snapshot(&[]),
+        &[("s-github", "github"), ("s-slack", "slack")],
+    );
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],
+        "mcp_access":{"allow":["slack__*"],
+                      "allow_ids":[{"server_id":"s-github","tool":"create_issue"}]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("github__create_issue"));
+    assert!(
+        !acl.permits("slack__post_message"),
+        "the name side is not read at all once the id side is present"
+    );
+
+    // Even a wide-open name side loses to an empty id side.
+    let widened = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],
+        "mcp_access":{"allow":["*"],"allow_ids":[]}
+    }));
+    assert!(!resolve_now(&snapshot, &widened).permits("github__create_issue"));
+}
+
+#[test]
+fn an_unresolvable_server_id_matches_nothing_and_spares_its_neighbours() {
+    let snapshot = with_servers(
+        policy_snapshot(&[]),
+        &[("s-github", "github"), ("s-slack", "slack")],
+    );
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],
+        "mcp_access":{"allow":[],"allow_ids":[
+            {"server_id":"s-gone","tool":"*"},
+            {"server_id":"s-slack","tool":"post_message"}
+        ]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("slack__post_message"));
+    assert!(!acl.permits("github__create_issue"));
+    assert!(!acl.permits("s-gone__anything"));
+}
+
+#[test]
+fn deny_ids_subtract_and_win_over_every_allow_layer() {
+    let snapshot = with_servers(
+        policy_snapshot(&[(
+            "p-env",
+            serde_json::json!({
+                "scope":"env","allow":["*"],"deny":[],
+                "deny_ids":[{"server_id":"s-github","tool":"delete_repo"}]
+            }),
+        )]),
+        &[("s-github", "github")],
+    );
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"mcp_access":{"allow":["*"]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("github__create_issue"));
+    assert!(!acl.permits("github__delete_repo"));
+}
+
+#[test]
+fn deny_ids_win_over_deny_on_the_same_layer() {
+    let snapshot = with_servers(
+        policy_snapshot(&[(
+            "p-env",
+            serde_json::json!({
+                "scope":"env","allow":["*"],
+                "deny":["github__create_issue"],
+                "deny_ids":[{"server_id":"s-github","tool":"delete_repo"}]
+            }),
+        )]),
+        &[("s-github", "github")],
+    );
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],"mcp_access":{"allow":["*"]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(
+        acl.permits("github__create_issue"),
+        "the name side of deny is not read once the id side is present"
+    );
+    assert!(!acl.permits("github__delete_repo"));
+}
+
+#[test]
+fn the_two_spellings_mix_across_layers() {
+    // An env layer written by name, a key layer written by id: both are
+    // resolved against the same addressed tool, so the intersection holds.
+    let snapshot = with_servers(
+        policy_snapshot(&[(
+            "p-env",
+            serde_json::json!({"scope":"env","allow":["github__*","slack__*"]}),
+        )]),
+        &[("s-github", "github"), ("s-slack", "slack")],
+    );
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],
+        "mcp_access":{"allow":[],"allow_ids":[{"server_id":"s-github","tool":"*"}]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("github__create_issue"));
+    assert!(
+        !acl.permits("slack__post_message"),
+        "the id-spelled key layer still narrows the name-spelled env layer"
+    );
+    assert!(!acl.permits("jira__create_ticket"));
+}
+
+#[test]
+fn a_server_id_is_never_glob_matched_through_its_name() {
+    // A registered name may legally contain a `*` (only `__` and a
+    // trailing `_` are forbidden). Resolving an id to that name and
+    // pasting it into a `<name>__<tool>` pattern would let one server's
+    // grant reach another server's tools, so the server half is compared
+    // as an exact id instead.
+    let snapshot = with_servers(
+        policy_snapshot(&[]),
+        &[("s-star", "gh*"), ("s-other", "ghost")],
+    );
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],
+        "mcp_access":{"allow":[],"allow_ids":[{"server_id":"s-star","tool":"*"}]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(acl.permits("gh*__read"));
+    assert!(
+        !acl.permits("ghost__read"),
+        "the grant must not spread to a server whose name the other's matches as a glob"
+    );
+}
+
+#[test]
+fn an_id_layer_admits_nothing_for_a_tool_outside_every_namespace() {
+    let snapshot = with_servers(policy_snapshot(&[]), &[("s-github", "github")]);
+    let key = acl_key(serde_json::json!({
+        "key_hash":"h","allowed_models":[],
+        "mcp_access":{"allow":[],"allow_ids":[{"server_id":"s-github","tool":"*"}]}
+    }));
+    let acl = resolve_now(&snapshot, &key);
+    assert!(!acl.permits("create_issue"), "no namespace prefix at all");
+    assert!(!acl.permits("unregistered__create_issue"));
 }

--- a/crates/aisix-proxy/src/mcp.rs
+++ b/crates/aisix-proxy/src/mcp.rs
@@ -587,7 +587,7 @@ async fn dispatch(
     // from the key together with the environment/team MCP access policies —
     // so MCP tool access is governed by the same key object as LLM access.
     let acl = {
-        let resolved = aisix_mcp::ToolAcl::resolve(&snapshot, auth.key());
+        let resolved = aisix_mcp::ToolAcl::resolve(&snapshot, &state.mcp_servers, auth.key());
         // The anonymous allowlist is a CEILING on the bound principal,
         // not just the entry gate. Applied here — one layer on the ACL
         // both endpoints share — it constrains `tools/list` and

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -355,7 +355,11 @@ async fn reserve_layers(
     // `mcp:<api_key_id>:<server>` so each server the key reaches counts
     // independently — of the other servers, and of every other key.
     if let Some(server) = mcp_server {
-        if let Some(limits) = auth.key().mcp_rate_limit(server) {
+        // Through the same registered-server index the tool ACL resolves
+        // against, so a key that names its limits by server id and its
+        // grants by server id sees one rename take effect at one instant.
+        let servers = state.mcp_servers.for_snapshot(snapshot);
+        if let Some(limits) = auth.key().mcp_rate_limit(&servers, server) {
             let rl = RateLimit::from(limits);
             if !rl.is_unrestricted() {
                 let key = format!("mcp:{}:{}", auth.entry.id, server);

--- a/crates/aisix-proxy/src/quota.rs
+++ b/crates/aisix-proxy/src/quota.rs
@@ -353,16 +353,19 @@ async fn reserve_layers(
 
     // Layer 3: per-MCP-server limit carried by this key. Bucketed on
     // `mcp:<api_key_id>:<server>` so each server the key reaches counts
-    // independently — of the other servers, and of every other key.
+    // independently — of the other servers, and of every other key. The
+    // `<server>` half is whichever identity selected the limit (see
+    // `McpServerLimit`), so a rename does not silently hand the key a
+    // fresh window on a limit that was attached by id.
     if let Some(server) = mcp_server {
         // Through the same registered-server index the tool ACL resolves
         // against, so a key that names its limits by server id and its
         // grants by server id sees one rename take effect at one instant.
         let servers = state.mcp_servers.for_snapshot(snapshot);
-        if let Some(limits) = auth.key().mcp_rate_limit(&servers, server) {
-            let rl = RateLimit::from(limits);
+        if let Some(limit) = auth.key().mcp_rate_limit(&servers, server) {
+            let rl = RateLimit::from(limit.limits);
             if !rl.is_unrestricted() {
-                let key = format!("mcp:{}:{}", auth.entry.id, server);
+                let key = format!("mcp:{}:{}", auth.entry.id, limit.bucket);
                 let r = state
                     .limiter
                     .pre_commit(&key, &rl)

--- a/crates/aisix-proxy/src/state.rs
+++ b/crates/aisix-proxy/src/state.rs
@@ -16,7 +16,7 @@
 
 use aisix_cache::{Cache, MemoryCache, MemorySemanticCache, SemanticCacheStore};
 use aisix_core::models::CacheBackend;
-use aisix_core::models::LivePricingIndex;
+use aisix_core::models::{LiveMcpServerIndex, LivePricingIndex};
 use aisix_core::snapshot::SnapshotHandle;
 use aisix_core::{AisixSnapshot, ProxyConfig};
 use aisix_gateway::Hub;
@@ -189,6 +189,11 @@ pub struct ProxyStateInner {
     /// the usage events — so ranking and billing cannot disagree about
     /// what a model costs.
     pub pricing: Arc<LivePricingIndex>,
+    /// Registered MCP servers by name → resource id, rebuilt only when the
+    /// `mcp_servers` table changes. Both MCP gates that a key can address by
+    /// server id read it — the tool ACL and the per-server rate limit — so
+    /// the two resolve a rename at the same instant.
+    pub mcp_servers: Arc<LiveMcpServerIndex>,
     /// Per-request budget gate. Asks cp-api whether the api_key may
     /// proceed; cached for 5s with sticky fallback on cp-api outage.
     pub budgets: Arc<BudgetClient>,
@@ -330,6 +335,7 @@ impl ProxyState {
             semantic_cache,
             guardrail_index,
             pricing: Arc::new(LivePricingIndex::new()),
+            mcp_servers: Arc::new(LiveMcpServerIndex::new()),
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
             livez: Arc::new(LivezState::new()),
@@ -379,6 +385,7 @@ impl ProxyState {
             semantic_cache,
             guardrail_index,
             pricing: Arc::new(LivePricingIndex::new()),
+            mcp_servers: Arc::new(LiveMcpServerIndex::new()),
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::new()),
             livez: Arc::new(LivezState::new()),
@@ -442,6 +449,7 @@ impl ProxyState {
             semantic_cache,
             guardrail_index,
             pricing: Arc::new(LivePricingIndex::new()),
+            mcp_servers: Arc::new(LiveMcpServerIndex::new()),
             budgets: Arc::new(BudgetClient::disabled()),
             health: Arc::new(HealthTracker::with_flags(bookkeeping_flags)),
             livez: Arc::new(LivezState::new()),

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -84,6 +84,7 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
     let provider_key_names = id_to_name(&snapshot.provider_keys, |pk| pk.display_name.clone());
     let model_names = id_to_name(&snapshot.models, |m| m.display_name.clone());
     let api_key_names = id_to_name(&snapshot.apikeys, |k| synthetic_api_key_name(&k.key_hash));
+    let mcp_server_names = id_to_name(&snapshot.mcp_servers, |s| s.name.clone());
 
     let mut collections: Vec<(&'static str, Vec<Value>)> = Vec::new();
 
@@ -157,6 +158,7 @@ pub fn build_export_document(snapshot: &AisixSnapshot, reveal_secrets: bool) -> 
                     map.insert("display_name".into(), Value::String(identity.to_string()));
                 }
                 resugar_allowed_models(doc, identity, &model_names, diag);
+                resugar_mcp_refs(doc, identity, &mcp_server_names, diag);
             },
             |_, _| {},
         ),
@@ -808,6 +810,79 @@ fn resugar_model_refs(
     });
     diag.blocking.extend(blocking);
     diag.warnings.extend(warnings);
+}
+
+/// An API key's MCP references (etcd server ids) → the name form.
+///
+/// Three fields carry a server by id: `mcp_rate_limits_by_id`, and the
+/// `allow_ids` / `deny_ids` sides of `mcp_access`. The file source grants
+/// and limits MCP servers by name, so each is resolved to the identity the
+/// `mcp_servers` collection is keyed by and re-emitted under the name field
+/// it shadows. The id form is a control-plane projection and is never
+/// written to a resources file.
+///
+/// The id form is authoritative at runtime, so the name form it shadows is
+/// REPLACED rather than merged: keeping both would export a key whose stored
+/// grant and exported grant differ.
+///
+/// An entry naming no exported server is dropped with a warning. For a grant
+/// that makes the key reach LESS, which is the safe direction and the one the
+/// gateway already takes for an unresolvable id; for a limit it means the
+/// exported key is bounded by its own `rate_limit` alone, which is why that
+/// case warns too.
+fn resugar_mcp_refs(
+    doc: &mut Value,
+    api_key: &str,
+    mcp_server_names: &BTreeMap<String, String>,
+    diag: &mut Diagnostics,
+) {
+    let Some(map) = doc.as_object_mut() else {
+        return;
+    };
+
+    if let Some(Value::Object(by_id)) = map.remove("mcp_rate_limits_by_id") {
+        let mut by_name = serde_json::Map::new();
+        for (id, limits) in by_id {
+            match mcp_server_names.get(&id) {
+                Some(name) => {
+                    by_name.insert(name.clone(), limits);
+                }
+                None => diag.warnings.push(format!(
+                    "api key {api_key:?} limits MCP server id {id:?}, which is not among the \
+                     exported MCP servers — the limit is dropped (the gateway already treats it \
+                     as imposing nothing)"
+                )),
+            }
+        }
+        map.insert("mcp_rate_limits".into(), Value::Object(by_name));
+    }
+
+    let Some(Value::Object(access)) = map.get_mut("mcp_access") else {
+        return;
+    };
+    for (id_field, name_field) in [("allow_ids", "allow"), ("deny_ids", "deny")] {
+        let Some(Value::Array(refs)) = access.remove(id_field) else {
+            continue;
+        };
+        let mut patterns = Vec::with_capacity(refs.len());
+        for entry in &refs {
+            let (Some(id), Some(tool)) = (
+                entry.get("server_id").and_then(Value::as_str),
+                entry.get("tool").and_then(Value::as_str),
+            ) else {
+                continue;
+            };
+            match mcp_server_names.get(id) {
+                Some(name) => patterns.push(Value::String(format!("{name}__{tool}"))),
+                None => diag.warnings.push(format!(
+                    "api key {api_key:?} names MCP server id {id:?} under \
+                     `mcp_access.{id_field}`, which is not among the exported MCP servers — the \
+                     entry is dropped (the gateway already treats it as matching nothing)"
+                )),
+            }
+        }
+        access.insert(name_field.into(), Value::Array(patterns));
+    }
 }
 
 /// `claim_mapping.resolve.api_key_id` (etcd id) → `resolve.api_key`

--- a/crates/aisix-server/src/export/document.rs
+++ b/crates/aisix-server/src/export/document.rs
@@ -830,6 +830,10 @@ fn resugar_model_refs(
 /// gateway already takes for an unresolvable id; for a limit it means the
 /// exported key is bounded by its own `rate_limit` alone, which is why that
 /// case warns too.
+///
+/// An entry whose server's NAME contains a `*` gets no name form at all: see
+/// the comment at the match below. The per-server limits are unaffected —
+/// they key a map by the exact name rather than building a glob.
 fn resugar_mcp_refs(
     doc: &mut Value,
     api_key: &str,
@@ -873,6 +877,33 @@ fn resugar_mcp_refs(
                 continue;
             };
             match mcp_server_names.get(id) {
+                // A registered name may legally contain a `*` — the name
+                // pattern only forbids `__` and a trailing `_` — and the
+                // name form is glob-matched, so `gh*__read` built from a
+                // server named `gh*` would also cover `ghost__read`. The
+                // runtime never does this (it compares the server id
+                // exactly); neither may the export. The name form simply
+                // cannot express such a reference, so the entry does not
+                // get one — dropped on the allow side, where reaching less
+                // is the safe direction, and blocking on the deny side,
+                // where dropping it would let the file permit what the
+                // gateway forbids.
+                Some(name) if name.contains('*') => {
+                    let note = format!(
+                        "api key {api_key:?} names MCP server {name:?} under \
+                         `mcp_access.{id_field}`, whose name contains `*`; a \
+                         `<server>__<tool>` pattern built from it would match a different \
+                         server"
+                    );
+                    if name_field == "deny" {
+                        diag.blocking.push(format!(
+                            "{note} — the exported file cannot express this denial and would \
+                             permit a tool the gateway blocks"
+                        ));
+                    } else {
+                        diag.warnings.push(format!("{note} — the entry is dropped"));
+                    }
+                }
                 Some(name) => patterns.push(Value::String(format!("{name}__{tool}"))),
                 None => diag.warnings.push(format!(
                     "api key {api_key:?} names MCP server id {id:?} under \

--- a/crates/aisix-server/src/export/document_tests.rs
+++ b/crates/aisix-server/src/export/document_tests.rs
@@ -1060,3 +1060,116 @@ fn guardrail_embedder_id_resugars_to_a_name() {
         doc.warnings
     );
 }
+
+/// Register `(id, name)` MCP servers on `snap`.
+fn register_mcp_servers(snap: &AisixSnapshot, servers: &[(&str, &str)]) {
+    for (id, name) in servers {
+        snap.mcp_servers.insert(ResourceEntry::new(
+            *id,
+            serde_json::from_value(json!({"name": name, "url": "https://example.test/mcp"}))
+                .unwrap(),
+            1,
+        ));
+    }
+}
+
+#[test]
+fn api_key_mcp_reference_ids_resugar_to_names() {
+    let snap = AisixSnapshot::new();
+    register_mcp_servers(&snap, &[("s-uuid-1", "github"), ("s-uuid-2", "slack")]);
+    snap.apikeys.insert(ResourceEntry::new(
+        "k-uuid-1",
+        serde_json::from_value(json!({
+            "key_hash": "aa".repeat(32),
+            "allowed_models": [],
+            "mcp_rate_limits": {"stale-name": {"rpm": 9}},
+            "mcp_rate_limits_by_id": {"s-uuid-2": {"rpm": 1}},
+            "mcp_access": {
+                "allow": ["stale-name__*"],
+                "allow_ids": [{"server_id": "s-uuid-1", "tool": "create_issue"}],
+                "deny": ["stale-name__drop"],
+                "deny_ids": [{"server_id": "s-uuid-1", "tool": "delete_*"}]
+            }
+        }))
+        .unwrap(),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    let keys = find(&doc, "api_keys");
+    // The file source names its MCP servers: the id form never reaches it,
+    // and each name it resolves to replaces the shadowed name field
+    // wholesale — keeping the stale one would export a different ACL than
+    // the gateway is enforcing.
+    assert!(keys[0].get("mcp_rate_limits_by_id").is_none());
+    assert_eq!(keys[0]["mcp_rate_limits"], json!({"slack": {"rpm": 1}}));
+    assert!(keys[0]["mcp_access"].get("allow_ids").is_none());
+    assert!(keys[0]["mcp_access"].get("deny_ids").is_none());
+    assert_eq!(
+        keys[0]["mcp_access"]["allow"],
+        json!(["github__create_issue"])
+    );
+    assert_eq!(keys[0]["mcp_access"]["deny"], json!(["github__delete_*"]));
+    assert!(doc.warnings.is_empty(), "{:?}", doc.warnings);
+    assert!(doc.blocking.is_empty(), "{:?}", doc.blocking);
+}
+
+#[test]
+fn api_key_unresolvable_mcp_server_ids_are_dropped_and_warned() {
+    let snap = AisixSnapshot::new();
+    register_mcp_servers(&snap, &[("s-uuid-1", "github")]);
+    snap.apikeys.insert(ResourceEntry::new(
+        "k-uuid-1",
+        serde_json::from_value(json!({
+            "key_hash": "aa".repeat(32),
+            "allowed_models": [],
+            "mcp_rate_limits_by_id": {"s-uuid-1": {"rpm": 1}, "s-gone": {"rpm": 2}},
+            "mcp_access": {
+                "allow": [],
+                "allow_ids": [
+                    {"server_id": "s-uuid-1", "tool": "*"},
+                    {"server_id": "s-gone", "tool": "*"}
+                ]
+            }
+        }))
+        .unwrap(),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    let keys = find(&doc, "api_keys");
+    assert_eq!(keys[0]["mcp_rate_limits"], json!({"github": {"rpm": 1}}));
+    assert_eq!(keys[0]["mcp_access"]["allow"], json!(["github__*"]));
+    assert_eq!(
+        doc.warnings.iter().filter(|w| w.contains("s-gone")).count(),
+        2,
+        "one warning for the dropped limit and one for the dropped grant: {:?}",
+        doc.warnings
+    );
+    assert!(doc.blocking.is_empty(), "{:?}", doc.blocking);
+}
+
+#[test]
+fn api_key_empty_mcp_id_forms_export_as_no_grant_and_no_limit() {
+    let snap = AisixSnapshot::new();
+    register_mcp_servers(&snap, &[("s-uuid-1", "github")]);
+    snap.apikeys.insert(ResourceEntry::new(
+        "k-uuid-1",
+        serde_json::from_value(json!({
+            "key_hash": "aa".repeat(32),
+            "allowed_models": [],
+            "mcp_rate_limits": {"github": {"rpm": 9}},
+            "mcp_rate_limits_by_id": {},
+            "mcp_access": {"allow": ["*"], "allow_ids": []}
+        }))
+        .unwrap(),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    let keys = find(&doc, "api_keys");
+    // Both empty id forms are authoritative at runtime, so the exported
+    // file must not resurrect the ignored name forms.
+    assert_eq!(keys[0]["mcp_rate_limits"], json!({}));
+    assert_eq!(keys[0]["mcp_access"]["allow"], json!([]));
+}

--- a/crates/aisix-server/src/export/document_tests.rs
+++ b/crates/aisix-server/src/export/document_tests.rs
@@ -1173,3 +1173,71 @@ fn api_key_empty_mcp_id_forms_export_as_no_grant_and_no_limit() {
     assert_eq!(keys[0]["mcp_rate_limits"], json!({}));
     assert_eq!(keys[0]["mcp_access"]["allow"], json!([]));
 }
+
+#[test]
+fn a_server_name_containing_a_star_gets_no_name_form_grant() {
+    // A registered name may legally contain a `*`. The runtime compares
+    // the server id exactly, so an id grant on `gh*` reaches `gh*` alone —
+    // but `gh*__read` as a name-form pattern also matches `ghost__read`.
+    // The export must not manufacture that grant.
+    let snap = AisixSnapshot::new();
+    register_mcp_servers(&snap, &[("s-star", "gh*"), ("s-other", "ghost")]);
+    snap.apikeys.insert(ResourceEntry::new(
+        "k-uuid-1",
+        serde_json::from_value(json!({
+            "key_hash": "aa".repeat(32),
+            "allowed_models": [],
+            "mcp_access": {
+                "allow": [],
+                "allow_ids": [
+                    {"server_id": "s-star", "tool": "read"},
+                    {"server_id": "s-other", "tool": "read"}
+                ]
+            }
+        }))
+        .unwrap(),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    let keys = find(&doc, "api_keys");
+    assert_eq!(keys[0]["mcp_access"]["allow"], json!(["ghost__read"]));
+    assert!(
+        doc.warnings.iter().any(|w| w.contains("gh*")),
+        "{:?}",
+        doc.warnings
+    );
+    assert!(doc.blocking.is_empty(), "{:?}", doc.blocking);
+}
+
+#[test]
+fn a_star_named_server_on_the_deny_side_blocks_the_export() {
+    // Dropping the entry would leave the exported file permitting a tool
+    // the gateway blocks, and emitting `gh*__delete` would deny one it
+    // allows. Neither is a file that reproduces the gateway, so the export
+    // says so instead of picking.
+    let snap = AisixSnapshot::new();
+    register_mcp_servers(&snap, &[("s-star", "gh*")]);
+    snap.apikeys.insert(ResourceEntry::new(
+        "k-uuid-1",
+        serde_json::from_value(json!({
+            "key_hash": "aa".repeat(32),
+            "allowed_models": [],
+            "mcp_access": {
+                "allow": ["*"],
+                "deny_ids": [{"server_id": "s-star", "tool": "delete"}]
+            }
+        }))
+        .unwrap(),
+        1,
+    ));
+
+    let doc = build_export_document(&snap, false);
+    assert!(
+        doc.blocking.iter().any(|b| b.contains("gh*")),
+        "{:?}",
+        doc.blocking
+    );
+    let keys = find(&doc, "api_keys");
+    assert_eq!(keys[0]["mcp_access"]["deny"], json!([]));
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -135,10 +135,11 @@ either way, so rejecting it is what makes it visible in
 These come from the four producers that take a `strict` flag in
 `crates/aisix-core/src/models/schema.rs` and are deliberate.
 
-Separately, the lenient files keep three `default` annotations the
+Separately, the lenient files keep five `default` annotations the
 strict producer strips on purpose — `default: 0.75` on the `semantic`
 guardrail's `allow_threshold`/`deny_threshold`, and `default: ""` on the
-`custom` kind's `script`, which sits beside `minLength: 1`. They change
+`custom` kind's `script` and on both halves of `McpToolRef`, each of
+which sits beside `minLength: 1`. They change
 nothing about what validates, but a form generator that honours them
 pre-fills a threshold the operator was deliberately asked to choose, or
 a script value the same branch refuses. Generate forms from

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -112,10 +112,20 @@ so a consumer that models the lenient set as "the strict set with
 
 | resource | additionally relaxed on read |
 | --- | --- |
-| `api_key` | `McpAccess.allow` is not required |
+| `api_key` | `McpAccess.allow` is not required; an `McpToolRef` entry needs neither half, and neither has to be non-empty; the write-path guards requiring `deny` beside `deny_ids` and `mcp_rate_limits` beside `mcp_rate_limits_by_id` are absent |
 | `guardrail` | the `semantic` kind requires neither an embedding model (under either spelling) nor a threshold beside each example list |
-| `mcp_policy` | `allow` is not required |
+| `mcp_policy` | `allow` is not required; the `McpToolRef` relaxations above apply here too, as does the absent `deny`-beside-`deny_ids` guard (its team-scope guard is on both sets) |
 | `model` | the per-kind `not`/`anyOf` lists that forbid a knob a kind never resolves are shorter — a stored row keeps loading and `Model::strip_kind_inapplicable` drops the dead knob |
+
+Two of those are worth spelling out. A half-written `McpToolRef` entry
+has to keep DESERIALIZING, not merely validating: the loader skips a row
+it cannot deserialize whole, and for an `api_key` that stops the key
+authenticating every kind of traffic rather than costing it MCP access.
+The malformed entry matches no server and no tool instead. And the
+name-form guards are a write contract only — a stored row that carries
+just the id spelling still loads, it is only new writes that must carry
+both, so that a gateway one release behind the control plane can still
+read the restriction.
 
 Note what is NOT in that table: the `custom` guardrail's `script` is
 required on **both** sets. A scriptless `custom` row screens nothing

--- a/schemas/resources-lenient/api_key.schema.json
+++ b/schemas/resources-lenient/api_key.schema.json
@@ -13,7 +13,7 @@
           "type": "array"
         },
         "allow_ids": {
-          "description": "This key's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the key may reach. Present — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Absent or `null`, the key falls back to `allow`.",
+          "description": "This key's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the key may reach. Present — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Absent or `null`, the key falls back to `allow`.\n\nIt cannot express \"every server\": each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow. To allow (or deny) every server, present and future, leave this absent and use the name form's `\"*\"`.",
           "items": {
             "$ref": "#/definitions/McpToolRef"
           },
@@ -30,7 +30,7 @@
           "type": "array"
         },
         "deny_ids": {
-          "description": "This key's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the key falls back to `deny`.",
+          "description": "This key's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the key falls back to `deny`.\n\nIt cannot express \"every server\": each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow. To allow (or deny) every server, present and future, leave this absent and use the name form's `\"*\"`.",
           "items": {
             "$ref": "#/definitions/McpToolRef"
           },
@@ -94,23 +94,19 @@
       "type": "object"
     },
     "McpToolRef": {
-      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.",
+      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.\n\nBoth halves are required on the WRITE path and defaulted by the runtime loader — the strict schemas add them to this definition's `required`, the types do not. An entry these were required of at the type level would fail to deserialize, and the loader skips a row it cannot deserialize whole: one malformed entry in one `allow_ids` array would stop the entire `api_key` from authenticating any traffic at all, not merely lose it MCP access. Defaulted, the malformed entry matches nothing instead — an empty `server_id` names no registered server, and an empty `tool` glob covers no tool name the gateway exposes.",
       "properties": {
         "server_id": {
+          "default": "",
           "description": "Resource id of the registered MCP server (`mcp_servers/<id>`) this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
-          "minLength": 1,
           "type": "string"
         },
         "tool": {
+          "default": "",
           "description": "Tool on that server, matched as a single-`*` glob against the bare tool name — the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
-          "minLength": 1,
           "type": "string"
         }
       },
-      "required": [
-        "server_id",
-        "tool"
-      ],
       "type": "object"
     },
     "RateLimit": {
@@ -286,7 +282,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/McpRateLimit"
       },
-      "description": "The same per-server limits, keyed by the MCP server's resource id (`mcp_servers/<id>`) rather than by its name, so renaming a server does not detach the limit that was set for it.\n\nPresent — including as an empty object — it is authoritative and `mcp_rate_limits` is ignored; an empty object therefore leaves every server bounded by `rate_limit` alone. A key naming no registered server imposes nothing, and the other entries are unaffected. Set to `null` it means the same as omitted: the key falls back to `mcp_rate_limits`.",
+      "description": "The same per-server limits, keyed by the MCP server's resource id (`mcp_servers/<id>`) rather than by its name, so renaming a server does not detach the limit that was set for it.\n\nPresent — including as an empty object — it is authoritative and `mcp_rate_limits` is ignored; an empty object therefore leaves every server bounded by `rate_limit` alone. A key naming no registered server imposes nothing, and the other entries are unaffected. Set to `null` it means the same as omitted: the key falls back to `mcp_rate_limits`.\n\nEach key names one server exactly; there is no \"every server\" key, which is the same as today — a server with no entry is bounded by `rate_limit` alone.",
       "type": [
         "object",
         "null"

--- a/schemas/resources-lenient/api_key.schema.json
+++ b/schemas/resources-lenient/api_key.schema.json
@@ -6,18 +6,38 @@
       "properties": {
         "allow": {
           "default": [],
-          "description": "Namespaced `<server>__<tool>` patterns this key allows, intersected with the environment and team layers. Same single-`*` glob matching a policy's `allow` uses; an empty list leaves the key no MCP access, and `[\"*\"]` narrows nothing (useful with `deny` alone).\n\nRequired on the write path and defaulted by the runtime loader, for the reason given on [`McpPolicy::allow`].",
+          "description": "Namespaced `<server>__<tool>` patterns this key allows, intersected with the environment and team layers. Same single-`*` glob matching a policy's `allow` uses; an empty list leaves the key no MCP access, and `[\"*\"]` narrows nothing (useful with `deny` alone).\n\nRequired on the write path and defaulted by the runtime loader, for the reason given on [`McpPolicy::allow`]. Read only when `allow_ids` is absent; ignored entirely when it is present.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
+        "allow_ids": {
+          "description": "This key's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the key may reach. Present — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Absent or `null`, the key falls back to `allow`.",
+          "items": {
+            "$ref": "#/definitions/McpToolRef"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "deny": {
-          "description": "Namespaced `<server>__<tool>` patterns subtracted from this key's effective grant, using the same single-`*` glob matching as `allow`.",
+          "description": "Namespaced `<server>__<tool>` patterns subtracted from this key's effective grant, using the same single-`*` glob matching as `allow`. Read only when `deny_ids` is absent.",
           "items": {
             "type": "string"
           },
           "type": "array"
+        },
+        "deny_ids": {
+          "description": "This key's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the key falls back to `deny`.",
+          "items": {
+            "$ref": "#/definitions/McpToolRef"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
       "type": "object"
@@ -71,6 +91,26 @@
           ]
         }
       },
+      "type": "object"
+    },
+    "McpToolRef": {
+      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.",
+      "properties": {
+        "server_id": {
+          "description": "Resource id of the registered MCP server (`mcp_servers/<id>`) this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "tool": {
+          "description": "Tool on that server, matched as a single-`*` glob against the bare tool name — the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "server_id",
+        "tool"
+      ],
       "type": "object"
     },
     "RateLimit": {
@@ -230,13 +270,23 @@
           "type": "null"
         }
       ],
-      "description": "This key's own layer of the MCP tool ACL, as namespaced `<server>__<tool>` glob patterns. It is intersected with the environment and team MCP access policies: every present layer must allow a tool and no layer may deny it. When omitted the key adds no constraint of its own — but with no layer present anywhere the grant is empty, so MCP access is always granted explicitly."
+      "description": "This key's own layer of the MCP tool ACL, as namespaced `<server>__<tool>` glob patterns, or as `allow_ids` / `deny_ids` entries naming the server by resource id. It is intersected with the environment and team MCP access policies: every present layer must allow a tool and no layer may deny it. When omitted the key adds no constraint of its own — but with no layer present anywhere the grant is empty, so MCP access is always granted explicitly."
     },
     "mcp_rate_limits": {
       "additionalProperties": {
         "$ref": "#/definitions/McpRateLimit"
       },
-      "description": "Per-MCP-server limits for this key, keyed by the registered MCP server name — the `<server>` half of the `<server>__<tool>` names the gateway exposes. A `tools/call` is metered against the entry for the server it targets **and** the key's own `rate_limit`, each in its own counter, so a burst against one server never consumes another's budget. A server with no entry here is bounded by `rate_limit` alone. Only tool calls are metered; the `initialize` / `tools/list` handshake is not.",
+      "description": "Per-MCP-server limits for this key, keyed by the registered MCP server name — the `<server>` half of the `<server>__<tool>` names the gateway exposes. A `tools/call` is metered against the entry for the server it targets **and** the key's own `rate_limit`, each in its own counter, so a burst against one server never consumes another's budget. A server with no entry here is bounded by `rate_limit` alone. Only tool calls are metered; the `initialize` / `tools/list` handshake is not.\n\nRead only when `mcp_rate_limits_by_id` is absent; ignored entirely when it is present.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "mcp_rate_limits_by_id": {
+      "additionalProperties": {
+        "$ref": "#/definitions/McpRateLimit"
+      },
+      "description": "The same per-server limits, keyed by the MCP server's resource id (`mcp_servers/<id>`) rather than by its name, so renaming a server does not detach the limit that was set for it.\n\nPresent — including as an empty object — it is authoritative and `mcp_rate_limits` is ignored; an empty object therefore leaves every server bounded by `rate_limit` alone. A key naming no registered server imposes nothing, and the other entries are unaffected. Set to `null` it means the same as omitted: the key falls back to `mcp_rate_limits`.",
       "type": [
         "object",
         "null"

--- a/schemas/resources-lenient/mcp_policy.schema.json
+++ b/schemas/resources-lenient/mcp_policy.schema.json
@@ -43,23 +43,19 @@
       ]
     },
     "McpToolRef": {
-      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.",
+      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.\n\nBoth halves are required on the WRITE path and defaulted by the runtime loader — the strict schemas add them to this definition's `required`, the types do not. An entry these were required of at the type level would fail to deserialize, and the loader skips a row it cannot deserialize whole: one malformed entry in one `allow_ids` array would stop the entire `api_key` from authenticating any traffic at all, not merely lose it MCP access. Defaulted, the malformed entry matches nothing instead — an empty `server_id` names no registered server, and an empty `tool` glob covers no tool name the gateway exposes.",
       "properties": {
         "server_id": {
+          "default": "",
           "description": "Resource id of the registered MCP server (`mcp_servers/<id>`) this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
-          "minLength": 1,
           "type": "string"
         },
         "tool": {
+          "default": "",
           "description": "Tool on that server, matched as a single-`*` glob against the bare tool name — the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
-          "minLength": 1,
           "type": "string"
         }
       },
-      "required": [
-        "server_id",
-        "tool"
-      ],
       "type": "object"
     }
   },
@@ -73,7 +69,7 @@
       "type": "array"
     },
     "allow_ids": {
-      "description": "This layer's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the layer allows. Each entry names one MCP server by the id it is registered under and one tool by name, the tool matched as a single-`*` glob against the bare tool name.\n\nPresent — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Set to `null` it means the same as omitted: the layer falls back to `allow`.",
+      "description": "This layer's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the layer allows. Each entry names one MCP server by the id it is registered under and one tool by name, the tool matched as a single-`*` glob against the bare tool name.\n\nPresent — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Set to `null` it means the same as omitted: the layer falls back to `allow`.\n\nIt cannot express \"every server\": each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow. To allow (or deny) every server, present and future, leave this absent and use the name form's `\"*\"`.",
       "items": {
         "$ref": "#/definitions/McpToolRef"
       },
@@ -90,7 +86,7 @@
       "type": "array"
     },
     "deny_ids": {
-      "description": "This layer's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the layer falls back to `deny`.",
+      "description": "This layer's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the layer falls back to `deny`.\n\nIt cannot express \"every server\": each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow. To allow (or deny) every server, present and future, leave this absent and use the name form's `\"*\"`.",
       "items": {
         "$ref": "#/definitions/McpToolRef"
       },

--- a/schemas/resources-lenient/mcp_policy.schema.json
+++ b/schemas/resources-lenient/mcp_policy.schema.json
@@ -41,23 +41,63 @@
           "type": "string"
         }
       ]
+    },
+    "McpToolRef": {
+      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.",
+      "properties": {
+        "server_id": {
+          "description": "Resource id of the registered MCP server (`mcp_servers/<id>`) this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "tool": {
+          "description": "Tool on that server, matched as a single-`*` glob against the bare tool name — the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "server_id",
+        "tool"
+      ],
+      "type": "object"
     }
   },
   "properties": {
     "allow": {
       "default": [],
-      "description": "Namespaced `<server>__<tool>` patterns this layer allows. Entries are matched as single-`*` globs: `\"*\"` allows every tool, `\"<server>__*\"` every tool on one server, and an entry without a `*` matches one tool exactly. An empty list allows nothing, which is how a policy blocks all MCP access; a policy that only means to subtract tools writes `[\"*\"]` here and lists them under `deny`.\n\nThe write path requires the field (the strict schema adds it to `required`), so a layer never allows something by omission. The runtime loader defaults it to empty instead of rejecting the row: a document written before the layered shape would otherwise fail to deserialize, and a skipped `api_key` row stops authenticating altogether rather than merely losing MCP access.",
+      "description": "Namespaced `<server>__<tool>` patterns this layer allows. Entries are matched as single-`*` globs: `\"*\"` allows every tool, `\"<server>__*\"` every tool on one server, and an entry without a `*` matches one tool exactly. An empty list allows nothing, which is how a policy blocks all MCP access; a policy that only means to subtract tools writes `[\"*\"]` here and lists them under `deny`.\n\nThe write path requires the field (the strict schema adds it to `required`), so a layer never allows something by omission. The runtime loader defaults it to empty instead of rejecting the row: a document written before the layered shape would otherwise fail to deserialize, and a skipped `api_key` row stops authenticating altogether rather than merely losing MCP access.\n\nRead only when `allow_ids` is absent; ignored entirely when it is present.",
       "items": {
         "type": "string"
       },
       "type": "array"
     },
+    "allow_ids": {
+      "description": "This layer's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the layer allows. Each entry names one MCP server by the id it is registered under and one tool by name, the tool matched as a single-`*` glob against the bare tool name.\n\nPresent — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Set to `null` it means the same as omitted: the layer falls back to `allow`.",
+      "items": {
+        "$ref": "#/definitions/McpToolRef"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
     "deny": {
-      "description": "Namespaced `<server>__<tool>` patterns subtracted from the effective grant of every key the policy applies to, using the same single-`*` glob matching as `allow`. Deny always wins: a tool matched here stays unavailable however the other layers allow it.",
+      "description": "Namespaced `<server>__<tool>` patterns subtracted from the effective grant of every key the policy applies to, using the same single-`*` glob matching as `allow`. Deny always wins: a tool matched here stays unavailable however the other layers allow it.\n\nRead only when `deny_ids` is absent; ignored entirely when it is present.",
       "items": {
         "type": "string"
       },
       "type": "array"
+    },
+    "deny_ids": {
+      "description": "This layer's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the layer falls back to `deny`.",
+      "items": {
+        "$ref": "#/definitions/McpToolRef"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
     },
     "enabled": {
       "default": true,

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -1,9 +1,47 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "mcp_rate_limits_by_id": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "mcp_rate_limits_by_id"
+        ]
+      },
+      "then": {
+        "required": [
+          "mcp_rate_limits"
+        ]
+      }
+    }
+  ],
   "definitions": {
     "McpAccess": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "deny_ids": {
+                "type": "array"
+              }
+            },
+            "required": [
+              "deny_ids"
+            ]
+          },
+          "then": {
+            "required": [
+              "deny"
+            ]
+          }
+        }
+      ],
       "description": "The API key's own layer of the MCP tool ACL, the same `allow`/`deny` shape an MCP access policy carries. Present means the key constrains its grant; omitted means the key adds no constraint of its own and takes whatever the environment and team layers leave.",
       "properties": {
         "allow": {
@@ -15,7 +53,7 @@
           "type": "array"
         },
         "allow_ids": {
-          "description": "This key's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the key may reach. Present — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Absent or `null`, the key falls back to `allow`.",
+          "description": "This key's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the key may reach. Present — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Absent or `null`, the key falls back to `allow`.\n\nIt cannot express \"every server\": each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow. To allow (or deny) every server, present and future, leave this absent and use the name form's `\"*\"`.",
           "items": {
             "$ref": "#/definitions/McpToolRef"
           },
@@ -32,7 +70,7 @@
           "type": "array"
         },
         "deny_ids": {
-          "description": "This key's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the key falls back to `deny`.",
+          "description": "This key's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the key falls back to `deny`.\n\nIt cannot express \"every server\": each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow. To allow (or deny) every server, present and future, leave this absent and use the name form's `\"*\"`.",
           "items": {
             "$ref": "#/definitions/McpToolRef"
           },
@@ -101,14 +139,16 @@
     },
     "McpToolRef": {
       "additionalProperties": false,
-      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.",
+      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.\n\nBoth halves are required on the WRITE path and defaulted by the runtime loader — the strict schemas add them to this definition's `required`, the types do not. An entry these were required of at the type level would fail to deserialize, and the loader skips a row it cannot deserialize whole: one malformed entry in one `allow_ids` array would stop the entire `api_key` from authenticating any traffic at all, not merely lose it MCP access. Defaulted, the malformed entry matches nothing instead — an empty `server_id` names no registered server, and an empty `tool` glob covers no tool name the gateway exposes.",
       "properties": {
         "server_id": {
+          "default": "",
           "description": "Resource id of the registered MCP server (`mcp_servers/<id>`) this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
           "minLength": 1,
           "type": "string"
         },
         "tool": {
+          "default": "",
           "description": "Tool on that server, matched as a single-`*` glob against the bare tool name — the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
           "minLength": 1,
           "type": "string"
@@ -294,7 +334,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/McpRateLimit"
       },
-      "description": "The same per-server limits, keyed by the MCP server's resource id (`mcp_servers/<id>`) rather than by its name, so renaming a server does not detach the limit that was set for it.\n\nPresent — including as an empty object — it is authoritative and `mcp_rate_limits` is ignored; an empty object therefore leaves every server bounded by `rate_limit` alone. A key naming no registered server imposes nothing, and the other entries are unaffected. Set to `null` it means the same as omitted: the key falls back to `mcp_rate_limits`.",
+      "description": "The same per-server limits, keyed by the MCP server's resource id (`mcp_servers/<id>`) rather than by its name, so renaming a server does not detach the limit that was set for it.\n\nPresent — including as an empty object — it is authoritative and `mcp_rate_limits` is ignored; an empty object therefore leaves every server bounded by `rate_limit` alone. A key naming no registered server imposes nothing, and the other entries are unaffected. Set to `null` it means the same as omitted: the key falls back to `mcp_rate_limits`.\n\nEach key names one server exactly; there is no \"every server\" key, which is the same as today — a server with no entry is bounded by `rate_limit` alone.",
       "type": [
         "object",
         "null"

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -142,13 +142,11 @@
       "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.\n\nBoth halves are required on the WRITE path and defaulted by the runtime loader — the strict schemas add them to this definition's `required`, the types do not. An entry these were required of at the type level would fail to deserialize, and the loader skips a row it cannot deserialize whole: one malformed entry in one `allow_ids` array would stop the entire `api_key` from authenticating any traffic at all, not merely lose it MCP access. Defaulted, the malformed entry matches nothing instead — an empty `server_id` names no registered server, and an empty `tool` glob covers no tool name the gateway exposes.",
       "properties": {
         "server_id": {
-          "default": "",
           "description": "Resource id of the registered MCP server (`mcp_servers/<id>`) this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
           "minLength": 1,
           "type": "string"
         },
         "tool": {
-          "default": "",
           "description": "Tool on that server, matched as a single-`*` glob against the bare tool name — the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
           "minLength": 1,
           "type": "string"

--- a/schemas/resources/api_key.schema.json
+++ b/schemas/resources/api_key.schema.json
@@ -8,18 +8,38 @@
       "properties": {
         "allow": {
           "default": [],
-          "description": "Namespaced `<server>__<tool>` patterns this key allows, intersected with the environment and team layers. Same single-`*` glob matching a policy's `allow` uses; an empty list leaves the key no MCP access, and `[\"*\"]` narrows nothing (useful with `deny` alone).\n\nRequired on the write path and defaulted by the runtime loader, for the reason given on [`McpPolicy::allow`].",
+          "description": "Namespaced `<server>__<tool>` patterns this key allows, intersected with the environment and team layers. Same single-`*` glob matching a policy's `allow` uses; an empty list leaves the key no MCP access, and `[\"*\"]` narrows nothing (useful with `deny` alone).\n\nRequired on the write path and defaulted by the runtime loader, for the reason given on [`McpPolicy::allow`]. Read only when `allow_ids` is absent; ignored entirely when it is present.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
+        "allow_ids": {
+          "description": "This key's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the key may reach. Present — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Absent or `null`, the key falls back to `allow`.",
+          "items": {
+            "$ref": "#/definitions/McpToolRef"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "deny": {
-          "description": "Namespaced `<server>__<tool>` patterns subtracted from this key's effective grant, using the same single-`*` glob matching as `allow`.",
+          "description": "Namespaced `<server>__<tool>` patterns subtracted from this key's effective grant, using the same single-`*` glob matching as `allow`. Read only when `deny_ids` is absent.",
           "items": {
             "type": "string"
           },
           "type": "array"
+        },
+        "deny_ids": {
+          "description": "This key's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the key falls back to `deny`.",
+          "items": {
+            "$ref": "#/definitions/McpToolRef"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
       "required": [
@@ -77,6 +97,27 @@
           ]
         }
       },
+      "type": "object"
+    },
+    "McpToolRef": {
+      "additionalProperties": false,
+      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.",
+      "properties": {
+        "server_id": {
+          "description": "Resource id of the registered MCP server (`mcp_servers/<id>`) this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "tool": {
+          "description": "Tool on that server, matched as a single-`*` glob against the bare tool name — the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "server_id",
+        "tool"
+      ],
       "type": "object"
     },
     "RateLimit": {
@@ -237,13 +278,23 @@
           "type": "null"
         }
       ],
-      "description": "This key's own layer of the MCP tool ACL, as namespaced `<server>__<tool>` glob patterns. It is intersected with the environment and team MCP access policies: every present layer must allow a tool and no layer may deny it. When omitted the key adds no constraint of its own — but with no layer present anywhere the grant is empty, so MCP access is always granted explicitly."
+      "description": "This key's own layer of the MCP tool ACL, as namespaced `<server>__<tool>` glob patterns, or as `allow_ids` / `deny_ids` entries naming the server by resource id. It is intersected with the environment and team MCP access policies: every present layer must allow a tool and no layer may deny it. When omitted the key adds no constraint of its own — but with no layer present anywhere the grant is empty, so MCP access is always granted explicitly."
     },
     "mcp_rate_limits": {
       "additionalProperties": {
         "$ref": "#/definitions/McpRateLimit"
       },
-      "description": "Per-MCP-server limits for this key, keyed by the registered MCP server name — the `<server>` half of the `<server>__<tool>` names the gateway exposes. A `tools/call` is metered against the entry for the server it targets **and** the key's own `rate_limit`, each in its own counter, so a burst against one server never consumes another's budget. A server with no entry here is bounded by `rate_limit` alone. Only tool calls are metered; the `initialize` / `tools/list` handshake is not.",
+      "description": "Per-MCP-server limits for this key, keyed by the registered MCP server name — the `<server>` half of the `<server>__<tool>` names the gateway exposes. A `tools/call` is metered against the entry for the server it targets **and** the key's own `rate_limit`, each in its own counter, so a burst against one server never consumes another's budget. A server with no entry here is bounded by `rate_limit` alone. Only tool calls are metered; the `initialize` / `tools/list` handshake is not.\n\nRead only when `mcp_rate_limits_by_id` is absent; ignored entirely when it is present.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "mcp_rate_limits_by_id": {
+      "additionalProperties": {
+        "$ref": "#/definitions/McpRateLimit"
+      },
+      "description": "The same per-server limits, keyed by the MCP server's resource id (`mcp_servers/<id>`) rather than by its name, so renaming a server does not detach the limit that was set for it.\n\nPresent — including as an empty object — it is authoritative and `mcp_rate_limits` is ignored; an empty object therefore leaves every server bounded by `rate_limit` alone. A key naming no registered server imposes nothing, and the other entries are unaffected. Set to `null` it means the same as omitted: the key falls back to `mcp_rate_limits`.",
       "type": [
         "object",
         "null"

--- a/schemas/resources/mcp_policy.schema.json
+++ b/schemas/resources/mcp_policy.schema.json
@@ -42,23 +42,64 @@
           "type": "string"
         }
       ]
+    },
+    "McpToolRef": {
+      "additionalProperties": false,
+      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.",
+      "properties": {
+        "server_id": {
+          "description": "Resource id of the registered MCP server (`mcp_servers/<id>`) this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "tool": {
+          "description": "Tool on that server, matched as a single-`*` glob against the bare tool name — the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "server_id",
+        "tool"
+      ],
+      "type": "object"
     }
   },
   "properties": {
     "allow": {
       "default": [],
-      "description": "Namespaced `<server>__<tool>` patterns this layer allows. Entries are matched as single-`*` globs: `\"*\"` allows every tool, `\"<server>__*\"` every tool on one server, and an entry without a `*` matches one tool exactly. An empty list allows nothing, which is how a policy blocks all MCP access; a policy that only means to subtract tools writes `[\"*\"]` here and lists them under `deny`.\n\nThe write path requires the field (the strict schema adds it to `required`), so a layer never allows something by omission. The runtime loader defaults it to empty instead of rejecting the row: a document written before the layered shape would otherwise fail to deserialize, and a skipped `api_key` row stops authenticating altogether rather than merely losing MCP access.",
+      "description": "Namespaced `<server>__<tool>` patterns this layer allows. Entries are matched as single-`*` globs: `\"*\"` allows every tool, `\"<server>__*\"` every tool on one server, and an entry without a `*` matches one tool exactly. An empty list allows nothing, which is how a policy blocks all MCP access; a policy that only means to subtract tools writes `[\"*\"]` here and lists them under `deny`.\n\nThe write path requires the field (the strict schema adds it to `required`), so a layer never allows something by omission. The runtime loader defaults it to empty instead of rejecting the row: a document written before the layered shape would otherwise fail to deserialize, and a skipped `api_key` row stops authenticating altogether rather than merely losing MCP access.\n\nRead only when `allow_ids` is absent; ignored entirely when it is present.",
       "items": {
         "type": "string"
       },
       "type": "array"
     },
+    "allow_ids": {
+      "description": "This layer's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the layer allows. Each entry names one MCP server by the id it is registered under and one tool by name, the tool matched as a single-`*` glob against the bare tool name.\n\nPresent — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Set to `null` it means the same as omitted: the layer falls back to `allow`.",
+      "items": {
+        "$ref": "#/definitions/McpToolRef"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
     "deny": {
-      "description": "Namespaced `<server>__<tool>` patterns subtracted from the effective grant of every key the policy applies to, using the same single-`*` glob matching as `allow`. Deny always wins: a tool matched here stays unavailable however the other layers allow it.",
+      "description": "Namespaced `<server>__<tool>` patterns subtracted from the effective grant of every key the policy applies to, using the same single-`*` glob matching as `allow`. Deny always wins: a tool matched here stays unavailable however the other layers allow it.\n\nRead only when `deny_ids` is absent; ignored entirely when it is present.",
       "items": {
         "type": "string"
       },
       "type": "array"
+    },
+    "deny_ids": {
+      "description": "This layer's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the layer falls back to `deny`.",
+      "items": {
+        "$ref": "#/definitions/McpToolRef"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
     },
     "enabled": {
       "default": true,

--- a/schemas/resources/mcp_policy.schema.json
+++ b/schemas/resources/mcp_policy.schema.json
@@ -65,13 +65,11 @@
       "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.\n\nBoth halves are required on the WRITE path and defaulted by the runtime loader — the strict schemas add them to this definition's `required`, the types do not. An entry these were required of at the type level would fail to deserialize, and the loader skips a row it cannot deserialize whole: one malformed entry in one `allow_ids` array would stop the entire `api_key` from authenticating any traffic at all, not merely lose it MCP access. Defaulted, the malformed entry matches nothing instead — an empty `server_id` names no registered server, and an empty `tool` glob covers no tool name the gateway exposes.",
       "properties": {
         "server_id": {
-          "default": "",
           "description": "Resource id of the registered MCP server (`mcp_servers/<id>`) this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
           "minLength": 1,
           "type": "string"
         },
         "tool": {
-          "default": "",
           "description": "Tool on that server, matched as a single-`*` glob against the bare tool name — the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
           "minLength": 1,
           "type": "string"

--- a/schemas/resources/mcp_policy.schema.json
+++ b/schemas/resources/mcp_policy.schema.json
@@ -21,6 +21,23 @@
           "scope_ref"
         ]
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "deny_ids": {
+            "type": "array"
+          }
+        },
+        "required": [
+          "deny_ids"
+        ]
+      },
+      "then": {
+        "required": [
+          "deny"
+        ]
+      }
     }
   ],
   "definitions": {
@@ -45,14 +62,16 @@
     },
     "McpToolRef": {
       "additionalProperties": false,
-      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.",
+      "description": "One tool on one MCP server, the server named by its resource id and the tool by name.\n\nThe tool half is matched with the same single-`*` glob rule the name form uses, so `tool: \"*\"` is the id spelling of `<server>__*`. The server half is an exact id: it is compared against the id of the server the addressed tool actually belongs to, never glob-matched, so a server whose *name* happens to contain a `*` cannot widen a grant.\n\nBoth halves are required on the WRITE path and defaulted by the runtime loader — the strict schemas add them to this definition's `required`, the types do not. An entry these were required of at the type level would fail to deserialize, and the loader skips a row it cannot deserialize whole: one malformed entry in one `allow_ids` array would stop the entire `api_key` from authenticating any traffic at all, not merely lose it MCP access. Defaulted, the malformed entry matches nothing instead — an empty `server_id` names no registered server, and an empty `tool` glob covers no tool name the gateway exposes.",
       "properties": {
         "server_id": {
+          "default": "",
           "description": "Resource id of the registered MCP server (`mcp_servers/<id>`) this entry refers to. An id matching no registered server refers to nothing: the entry never matches, and the other entries are unaffected.",
           "minLength": 1,
           "type": "string"
         },
         "tool": {
+          "default": "",
           "description": "Tool on that server, matched as a single-`*` glob against the bare tool name — the part after the `<server>__` namespace prefix. `\"*\"` covers every tool the server exposes.",
           "minLength": 1,
           "type": "string"
@@ -75,7 +94,7 @@
       "type": "array"
     },
     "allow_ids": {
-      "description": "This layer's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the layer allows. Each entry names one MCP server by the id it is registered under and one tool by name, the tool matched as a single-`*` glob against the bare tool name.\n\nPresent — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Set to `null` it means the same as omitted: the layer falls back to `allow`.",
+      "description": "This layer's allow side written by MCP server resource id instead of by server name, so renaming a server does not change what the layer allows. Each entry names one MCP server by the id it is registered under and one tool by name, the tool matched as a single-`*` glob against the bare tool name.\n\nPresent — including as an empty array — it is authoritative and `allow` is ignored; an empty array therefore allows nothing. Set to `null` it means the same as omitted: the layer falls back to `allow`.\n\nIt cannot express \"every server\": each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow. To allow (or deny) every server, present and future, leave this absent and use the name form's `\"*\"`.",
       "items": {
         "$ref": "#/definitions/McpToolRef"
       },
@@ -92,7 +111,7 @@
       "type": "array"
     },
     "deny_ids": {
-      "description": "This layer's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the layer falls back to `deny`.",
+      "description": "This layer's deny side written by MCP server resource id instead of by server name. Present — including as an empty array — it is authoritative and `deny` is ignored; an empty array subtracts nothing. Absent or `null`, the layer falls back to `deny`.\n\nIt cannot express \"every server\": each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow. To allow (or deny) every server, present and future, leave this absent and use the name form's `\"*\"`.",
       "items": {
         "$ref": "#/definitions/McpToolRef"
       },

--- a/tests/e2e/src/cases/mcp-server-reference-ids-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-server-reference-ids-e2e.test.ts
@@ -38,6 +38,7 @@ const KEYS = {
   partial: "sk-mcp-ids-partial",
   unresolvedOnly: "sk-mcp-ids-unresolved-only",
   denyIds: "sk-mcp-ids-deny",
+  envPolicy: "sk-mcp-ids-env-policy",
   rename: "sk-mcp-ids-rename",
   capped: "sk-mcp-ids-capped",
   cappedRename: "sk-mcp-ids-capped-rename",
@@ -281,6 +282,24 @@ describe("mcp server reference ids: grants follow the server id, not its name", 
         mcp_rate_limits_by_id: { [renameId]: { rpm: CAP_RPM } },
       }),
     );
+    // The environment MCP access policy, written by id. Its own key, and
+    // an `mcp_policies` row rather than a key field, because a policy row
+    // travels a different path from etcd to the ACL than a key's own
+    // `mcp_access` block does and only this layer proves it arrives.
+    await seed.createApiKey(
+      key(KEYS.envPolicy, {
+        team_id: "team-mcp-ids",
+        mcp_access: { allow: ["*"] },
+      }),
+    );
+    await seed.update("mcp_policies", randomUUID(), {
+      scope: "team",
+      scope_ref: "team-mcp-ids",
+      allow: [],
+      allow_ids: [{ server_id: alphaId, tool: "echo" }],
+      enabled: true,
+    });
+
     // Seeded last and unrestricted: gating on it implies the whole seed
     // set has landed without exercising any behavior under test.
     await seed.createApiKey(
@@ -360,6 +379,21 @@ describe("mcp server reference ids: grants follow the server id, not its name", 
     expect(names).not.toContain("alpha__reverse");
     expect(await refused(KEYS.denyIds, "alpha__reverse")).toBe(true);
     expect(await served(KEYS.denyIds, "beta__reverse")).toBe(true);
+  });
+
+  test("a policy layer may write its allow side by id too", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    // The key's own layer is wide open, so everything below is the team
+    // policy's id-spelled allow side narrowing it.
+    expect(await listToolNames(KEYS.envPolicy)).toEqual(["alpha__echo"]);
+    expect(await served(KEYS.envPolicy, "alpha__echo")).toBe(true);
+    expect(await refused(KEYS.envPolicy, "alpha__reverse")).toBe(true);
+    expect(await refused(KEYS.envPolicy, "beta__echo")).toBe(true);
+
+    // A key outside that team is not narrowed by it, so the policy really
+    // is what produced the result above.
+    expect(await served(KEYS.sentinel, "beta__echo")).toBe(true);
   });
 
   test("a per-server limit keyed by id binds on that server alone", async (ctx) => {

--- a/tests/e2e/src/cases/mcp-server-reference-ids-e2e.test.ts
+++ b/tests/e2e/src/cases/mcp-server-reference-ids-e2e.test.ts
@@ -1,0 +1,507 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  awaitWindowHeadroom,
+  spawnApp,
+  startMcpUpstream,
+  waitConfigPropagation,
+  type McpUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: a key or a policy may point at an MCP server by resource id
+// instead of by name — `mcp_access.allow_ids` / `deny_ids`,
+// `mcp_policies.allow_ids` / `deny_ids`, and `mcp_rate_limits_by_id`.
+// The id form is authoritative for the side it shadows, resolves to
+// whatever name the server currently carries, and matches nothing for an
+// id that names no server.
+//
+// Driven against a real gateway + etcd + two real MCP upstreams (official
+// TypeScript SDK servers), through the public `/mcp` surface only.
+
+const execFileP = promisify(execFile);
+
+const sha256 = (s: string) => createHash("sha256").update(s).digest("hex");
+
+const KEYS = {
+  byId: "sk-mcp-ids-by-id",
+  wildcardTool: "sk-mcp-ids-wildcard-tool",
+  conflict: "sk-mcp-ids-conflict",
+  emptyIds: "sk-mcp-ids-empty",
+  partial: "sk-mcp-ids-partial",
+  unresolvedOnly: "sk-mcp-ids-unresolved-only",
+  denyIds: "sk-mcp-ids-deny",
+  rename: "sk-mcp-ids-rename",
+  capped: "sk-mcp-ids-capped",
+  cappedRename: "sk-mcp-ids-capped-rename",
+  sentinel: "sk-mcp-ids-sentinel",
+};
+
+const CAP_RPM = 2;
+
+interface RpcReply {
+  status: number;
+  json?: {
+    result?: {
+      tools?: Array<{ name: string }>;
+      content?: Array<{ type: string; text?: string }>;
+      isError?: boolean;
+    };
+    error?: { code: number; message: string };
+  };
+}
+
+describe("mcp server reference ids: grants follow the server id, not its name", () => {
+  let app: SpawnedApp | undefined;
+  let alpha: McpUpstream | undefined;
+  let beta: McpUpstream | undefined;
+  let seed: SeedClient | undefined;
+  let etcdReachable = false;
+  let alphaId = "";
+  let renameId = "";
+  let renameUrl = "";
+
+  const post = async (token: string, body: unknown): Promise<RpcReply> => {
+    const res = await fetch(`${app!.proxyUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    let json: RpcReply["json"];
+    try {
+      json = text ? JSON.parse(text) : undefined;
+    } catch {
+      json = undefined;
+    }
+    return { status: res.status, json };
+  };
+
+  /** Spec-faithful per-operation handshake (the endpoint is stateless). */
+  const initialize = async (token: string): Promise<number> => {
+    const init = await post(token, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "mcp-server-ids-e2e", version: "0.1" },
+      },
+    });
+    await post(token, { jsonrpc: "2.0", method: "notifications/initialized" });
+    return init.status;
+  };
+
+  const listToolNames = async (token: string): Promise<string[]> => {
+    const status = await initialize(token);
+    if (status !== 200) return [];
+    const r = await post(token, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+    return (r.json?.result?.tools ?? []).map((t) => t.name).sort();
+  };
+
+  /**
+   * One `tools/call`, reported as the HTTP status plus the tool text on
+   * success. A call the ACL refuses answers 200 with a JSON-RPC error, so
+   * `denied` reads the error rather than the status.
+   */
+  const callTool = async (
+    token: string,
+    name: string,
+  ): Promise<{ status: number; text?: string; error?: string }> => {
+    const r = await post(token, {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name, arguments: { text: "hi" } },
+    });
+    return {
+      status: r.status,
+      text: r.json?.result?.content?.[0]?.text,
+      error: r.json?.error?.message,
+    };
+  };
+
+  /** True when the call reached the tool and returned its answer. */
+  const served = async (token: string, name: string): Promise<boolean> => {
+    const call = await callTool(token, name);
+    return call.status === 200 && call.text !== undefined;
+  };
+
+  /**
+   * True when the ACL refused the call by name — the gateway's own
+   * refusal, not a transport failure and not the upstream erroring.
+   */
+  const refused = async (token: string, name: string): Promise<boolean> => {
+    const call = await callTool(token, name);
+    return call.status === 200 && (call.error ?? "").includes("not available");
+  };
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    alpha = await startMcpUpstream("alpha");
+    beta = await startMcpUpstream("beta");
+    app = await spawnApp();
+    seed = new SeedClient(etcd, app.etcdPrefix);
+
+    alphaId = randomUUID();
+    const betaId = randomUUID();
+    renameId = randomUUID();
+    renameUrl = beta.url;
+
+    await seed.update("mcp_servers", alphaId, {
+      name: "alpha",
+      url: alpha.url,
+      enabled: true,
+    });
+    await seed.update("mcp_servers", betaId, {
+      name: "beta",
+      url: beta.url,
+      enabled: true,
+    });
+    // Its own server, so the rename case can move a name without
+    // disturbing the inventory every other case asserts on.
+    await seed.update("mcp_servers", renameId, {
+      name: "gamma",
+      url: renameUrl,
+      enabled: true,
+    });
+
+    const key = (
+      plaintext: string,
+      extra: Record<string, unknown>,
+    ): Record<string, unknown> => ({
+      key_hash: sha256(plaintext),
+      allowed_models: [],
+      ...extra,
+    });
+
+    // Grant by id, tool by name.
+    await seed.createApiKey(
+      key(KEYS.byId, {
+        mcp_access: {
+          allow: [],
+          allow_ids: [{ server_id: alphaId, tool: "echo" }],
+        },
+      }),
+    );
+    // A `*` tool covers the whole server the id names.
+    await seed.createApiKey(
+      key(KEYS.wildcardTool, {
+        mcp_access: {
+          allow: [],
+          allow_ids: [{ server_id: alphaId, tool: "*" }],
+        },
+      }),
+    );
+    // Both spellings present and disagreeing: the id side decides.
+    await seed.createApiKey(
+      key(KEYS.conflict, {
+        mcp_access: {
+          allow: ["beta__*"],
+          allow_ids: [{ server_id: alphaId, tool: "*" }],
+        },
+      }),
+    );
+    // An empty id array is authoritative too — it grants nothing, and the
+    // wide-open name side is not read.
+    await seed.createApiKey(
+      key(KEYS.emptyIds, { mcp_access: { allow: ["*"], allow_ids: [] } }),
+    );
+    // One unresolvable id beside a good one.
+    await seed.createApiKey(
+      key(KEYS.partial, {
+        mcp_access: {
+          allow: [],
+          allow_ids: [
+            { server_id: randomUUID(), tool: "*" },
+            { server_id: alphaId, tool: "echo" },
+          ],
+        },
+      }),
+    );
+    // Nothing but an unresolvable id, with a wide-open name side that must
+    // stay unread.
+    await seed.createApiKey(
+      key(KEYS.unresolvedOnly, {
+        mcp_access: {
+          allow: ["*"],
+          allow_ids: [{ server_id: randomUUID(), tool: "*" }],
+        },
+      }),
+    );
+    // Deny by id subtracts from a wide-open allow side.
+    await seed.createApiKey(
+      key(KEYS.denyIds, {
+        mcp_access: {
+          allow: ["*"],
+          deny_ids: [{ server_id: alphaId, tool: "reverse" }],
+        },
+      }),
+    );
+    // The rename case: the grant names `gamma`'s id, never its name.
+    await seed.createApiKey(
+      key(KEYS.rename, {
+        mcp_access: {
+          allow: [],
+          allow_ids: [{ server_id: renameId, tool: "*" }],
+        },
+      }),
+    );
+    // Per-server limits keyed by id, one before and one across a rename.
+    await seed.createApiKey(
+      key(KEYS.capped, {
+        mcp_access: { allow: ["*"] },
+        mcp_rate_limits: { beta: { rpm: CAP_RPM } },
+        mcp_rate_limits_by_id: { [alphaId]: { rpm: CAP_RPM } },
+      }),
+    );
+    await seed.createApiKey(
+      key(KEYS.cappedRename, {
+        mcp_access: { allow: ["*"] },
+        mcp_rate_limits_by_id: { [renameId]: { rpm: CAP_RPM } },
+      }),
+    );
+    // Seeded last and unrestricted: gating on it implies the whole seed
+    // set has landed without exercising any behavior under test.
+    await seed.createApiKey(
+      key(KEYS.sentinel, { mcp_access: { allow: ["*"] } }),
+    );
+
+    // `tools/list` is unmetered, so this probe spends no key's budget.
+    await waitConfigPropagation(async () => {
+      const names = await listToolNames(KEYS.sentinel);
+      return (
+        names.length === 6 &&
+        names.includes("alpha__echo") &&
+        names.includes("beta__echo") &&
+        names.includes("gamma__echo")
+      );
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.exit();
+    await alpha?.close();
+    await beta?.close();
+  });
+
+  test("an id grant covers exactly the named server's named tool", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    expect(await listToolNames(KEYS.byId)).toEqual(["alpha__echo"]);
+    expect(await served(KEYS.byId, "alpha__echo")).toBe(true);
+    expect(await refused(KEYS.byId, "alpha__reverse")).toBe(true);
+    expect(await refused(KEYS.byId, "beta__echo")).toBe(true);
+  });
+
+  test("a `*` tool on an id grant covers that server and no other", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    expect(await listToolNames(KEYS.wildcardTool)).toEqual([
+      "alpha__echo",
+      "alpha__reverse",
+    ]);
+    expect(await refused(KEYS.wildcardTool, "beta__echo")).toBe(true);
+  });
+
+  test("the id side decides when both spellings are present", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    // `allow` says beta, `allow_ids` says alpha. The names are not read.
+    expect(await listToolNames(KEYS.conflict)).toEqual([
+      "alpha__echo",
+      "alpha__reverse",
+    ]);
+    expect(await refused(KEYS.conflict, "beta__echo")).toBe(true);
+
+    // An empty id array is the authoritative "nothing", even beside `*`.
+    expect(await listToolNames(KEYS.emptyIds)).toEqual([]);
+    expect(await refused(KEYS.emptyIds, "alpha__echo")).toBe(true);
+  });
+
+  test("an unresolvable server id matches nothing and spares its neighbours", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    expect(await listToolNames(KEYS.partial)).toEqual(["alpha__echo"]);
+    expect(await served(KEYS.partial, "alpha__echo")).toBe(true);
+
+    // The whole grant is unresolvable, and the wide-open name side stays
+    // unread rather than filling in for it.
+    expect(await listToolNames(KEYS.unresolvedOnly)).toEqual([]);
+    expect(await refused(KEYS.unresolvedOnly, "alpha__echo")).toBe(true);
+  });
+
+  test("a deny written by id subtracts from an allow written by name", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    const names = await listToolNames(KEYS.denyIds);
+    expect(names).toContain("alpha__echo");
+    expect(names).toContain("beta__reverse");
+    expect(names).not.toContain("alpha__reverse");
+    expect(await refused(KEYS.denyIds, "alpha__reverse")).toBe(true);
+    expect(await served(KEYS.denyIds, "beta__reverse")).toBe(true);
+  });
+
+  test("a per-server limit keyed by id binds on that server alone", async (ctx) => {
+    if (!etcdReachable || !app) return ctx.skip();
+
+    // The limiter buckets on fixed wall-clock minutes; keep the burst
+    // inside one window so the 429 cannot straddle a roll-over.
+    await awaitWindowHeadroom();
+
+    for (let i = 0; i < CAP_RPM; i++) {
+      expect((await callTool(KEYS.capped, "alpha__echo")).status).toBe(200);
+    }
+    expect((await callTool(KEYS.capped, "alpha__echo")).status).toBe(429);
+    // The same server's other tool shares that server's counter.
+    expect((await callTool(KEYS.capped, "alpha__reverse")).status).toBe(429);
+    // `beta` is capped only by the NAME form, which the id form shadows —
+    // so this key has no limit on beta at all.
+    for (let i = 0; i < CAP_RPM + 2; i++) {
+      expect((await callTool(KEYS.capped, "beta__echo")).status).toBe(200);
+    }
+  }, 60_000);
+
+  // Last: the rename mutates shared state, and the server it renames is
+  // used by no other case.
+  test("renaming a server moves the grant and the limit with it, documents untouched", async (ctx) => {
+    if (!etcdReachable || !app || !seed) return ctx.skip();
+
+    expect(await served(KEYS.rename, "gamma__echo")).toBe(true);
+
+    // Same etcd key (same resource id), new name. Neither key document is
+    // rewritten anywhere in this test.
+    await seed.update("mcp_servers", renameId, {
+      name: "gamma-v2",
+      url: renameUrl,
+      enabled: true,
+    });
+    // Gate on the rename landing, observed through the unrestricted
+    // sentinel key rather than through the keys under test.
+    await waitConfigPropagation(async () => {
+      const names = await listToolNames(KEYS.sentinel);
+      return (
+        names.includes("gamma-v2__echo") && !names.includes("gamma__echo")
+      );
+    });
+
+    // The grant followed the id into the server's new namespace...
+    expect(await listToolNames(KEYS.rename)).toEqual([
+      "gamma-v2__echo",
+      "gamma-v2__reverse",
+    ]);
+    expect(await served(KEYS.rename, "gamma-v2__echo")).toBe(true);
+    // ...and did not linger on the old name, which now names no server.
+    expect(await served(KEYS.rename, "gamma__echo")).toBe(false);
+
+    // So did the per-server limit.
+    await awaitWindowHeadroom();
+    for (let i = 0; i < CAP_RPM; i++) {
+      expect(
+        (await callTool(KEYS.cappedRename, "gamma-v2__echo")).status,
+      ).toBe(200);
+    }
+    expect((await callTool(KEYS.cappedRename, "gamma-v2__echo")).status).toBe(
+      429,
+    );
+  }, 60_000);
+});
+
+// The id spelling is a control-plane projection: a resources file derives
+// its ids from its own entry names, so an id written there could never
+// resolve. `aisix validate` refuses each of them by name rather than
+// loading a file whose grants and limits silently point at nothing.
+describe("resources file: every MCP server reference id spelling is refused", () => {
+  const BIN_PATH =
+    process.env.AISIX_BIN ??
+    join(process.cwd(), "..", "..", "target", "debug", "aisix");
+
+  const PRELUDE = [
+    '_format_version: "1"',
+    "mcp_servers:",
+    "  - name: github",
+    "    url: https://example.test/mcp",
+    "api_keys:",
+    "  - display_name: k",
+    "    key_env: MCP_REF_IDS_CALLER_KEY",
+    "    allowed_models: []",
+  ].join("\n");
+
+  const ID = "11111111-1111-1111-1111-111111111111";
+  const ENV = { ...process.env, MCP_REF_IDS_CALLER_KEY: "sk-caller" };
+
+  const CASES = [
+    {
+      label: "per-server rate limits",
+      field: "mcp_rate_limits_by_id",
+      withId: `\n    mcp_rate_limits_by_id:\n      "${ID}":\n        rpm: 1\n`,
+      without: "",
+    },
+    {
+      label: "mcp_access allow",
+      field: "mcp_access.allow_ids",
+      withId: `\n    mcp_access:\n      allow: []\n      allow_ids:\n        - server_id: "${ID}"\n          tool: "*"\n`,
+      without: `\n    mcp_access:\n      allow: []\n`,
+    },
+    {
+      label: "mcp_access deny",
+      field: "mcp_access.deny_ids",
+      withId: `\n    mcp_access:\n      allow: ["*"]\n      deny_ids:\n        - server_id: "${ID}"\n          tool: drop\n`,
+      without: `\n    mcp_access:\n      allow: ["*"]\n`,
+    },
+  ];
+
+  test("each id field is rejected by name, and the same file without it validates", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "aisix-mcp-ref-ids-"));
+    try {
+      for (const { label, field, withId, without } of CASES) {
+        const bad = join(dir, `bad-${label.replace(/\W+/g, "-")}.yaml`);
+        await writeFile(bad, PRELUDE + withId, "utf8");
+        let failure: (Error & { code?: number; stderr?: string }) | undefined;
+        try {
+          await execFileP(BIN_PATH, ["validate", "--resources", bad], { env: ENV });
+        } catch (e) {
+          failure = e as Error & { code?: number; stderr?: string };
+        }
+        if (!failure) {
+          throw new Error(`${label}: expected \`aisix validate\` to fail`);
+        }
+        expect(failure.code, label).toBe(1);
+        expect(String(failure.stderr), label).toContain(
+          `does not accept \`${field}\``,
+        );
+
+        // The same file with the id field removed validates, so the
+        // refusal is that field and not anything else in the fixture.
+        const good = join(dir, `good-${label.replace(/\W+/g, "-")}.yaml`);
+        await writeFile(good, PRELUDE + without, "utf8");
+        const ok = await execFileP(BIN_PATH, ["validate", "--resources", good], {
+          env: ENV,
+        });
+        expect(ok.stdout, label).toContain("OK:");
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## MCP server references by resource id

An MCP server is named literally wherever a key or a policy points at it: the `<server>` half of an `mcp_access` / `mcp_policies` allow or deny pattern, and the key of a per-key `mcp_rate_limits` entry. Renaming a registered server therefore invalidated every referencing document at once, and the only repair was for the control plane to rewrite every api_key and every policy of the organization.

Each of those sites now also accepts the server's resource id, with the tool still named:

| site | new field | shape |
| --- | --- | --- |
| `api_keys.mcp_access` | `allow_ids`, `deny_ids` | `[{ "server_id": "<mcp_servers id>", "tool": "<single-* glob>" }]` |
| `mcp_policies` (env / team) | `allow_ids`, `deny_ids` | same |
| `api_keys` | `mcp_rate_limits_by_id` | `{ "<mcp_servers id>": { rpm/rph/rpd/concurrency } }` — the `mcp_rate_limits` value shape, keyed by id |

Semantics, uniform across the three:

- Each id field is authoritative for the one side it shadows — an empty array or object included, which is why `[]` and `null` are opposite grants. Absent or `null`, that side keeps reading the name form exactly as today.
- `tool` is matched as a single-`*` glob against the bare tool name, so `tool: "*"` is the id spelling of `<server>__*`.
- An id naming no registered server matches nothing and imposes no limit. Only that entry is affected; the document still loads.
- The two spellings mix freely across layers and across the two sides of one layer, because every layer is resolved against the same addressed tool.
- **The id form cannot express "every server".** Each entry names one server exactly and `server_id` is never a glob, so an enumeration of the servers registered today silently fails to cover one registered tomorrow. That case omits the id form and uses the name form's `"*"`.
- **A writer must write the name form beside the id form**, and the write path enforces it: `allow` was already required outright, and `deny` is now required whenever `deny_ids` carries a real value, as is `mcp_rate_limits` whenever `mcp_rate_limits_by_id` does. A gateway one release behind the control plane cannot see the id form at all, and the name form is the only thing it can read — left optional, a denial or a per-server limit written only in the id spelling would simply not exist there for the length of the upgrade window: a restriction failing open, silently. An explicit `null` means absent and demands nothing. The name form must be the current expansion of the id form, not something wider.

At request time the client-facing `<server>__<tool>` name is split as it always was and the server half resolved to the id it is registered under, through an index rebuilt only when the `mcp_servers` table changes (never on an unrelated configuration write). So a rename moves the client-facing namespace and leaves every key and policy document valid and untouched.

The server half is compared as an exact id rather than glob-matched through the resolved name. A registered name may legally contain a `*` — the name pattern only forbids `__` and a trailing `_` — so pasting a resolved name into a `<name>__<tool>` pattern would let a grant on a server named `gh*` reach the tools of one named `ghost`.

Both entry points that can be addressed by id go through one resolver each and nothing else: `ToolAcl::resolve` / `permits` for the tool ACL (both `tools/list` filtering and `tools/call`), and `ApiKey::mcp_rate_limit` for the per-server limit. No other call site reads either field.

### Schemas, file source, export

The strict and lenient schemas gain the new optional fields plus a shared `McpToolRef` definition. The write path still requires the name-form `allow`, deliberately: a control plane writing the id form writes the name form beside it, so a gateway one release behind — which cannot see the id form at all — keeps reading the grant it always did instead of losing MCP access the moment the control plane is upgraded.

The `McpToolRef` halves are required and non-empty on the write path only. They are defaulted for the loader, because a row it cannot deserialize is skipped whole — one malformed entry in one `allow_ids` array would otherwise stop the whole `api_key` from authenticating any traffic rather than costing it MCP access. A half-written entry matches no server and no tool instead.

A resources file refuses each new field by name, as it already refuses the id spelling of a model reference: a file derives its ids from its own entry names, so an id written there resolves to nothing and would silently grant nothing. `aisix export` resolves each id back to the server's current name and emits the name form only, replacing the shadowed field rather than merging with it; an id naming no exported server is dropped with a warning. An entry whose server's *name* contains a `*` gets no name form at all — a registered name may legally contain one, and a pattern built from it would match a different server — so it is dropped with a warning on the allow side and reported as blocking on the deny side, where dropping it would let the exported file permit what the gateway forbids.

`mcp_policies` has no resources-file collection and is not exported, so neither path applies to the policy fields.

### The control-plane half is not in this pull request

These are user-configurable surfaces, and the control plane is the only writer of the documents that carry them, so nothing here is reachable by a user until `cp-admin.yaml`, the typed model plus projection, and the dashboard forms carry the same three field shapes. That half is tracked in api7/AISIX-Cloud#1546 and lands separately; this pull request is the data-plane side alone.

### Behavior changes

- A stored key or policy is unaffected unless it carries one of the new fields: every existing document keeps the meaning it had.
- The per-MCP-server rate-limit counter is bucketed on whichever identity selected the limit — the server's resource id for `mcp_rate_limits_by_id`, its name for `mcp_rate_limits`. A limit attached by id therefore keeps its window across a rename, which a name-keyed bucket would have reset. Nothing changes for a key that carries only the name form.
- `applied_revision` in the heartbeat is now the minimum header revision across the watched prefixes, not the maximum. The range reads run in sequence, so a write landing between the first prefix's read and the last one's is below the later read's revision and absent from the union all the same — the union is consistent only as far as the earliest read. Reporting the maximum claimed the gateway had applied a write it has not seen, which is the one question the field exists to answer. A gateway that watches a single prefix is unaffected.
- A tolerated refusal on the shared pricing catalog no longer empties the catalog table. The rows last read from that prefix are carried into every subsequent union until a read of it succeeds again, and only a successful read replaces them. Previously a control plane that started refusing the prefix dropped every catalog price at once, silently stopping `least_cost` ranking and emptying `cost_usd` on realtime and batch usage events. The existing WARN still fires once per outage — its wording now says the prices are kept — and the cycle keeps retrying at the normal cadence.

### Tests

`tests/e2e/src/cases/mcp-server-reference-ids-e2e.test.ts` drives eight cases against a real `aisix` + etcd + two SDK MCP upstreams through the public `/mcp` surface: a grant by id; a `*` tool covering the whole server; the id side winning when both spellings are written, including the empty array; an unresolvable id matching nothing while its neighbours keep working; a deny by id subtracting from an allow by name; a per-server limit keyed by id binding on its server while the shadowed name-form limit stays unread; a rename moving both the grant and the limit with neither key document rewritten; and the resources file refusing each new field, with the same file minus the field validating.

Unit coverage sits with each piece: the ACL layer resolution in `aisix-mcp`, the limit chokepoint and the server index in `aisix-core`, the schema acceptance and the file refusal, and the export resugaring. The supervisor gains a test walking one prefix through success → refusal → success with different content.

Every case was checked to go red against a build without its fix.

Ref api7/AISIX-Cloud#1546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP access policies and API keys can reference servers by stable resource ID for tool permissions and rate limits.
  * ID-based permissions take precedence over name-based rules and continue working when servers are renamed.
  * Exported configurations convert server ID references back to server names where possible.

* **Bug Fixes**
  * Improved revision handling and catalog retention during temporary source interruptions.

* **Validation**
  * Added validation for companion fields, unresolved references, wildcard limitations, and ID-based MCP configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->