### PR TITLE
fix(a2a): parse multi-line SSE events

### DIFF
--- a/crates/aisix-a2a/src/bridge.rs
+++ b/crates/aisix-a2a/src/bridge.rs
@@ -590,17 +590,17 @@ impl A2aBridge for HttpBridge {
     }
 }
 
-/// Parse an upstream SSE body into the JSON-RPC envelope of each `data:` field.
+/// Parse an upstream SSE body into one JSON-RPC envelope per event.
 ///
-/// Deliberately minimal: A2A carries one JSON-RPC envelope per `data:` line, so
-/// `event:` / `id:` / `retry:` fields and comments are metadata this gateway has
-/// no use for and passes over. A `data:` line that is not JSON ends the stream
-/// with an error rather than being skipped — a caller that silently dropped
-/// events would report a truncated task as a complete one.
+/// Join an event's `data:` fields with newlines before parsing, as specified by
+/// https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation.
+/// Metadata and comments are ignored. Malformed JSON fails the stream once the
+/// event ends, rather than silently reporting a truncated task as complete.
 fn sse_events(resp: reqwest::Response) -> impl futures::Stream<Item = A2aEvent> + Send {
     async_stream::stream! {
         let mut bytes = resp.bytes_stream();
         let mut pending: Vec<u8> = Vec::new();
+        let mut line_start = 0;
         loop {
             let chunk = match bytes.next().await {
                 Some(Ok(chunk)) => chunk,
@@ -610,34 +610,37 @@ fn sse_events(resp: reqwest::Response) -> impl futures::Stream<Item = A2aEvent> 
                 }
                 None => break,
             };
-            pending.extend_from_slice(&chunk);
-            // A single event is bounded even though the stream is not: an
-            // upstream that never emits a newline must not grow this buffer
-            // without limit.
-            if pending.len() > MAX_SSE_EVENT_BYTES {
-                yield Err(A2aError::Request(
-                    "upstream SSE event exceeded size cap".to_string(),
-                ));
-                return;
-            }
-            while let Some(newline) = pending.iter().position(|b| *b == b'\n') {
-                let line: Vec<u8> = pending.drain(..=newline).collect();
-                match parse_sse_data_line(&line) {
-                    Ok(Some(event)) => yield Ok(event),
-                    Ok(None) => {}
-                    Err(e) => {
-                        yield Err(e);
-                        return;
+            for byte in chunk {
+                pending.push(byte);
+                // Bound the whole event, including multiple data lines, rather
+                // than a network chunk that may contain many small events.
+                if pending.len() > MAX_SSE_EVENT_BYTES {
+                    yield Err(A2aError::Request(
+                        "upstream SSE event exceeded size cap".to_string(),
+                    ));
+                    return;
+                }
+                if byte == b'\n' {
+                    let line = &pending[line_start..];
+                    if line == b"\n" || line == b"\r\n" {
+                        match parse_sse_frame(&pending) {
+                            Ok(Some(event)) => yield Ok(event),
+                            Ok(None) => {}
+                            Err(e) => {
+                                yield Err(e);
+                                return;
+                            }
+                        }
+                        pending.clear();
                     }
+                    line_start = pending.len();
                 }
             }
         }
         // A body that ends without its final newline still carries an event —
-        // and if that last line is malformed it fails the stream like any
-        // other. Swallowing the error here would make a truncated task read as
-        // a clean end, which is the exact failure the per-line rule exists to
-        // prevent.
-        match parse_sse_data_line(&pending) {
+        // preserve that compatibility, but parse all of its data fields together.
+        // A malformed trailing event must still fail rather than end quietly.
+        match parse_sse_frame(&pending) {
             Ok(Some(event)) => yield Ok(event),
             Ok(None) => {}
             Err(e) => yield Err(e),
@@ -645,14 +648,22 @@ fn sse_events(resp: reqwest::Response) -> impl futures::Stream<Item = A2aEvent> 
     }
 }
 
-/// Extract the JSON-RPC envelope from one SSE line, or `None` when the line
-/// carries no `data:` field.
-fn parse_sse_data_line(line: &[u8]) -> Result<Option<serde_json::Value>, A2aError> {
-    let text = std::str::from_utf8(line)
+/// Extract the JSON-RPC envelope from an SSE event's joined data fields.
+fn parse_sse_frame(frame: &[u8]) -> Result<Option<serde_json::Value>, A2aError> {
+    let text = std::str::from_utf8(frame)
         .map_err(|_| A2aError::Request("upstream SSE event was not valid UTF-8".to_string()))?;
-    let Some(payload) = text.trim_end_matches(['\r', '\n']).strip_prefix("data:") else {
-        return Ok(None);
-    };
+    let payload = text
+        .lines()
+        .filter_map(|line| {
+            let data = if line == "data" {
+                ""
+            } else {
+                line.strip_prefix("data:")?
+            };
+            Some(data.strip_prefix(' ').unwrap_or(data))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
     let payload = payload.trim();
     if payload.is_empty() {
         return Ok(None);
@@ -784,7 +795,7 @@ mod tests {
 
     #[test]
     fn sse_lines_yield_only_data_payloads() {
-        let event = |line: &str| parse_sse_data_line(line.as_bytes()).unwrap();
+        let event = |line: &str| parse_sse_frame(line.as_bytes()).unwrap();
 
         assert_eq!(
             event("data: {\"jsonrpc\":\"2.0\",\"id\":1}\n").unwrap()["id"],
@@ -804,15 +815,38 @@ mod tests {
     }
 
     #[test]
+    fn sse_frame_joins_data_fields_before_parsing() {
+        for newline in ["\n", "\r\n"] {
+            let frame = [
+                "data: {\"jsonrpc\":\"2.0\",",
+                ": keep-alive",
+                "event: status-update",
+                "data",
+                "data:\"result\":{\"final\":true}}",
+                "",
+                "",
+            ]
+            .join(newline);
+            assert_eq!(
+                parse_sse_frame(frame.as_bytes()).unwrap().unwrap(),
+                serde_json::json!({"jsonrpc": "2.0", "result": {"final": true}})
+            );
+        }
+        // Joining without the required newline would silently turn invalid
+        // JSON into a different, valid string.
+        assert!(parse_sse_frame(b"data: {\"text\":\"hel\ndata: lo\"}\n\n").is_err());
+    }
+
+    #[test]
     fn a_data_line_that_is_not_json_is_an_error_not_a_skip() {
         // Silently dropping it would let a truncated task read as a complete
         // one, which is worse than failing the stream.
-        let err = parse_sse_data_line(b"data: not-json\n").unwrap_err();
+        let err = parse_sse_frame(b"data: not-json\n").unwrap_err();
         assert!(
             matches!(err, A2aError::Request(ref m) if m.contains("malformed JSON-RPC event")),
             "got {err:?}"
         );
-        assert!(parse_sse_data_line(b"data: \xff\xfe\n").is_err());
+        assert!(parse_sse_frame(b"data: \xff\xfe\n").is_err());
     }
 
     #[test]

--- a/crates/aisix-a2a/tests/upstream_roundtrip.rs
+++ b/crates/aisix-a2a/tests/upstream_roundtrip.rs
@@ -371,7 +371,7 @@ async fn the_card_fetch_deadline_covers_the_whole_candidate_walk() {
 }
 
 /// An upstream that answers `message/stream` with a real SSE body, written in
-/// awkward chunks: two events in one write, an event split across two writes,
+/// awkward chunks: two events in one write, an event split across several writes,
 /// and comment / `event:` framing in between. Proves the reader reassembles
 /// across chunk boundaries rather than assuming one chunk is one event.
 async fn spawn_streaming_agent() -> SocketAddr {
@@ -388,8 +388,9 @@ async fn spawn_streaming_agent() -> SocketAddr {
                 ": open\ndata: {{\"jsonrpc\":\"2.0\",\"id\":\"s\",\"result\":{{\"seq\":1,\"version\":{seen_version},\"accept\":\"{accept}\",\"headers\":{seen_headers}}}}}\n\n\
                  event: status-update\ndata: {{\"jsonrpc\":\"2.0\",\"id\":\"s\",\"result\":{{\"seq\":2}}}}\n\n"
             )),
-            Ok("data: {\"jsonrpc\":\"2.0\",\"id\":\"s\",\"resu".to_string()),
-            Ok("lt\":{\"seq\":3,\"final\":true}}\n\n".to_string()),
+            Ok("data: {\"jsonrpc\":\"2.0\",\r\ndata: \"id\":\"s\",\r".to_string()),
+            Ok("\n: keep-alive\r\nevent: status-update\r\ndata: \"resu".to_string()),
+            Ok("lt\":{\"seq\":3,\"final\":true}}\r\n\r\n".to_string()),
         ];
         (
             [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
@@ -426,7 +427,7 @@ async fn streams_events_as_they_arrive_across_chunk_boundaries() {
     assert_eq!(events.len(), 3, "got {events:#?}");
     assert_eq!(events[0]["result"]["seq"], 1);
     assert_eq!(events[1]["result"]["seq"], 2);
-    // Reassembled from two writes that split mid-JSON.
+    // One envelope spans multiple data fields and writes, including a split CRLF.
     assert_eq!(events[2]["result"]["seq"], 3);
     assert_eq!(events[2]["result"]["final"], true);
     // A streaming call is still an A2A call: it announces its version and asks
@@ -560,6 +561,45 @@ async fn a_malformed_final_line_fails_the_stream() {
     assert!(
         events[1].is_err(),
         "a truncated trailing event must fail the stream, not end it quietly"
+    );
+}
+
+#[tokio::test]
+async fn an_oversized_multiline_event_fails_the_stream() {
+    use futures::StreamExt;
+
+    async fn oversized() -> impl IntoResponse {
+        // Each line fits below the cap, but without a blank line they belong
+        // to one event. Discarding lines as they arrive would evade the cap.
+        let line = format!(": {}\n", "x".repeat(1024));
+        let chunks = (0..16 * 1024).map(move |_| Ok::<_, std::convert::Infallible>(line.clone()));
+        (
+            [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+            axum::body::Body::from_stream(futures::stream::iter(chunks)),
+        )
+    }
+    let app = Router::new().route("/a2a", post(oversized));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    let bridge = HttpBridge::new(upstream(format!("http://{addr}/a2a"), A2aAuth::None));
+    let events: Vec<_> = bridge
+        .send_stream(&json!({"jsonrpc":"2.0","id":"s","method":"message/stream"}))
+        .await
+        .expect("stream opens")
+        .collect()
+        .await;
+    server.abort();
+
+    assert_eq!(events.len(), 1, "got {events:#?}");
+    assert!(
+        matches!(&events[0], Err(A2aError::Request(message)) if message.contains("size cap")),
+        "got {events:#?}"
     );
 }
 


### PR DESCRIPTION
Fixes #1143.

An A2A agent can split a JSON-RPC envelope across several `data:` fields in one SSE event. The relay previously parsed each line separately and terminated the stream on the first incomplete JSON fragment.

Buffer until the event's blank line, join its data fields with newlines, and parse the envelope once, following the [SSE event-stream rules](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation). This handles LF/CRLF framing and network chunk boundaries while ignoring comments and metadata. The existing 16 MiB limit now bounds the accumulated event. Existing compatibility for an unterminated final event is retained.

Malformed JSON is now reported when the complete event arrives, or at EOF, rather than after its first data line. Existing configurations need no changes.

Regression coverage includes multiline payloads, interspersed metadata, split CRLF/JSON writes, malformed JSON, and an oversized event made of individually small lines. The HTTP round-trip regression fails against the original reader with `malformed JSON-RPC event` and passes with this change.

### Validation

Validated on Rust 1.93.1 in a Linux checkout, at commit `7f73bb63b569288a3284559dcbb28d741c911567`:

- `cargo fmt --all --check` passed.
- `cargo check --locked --workspace` passed.
- `cargo clippy --locked --workspace -- -D warnings` passed.
- A2A: 34 unit tests and 23 HTTP integration tests passed.
- `cargo test --locked --workspace --no-fail-fast` has one failing test: `aisix-mcp::bridge::tests::connect_timeout_bounds_an_unreachable_upstream`.

The same full-workspace test command, in the same environment, on unmodified upstream `main` (`c8e96aa`) fails only that same MCP test. It exceeds the test's eight-second bound while reaching the unreachable test address. No tests were skipped or weakened to hide this failure. Local proxy/network behavior affects this test, so this draft does not claim a green full-workspace test run; upstream CI still needs to validate it.

The separate repository E2E suite has not been run locally. This change is limited to the A2A reader and its tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming event handling for responses split across multiple data fields or network chunks.
  * Correctly reassembles multiline event payloads, including streams using CRLF line endings and keep-alive messages.
  * Prevents oversized events from being processed and reports a clear stream error when the size limit is exceeded.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->