### PR TITLE
fix(routing): avoid deadlock when exclusion log throttle expires

### DIFF
--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -1644,6 +1644,20 @@ mod tests {
     }
 
     #[test]
+    fn exclusion_log_gate_does_not_extend_the_window_when_suppressed() {
+        let t = ModelRuntimeStatusTracker::new();
+        let key = ("g-1".to_string(), "m-1".to_string(), "cooling");
+        let logged_at = Instant::now() - EXCLUSION_LOG_INTERVAL / 2;
+        t.exclusion_log.insert(key.clone(), logged_at);
+
+        for _ in 0..8 {
+            assert!(!t.should_log_exclusion("g-1", "m-1", "cooling"));
+            // Busy traffic must not postpone the next log indefinitely.
+            assert_eq!(*t.exclusion_log.get(&key).unwrap(), logged_at);
+        }
+    }
+
+    #[test]
     fn exclusion_log_gate_reopens_after_the_interval_without_blocking() {
         let t = Arc::new(ModelRuntimeStatusTracker::new());
         t.exclusion_log.insert(

--- a/crates/aisix-proxy/src/health.rs
+++ b/crates/aisix-proxy/src/health.rs
@@ -721,12 +721,20 @@ impl ModelRuntimeStatusTracker {
         model_id: &str,
         reason: &'static str,
     ) -> bool {
-        let now = Instant::now();
         let key = (virtual_name.to_string(), model_id.to_string(), reason);
-        match self.exclusion_log.get(&key) {
-            Some(at) if now.duration_since(*at) < EXCLUSION_LOG_INTERVAL => false,
-            _ => {
-                self.exclusion_log.insert(key, now);
+        // Decide and update under one guard. A get() guard held by a match
+        // scrutinee would survive into insert() and deadlock on expiration.
+        match self.exclusion_log.entry(key) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                let now = Instant::now();
+                if now.duration_since(*entry.get()) < EXCLUSION_LOG_INTERVAL {
+                    return false;
+                }
+                entry.insert(now);
+                true
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                entry.insert(Instant::now());
                 true
             }
         }
@@ -1633,6 +1641,68 @@ mod tests {
         // its own operator reading it.
         assert!(t.should_log_exclusion("g-2", "m-1", "cooling"));
         assert!(!t.should_log_exclusion("g-2", "m-1", "cooling"));
+    }
+
+    #[test]
+    fn exclusion_log_gate_reopens_after_the_interval_without_blocking() {
+        let t = Arc::new(ModelRuntimeStatusTracker::new());
+        t.exclusion_log.insert(
+            ("g-1".to_string(), "m-1".to_string(), "cooling"),
+            Instant::now() - EXCLUSION_LOG_INTERVAL,
+        );
+        let (tx, rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let reopened = t.should_log_exclusion("g-1", "m-1", "cooling");
+            let repeated = t.should_log_exclusion("g-1", "m-1", "cooling");
+            tx.send((reopened, repeated)).unwrap();
+        });
+        // A synchronous lock deadlock cannot be bounded by a Tokio timeout
+        // on the same worker. Keep the watchdog on the test thread.
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(2))
+                .expect("exclusion logging blocked after its throttle expired"),
+            (true, false),
+        );
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn exclusion_log_gate_allows_one_concurrent_writer_per_window() {
+        for expired in [false, true] {
+            let t = Arc::new(ModelRuntimeStatusTracker::new());
+            if expired {
+                t.exclusion_log.insert(
+                    ("g-1".to_string(), "m-1".to_string(), "cooling"),
+                    Instant::now() - EXCLUSION_LOG_INTERVAL,
+                );
+            }
+            let barrier = Arc::new(std::sync::Barrier::new(8));
+            let (tx, rx) = std::sync::mpsc::channel();
+            let workers: Vec<_> = (0..8)
+                .map(|_| {
+                    let t = t.clone();
+                    let barrier = barrier.clone();
+                    let tx = tx.clone();
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        tx.send(t.should_log_exclusion("g-1", "m-1", "cooling"))
+                            .unwrap();
+                    })
+                })
+                .collect();
+            let allowed = (0..8)
+                .map(|_| {
+                    usize::from(
+                        rx.recv_timeout(Duration::from_secs(2))
+                            .expect("concurrent exclusion logging blocked"),
+                    )
+                })
+                .sum::<usize>();
+            assert_eq!(allowed, 1, "expired={expired}");
+            for worker in workers {
+                worker.join().unwrap();
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
When a routing target is excluded repeatedly, the first exclusion after its 60-second log throttle expires can block the request worker indefinitely before provider dispatch. In `should_log_exclusion`, the `DashMap::get()` guard used as the match scrutinee remains alive in the fallback arm, where `insert()` attempts to acquire the same shard's write lock. This also prevents the request from reaching the upstream timeout and can accumulate blocked workers during an outage.

Use `DashMap::entry()` to check and update the timestamp under one guard. This removes the lock upgrade and ensures concurrent callers emit at most one exclusion log per group/model/reason per interval. Routing order, cooldown settings, and public interfaces remain unchanged.

Validation:
- The expiry regression reproduces the original deadlock and fails through a separate two-second watchdog instead of hanging the test suite.
- Concurrent fresh-entry and expired-entry tests require exactly one caller to pass the throttle. A further regression verifies suppressed calls do not refresh the timestamp and postpone logging indefinitely; deliberately introducing that defect makes the test fail.
- All 1,209 proxy unit tests pass on upstream main, including 35 health tests and 76 routing tests. All 33 health tests and 68 routing tests also pass against v1.1.0 with the same fix.
- `cargo fmt --all -- --check` and `git diff --check` pass.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate limiting for health-related logging to prevent race conditions and deadlocks.
  * Ensured suppressed log attempts do not extend the throttle window.
  * Corrected throttling behavior so the gate reopens after the configured interval.
  * Limited concurrent logging to one permitted writer per interval.

* **Tests**
  * Added coverage for throttle expiration, suppressed calls, and concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->