### PR TITLE
feat(guardrails): add input_messages to scan only the latest turn

### DIFF
--- a/crates/aisix-admin/src/openapi.rs
+++ b/crates/aisix-admin/src/openapi.rs
@@ -2231,6 +2231,10 @@ fn add_variant_titles(doc: &mut Value) {
             &["Input", "Output", "Both"],
         ),
         (
+            "/components/schemas/GuardrailInputMessages/oneOf",
+            &["All messages", "Latest turn only"],
+        ),
+        (
             "/components/schemas/KeywordPattern/oneOf",
             &["Literal", "Regex"],
         ),

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -55,14 +55,15 @@ pub use models::{
     validate_mcp_server, validate_model, validate_observability_exporter, validate_provider_key,
     validate_rate_limit_policy, A2aAgent, A2aAuthType, A2aProtocolVersion, Adapter, AisixSnapshot,
     ApiEndpoint, ApiKey, ApiSurface, AppliedGuardrail, CachePolicy, CooldownConfig, ExporterKind,
-    Guardrail, GuardrailEnforcedHit, GuardrailExecution, GuardrailHookPoint, GuardrailKind,
-    GuardrailMetricsSink, GuardrailMonitorHit, GuardrailScore, HashOnSource, HashOnType,
-    KeywordConfig, KeywordPattern, McpAuthType, McpProtocolVersion, McpRateLimit, McpServer,
-    McpServerType, McpTransport, Model, ObservabilityExporter, ParamConstraints,
-    PassthroughAuthMode, PassthroughCredentialMode, PassthroughRoute, PolicyScope, PolicyWindow,
-    ProviderApis, ProviderKey, RateLimit, RateLimitPolicy, RequestOverrides, ResponseOverrides,
-    Routing, RoutingStrategy, RoutingTarget, SchemaError, StreamDoneMarker, TelemetryKind,
-    TelemetryTags, WhenAllUnavailablePolicy, DEFAULT_COOLDOWN_TRIGGER_STATUSES,
+    Guardrail, GuardrailEnforcedHit, GuardrailExecution, GuardrailHookPoint,
+    GuardrailInputMessages, GuardrailKind, GuardrailMetricsSink, GuardrailMonitorHit,
+    GuardrailScore, HashOnSource, HashOnType, KeywordConfig, KeywordPattern, McpAuthType,
+    McpProtocolVersion, McpRateLimit, McpServer, McpServerType, McpTransport, Model,
+    ObservabilityExporter, ParamConstraints, PassthroughAuthMode, PassthroughCredentialMode,
+    PassthroughRoute, PolicyScope, PolicyWindow, ProviderApis, ProviderKey, RateLimit,
+    RateLimitPolicy, RequestOverrides, ResponseOverrides, Routing, RoutingStrategy, RoutingTarget,
+    SchemaError, StreamDoneMarker, TelemetryKind, TelemetryTags, WhenAllUnavailablePolicy,
+    DEFAULT_COOLDOWN_TRIGGER_STATUSES,
 };
 pub use resource::{Resource, ResourceEntry};
 pub use similarity::{best_similarity, best_similarity_by, cosine_similarity};

--- a/crates/aisix-core/src/models/guardrail.rs
+++ b/crates/aisix-core/src/models/guardrail.rs
@@ -69,6 +69,29 @@ pub enum GuardrailHookPoint {
     Both,
 }
 
+/// How much of a request's message history an input guardrail reads.
+///
+/// IDE and agent clients replay the whole conversation on every call, so a
+/// rule that matched once keeps matching for the rest of the session even
+/// after the offending message is long past. `LatestTurn` narrows every
+/// input hook — the block check and the masking pass alike — to the part
+/// of the conversation the model has not answered yet.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum GuardrailInputMessages {
+    /// Read every message in the request, including replayed history and
+    /// system prompts.
+    #[default]
+    All,
+    /// Read only the messages after the last assistant message, excluding
+    /// system messages: the current user message together with any tool
+    /// results answering it. Messages the model has already replied to are
+    /// neither screened nor rewritten.
+    LatestTurn,
+}
+
 /// Literal or regular-expression pattern used by a keyword guardrail.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", content = "value", rename_all = "lowercase")]
@@ -1342,6 +1365,26 @@ pub struct Guardrail {
     /// Where in the lifecycle this rule runs.
     #[serde(default)]
     pub hook_point: GuardrailHookPoint,
+
+    /// How much of the request this rule reads at the input hook.
+    ///
+    /// `all` (the default) scans every message the caller sent, including
+    /// replayed history and system prompts. `latest_turn` scans only the
+    /// messages after the last assistant message, with system messages
+    /// excluded — the current user message plus any tool results answering
+    /// it. It exists for clients that resend the whole conversation on
+    /// every call, where a rule that matched one earlier message would
+    /// otherwise keep refusing the rest of the session.
+    ///
+    /// The narrowing governs everything the rule does on the request:
+    /// under `latest_turn` a masking rule rewrites only the current turn,
+    /// and messages outside it reach the upstream exactly as the caller
+    /// sent them. A rule whose job is to mask the whole conversation
+    /// belongs on `all`.
+    ///
+    /// Ignored at the output hook, which always reads the whole response.
+    #[serde(default)]
+    pub input_messages: GuardrailInputMessages,
 
     /// Behavior when this guardrail cannot complete its check. Two
     /// causes: a remote provider that is unreachable, timing out,

--- a/crates/aisix-core/src/models/mod.rs
+++ b/crates/aisix-core/src/models/mod.rs
@@ -52,10 +52,10 @@ pub use guardrail::{
     AliyunAiGuardrailConfig, AliyunTextModerationConfig, AppliedGuardrail,
     AzureContentSafetyConfig, AzureContentSafetyTextModerationConfig, BedrockAWSCredentials,
     BedrockConfig, BedrockLatencyMode, CustomConfig, Guardrail, GuardrailAttachment,
-    GuardrailEnforcedHit, GuardrailExecution, GuardrailHookPoint, GuardrailKind,
-    GuardrailMetricsSink, GuardrailMonitorHit, GuardrailScopeType, GuardrailScore, KeywordConfig,
-    KeywordPattern, LakeraConfig, OpenaiModerationConfig, PiiConfig, PiiCustomPattern,
-    PiiDetectorConfig, PresidioConfig, PresidioEntityConfig, SemanticConfig,
+    GuardrailEnforcedHit, GuardrailExecution, GuardrailHookPoint, GuardrailInputMessages,
+    GuardrailKind, GuardrailMetricsSink, GuardrailMonitorHit, GuardrailScopeType, GuardrailScore,
+    KeywordConfig, KeywordPattern, LakeraConfig, OpenaiModerationConfig, PiiConfig,
+    PiiCustomPattern, PiiDetectorConfig, PresidioConfig, PresidioEntityConfig, SemanticConfig,
 };
 pub use mcp_auth_settings::{McpAnonymousAccess, McpAuthSettings, McpServerAllowlist};
 pub use mcp_policy::{McpAccess, McpPolicy, McpPolicyScope};

--- a/crates/aisix-gateway/src/chat.rs
+++ b/crates/aisix-gateway/src/chat.rs
@@ -213,6 +213,22 @@ impl ChatMessage {
         }
     }
 
+    /// A tool RESULT the caller replays. `tool_call_id` is left unset:
+    /// the constructor exists for the scan-side views (`ChatFormat`s built
+    /// only to be handed to the guardrail chain), which read role and text
+    /// and never dispatch. A message built for dispatch must set the id
+    /// itself — OpenAI rejects a `role: "tool"` message without one.
+    pub fn tool(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Tool,
+            content: Some(content.into()),
+            content_blocks: None,
+            name: None,
+            tool_call_id: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
     /// The text content as a `&str`, treating absent (`null`) content as
     /// `""`. Use this for bridges/guardrails that need a plain string and
     /// for which the string-vs-null distinction is irrelevant.

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -16,7 +16,8 @@ use std::sync::{Arc, Mutex};
 
 use aisix_core::models::{
     AisixSnapshot, AppliedGuardrail, Guardrail as DomainGuardrail, GuardrailAttachment,
-    GuardrailHookPoint, GuardrailKind, GuardrailMonitorHit, GuardrailScopeType, KeywordPattern,
+    GuardrailHookPoint, GuardrailInputMessages, GuardrailKind, GuardrailMonitorHit,
+    GuardrailScopeType, KeywordPattern,
 };
 use aisix_core::snapshot::ResourceTable;
 use aisix_core::{ConfigStatus, IncomingRejection, SnapshotHandle};
@@ -96,7 +97,7 @@ fn build_chain_from_snapshot_reported(
     embedder: &GuardrailEmbedderSlot,
     instances: &mut GuardrailInstances,
 ) -> (GuardrailChain, Vec<GuardrailBuildRejection>) {
-    let mut chain: Vec<(String, Arc<dyn Guardrail>)> = Vec::new();
+    let mut chain: Vec<(String, Arc<dyn Guardrail>, GuardrailInputMessages)> = Vec::new();
     // `applied` mirrors `chain` 1:1 — the `{kind, hook}` of each member that
     // actually materialised, for applied-guardrail telemetry (#379). Pushed
     // only on the `Ok(Some)` path so inert/invalid rows (which never join the
@@ -117,7 +118,7 @@ fn build_chain_from_snapshot_reported(
             &mut BuildReuse::default(),
         ) {
             Ok(Some(g)) => {
-                chain.push((row.name.clone(), g));
+                chain.push((row.name.clone(), g, row.input_messages));
                 applied.push(applied_for(row));
             }
             Ok(None) => {
@@ -1297,6 +1298,7 @@ fn build_index_from_snapshot_reported(
             attachment.scope_id.clone(),
             attachment.priority,
             runtime_guardrail,
+            row.input_messages,
             applied_for(row),
         ));
     }

--- a/crates/aisix-guardrails/src/build.rs
+++ b/crates/aisix-guardrails/src/build.rs
@@ -1163,6 +1163,17 @@ impl Guardrail for LiveGuardrailChain {
         self.current().redact_input_text(text)
     }
 
+    /// Forwarded for the same reason the hold-back methods above are: the
+    /// trait default would delegate to `redact_input_text`, dropping the
+    /// window and quietly letting an `input_messages: latest_turn` row
+    /// rewrite history. (This wrapper does not forward the segment hooks
+    /// either, which predates this change — it is exported but unused by
+    /// the proxy, which resolves chains through `LiveGuardrailIndex`.)
+    fn redact_input_text_in_turn(&self, text: &str, in_latest_turn: bool) -> Option<Redaction> {
+        self.current()
+            .redact_input_text_in_turn(text, in_latest_turn)
+    }
+
     fn redact_output_text(&self, text: &str) -> Option<Redaction> {
         self.current().redact_output_text(text)
     }

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -15,7 +15,8 @@ use aisix_gateway::{ChatFormat, ChatResponse};
 use async_trait::async_trait;
 
 use aisix_core::models::{
-    GuardrailEnforcedHit, GuardrailExecution, GuardrailMetricsSink, GuardrailMonitorHit,
+    GuardrailEnforcedHit, GuardrailExecution, GuardrailInputMessages, GuardrailMetricsSink,
+    GuardrailMonitorHit,
 };
 
 use crate::audit::GuardrailAuditLog;
@@ -31,6 +32,10 @@ struct ChainMember {
     name: String,
     kind: String,
     guardrail: Arc<dyn Guardrail>,
+    /// The row's `input_messages`. Lives on the member rather than the
+    /// guardrail because it is common to all twelve kinds and none of them
+    /// needs to know its own window — the chain narrows what it hands over.
+    input_messages: GuardrailInputMessages,
 }
 
 #[derive(Clone)]
@@ -57,6 +62,31 @@ pub struct GuardrailChain {
     audit: Option<Arc<GuardrailAuditLog>>,
 }
 
+/// The message window each member reads, resolved once per fold.
+///
+/// `None` when no member narrows — the common case, and the one that must
+/// stay allocation-free: `latest_turn_view` clones the request's messages.
+fn latest_turn_view_if_needed(members: &[ChainMember], req: &ChatFormat) -> Option<ChatFormat> {
+    members
+        .iter()
+        .any(|m| m.input_messages == GuardrailInputMessages::LatestTurn)
+        .then(|| crate::latest_turn_view(req))
+}
+
+/// What `m` is allowed to read of `req`.
+fn member_input<'a>(
+    m: &ChainMember,
+    req: &'a ChatFormat,
+    narrowed: &'a Option<ChatFormat>,
+) -> &'a ChatFormat {
+    match m.input_messages {
+        GuardrailInputMessages::All => req,
+        // `narrowed` is `Some` whenever any member asks for it, so the
+        // fallback is unreachable rather than a silent widening.
+        GuardrailInputMessages::LatestTurn => narrowed.as_ref().unwrap_or(req),
+    }
+}
+
 impl std::fmt::Debug for GuardrailChain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GuardrailChain")
@@ -74,6 +104,7 @@ impl GuardrailChain {
                     name: g.name().to_owned(),
                     kind: g.name().to_owned(),
                     guardrail: g,
+                    input_messages: GuardrailInputMessages::All,
                 })
                 .collect(),
             applied: Vec::new(),
@@ -90,26 +121,44 @@ impl GuardrailChain {
     /// chain's runtime behaviour does not depend on that — `applied` is
     /// telemetry-only.
     pub fn new_with_applied(
-        members: Vec<(String, Arc<dyn Guardrail>)>,
+        members: Vec<(String, Arc<dyn Guardrail>, GuardrailInputMessages)>,
         applied: Vec<AppliedGuardrail>,
     ) -> Self {
         Self {
             members: members
                 .into_iter()
                 .enumerate()
-                .map(|(i, (name, guardrail))| ChainMember {
+                .map(|(i, (name, guardrail, input_messages))| ChainMember {
                     kind: applied
                         .get(i)
                         .map(|a| a.kind.clone())
                         .unwrap_or_else(|| guardrail.name().to_owned()),
                     name,
                     guardrail,
+                    input_messages,
                 })
                 .collect(),
             applied,
             sink: None,
             audit: None,
         }
+    }
+
+    /// Test shorthand for a chain whose every member is left on
+    /// `input_messages: all` — the default, and what the folds behave like
+    /// when nothing narrows.
+    #[cfg(test)]
+    pub fn new_with_applied_all(
+        members: Vec<(String, Arc<dyn Guardrail>)>,
+        applied: Vec<AppliedGuardrail>,
+    ) -> Self {
+        Self::new_with_applied(
+            members
+                .into_iter()
+                .map(|(name, g)| (name, g, GuardrailInputMessages::All))
+                .collect(),
+            applied,
+        )
     }
 
     /// Attach a per-execution telemetry sink (AISIX-Cloud#1076). Called by
@@ -555,9 +604,13 @@ impl Guardrail for GuardrailChain {
 
     async fn check_input(&self, req: &ChatFormat) -> GuardrailVerdict {
         let mut bypass: Option<String> = None;
+        let narrowed = latest_turn_view_if_needed(&self.members, req);
         for m in &self.members {
             let started = Instant::now();
-            let verdict = m.guardrail.check_input(req).await;
+            let verdict = m
+                .guardrail
+                .check_input(member_input(m, req, &narrowed))
+                .await;
             record_execution(
                 self.recorders(),
                 m,
@@ -635,9 +688,13 @@ impl Guardrail for GuardrailChain {
     ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
         let mut bypass: Option<String> = None;
         let mut hits: Vec<GuardrailMonitorHit> = Vec::new();
+        let narrowed = latest_turn_view_if_needed(&self.members, req);
         for m in &self.members {
             let started = Instant::now();
-            let (verdict, member_hits) = m.guardrail.check_input_observed(req).await;
+            let (verdict, member_hits) = m
+                .guardrail
+                .check_input_observed(member_input(m, req, &narrowed))
+                .await;
             record_execution(
                 self.recorders(),
                 m,
@@ -727,9 +784,13 @@ impl Guardrail for GuardrailChain {
     ) -> (GuardrailVerdict, Vec<GuardrailMonitorHit>) {
         let mut bypass: Option<String> = None;
         let mut hits: Vec<GuardrailMonitorHit> = Vec::new();
+        let narrowed = latest_turn_view_if_needed(&self.members, req);
         for m in &self.members {
             let started = Instant::now();
-            let (verdict, member_hits) = m.guardrail.check_input_non_segment_observed(req).await;
+            let (verdict, member_hits) = m
+                .guardrail
+                .check_input_non_segment_observed(member_input(m, req, &narrowed))
+                .await;
             // A segment-moderating member answers via the segment pass —
             // this call is an instant Allow, not an execution; recording
             // it would pollute the member's series with zero-length
@@ -832,11 +893,26 @@ impl Guardrail for GuardrailChain {
     /// member moderates the previous member's masked output, mirroring
     /// `fold_redactions`; the first Bypass reason sticks. Counts merge.
     async fn moderate_input_segments(&self, texts: &[String]) -> SegmentsOutcome {
-        fold_segments(&self.members, self.recorders(), texts, true).await
+        fold_segments(&self.members, self.recorders(), texts, true, None).await
+    }
+
+    async fn moderate_input_segments_in_turn(
+        &self,
+        texts: &[String],
+        in_latest_turn: &[bool],
+    ) -> SegmentsOutcome {
+        fold_segments(
+            &self.members,
+            self.recorders(),
+            texts,
+            true,
+            Some(in_latest_turn),
+        )
+        .await
     }
 
     async fn moderate_output_segments(&self, texts: &[String]) -> SegmentsOutcome {
-        fold_segments(&self.members, self.recorders(), texts, false).await
+        fold_segments(&self.members, self.recorders(), texts, false, None).await
     }
 
     /// The check fold minus segment-moderating members — the pass those
@@ -846,9 +922,13 @@ impl Guardrail for GuardrailChain {
     /// rather than being skipped wholesale.
     async fn check_input_non_segment(&self, req: &ChatFormat) -> GuardrailVerdict {
         let mut bypass: Option<String> = None;
+        let narrowed = latest_turn_view_if_needed(&self.members, req);
         for m in &self.members {
             let started = Instant::now();
-            let verdict = m.guardrail.check_input_non_segment(req).await;
+            let verdict = m
+                .guardrail
+                .check_input_non_segment(member_input(m, req, &narrowed))
+                .await;
             if !m.guardrail.moderates_segments() {
                 record_execution(
                     self.recorders(),
@@ -930,9 +1010,16 @@ impl Guardrail for GuardrailChain {
     /// output, so stacked redacting guardrails compose. Counts merge across
     /// members.
     fn redact_input_text(&self, text: &str) -> Option<Redaction> {
+        self.redact_input_text_in_turn(text, true)
+    }
+
+    fn redact_input_text_in_turn(&self, text: &str, in_latest_turn: bool) -> Option<Redaction> {
         fold_redactions(
             text,
-            self.members.iter().filter(|m| m.guardrail.redacts_input()),
+            self.members.iter().filter(|m| {
+                m.guardrail.redacts_input()
+                    && (in_latest_turn || m.input_messages == GuardrailInputMessages::All)
+            }),
             true,
             self.audit.as_deref(),
         )
@@ -952,11 +1039,19 @@ impl Guardrail for GuardrailChain {
 /// check folds (first Block short-circuits with attribution, first Bypass
 /// reason sticks) plus mask composition: each member moderates the
 /// previous member's masked output. Counts merge across members.
+///
+/// `in_latest_turn` (input side only) flags which of `texts` sit inside the
+/// latest-turn window; a member configured `input_messages: latest_turn` is
+/// offered only those slots and its masked reply is spliced back onto the
+/// positions it was given, so the slots it never saw keep the caller's text
+/// verbatim. `None` — the output side, and any input chain with no such
+/// member — offers every slot to everyone, allocation-free.
 async fn fold_segments(
     members: &[ChainMember],
     to: Recorders<'_>,
     texts: &[String],
     input: bool,
+    in_latest_turn: Option<&[bool]>,
 ) -> SegmentsOutcome {
     let phase = if input { "input" } else { "output" };
     let mut masked: Option<Vec<String>> = None;
@@ -967,7 +1062,25 @@ async fn fold_segments(
         if !m.guardrail.moderates_segments() {
             continue;
         }
-        let src: &[String] = masked.as_deref().unwrap_or(texts);
+        let full: &[String] = masked.as_deref().unwrap_or(texts);
+        // Slots this member may read, as indices into `full`. `None` = all
+        // of them. A flag missing for a slot counts as in-window: the
+        // walker and the collector enumerate the same body, so a short
+        // flag vector is a bug, and erring toward scanning MORE keeps a
+        // block rule firing rather than silently going quiet.
+        let window: Option<Vec<usize>> = match (m.input_messages, in_latest_turn) {
+            (GuardrailInputMessages::LatestTurn, Some(flags)) => {
+                let idx: Vec<usize> = (0..full.len())
+                    .filter(|i| flags.get(*i).copied().unwrap_or(true))
+                    .collect();
+                (idx.len() != full.len()).then_some(idx)
+            }
+            _ => None,
+        };
+        let narrowed: Option<Vec<String>> = window
+            .as_ref()
+            .map(|idx| idx.iter().map(|&i| full[i].clone()).collect());
+        let src: &[String] = narrowed.as_deref().unwrap_or(full);
         let started = Instant::now();
         let mut outcome = if input {
             m.guardrail.moderate_input_segments(src).await
@@ -1020,7 +1133,19 @@ async fn fold_segments(
             // APPLIED anonymization (`redacted_entity_counts`), so a
             // refused mask must not inflate them.
             if new_masked.len() == src.len() {
-                masked = Some(new_masked);
+                masked = Some(match window {
+                    // Splice the member's window back into the full slot
+                    // list; everything outside it keeps the text the
+                    // previous member left.
+                    Some(idx) => {
+                        let mut spliced = full.to_vec();
+                        for (k, &i) in idx.iter().enumerate() {
+                            spliced[i] = new_masked[k].clone();
+                        }
+                        spliced
+                    }
+                    None => new_masked,
+                });
                 Redaction::merge_counts(&mut counts, &outcome.counts);
             } else {
                 tracing::warn!(
@@ -1095,7 +1220,7 @@ fn fold_redactions<'a>(
 mod tests {
     use super::*;
     use crate::{KeywordBlocklist, KeywordRule};
-    use aisix_gateway::{ChatMessage, FinishReason, UsageStats};
+    use aisix_gateway::{ChatMessage, FinishReason, Role, UsageStats};
 
     /// AISIX-Cloud#1330: the audit log and the metrics sink are gated
     /// independently. `record_execution` used to bail the moment the sink
@@ -1105,7 +1230,7 @@ mod tests {
     #[tokio::test]
     async fn a_block_is_audited_even_with_no_metrics_sink_attached() {
         let audit = Arc::new(GuardrailAuditLog::new());
-        let chain = GuardrailChain::new_with_applied(
+        let chain = GuardrailChain::new_with_applied_all(
             vec![(
                 "deny-secrets".to_owned(),
                 Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("nope")]))
@@ -1198,7 +1323,7 @@ mod tests {
         }
 
         let audit = Arc::new(GuardrailAuditLog::new());
-        let chain = GuardrailChain::new_with_applied(
+        let chain = GuardrailChain::new_with_applied_all(
             vec![
                 (
                     "open-row".to_owned(),
@@ -1317,7 +1442,7 @@ mod tests {
         }
 
         let audit = Arc::new(GuardrailAuditLog::new());
-        let chain = GuardrailChain::new_with_applied(
+        let chain = GuardrailChain::new_with_applied_all(
             vec![(
                 "lakera-prod".to_owned(),
                 Arc::new(Unavailable) as Arc<dyn Guardrail>,
@@ -1471,7 +1596,7 @@ mod tests {
     /// reason.
     #[tokio::test]
     async fn block_is_attributed_to_the_firing_member_by_name() {
-        let chain = GuardrailChain::new_with_applied(
+        let chain = GuardrailChain::new_with_applied_all(
             vec![
                 (
                     "pass-through".to_owned(),
@@ -1515,7 +1640,7 @@ mod tests {
     /// pass it through (innermost name wins, no double prefix).
     #[tokio::test]
     async fn nested_chain_block_keeps_innermost_attribution() {
-        let inner = GuardrailChain::new_with_applied(
+        let inner = GuardrailChain::new_with_applied_all(
             vec![(
                 "inner-rule".to_owned(),
                 Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("AKIA")]))
@@ -1523,7 +1648,7 @@ mod tests {
             )],
             Vec::new(),
         );
-        let outer = GuardrailChain::new_with_applied(
+        let outer = GuardrailChain::new_with_applied_all(
             vec![(
                 "outer-chain".to_owned(),
                 Arc::new(inner) as Arc<dyn Guardrail>,
@@ -1790,6 +1915,217 @@ mod tests {
         }
     }
 
+    // ── input_messages: latest_turn (AISIX-Cloud#1558) ───────────────────
+
+    fn conversation() -> ChatFormat {
+        ChatFormat::new(
+            "m",
+            vec![
+                ChatMessage::system("system AKIA"),
+                ChatMessage::user("old AKIA"),
+                ChatMessage::assistant("sure"),
+                ChatMessage::user("fresh"),
+                ChatMessage::tool("tool result"),
+            ],
+        )
+    }
+
+    fn member(
+        name: &str,
+        g: Arc<dyn Guardrail>,
+        scope: GuardrailInputMessages,
+    ) -> (String, Arc<dyn Guardrail>, GuardrailInputMessages) {
+        (name.to_owned(), g, scope)
+    }
+
+    fn applied(n: usize) -> Vec<AppliedGuardrail> {
+        (0..n)
+            .map(|_| AppliedGuardrail {
+                kind: "keyword".to_owned(),
+                hook: "both".to_owned(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn latest_turn_view_starts_after_the_last_assistant_and_drops_system() {
+        let view = crate::latest_turn_view(&conversation());
+        let seen: Vec<_> = view
+            .messages
+            .iter()
+            .map(|m| (m.role, m.content_str().to_owned()))
+            .collect();
+        assert_eq!(
+            seen,
+            vec![
+                (Role::User, "fresh".to_owned()),
+                (Role::Tool, "tool result".to_owned()),
+            ],
+        );
+    }
+
+    #[test]
+    fn latest_turn_view_with_no_assistant_keeps_every_non_system_message() {
+        let req = ChatFormat::new(
+            "m",
+            vec![
+                ChatMessage::system("sys"),
+                ChatMessage::user("a"),
+                ChatMessage::tool("b"),
+            ],
+        );
+        let roles: Vec<_> = crate::latest_turn_view(&req)
+            .messages
+            .iter()
+            .map(|m| m.role)
+            .collect();
+        assert_eq!(roles, vec![Role::User, Role::Tool]);
+    }
+
+    /// The customer report: the pattern sits in replayed history and the
+    /// new prompt is clean. A `latest_turn` row must let it through while
+    /// an `all` row on the same wording still refuses it.
+    #[tokio::test]
+    async fn latest_turn_member_does_not_see_history_but_an_all_member_does() {
+        let kw = || {
+            Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("AKIA")]))
+                as Arc<dyn Guardrail>
+        };
+        let narrowed = GuardrailChain::new_with_applied(
+            vec![member("narrow", kw(), GuardrailInputMessages::LatestTurn)],
+            applied(1),
+        );
+        assert_eq!(
+            narrowed.check_input(&conversation()).await,
+            GuardrailVerdict::Allow,
+        );
+
+        let whole = GuardrailChain::new_with_applied(
+            vec![member("whole", kw(), GuardrailInputMessages::All)],
+            applied(1),
+        );
+        assert!(
+            whole.check_input(&conversation()).await.is_block(),
+            "an `all` row still reads the replayed history",
+        );
+    }
+
+    /// The window is per member, so one narrowed row must not narrow its
+    /// peers — the same fold hands each member a different view.
+    #[tokio::test]
+    async fn a_narrowed_member_does_not_narrow_its_peers() {
+        let chain = GuardrailChain::new_with_applied(
+            vec![
+                // Matches history only. It is FIRST in the chain, so if
+                // the fold handed it the whole request it would block and
+                // take the attribution below.
+                member(
+                    "narrow",
+                    Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("AKIA")]))
+                        as Arc<dyn Guardrail>,
+                    GuardrailInputMessages::LatestTurn,
+                ),
+                // Matches the current turn.
+                member(
+                    "whole",
+                    Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("fresh")]))
+                        as Arc<dyn Guardrail>,
+                    GuardrailInputMessages::All,
+                ),
+            ],
+            applied(2),
+        );
+        let verdict = chain.check_input(&conversation()).await;
+        match verdict {
+            GuardrailVerdict::Block { guardrail_name, .. } => {
+                assert_eq!(guardrail_name.as_deref(), Some("whole"));
+            }
+            other => panic!("expected the `all` member to block, got {other:?}"),
+        }
+    }
+
+    /// A masking row on `latest_turn` rewrites only the slots inside the
+    /// window; the history keeps the caller's bytes.
+    #[tokio::test]
+    async fn a_narrowed_segment_member_masks_only_in_window_slots() {
+        let chain = GuardrailChain::new_with_applied(
+            vec![member(
+                "seg",
+                Arc::new(StubSegments {
+                    verdict: GuardrailVerdict::Allow,
+                    mask: true,
+                }) as Arc<dyn Guardrail>,
+                GuardrailInputMessages::LatestTurn,
+            )],
+            applied(1),
+        );
+        let texts = vec!["history".to_owned(), "current".to_owned()];
+        let out = chain
+            .moderate_input_segments_in_turn(&texts, &[false, true])
+            .await;
+        assert_eq!(
+            out.masked.expect("mask applied"),
+            vec!["history".to_owned(), "CURRENT".to_owned()],
+        );
+    }
+
+    /// The same member on `all` still rewrites everything — the assertion
+    /// above must be pinning the window, not the stub.
+    #[tokio::test]
+    async fn an_unnarrowed_segment_member_masks_every_slot() {
+        let chain = GuardrailChain::new_with_applied(
+            vec![member(
+                "seg",
+                Arc::new(StubSegments {
+                    verdict: GuardrailVerdict::Allow,
+                    mask: true,
+                }) as Arc<dyn Guardrail>,
+                GuardrailInputMessages::All,
+            )],
+            applied(1),
+        );
+        let texts = vec!["history".to_owned(), "current".to_owned()];
+        let out = chain
+            .moderate_input_segments_in_turn(&texts, &[false, true])
+            .await;
+        assert_eq!(
+            out.masked.expect("mask applied"),
+            vec!["HISTORY".to_owned(), "CURRENT".to_owned()],
+        );
+    }
+
+    /// The sync mask channel (`pii`) takes the window through the same
+    /// per-member filter.
+    #[test]
+    fn the_sync_mask_channel_skips_a_narrowed_member_outside_the_window() {
+        let chain = GuardrailChain::new_with_applied(
+            vec![member(
+                "pii",
+                Arc::new(crate::PiiGuardrail::new(
+                    vec![crate::builtin_rule("email", crate::PiiAction::Mask)
+                        .expect("builtin email rule")],
+                    aisix_core::models::GuardrailHookPoint::Both,
+                    0,
+                    false,
+                )) as Arc<dyn Guardrail>,
+                GuardrailInputMessages::LatestTurn,
+            )],
+            applied(1),
+        );
+        assert!(
+            chain
+                .redact_input_text_in_turn("mail alice@example.com", false)
+                .is_none(),
+            "history is forwarded byte-identical",
+        );
+        assert!(
+            chain
+                .redact_input_text_in_turn("mail alice@example.com", true)
+                .is_some(),
+            "the current turn is still masked",
+        );
+    }
+
     /// The non-segment check fold skips segment members (they're consulted
     /// via the segment pass) while normal members still run — the panic in
     /// the stub's `check_input` proves the skip.
@@ -1826,7 +2162,7 @@ mod tests {
     async fn segment_fold_composes_masks_and_attributes_blocks() {
         // Two maskers: uppercase then uppercase again (idempotent — the
         // composition is observable via counts merging to 2 members).
-        let chain = GuardrailChain::new_with_applied(
+        let chain = GuardrailChain::new_with_applied_all(
             vec![
                 (
                     "mask-a".to_owned(),
@@ -1855,7 +2191,7 @@ mod tests {
         assert_eq!(out.counts.get("STUB"), Some(&4), "2 members × 2 slots");
 
         // Block short-circuits and is attributed to the firing member.
-        let blocking = GuardrailChain::new_with_applied(
+        let blocking = GuardrailChain::new_with_applied_all(
             vec![(
                 "seg-blocker".to_owned(),
                 Arc::new(StubSegments {
@@ -1925,7 +2261,7 @@ mod tests {
                 hook: "both".to_owned(),
             },
         ];
-        let chain = GuardrailChain::new_with_applied(vec![], applied.clone());
+        let chain = GuardrailChain::new_with_applied_all(vec![], applied.clone());
         assert_eq!(chain.applied(), applied.as_slice());
     }
 
@@ -1979,7 +2315,7 @@ mod tests {
         applied: Vec<AppliedGuardrail>,
     ) -> (GuardrailChain, Arc<RecordingSink>) {
         let sink = Arc::new(RecordingSink::default());
-        let chain = GuardrailChain::new_with_applied(members, applied)
+        let chain = GuardrailChain::new_with_applied_all(members, applied)
             .with_metrics_sink(Some(sink.clone()));
         (chain, sink)
     }

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -1993,6 +1993,36 @@ mod tests {
         );
     }
 
+    /// The prefill rule is measured against the last NON-SYSTEM message.
+    /// Otherwise appending a system message after the prefill makes the
+    /// prefill look answered, and the window is left holding system
+    /// messages alone — which, since system messages are excluded, is an
+    /// empty window and the same bypass one step further out.
+    #[tokio::test]
+    async fn a_system_message_after_a_prefill_does_not_reopen_the_bypass() {
+        let chain = GuardrailChain::new_with_applied(
+            vec![member(
+                "narrow",
+                Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("AKIA")]))
+                    as Arc<dyn Guardrail>,
+                GuardrailInputMessages::LatestTurn,
+            )],
+            applied(1),
+        );
+        let req = ChatFormat::new(
+            "m",
+            vec![
+                ChatMessage::user("please handle AKIA"),
+                ChatMessage::assistant("Sure, here is"),
+                ChatMessage::system("trailing policy"),
+            ],
+        );
+        assert!(
+            chain.check_input(&req).await.is_block(),
+            "the window must still hold the user message",
+        );
+    }
+
     #[tokio::test]
     async fn a_trailing_assistant_message_cannot_silence_a_narrowed_row() {
         let chain = GuardrailChain::new_with_applied(

--- a/crates/aisix-guardrails/src/chain.rs
+++ b/crates/aisix-guardrails/src/chain.rs
@@ -1964,6 +1964,59 @@ mod tests {
         );
     }
 
+    /// A trailing assistant message is a prefill, not an answered turn.
+    /// If it closed the window the window would be EMPTY, and appending
+    /// one would be a one-line bypass of every `latest_turn` rule.
+    #[test]
+    fn a_trailing_assistant_prefill_does_not_close_the_window() {
+        let req = ChatFormat::new(
+            "m",
+            vec![
+                ChatMessage::system("sys"),
+                ChatMessage::user("old AKIA"),
+                ChatMessage::assistant("answered"),
+                ChatMessage::user("fresh"),
+                ChatMessage::assistant("Sure, here is"),
+            ],
+        );
+        let seen: Vec<_> = crate::latest_turn_view(&req)
+            .messages
+            .iter()
+            .map(|m| (m.role, m.content_str().to_owned()))
+            .collect();
+        assert_eq!(
+            seen,
+            vec![
+                (Role::User, "fresh".to_owned()),
+                (Role::Assistant, "Sure, here is".to_owned()),
+            ],
+        );
+    }
+
+    #[tokio::test]
+    async fn a_trailing_assistant_message_cannot_silence_a_narrowed_row() {
+        let chain = GuardrailChain::new_with_applied(
+            vec![member(
+                "narrow",
+                Arc::new(KeywordBlocklist::new(vec![KeywordRule::literal("AKIA")]))
+                    as Arc<dyn Guardrail>,
+                GuardrailInputMessages::LatestTurn,
+            )],
+            applied(1),
+        );
+        let req = ChatFormat::new(
+            "m",
+            vec![
+                ChatMessage::user("please handle AKIA"),
+                ChatMessage::assistant("Sure, here is"),
+            ],
+        );
+        assert!(
+            chain.check_input(&req).await.is_block(),
+            "appending an assistant message must not empty the window",
+        );
+    }
+
     #[test]
     fn latest_turn_view_with_no_assistant_keeps_every_non_system_message() {
         let req = ChatFormat::new(
@@ -2066,6 +2119,59 @@ mod tests {
         assert_eq!(
             out.masked.expect("mask applied"),
             vec!["history".to_owned(), "CURRENT".to_owned()],
+        );
+    }
+
+    /// Two members with DIFFERENT windows compose on one slot list: the
+    /// `all` member rewrites everything, then the `latest_turn` member
+    /// rewrites its window ON TOP of that. A history slot must carry the
+    /// first member's mark and only that; a window slot must carry both.
+    /// Nothing else covers this — the check fold has
+    /// `a_narrowed_member_does_not_narrow_its_peers`, the segment fold had
+    /// no equivalent, and each e2e lane carries a single row.
+    #[tokio::test]
+    async fn members_with_different_windows_compose_on_the_same_slots() {
+        struct Suffix(&'static str);
+        #[async_trait]
+        impl Guardrail for Suffix {
+            fn name(&self) -> &'static str {
+                "suffix"
+            }
+            fn moderates_segments(&self) -> bool {
+                true
+            }
+            async fn moderate_input_segments(&self, texts: &[String]) -> crate::SegmentsOutcome {
+                crate::SegmentsOutcome {
+                    verdict: GuardrailVerdict::Allow,
+                    masked: Some(texts.iter().map(|t| format!("{t}{}", self.0)).collect()),
+                    counts: std::collections::BTreeMap::new(),
+                    monitor_hits: Vec::new(),
+                }
+            }
+        }
+
+        let chain = GuardrailChain::new_with_applied(
+            vec![
+                member(
+                    "whole",
+                    Arc::new(Suffix("+A")) as Arc<dyn Guardrail>,
+                    GuardrailInputMessages::All,
+                ),
+                member(
+                    "narrow",
+                    Arc::new(Suffix("+L")) as Arc<dyn Guardrail>,
+                    GuardrailInputMessages::LatestTurn,
+                ),
+            ],
+            applied(2),
+        );
+        let texts = vec!["history".to_owned(), "current".to_owned()];
+        let out = chain
+            .moderate_input_segments_in_turn(&texts, &[false, true])
+            .await;
+        assert_eq!(
+            out.masked.expect("mask applied"),
+            vec!["history+A".to_owned(), "current+A+L".to_owned()],
         );
     }
 

--- a/crates/aisix-guardrails/src/index.rs
+++ b/crates/aisix-guardrails/src/index.rs
@@ -29,6 +29,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use aisix_core::models::GuardrailInputMessages;
 use aisix_core::AppliedGuardrail;
 
 use crate::{Guardrail, GuardrailChain};
@@ -59,6 +60,10 @@ pub(crate) struct IndexEntry {
     /// Higher = higher precedence. Entries are pre-sorted descending.
     priority: i32,
     guardrail: Arc<dyn Guardrail>,
+    /// The row's `input_messages`, carried onto the resolved chain so a
+    /// `latest_turn` rule is handed only the part of the conversation the
+    /// model has not answered yet.
+    input_messages: GuardrailInputMessages,
     /// The `{kind, hook}` of this entry's guardrail, captured at index-build
     /// time (the only place the domain row's `kind` + `hook_point` are in
     /// scope). `resolve` collects these from the entries it keeps so the
@@ -185,7 +190,7 @@ impl GuardrailIndex {
     /// Complexity: O(n) in the number of attachment entries.
     pub fn resolve(&self, ctx: &RequestContext<'_>) -> GuardrailChain {
         let mut seen: HashSet<&str> = HashSet::new();
-        let mut chain: Vec<(String, Arc<dyn Guardrail>)> = Vec::new();
+        let mut chain: Vec<(String, Arc<dyn Guardrail>, GuardrailInputMessages)> = Vec::new();
         // `applied` mirrors `chain` 1:1 — the `{kind, hook}` of each member
         // we keep, for applied-guardrail telemetry (#379). Pushed on the same
         // (matched + not-deduplicated) path so it never drifts from `chain`.
@@ -199,7 +204,11 @@ impl GuardrailIndex {
                 continue;
             }
             seen.insert(entry.guardrail_id.as_str());
-            chain.push((entry.guardrail_name.clone(), Arc::clone(&entry.guardrail)));
+            chain.push((
+                entry.guardrail_name.clone(),
+                Arc::clone(&entry.guardrail),
+                entry.input_messages,
+            ));
             applied.push(entry.applied.clone());
         }
 
@@ -212,6 +221,7 @@ impl GuardrailIndex {
 // ---------------------------------------------------------------------------
 
 impl GuardrailIndex {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn push_entry(
         guardrail_id: impl Into<String>,
         guardrail_name: impl Into<String>,
@@ -219,6 +229,7 @@ impl GuardrailIndex {
         scope_id: Option<String>,
         priority: i32,
         guardrail: Arc<dyn Guardrail>,
+        input_messages: GuardrailInputMessages,
         applied: AppliedGuardrail,
     ) -> IndexEntry {
         IndexEntry {
@@ -228,6 +239,7 @@ impl GuardrailIndex {
             scope_id,
             priority,
             guardrail,
+            input_messages,
             applied,
         }
     }
@@ -307,6 +319,7 @@ mod tests {
             sid.map(str::to_owned),
             priority,
             g,
+            GuardrailInputMessages::All,
             AppliedGuardrail {
                 kind: "keyword".to_owned(),
                 hook: "both".to_owned(),

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -175,13 +175,21 @@ pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
 /// Responses `function_call_output` item). A request with no assistant
 /// message narrows to every non-system message.
 ///
+/// A TRAILING assistant message does not close the window. It is a
+/// prefill — text the caller wrote for the model to continue, not a turn
+/// the model has answered — so it belongs to the current turn and is
+/// scanned with it. Treating it as a boundary would empty the window and
+/// hand every caller a one-line bypass: append a dummy assistant message
+/// and a `latest_turn` rule goes quiet. Anthropic's documented
+/// assistant-prefill feature reaches the same shape by accident.
+///
 /// This is the CHECK pass's half of the rule. The masking walkers in
 /// `aisix-proxy::redact` apply the same rule to each wire shape directly,
 /// because their slots are raw JSON with no `ChatFormat` to index against;
 /// the e2e cases pin both halves per protocol.
 pub fn latest_turn_view(req: &ChatFormat) -> ChatFormat {
-    let start = req
-        .messages
+    let answered = req.messages.len().saturating_sub(1);
+    let start = req.messages[..answered]
         .iter()
         .rposition(|m| m.role == Role::Assistant)
         .map_or(0, |i| i + 1);

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -47,7 +47,7 @@ mod text_moderation;
 mod too_large;
 
 use aisix_core::models::GuardrailMonitorHit;
-use aisix_gateway::{ChatFormat, ChatMessage, ChatResponse};
+use aisix_gateway::{ChatFormat, ChatMessage, ChatResponse, Role};
 use async_trait::async_trait;
 
 /// Max bytes of an upstream guardrail-provider error body to echo into a log
@@ -162,6 +162,36 @@ pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
         }
     }
     parts.join("\n")
+}
+
+/// The messages a `input_messages: latest_turn` guardrail may read: every
+/// message after the last assistant one, with system messages dropped.
+///
+/// IDE and agent clients replay the whole conversation on every call, so a
+/// rule that matched one message keeps matching for the rest of the
+/// session. The window is the part the model has not answered yet — this
+/// turn's user message together with the tool results answering it
+/// (`Role::Tool` on the OpenAI wire, an Anthropic `tool_result` block, a
+/// Responses `function_call_output` item). A request with no assistant
+/// message narrows to every non-system message.
+///
+/// This is the CHECK pass's half of the rule. The masking walkers in
+/// `aisix-proxy::redact` apply the same rule to each wire shape directly,
+/// because their slots are raw JSON with no `ChatFormat` to index against;
+/// the e2e cases pin both halves per protocol.
+pub fn latest_turn_view(req: &ChatFormat) -> ChatFormat {
+    let start = req
+        .messages
+        .iter()
+        .rposition(|m| m.role == Role::Assistant)
+        .map_or(0, |i| i + 1);
+    let mut view = req.clone();
+    view.messages = req.messages[start..]
+        .iter()
+        .filter(|m| m.role != Role::System)
+        .cloned()
+        .collect();
+    view
 }
 
 /// The guardrail `kind` discriminators compiled into this binary whose
@@ -810,6 +840,23 @@ pub trait Guardrail: Send + Sync + 'static {
         None
     }
 
+    /// [`Self::redact_input_text`], told whether the text sits inside the
+    /// latest-turn window — `false` for a system message and for anything
+    /// the model has already replied to.
+    ///
+    /// Only [`GuardrailChain`] overrides this: it drops the members
+    /// configured `input_messages: latest_turn` for out-of-window text, so
+    /// a mask rule on that setting rewrites the current turn and leaves the
+    /// replayed history byte-identical. A leaf guardrail has no window of
+    /// its own — the setting belongs to the chain member, not the kind —
+    /// so the default ignores the flag and every caller that has no window
+    /// to report (the whole response side, and the single-input endpoints)
+    /// keeps using [`Self::redact_input_text`] directly.
+    fn redact_input_text_in_turn(&self, text: &str, in_latest_turn: bool) -> Option<Redaction> {
+        let _ = in_latest_turn;
+        self.redact_input_text(text)
+    }
+
     // --- remote segment moderation (#932 bedrock follow-up) ---------------
     //
     // A remote-API guardrail that can MASK (Bedrock PII anonymize) can't
@@ -838,6 +885,23 @@ pub trait Guardrail: Send + Sync + 'static {
     /// Moderate the response's text segments in one remote call.
     async fn moderate_output_segments(&self, _texts: &[String]) -> SegmentsOutcome {
         SegmentsOutcome::allow()
+    }
+
+    /// [`Self::moderate_input_segments`] with one window flag per text, in
+    /// the same order (see [`Self::redact_input_text_in_turn`]).
+    ///
+    /// Only [`GuardrailChain`] overrides it: a `latest_turn` member is
+    /// offered the in-window subset and its masked replies are mapped back
+    /// onto the original positions, so the slots it never saw keep the
+    /// caller's text. The per-kind segment hooks are untouched by the
+    /// setting — a kind never learns its own window.
+    async fn moderate_input_segments_in_turn(
+        &self,
+        texts: &[String],
+        in_latest_turn: &[bool],
+    ) -> SegmentsOutcome {
+        let _ = in_latest_turn;
+        self.moderate_input_segments(texts).await
     }
 
     /// `check_input` minus segment-moderating members — used by call

--- a/crates/aisix-guardrails/src/lib.rs
+++ b/crates/aisix-guardrails/src/lib.rs
@@ -183,12 +183,24 @@ pub(crate) fn message_scan_text(m: &ChatMessage) -> String {
 /// and a `latest_turn` rule goes quiet. Anthropic's documented
 /// assistant-prefill feature reaches the same shape by accident.
 ///
+/// "Trailing" is measured against the last NON-SYSTEM message, not the
+/// last message. System messages are outside the window wherever they
+/// sit, so an assistant message followed only by system ones has still
+/// answered nothing — and reading it as a boundary would leave a window
+/// holding system messages alone, which is to say an empty one. Appending
+/// a system message after the prefill would otherwise reopen the same
+/// bypass.
+///
 /// This is the CHECK pass's half of the rule. The masking walkers in
 /// `aisix-proxy::redact` apply the same rule to each wire shape directly,
 /// because their slots are raw JSON with no `ChatFormat` to index against;
 /// the e2e cases pin both halves per protocol.
 pub fn latest_turn_view(req: &ChatFormat) -> ChatFormat {
-    let answered = req.messages.len().saturating_sub(1);
+    let answered = req
+        .messages
+        .iter()
+        .rposition(|m| m.role != Role::System)
+        .unwrap_or(0);
     let start = req.messages[..answered]
         .iter()
         .rposition(|m| m.role == Role::Assistant)

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -21,7 +21,7 @@
 use std::collections::BTreeMap;
 use std::ops::Range;
 
-use aisix_gateway::{ChatChunk, ChatFormat, ChatResponse};
+use aisix_gateway::{ChatChunk, ChatFormat, ChatResponse, Role};
 use aisix_guardrails::Guardrail;
 use serde_json::Value;
 
@@ -36,13 +36,45 @@ pub fn merge_counts(into: &mut RedactionCounts, from: RedactionCounts) {
     }
 }
 
-/// Which side's redactor to run. The two sides can be configured
-/// independently (`hook_point`), so every JSON-walking helper takes the
-/// direction rather than hardcoding one.
+/// Which side's redactor to run, and — on the request side — which part of
+/// the conversation the text belongs to. The two sides can be configured
+/// independently (`hook_point`), so every JSON-walking helper takes this
+/// rather than hardcoding one.
+///
+/// The request side splits because a guardrail row may carry
+/// `input_messages: latest_turn`, which narrows it to the part of the
+/// conversation the model has not answered yet. Carrying the split in this
+/// type rather than in a parallel argument is what makes it total: every
+/// slot a walker offers has to name which half it is in, and the compiler
+/// asks the question at each new one.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Direction {
+    /// Request text inside the latest-turn window: this turn's user
+    /// message and the tool results answering it. Every input guardrail
+    /// reads it. Also the direction a caller names for a whole-request
+    /// pass, and the only one the single-input surfaces ever use.
     Input,
+    /// Request text the model has already replied to, plus every system
+    /// message. Only rows left on `input_messages: all` read it.
+    InputHistory,
     Output,
+}
+
+impl Direction {
+    /// Request side, either window.
+    pub fn is_input(self) -> bool {
+        matches!(self, Direction::Input | Direction::InputHistory)
+    }
+
+    /// The request-side direction for a slot, given whether it sits inside
+    /// the latest-turn window.
+    fn input_window(in_latest_turn: bool) -> Self {
+        if in_latest_turn {
+            Direction::Input
+        } else {
+            Direction::InputHistory
+        }
+    }
 }
 
 fn redact_str(
@@ -51,7 +83,8 @@ fn redact_str(
     text: &str,
 ) -> Option<aisix_guardrails::Redaction> {
     match dir {
-        Direction::Input => chain.redact_input_text(text),
+        Direction::Input => chain.redact_input_text_in_turn(text, true),
+        Direction::InputHistory => chain.redact_input_text_in_turn(text, false),
         Direction::Output => chain.redact_output_text(text),
     }
 }
@@ -86,23 +119,26 @@ fn redact_str(
 /// counts and reports the provider's entity counts instead.
 const SEGMENT_APPLY_MARKER: &str = "__segment_apply__";
 
-/// Pass-1 probe: records every text slot the walker offers. Never
-/// rewrites, so the body is bit-identical after the collect walk.
+/// Pass-1 probe: records every text slot the walker offers, with the
+/// latest-turn window each one belongs to. Never rewrites, so the body is
+/// bit-identical after the collect walk.
 #[derive(Default)]
 struct SegmentCollector {
-    texts: std::sync::Mutex<Vec<String>>,
+    texts: std::sync::Mutex<Vec<(String, bool)>>,
 }
 
 impl SegmentCollector {
-    fn take(&self) -> Vec<String> {
-        std::mem::take(&mut self.texts.lock().expect("collector poisoned"))
+    /// The collected slots and their window flags, positionally aligned.
+    fn take(&self) -> (Vec<String>, Vec<bool>) {
+        let mut slots = self.texts.lock().expect("collector poisoned");
+        std::mem::take(&mut *slots).into_iter().unzip()
     }
 
-    fn record(&self, text: &str) -> Option<aisix_guardrails::Redaction> {
+    fn record(&self, text: &str, in_latest_turn: bool) -> Option<aisix_guardrails::Redaction> {
         self.texts
             .lock()
             .expect("collector poisoned")
-            .push(text.to_owned());
+            .push((text.to_owned(), in_latest_turn));
         None
     }
 }
@@ -118,10 +154,20 @@ impl Guardrail for SegmentCollector {
         true
     }
     fn redact_input_text(&self, text: &str) -> Option<aisix_guardrails::Redaction> {
-        self.record(text)
+        self.record(text, true)
+    }
+    // The window arrives here and nowhere else: `redact_str` routes every
+    // request-side slot through this method, so overriding the plain one
+    // alone would collect the text and lose which half it came from.
+    fn redact_input_text_in_turn(
+        &self,
+        text: &str,
+        in_latest_turn: bool,
+    ) -> Option<aisix_guardrails::Redaction> {
+        self.record(text, in_latest_turn)
     }
     fn redact_output_text(&self, text: &str) -> Option<aisix_guardrails::Redaction> {
-        self.record(text)
+        self.record(text, true)
     }
 }
 
@@ -249,11 +295,14 @@ pub async fn moderate_body_scanning(
     }
     let collector = SegmentCollector::default();
     walk(&collector);
-    let mut texts = collector.take();
+    let (mut texts, mut in_latest_turn) = collector.take();
     // Everything past here is judged but unwritable; the apply walk only
     // ever offers the first `writable` slots back.
     let writable = texts.len();
     texts.extend(scan_only);
+    // The scan-only tail is Anthropic signed reasoning — assistant content,
+    // and so outside every latest-turn window by construction.
+    in_latest_turn.resize(texts.len(), false);
     // The pass runs even with zero collected slots. "Nothing to scan" is
     // not "nothing to decide": a segment-moderating member may hold a
     // verdict that does not depend on the text (a `kind: custom` policy
@@ -263,7 +312,11 @@ pub async fn moderate_body_scanning(
     // itself (bedrock/lakera/presidio/aliyun all refuse empty content), so
     // consulting the chain here costs no provider round-trip.
     let mut outcome = match dir {
-        Direction::Input => chain.moderate_input_segments(&texts).await,
+        Direction::Input | Direction::InputHistory => {
+            chain
+                .moderate_input_segments_in_turn(&texts, &in_latest_turn)
+                .await
+        }
         Direction::Output => chain.moderate_output_segments(&texts).await,
     };
     monitor_hits_out.append(&mut outcome.monitor_hits);
@@ -409,15 +462,17 @@ pub fn redact_chat_format(chain: &dyn Guardrail, req: &mut ChatFormat) -> Redact
     if !chain.redacts_input() {
         return counts;
     }
-    for msg in &mut req.messages {
+    let window_from = chat_latest_turn_start(&req.messages);
+    for (i, msg) in req.messages.iter_mut().enumerate() {
+        let dir = Direction::input_window(i >= window_from && msg.role != Role::System);
         if let Some(content) = msg.content.as_mut() {
-            apply_to_string(chain, Direction::Input, content, &mut counts);
+            apply_to_string(chain, dir, content, &mut counts);
         }
         if let Some(blocks) = msg.content_blocks.as_mut() {
             for block in blocks {
                 if block.get("type").and_then(Value::as_str) == Some("text") {
                     if let Some(text) = block.get_mut("text") {
-                        apply_to_value_string(chain, Direction::Input, text, &mut counts);
+                        apply_to_value_string(chain, dir, text, &mut counts);
                     }
                 }
             }
@@ -425,17 +480,32 @@ pub fn redact_chat_format(chain: &dyn Guardrail, req: &mut ChatFormat) -> Redact
         // History-replay tool calls: arguments travel to the upstream
         // verbatim through `extra`, so mask them like fresh content.
         if let Some(tool_calls) = msg.extra.get_mut("tool_calls") {
-            redact_tool_call_arguments(chain, Direction::Input, tool_calls, &mut counts);
+            redact_tool_call_arguments(chain, dir, tool_calls, &mut counts);
         }
         // Same reason for replayed reasoning: `reasoning_content` is the
         // canonical slot the provider overrides normalise every vendor
         // spelling onto, and it rides `extra` to the upstream untouched.
         // Nothing signs it on this wire, so masking it is safe.
         if let Some(reasoning @ Value::String(_)) = msg.extra.get_mut("reasoning_content") {
-            apply_to_value_string(chain, Direction::Input, reasoning, &mut counts);
+            apply_to_value_string(chain, dir, reasoning, &mut counts);
         }
     }
     counts
+}
+
+/// Index of the first message inside the latest-turn window: one past the
+/// last assistant message, or 0 when the request carries none.
+///
+/// The wire-level half of `aisix_guardrails::latest_turn_view`, which
+/// answers the same question for the CHECK pass over the parsed
+/// `ChatFormat`. Both are pinned per protocol by the e2e cases — this one
+/// has to exist separately because the mask walkers rewrite raw slots and
+/// have no parsed view to index against.
+fn chat_latest_turn_start(messages: &[aisix_gateway::ChatMessage]) -> usize {
+    messages
+        .iter()
+        .rposition(|m| m.role == Role::Assistant)
+        .map_or(0, |i| i + 1)
 }
 
 /// Mask `function.arguments` (JSON-encoded string) on each element of an
@@ -469,17 +539,38 @@ pub fn redact_anthropic_request(chain: &dyn Guardrail, body: &mut Value) -> Reda
     if !chain.redacts_input() {
         return counts;
     }
+    // The top-level `system` prompt is never in the window.
     if let Some(system) = body.get_mut("system") {
-        redact_anthropic_content(chain, Direction::Input, system, &mut counts);
+        redact_anthropic_content(chain, Direction::InputHistory, system, &mut counts);
     }
     if let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) {
-        for msg in messages {
+        let window_from = anthropic_latest_turn_start(messages);
+        for (i, msg) in messages.iter_mut().enumerate() {
+            // A `role: "system"` entry is not in the Anthropic spec but
+            // Claude Code sends it (#597); it is a system message wherever
+            // it sits, so it stays out of the window like the field above.
+            let is_system = msg.get("role").and_then(Value::as_str) == Some("system");
+            let dir = Direction::input_window(i >= window_from && !is_system);
             if let Some(content) = msg.get_mut("content") {
-                redact_anthropic_content(chain, Direction::Input, content, &mut counts);
+                redact_anthropic_content(chain, dir, content, &mut counts);
             }
         }
     }
     counts
+}
+
+/// Index of the first `messages[]` entry inside the latest-turn window on
+/// the Anthropic wire: one past the last `role: "assistant"` entry.
+///
+/// A tool-loop turn is an assistant message carrying `tool_use` blocks,
+/// so the boundary lands where the parsed view puts it — the `tool_result`
+/// blocks answering it ride the FINAL user message, which is in the window
+/// whole.
+fn anthropic_latest_turn_start(messages: &[Value]) -> usize {
+    messages
+        .iter()
+        .rposition(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
+        .map_or(0, |i| i + 1)
 }
 
 /// Anthropic `content` is either a bare string or an array of typed
@@ -590,21 +681,66 @@ pub fn redact_responses_request(chain: &dyn Guardrail, body: &mut Value) -> Reda
     if !chain.redacts_input() {
         return counts;
     }
+    // `instructions` is this API's system prompt — never in the window.
     if let Some(instructions) = body.get_mut("instructions") {
-        apply_to_value_string(chain, Direction::Input, instructions, &mut counts);
+        apply_to_value_string(chain, Direction::InputHistory, instructions, &mut counts);
     }
     match body.get_mut("input") {
+        // A bare-string `input` is the whole current turn.
         Some(v @ Value::String(_)) => {
             apply_to_value_string(chain, Direction::Input, v, &mut counts)
         }
         Some(Value::Array(items)) => {
-            for item in items {
-                redact_responses_item(chain, Direction::Input, item, &mut counts);
+            let window_from = responses_latest_turn_start(items);
+            for (i, item) in items.iter_mut().enumerate() {
+                let dir =
+                    Direction::input_window(i >= window_from && !responses_item_is_system(item));
+                redact_responses_item(chain, dir, item, &mut counts);
             }
         }
         _ => {}
     }
     counts
+}
+
+/// Index of the first `input[]` item inside the latest-turn window on the
+/// Responses wire: one past the last assistant-side item.
+///
+/// Assistant-side is broader than `role: "assistant"` here, because this
+/// API spells a model turn as a typed item with no role at all — see
+/// [`responses_item_is_assistant`].
+fn responses_latest_turn_start(items: &[Value]) -> usize {
+    items
+        .iter()
+        .rposition(responses_item_is_assistant)
+        .map_or(0, |i| i + 1)
+}
+
+/// Whether one `input[]` item is something the MODEL produced, and so a
+/// boundary for the latest-turn window.
+///
+/// Three shapes, all of which `responses::responses_input_to_chat` maps to
+/// `Role::Assistant`: a `role: "assistant"` message, a tool call the model
+/// asked for (`function_call`, and the custom-tool spelling), and a
+/// `reasoning` item. A tool RESULT is the caller answering that call and
+/// is not a boundary.
+fn responses_item_is_assistant(item: &Value) -> bool {
+    if item.get("role").and_then(Value::as_str) == Some("assistant") {
+        return true;
+    }
+    matches!(
+        item.get("type").and_then(Value::as_str),
+        Some("function_call" | "custom_tool_call" | "reasoning")
+    )
+}
+
+/// Whether one `input[]` item is a system-side message. `developer` is
+/// this API's spelling of the same thing.
+fn responses_item_is_system(item: &Value) -> bool {
+    matches!(
+        item.get("role").and_then(Value::as_str),
+        Some("system" | "developer")
+    )
 }
 
 /// One `/v1/responses` input/output item. `message` items carry
@@ -668,7 +804,7 @@ fn redact_responses_item(
         // Input only. Reasoning the model GENERATES is out of
         // output-guardrail scope, so this arm must not fire on
         // `redact_responses_response`.
-        Some("reasoning") if dir == Direction::Input => {
+        Some("reasoning") if dir.is_input() => {
             for key in ["content", "summary"] {
                 if let Some(Value::Array(parts)) = item.get_mut(key) {
                     for part in parts {
@@ -1807,6 +1943,107 @@ mod tests {
 
     fn both() -> Arc<dyn Guardrail> {
         mask_chain(aisix_core::models::GuardrailHookPoint::Both)
+    }
+
+    // ── latest-turn window, wire level (AISIX-Cloud#1558) ────────────────
+    //
+    // The mask walkers rewrite raw slots and have no parsed `ChatFormat` to
+    // index against, so each wire shape answers the boundary question for
+    // itself. These pin the three answers against the one
+    // `aisix_guardrails::latest_turn_view` gives the check pass.
+
+    #[test]
+    fn chat_window_starts_after_the_last_assistant_message() {
+        let req: ChatFormat = serde_json::from_value(json!({
+            "model": "m",
+            "messages": [
+                {"role": "system", "content": "s"},
+                {"role": "user", "content": "old"},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": "fresh"},
+                {"role": "tool", "content": "result", "tool_call_id": "c1"},
+            ],
+        }))
+        .unwrap();
+        assert_eq!(chat_latest_turn_start(&req.messages), 3);
+    }
+
+    #[test]
+    fn chat_window_with_no_assistant_message_is_the_whole_request() {
+        let req: ChatFormat = serde_json::from_value(json!({
+            "model": "m",
+            "messages": [
+                {"role": "system", "content": "s"},
+                {"role": "user", "content": "only"},
+            ],
+        }))
+        .unwrap();
+        assert_eq!(chat_latest_turn_start(&req.messages), 0);
+    }
+
+    /// An Anthropic tool loop: the assistant turn carrying `tool_use` is
+    /// the boundary, and the `tool_result` answering it rides the final
+    /// user message, which is inside the window whole.
+    #[test]
+    fn anthropic_window_starts_after_the_tool_use_turn() {
+        let messages = json!([
+            {"role": "user", "content": "old"},
+            {"role": "assistant", "content": [{"type": "text", "text": "reply"}]},
+            {"role": "user", "content": "call it"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "t1", "name": "f", "input": {}}
+            ]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "result"}
+            ]},
+        ]);
+        assert_eq!(anthropic_latest_turn_start(messages.as_array().unwrap()), 4,);
+    }
+
+    /// The Responses API spells a model turn as a typed item with no role
+    /// at all, so `role: "assistant"` alone would put a whole agent tool
+    /// loop inside the window.
+    #[test]
+    fn responses_window_treats_typed_model_items_as_the_boundary() {
+        let items = json!([
+            {"role": "user", "content": "old"},
+            {"type": "function_call", "call_id": "c1", "name": "f", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "c1", "output": "result"},
+        ]);
+        // The tool RESULT is the caller answering, not a boundary — the
+        // window opens right after the call.
+        assert_eq!(responses_latest_turn_start(items.as_array().unwrap()), 2);
+    }
+
+    #[test]
+    fn responses_window_opens_after_a_replayed_assistant_message() {
+        let items = json!([
+            {"role": "user", "content": "old"},
+            {"role": "assistant", "type": "message",
+             "content": [{"type": "output_text", "text": "reply"}]},
+            {"role": "user", "content": "fresh"},
+        ]);
+        assert_eq!(responses_latest_turn_start(items.as_array().unwrap()), 2);
+    }
+
+    /// The window is what a `latest_turn` row reads; a row left on `all`
+    /// must keep rewriting the history, so the walkers cannot simply skip
+    /// out-of-window slots.
+    #[test]
+    fn an_all_row_still_masks_history_after_the_window_split() {
+        let chain = both();
+        let mut req: ChatFormat = serde_json::from_value(json!({
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "old alice@example.com"},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": "fresh bob@example.com"},
+            ],
+        }))
+        .unwrap();
+        let counts = redact_chat_format(chain.as_ref(), &mut req);
+        assert_eq!(counts.get("email"), Some(&2), "{counts:?}");
+        assert!(!req.messages[0].content_str().contains("alice@example.com"));
     }
 
     /// `message_scan_text` reads `extra["reasoning_content"]`, so this

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -502,7 +502,8 @@ pub fn redact_chat_format(chain: &dyn Guardrail, req: &mut ChatFormat) -> Redact
 /// has to exist separately because the mask walkers rewrite raw slots and
 /// have no parsed view to index against.
 fn chat_latest_turn_start(messages: &[aisix_gateway::ChatMessage]) -> usize {
-    messages
+    let answered = messages.len().saturating_sub(1);
+    messages[..answered]
         .iter()
         .rposition(|m| m.role == Role::Assistant)
         .map_or(0, |i| i + 1)
@@ -565,9 +566,11 @@ pub fn redact_anthropic_request(chain: &dyn Guardrail, body: &mut Value) -> Reda
 /// A tool-loop turn is an assistant message carrying `tool_use` blocks,
 /// so the boundary lands where the parsed view puts it — the `tool_result`
 /// blocks answering it ride the FINAL user message, which is in the window
-/// whole.
+/// whole. A TRAILING assistant message is a prefill and never closes the
+/// window; see `aisix_guardrails::latest_turn_view`.
 fn anthropic_latest_turn_start(messages: &[Value]) -> usize {
-    messages
+    let answered = messages.len().saturating_sub(1);
+    messages[..answered]
         .iter()
         .rposition(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
         .map_or(0, |i| i + 1)
@@ -710,7 +713,8 @@ pub fn redact_responses_request(chain: &dyn Guardrail, body: &mut Value) -> Reda
 /// API spells a model turn as a typed item with no role at all — see
 /// [`responses_item_is_assistant`].
 fn responses_latest_turn_start(items: &[Value]) -> usize {
-    items
+    let answered = items.len().saturating_sub(1);
+    items[..answered]
         .iter()
         .rposition(responses_item_is_assistant)
         .map_or(0, |i| i + 1)
@@ -719,28 +723,25 @@ fn responses_latest_turn_start(items: &[Value]) -> usize {
 /// Whether one `input[]` item is something the MODEL produced, and so a
 /// boundary for the latest-turn window.
 ///
-/// Three shapes, all of which `responses::responses_input_to_chat` maps to
-/// `Role::Assistant`: a `role: "assistant"` message, a tool call the model
-/// asked for (`function_call`, and the custom-tool spelling), and a
-/// `reasoning` item. A tool RESULT is the caller answering that call and
-/// is not a boundary.
+/// This API does not spell a model turn as a role: a tool call the model
+/// asked for is a bare `function_call` item, and so is a `reasoning`
+/// item. A tool RESULT is the caller answering that call and is not a
+/// boundary.
+///
+/// Asks `responses::responses_item_role` rather than re-deriving the
+/// answer, so this protocol has ONE role mapping and not two. Two of them
+/// disagreed on `{"role": "user", "type": "reasoning"}` — nothing sends
+/// that, but the whole point of the design is that the check pass and
+/// these walkers cannot drift, and a second copy is where drift comes
+/// from.
 fn responses_item_is_assistant(item: &Value) -> bool {
-    if item.get("role").and_then(Value::as_str) == Some("assistant") {
-        return true;
-    }
-    matches!(
-        item.get("type").and_then(Value::as_str),
-        Some("function_call" | "custom_tool_call" | "reasoning")
-    )
+    crate::responses::responses_item_role(item) == Role::Assistant
 }
 
 /// Whether one `input[]` item is a system-side message. `developer` is
 /// this API's spelling of the same thing.
 fn responses_item_is_system(item: &Value) -> bool {
-    matches!(
-        item.get("role").and_then(Value::as_str),
-        Some("system" | "developer")
-    )
+    crate::responses::responses_item_role(item) == Role::System
 }
 
 /// One `/v1/responses` input/output item. `message` items carry
@@ -778,7 +779,18 @@ fn redact_responses_item(
                 *args = owned;
             }
         }
-        Some("function_call_output") => {
+        // The custom-tool spelling of the same pair. Its argument slot is
+        // `input` and it is free-form text rather than JSON-encoded, so it
+        // is rewritten directly. Both are read by the scan
+        // (`responses::responses_item_text`), and a slot the scan reads
+        // and this walk does not is a Mask rule that reports a hit and
+        // then forwards the match unmasked.
+        Some("custom_tool_call") => {
+            if let Some(input) = item.get_mut("input") {
+                apply_to_value_string(chain, dir, input, counts);
+            }
+        }
+        Some("function_call_output" | "custom_tool_call_output") => {
             if let Some(output) = item.get_mut("output") {
                 apply_to_value_string(chain, dir, output, counts);
             }
@@ -1966,6 +1978,58 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(chat_latest_turn_start(&req.messages), 3);
+    }
+
+    /// The wire-level twin of
+    /// `chain::tests::a_trailing_assistant_prefill_does_not_close_the_window`.
+    #[test]
+    fn a_trailing_assistant_message_does_not_close_the_window_on_any_wire() {
+        let chat: ChatFormat = serde_json::from_value(json!({
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "old"},
+                {"role": "assistant", "content": "answered"},
+                {"role": "user", "content": "fresh"},
+                {"role": "assistant", "content": "Sure, here is"},
+            ],
+        }))
+        .unwrap();
+        assert_eq!(chat_latest_turn_start(&chat.messages), 2);
+
+        let anthropic = json!([
+            {"role": "user", "content": "old"},
+            {"role": "assistant", "content": "answered"},
+            {"role": "user", "content": "fresh"},
+            {"role": "assistant", "content": "Sure, here is"},
+        ]);
+        assert_eq!(
+            anthropic_latest_turn_start(anthropic.as_array().unwrap()),
+            2,
+        );
+
+        let responses = json!([
+            {"role": "user", "content": "old"},
+            {"role": "assistant", "type": "message",
+             "content": [{"type": "output_text", "text": "answered"}]},
+            {"role": "user", "content": "fresh"},
+            {"type": "reasoning", "encrypted_content": "opaque"},
+        ]);
+        assert_eq!(
+            responses_latest_turn_start(responses.as_array().unwrap()),
+            2,
+        );
+    }
+
+    /// A request that is nothing but one assistant prefill still has a
+    /// window — the whole request.
+    #[test]
+    fn a_request_of_one_assistant_message_is_entirely_in_the_window() {
+        let chat: ChatFormat = serde_json::from_value(json!({
+            "model": "m",
+            "messages": [{"role": "assistant", "content": "Sure, here is"}],
+        }))
+        .unwrap();
+        assert_eq!(chat_latest_turn_start(&chat.messages), 0);
     }
 
     #[test]

--- a/crates/aisix-proxy/src/redact.rs
+++ b/crates/aisix-proxy/src/redact.rs
@@ -502,7 +502,10 @@ pub fn redact_chat_format(chain: &dyn Guardrail, req: &mut ChatFormat) -> Redact
 /// has to exist separately because the mask walkers rewrite raw slots and
 /// have no parsed view to index against.
 fn chat_latest_turn_start(messages: &[aisix_gateway::ChatMessage]) -> usize {
-    let answered = messages.len().saturating_sub(1);
+    let answered = messages
+        .iter()
+        .rposition(|m| m.role != Role::System)
+        .unwrap_or(0);
     messages[..answered]
         .iter()
         .rposition(|m| m.role == Role::Assistant)
@@ -569,7 +572,10 @@ pub fn redact_anthropic_request(chain: &dyn Guardrail, body: &mut Value) -> Reda
 /// whole. A TRAILING assistant message is a prefill and never closes the
 /// window; see `aisix_guardrails::latest_turn_view`.
 fn anthropic_latest_turn_start(messages: &[Value]) -> usize {
-    let answered = messages.len().saturating_sub(1);
+    let answered = messages
+        .iter()
+        .rposition(|m| m.get("role").and_then(Value::as_str) != Some("system"))
+        .unwrap_or(0);
     messages[..answered]
         .iter()
         .rposition(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
@@ -713,7 +719,10 @@ pub fn redact_responses_request(chain: &dyn Guardrail, body: &mut Value) -> Reda
 /// API spells a model turn as a typed item with no role at all — see
 /// [`responses_item_is_assistant`].
 fn responses_latest_turn_start(items: &[Value]) -> usize {
-    let answered = items.len().saturating_sub(1);
+    let answered = items
+        .iter()
+        .rposition(|i| !responses_item_is_system(i))
+        .unwrap_or(0);
     items[..answered]
         .iter()
         .rposition(responses_item_is_assistant)
@@ -2017,6 +2026,46 @@ mod tests {
         assert_eq!(
             responses_latest_turn_start(responses.as_array().unwrap()),
             2,
+        );
+    }
+
+    /// The wire-level twin of
+    /// `chain::tests::a_system_message_after_a_prefill_does_not_reopen_the_bypass`:
+    /// a system message trailing the prefill must not make the prefill
+    /// look answered on any of the three shapes.
+    #[test]
+    fn a_system_message_after_a_prefill_does_not_close_the_window() {
+        let chat: ChatFormat = serde_json::from_value(json!({
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "secret"},
+                {"role": "assistant", "content": "Sure, here is"},
+                {"role": "system", "content": "trailing policy"},
+            ],
+        }))
+        .unwrap();
+        assert_eq!(chat_latest_turn_start(&chat.messages), 0);
+
+        // The non-spec `role: "system"` entry Claude Code sends (#597).
+        let anthropic = json!([
+            {"role": "user", "content": "secret"},
+            {"role": "assistant", "content": "Sure, here is"},
+            {"role": "system", "content": "trailing policy"},
+        ]);
+        assert_eq!(
+            anthropic_latest_turn_start(anthropic.as_array().unwrap()),
+            0,
+        );
+
+        let responses = json!([
+            {"role": "user", "content": "secret"},
+            {"role": "assistant", "type": "message",
+             "content": [{"type": "output_text", "text": "Sure, here is"}]},
+            {"role": "developer", "content": "trailing policy"},
+        ]);
+        assert_eq!(
+            responses_latest_turn_start(responses.as_array().unwrap()),
+            0,
         );
     }
 

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -986,28 +986,28 @@ fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
             for item in items {
                 // A bare-string array element is treated as user text; an
                 // object element is a message whose role we preserve.
+                //
+                // EVERY item becomes a message, including one that carries
+                // no readable text. That is what keeps this view aligned
+                // one-to-one with `input[]`, and the alignment is what
+                // makes the latest-turn window agree with the mask
+                // walkers in `crate::redact`, which compute the same
+                // boundary off the raw wire and cannot tell that an item
+                // held no text. Drop one here and the two halves disagree
+                // on where the current turn starts — a replayed
+                // `{"type": "reasoning", "encrypted_content": "…"}` (what
+                // an agent client sends on every turn with reasoning
+                // summaries off) or a `refusal`-only assistant message
+                // would make the check pass see no model turn at all and
+                // widen back to the whole conversation. An empty message
+                // contributes nothing to any kind's scan, so keeping it
+                // costs nothing.
                 if let Some(text) = item.as_str() {
-                    if !text.is_empty() {
-                        messages.push(ChatMessage::user(text.to_string()));
-                    }
+                    messages.push(ChatMessage::user(text.to_string()));
                     continue;
                 }
                 let text = responses_item_text(item);
-                let role = responses_item_role(item);
-                // A text-empty item carries nothing to scan and is dropped
-                // — EXCEPT an assistant-side one, which is where the
-                // latest-turn window opens. The mask walkers read that
-                // boundary off the wire and cannot tell that the item held
-                // no text, so dropping it here would make the two halves
-                // of the rule disagree: the check pass would see no model
-                // turn at all and widen back to the whole conversation.
-                // The shape is real — a `reasoning` item whose only
-                // payload is `encrypted_content` has no readable text and
-                // is replayed on every turn by agent clients.
-                if text.is_empty() && role != Role::Assistant {
-                    continue;
-                }
-                messages.push(match role {
+                messages.push(match responses_item_role(item) {
                     Role::Assistant => ChatMessage::assistant(text),
                     Role::System => ChatMessage::system(text),
                     Role::Tool => ChatMessage::tool(text),
@@ -1032,7 +1032,7 @@ fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
 /// Responses spelling of what `/v1/chat/completions` sends as an assistant
 /// message with `tool_calls` followed by `role: "tool"` messages.
 /// <https://platform.openai.com/docs/api-reference/responses/create>
-fn responses_item_role(item: &Value) -> Role {
+pub(crate) fn responses_item_role(item: &Value) -> Role {
     match item.get("role").and_then(|v| v.as_str()) {
         Some("assistant") => return Role::Assistant,
         Some("system") | Some("developer") => return Role::System,
@@ -1062,9 +1062,16 @@ fn responses_item_role(item: &Value) -> Role {
 ///   collapsed to empty text and was dropped from the scan: a block rule
 ///   that fires on `/v1/chat/completions` (where the same replayed call
 ///   rides `extra["tool_calls"]` and IS scanned) was bypassable by moving
-///   the payload into a tool call on this surface. The mask walker already
-///   rewrote both keys, so the two passes now read the same slots — the
-///   same pair the output scanner reads for a generated call.
+///   the payload into a tool call on this surface. The same pair the
+///   output scanner reads for a generated call.
+///
+/// `arguments` / `input` are rewritten by the mask walker
+/// (`redact::redact_responses_item`); `name` is NOT, exactly as a
+/// `tool_calls` function name is scanned but never rewritten on the chat
+/// wire — a tool name is structural, and masking it would break the call
+/// it identifies. So a Mask rule can report a hit on a tool NAME and
+/// forward it; a Block rule still refuses. That asymmetry is deliberate
+/// and shared with `/v1/chat/completions`.
 ///
 /// A `reasoning` item's `content[]` parts are covered by the `content`
 /// key above. Reasoning replayed on the REQUEST is caller-supplied text
@@ -3866,24 +3873,76 @@ mod tests {
                 aisix_gateway::Role::User,
             ],
         );
+        assert_eq!(chat.messages[1].content_str(), "", "no readable text");
         let window = aisix_guardrails::latest_turn_view(&chat);
         assert_eq!(window.messages.len(), 1);
         assert_eq!(window.messages[0].content_str(), "fresh");
     }
 
-    /// A text-empty item that is NOT a model turn is still dropped — the
-    /// exception above must be the boundary, not a blanket change.
+    /// The parsed view is one message per `input[]` item, whatever the
+    /// item carries. That alignment is what lets the check pass and the
+    /// mask walkers land on the same boundary; dropping the text-empty
+    /// item here would move the last model turn to the end of the list
+    /// and widen a `latest_turn` row back to the whole conversation.
     #[test]
-    fn responses_input_still_drops_a_text_empty_non_assistant_item() {
+    fn responses_input_keeps_one_message_per_item_even_when_text_is_empty() {
         let body = serde_json::json!({
             "model": "m",
             "input": [
-                {"role": "user", "content": "earlier"},
+                {"role": "user", "content": "earlier SECRET"},
+                {"role": "assistant", "type": "message",
+                 "content": [{"type": "output_text", "text": "answered"}]},
                 {"type": "function_call_output", "call_id": "c1", "output": ""},
             ],
         });
         let chat = super::responses_input_to_chat("m", &body);
-        assert_eq!(chat.messages.len(), 1);
+        assert_eq!(chat.messages.len(), 3);
+        let window = aisix_guardrails::latest_turn_view(&chat);
+        assert_eq!(
+            window.messages.len(),
+            1,
+            "only the empty tool result is in the window: {:?}",
+            window
+                .messages
+                .iter()
+                .map(|m| (m.role, m.content_str().to_owned()))
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    /// Naming a consequence of the role mapping so it is not rediscovered
+    /// as a bug: two kinds screen only user-role messages under their
+    /// DEFAULT `text_source` — `semantic` (`user_messages`) and
+    /// `azure_content_safety_text_moderation` (`concatenate_user_content`)
+    /// — so a replayed tool result on `/v1/responses` is now outside what
+    /// they read, exactly as a `role: "tool"` message already is on
+    /// `/v1/chat/completions`. Before the mapping it was mislabelled as
+    /// user text and they happened to scan it. Operators who want it
+    /// screened set `text_source` to the all-messages value, on either
+    /// surface.
+    #[test]
+    fn a_replayed_tool_result_is_not_user_role_on_either_surface() {
+        let responses = super::responses_input_to_chat(
+            "m",
+            &serde_json::json!({
+                "model": "m",
+                "input": [
+                    {"type": "function_call_output", "call_id": "c1", "output": "RESULT"},
+                ],
+            }),
+        );
+        let chat: aisix_gateway::ChatFormat = serde_json::from_value(serde_json::json!({
+            "model": "m",
+            "messages": [
+                {"role": "tool", "tool_call_id": "c1", "content": "RESULT"},
+            ],
+        }))
+        .unwrap();
+        assert_eq!(responses.messages[0].role, aisix_gateway::Role::Tool);
+        assert_eq!(
+            responses.messages[0].role, chat.messages[0].role,
+            "the two surfaces must agree on what a tool result is",
+        );
     }
 
     /// A tool RESULT is the caller answering, so it lands on `Role::Tool`

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -993,10 +993,21 @@ fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
                     continue;
                 }
                 let text = responses_item_text(item);
-                if text.is_empty() {
+                let role = responses_item_role(item);
+                // A text-empty item carries nothing to scan and is dropped
+                // — EXCEPT an assistant-side one, which is where the
+                // latest-turn window opens. The mask walkers read that
+                // boundary off the wire and cannot tell that the item held
+                // no text, so dropping it here would make the two halves
+                // of the rule disagree: the check pass would see no model
+                // turn at all and widen back to the whole conversation.
+                // The shape is real — a `reasoning` item whose only
+                // payload is `encrypted_content` has no readable text and
+                // is replayed on every turn by agent clients.
+                if text.is_empty() && role != Role::Assistant {
                     continue;
                 }
-                messages.push(match responses_item_role(item) {
+                messages.push(match role {
                     Role::Assistant => ChatMessage::assistant(text),
                     Role::System => ChatMessage::system(text),
                     Role::Tool => ChatMessage::tool(text),
@@ -3828,6 +3839,51 @@ mod tests {
         // The call's name and arguments are the scannable text.
         assert!(seen[5].1.contains("lookup"), "{:?}", seen[5]);
         assert!(seen[5].1.contains("SECRET"), "{:?}", seen[5]);
+    }
+
+    /// The check pass and the mask walkers each answer "where does the
+    /// latest turn start" for their own representation, so a model turn
+    /// that carries no readable text still has to reach the parsed view —
+    /// otherwise a `latest_turn` row would refuse on history that the
+    /// mask walkers correctly treat as out of window.
+    #[test]
+    fn responses_input_keeps_a_text_empty_assistant_item_as_a_boundary() {
+        let body = serde_json::json!({
+            "model": "m",
+            "input": [
+                {"role": "user", "content": "earlier"},
+                {"type": "reasoning", "encrypted_content": "opaque"},
+                {"role": "user", "content": "fresh"},
+            ],
+        });
+        let chat = super::responses_input_to_chat("m", &body);
+        let roles: Vec<_> = chat.messages.iter().map(|m| m.role).collect();
+        assert_eq!(
+            roles,
+            vec![
+                aisix_gateway::Role::User,
+                aisix_gateway::Role::Assistant,
+                aisix_gateway::Role::User,
+            ],
+        );
+        let window = aisix_guardrails::latest_turn_view(&chat);
+        assert_eq!(window.messages.len(), 1);
+        assert_eq!(window.messages[0].content_str(), "fresh");
+    }
+
+    /// A text-empty item that is NOT a model turn is still dropped — the
+    /// exception above must be the boundary, not a blanket change.
+    #[test]
+    fn responses_input_still_drops_a_text_empty_non_assistant_item() {
+        let body = serde_json::json!({
+            "model": "m",
+            "input": [
+                {"role": "user", "content": "earlier"},
+                {"type": "function_call_output", "call_id": "c1", "output": ""},
+            ],
+        });
+        let chat = super::responses_input_to_chat("m", &body);
+        assert_eq!(chat.messages.len(), 1);
     }
 
     /// A tool RESULT is the caller answering, so it lands on `Role::Tool`

--- a/crates/aisix-proxy/src/responses.rs
+++ b/crates/aisix-proxy/src/responses.rs
@@ -14,7 +14,7 @@
 //! Only OpenAI models support this endpoint. Non-OpenAI models receive a
 //! 400 with an explanatory message.
 
-use aisix_gateway::{ChatFormat, ChatMessage};
+use aisix_gateway::{ChatFormat, ChatMessage, Role};
 use aisix_obs::{
     content_capture_cap, AccessLog, CapturedContent, LatencyLabels, UsageEvent, UsageLabels,
 };
@@ -996,11 +996,11 @@ fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
                 if text.is_empty() {
                     continue;
                 }
-                let role = item.get("role").and_then(|v| v.as_str()).unwrap_or("user");
-                messages.push(match role {
-                    "assistant" => ChatMessage::assistant(text),
-                    "system" | "developer" => ChatMessage::system(text),
-                    _ => ChatMessage::user(text),
+                messages.push(match responses_item_role(item) {
+                    Role::Assistant => ChatMessage::assistant(text),
+                    Role::System => ChatMessage::system(text),
+                    Role::Tool => ChatMessage::tool(text),
+                    Role::User => ChatMessage::user(text),
                 });
             }
         }
@@ -1010,6 +1010,33 @@ fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
     ChatFormat::new(model, messages)
 }
 
+/// The role a Responses-API `input[]` item replays.
+///
+/// This API does not spell every turn as a `role`-bearing message: a model
+/// turn that called a tool is a bare `function_call` item, and the caller's
+/// answer is a bare `function_call_output`. Reading only `role` therefore
+/// used to report an agent's whole tool loop as user text, which both hid
+/// the assistant turns from anything that reasons about conversation
+/// structure and mislabelled tool results. The mapping below is the
+/// Responses spelling of what `/v1/chat/completions` sends as an assistant
+/// message with `tool_calls` followed by `role: "tool"` messages.
+/// <https://platform.openai.com/docs/api-reference/responses/create>
+fn responses_item_role(item: &Value) -> Role {
+    match item.get("role").and_then(|v| v.as_str()) {
+        Some("assistant") => return Role::Assistant,
+        Some("system") | Some("developer") => return Role::System,
+        Some(_) => return Role::User,
+        None => {}
+    }
+    match item.get("type").and_then(|v| v.as_str()) {
+        // The model asking for a tool, and its own reasoning.
+        Some("function_call" | "custom_tool_call" | "reasoning") => Role::Assistant,
+        // The caller answering that request.
+        Some("function_call_output" | "custom_tool_call_output") => Role::Tool,
+        _ => Role::User,
+    }
+}
+
 /// Collect the plain, caller-supplied text of one Responses-API input
 /// item, across every key on the `input`-item union that carries text the
 /// model will see:
@@ -1017,7 +1044,16 @@ fn responses_input_to_chat(model: &str, body: &Value) -> ChatFormat {
 /// - `output` — tool-result items (`function_call_output`,
 ///   `custom_tool_call_output`, `*_call_output`) the caller feeds back;
 /// - `reason` — an `mcp_approval_response` justification;
-/// - `summary` — a `reasoning` item's summary parts.
+/// - `summary` — a `reasoning` item's summary parts;
+/// - `name` plus `arguments` / `input` — a replayed tool call. These carry
+///   caller-controlled text straight to the model and a `function_call`
+///   item has none of the other four keys, so without them the whole item
+///   collapsed to empty text and was dropped from the scan: a block rule
+///   that fires on `/v1/chat/completions` (where the same replayed call
+///   rides `extra["tool_calls"]` and IS scanned) was bypassable by moving
+///   the payload into a tool call on this surface. The mask walker already
+///   rewrote both keys, so the two passes now read the same slots — the
+///   same pair the output scanner reads for a generated call.
 ///
 /// A `reasoning` item's `content[]` parts are covered by the `content`
 /// key above. Reasoning replayed on the REQUEST is caller-supplied text
@@ -1041,6 +1077,9 @@ fn responses_item_text(item: &Value) -> String {
         item.get("output"),
         item.get("reason"),
         item.get("summary"),
+        item.get("name"),
+        item.get("arguments"),
+        item.get("input"),
     ]
     .into_iter()
     .flatten()
@@ -3748,6 +3787,65 @@ fn emit_access_log(
 
 #[cfg(test)]
 mod tests {
+
+    /// The Responses API spells a model's tool call as a bare
+    /// `function_call` item with no `role`, and the caller's answer as a
+    /// bare `function_call_output`. Reading only `role` reported both as
+    /// user text — and, because a `function_call` carries none of the
+    /// text keys the scan used to read, dropped the call entirely, so a
+    /// payload parked in a replayed tool call reached the model unscanned
+    /// while `/v1/chat/completions` screened the same replay.
+    #[test]
+    fn responses_input_maps_tool_loop_items_to_assistant_and_tool() {
+        let body = serde_json::json!({
+            "model": "m",
+            "instructions": "be nice",
+            "input": [
+                {"role": "user", "content": "old"},
+                {"role": "assistant", "type": "message",
+                 "content": [{"type": "output_text", "text": "reply"}]},
+                {"role": "user", "content": "call it"},
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "thinking"}]},
+                {"type": "function_call", "call_id": "c1",
+                 "name": "lookup", "arguments": "{\"q\":\"SECRET\"}"},
+                {"type": "function_call_output", "call_id": "c1", "output": "result"},
+            ],
+        });
+        let chat = super::responses_input_to_chat("m", &body);
+        let seen: Vec<_> = chat
+            .messages
+            .iter()
+            .map(|m| (m.role, m.content_str().to_owned()))
+            .collect();
+        assert_eq!(seen.len(), 7, "{seen:?}");
+        assert_eq!(seen[0].0, aisix_gateway::Role::System);
+        assert_eq!(seen[1].0, aisix_gateway::Role::User);
+        assert_eq!(seen[2].0, aisix_gateway::Role::Assistant);
+        assert_eq!(seen[3].0, aisix_gateway::Role::User);
+        assert_eq!(seen[4].0, aisix_gateway::Role::Assistant, "reasoning");
+        assert_eq!(seen[5].0, aisix_gateway::Role::Assistant, "function_call");
+        assert_eq!(seen[6].0, aisix_gateway::Role::Tool, "function_call_output");
+        // The call's name and arguments are the scannable text.
+        assert!(seen[5].1.contains("lookup"), "{:?}", seen[5]);
+        assert!(seen[5].1.contains("SECRET"), "{:?}", seen[5]);
+    }
+
+    /// A tool RESULT is the caller answering, so it lands on `Role::Tool`
+    /// and stays inside the latest-turn window.
+    #[test]
+    fn responses_input_maps_a_tool_result_to_the_tool_role() {
+        let body = serde_json::json!({
+            "model": "m",
+            "input": [
+                {"type": "function_call", "call_id": "c1", "name": "f", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "c1", "output": "PAYLOAD"},
+            ],
+        });
+        let chat = super::responses_input_to_chat("m", &body);
+        assert_eq!(chat.messages.len(), 2);
+        assert_eq!(chat.messages[1].role, aisix_gateway::Role::Tool);
+        assert_eq!(chat.messages[1].content_str(), "PAYLOAD");
+    }
 
     use aisix_core::resource::ResourceEntry;
     use aisix_core::snapshot::SnapshotHandle;

--- a/schemas/resources-lenient/guardrail.schema.json
+++ b/schemas/resources-lenient/guardrail.schema.json
@@ -102,6 +102,25 @@
         }
       ]
     },
+    "GuardrailInputMessages": {
+      "description": "How much of a request's message history an input guardrail reads.\n\nIDE and agent clients replay the whole conversation on every call, so a rule that matched once keeps matching for the rest of the session even after the offending message is long past. `LatestTurn` narrows every input hook — the block check and the masking pass alike — to the part of the conversation the model has not answered yet.",
+      "oneOf": [
+        {
+          "description": "Read every message in the request, including replayed history and system prompts.",
+          "enum": [
+            "all"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Read only the messages after the last assistant message, excluding system messages: the current user message together with any tool results answering it. Messages the model has already replied to are neither screened nor rewritten.",
+          "enum": [
+            "latest_turn"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "KeywordPattern": {
       "description": "Literal or regular-expression pattern used by a keyword guardrail.",
       "oneOf": [
@@ -280,6 +299,15 @@
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
         },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
+        },
         "kind": {
           "description": "Guardrail provider type for literal and regular expression matching.",
           "enum": [
@@ -362,6 +390,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for Amazon Bedrock Guardrails.",
@@ -450,6 +487,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for Azure Prompt Shield.",
@@ -564,6 +610,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for Azure text moderation.",
@@ -724,6 +779,15 @@
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
         },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
+        },
         "kind": {
           "description": "Guardrail provider type for Aliyun text moderation.",
           "enum": [
@@ -861,6 +925,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for Aliyun AI Guardrails policy-driven moderation.",
@@ -1000,6 +1073,15 @@
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
         },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
+        },
         "kind": {
           "description": "Guardrail provider type for in-process sensitive-data detection and redaction.",
           "enum": [
@@ -1077,6 +1159,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for Lakera Guard screening.",
@@ -1185,6 +1276,15 @@
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
         },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
+        },
         "kind": {
           "description": "Guardrail provider type for the OpenAI Moderation API.",
           "enum": [
@@ -1286,6 +1386,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for PII detection and anonymization by a customer-run Presidio.",
@@ -1441,6 +1550,15 @@
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
         },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
+        },
         "kind": {
           "description": "Guardrail provider type for embedding-similarity screening against example texts, using an embedding-kind Model.",
           "enum": [
@@ -1540,6 +1658,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for screening by an operator-supplied script the gateway runs in a sandboxed engine.",
@@ -1670,6 +1797,15 @@
       ],
       "default": "both",
       "description": "Where in the lifecycle this rule runs."
+    },
+    "input_messages": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/GuardrailInputMessages"
+        }
+      ],
+      "default": "all",
+      "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
     },
     "name": {
       "description": "Operator-facing name that surfaces in metric labels and error reasons.",

--- a/schemas/resources/guardrail.schema.json
+++ b/schemas/resources/guardrail.schema.json
@@ -105,6 +105,25 @@
         }
       ]
     },
+    "GuardrailInputMessages": {
+      "description": "How much of a request's message history an input guardrail reads.\n\nIDE and agent clients replay the whole conversation on every call, so a rule that matched once keeps matching for the rest of the session even after the offending message is long past. `LatestTurn` narrows every input hook — the block check and the masking pass alike — to the part of the conversation the model has not answered yet.",
+      "oneOf": [
+        {
+          "description": "Read every message in the request, including replayed history and system prompts.",
+          "enum": [
+            "all"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Read only the messages after the last assistant message, excluding system messages: the current user message together with any tool results answering it. Messages the model has already replied to are neither screened nor rewritten.",
+          "enum": [
+            "latest_turn"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "KeywordPattern": {
       "description": "Literal or regular-expression pattern used by a keyword guardrail.",
       "oneOf": [
@@ -289,6 +308,15 @@
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
         },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
+        },
         "kind": {
           "description": "Guardrail provider type for literal and regular expression matching.",
           "enum": [
@@ -372,6 +400,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for Amazon Bedrock Guardrails.",
@@ -461,6 +498,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for Azure Prompt Shield.",
@@ -576,6 +622,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for Azure text moderation.",
@@ -737,6 +792,15 @@
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
         },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
+        },
         "kind": {
           "description": "Guardrail provider type for Aliyun text moderation.",
           "enum": [
@@ -875,6 +939,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for Aliyun AI Guardrails policy-driven moderation.",
@@ -1015,6 +1088,15 @@
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
         },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
+        },
         "kind": {
           "description": "Guardrail provider type for in-process sensitive-data detection and redaction.",
           "enum": [
@@ -1093,6 +1175,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for Lakera Guard screening.",
@@ -1202,6 +1293,15 @@
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
         },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
+        },
         "kind": {
           "description": "Guardrail provider type for the OpenAI Moderation API.",
           "enum": [
@@ -1304,6 +1404,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for PII detection and anonymization by a customer-run Presidio.",
@@ -1518,6 +1627,15 @@
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
         },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
+        },
         "kind": {
           "description": "Guardrail provider type for embedding-similarity screening against example texts, using an embedding-kind Model.",
           "enum": [
@@ -1618,6 +1736,15 @@
           ],
           "default": "both",
           "description": "Where in the lifecycle this rule runs."
+        },
+        "input_messages": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/GuardrailInputMessages"
+            }
+          ],
+          "default": "all",
+          "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
         },
         "kind": {
           "description": "Guardrail provider type for screening by an operator-supplied script the gateway runs in a sandboxed engine.",
@@ -1747,6 +1874,15 @@
       ],
       "default": "both",
       "description": "Where in the lifecycle this rule runs."
+    },
+    "input_messages": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/GuardrailInputMessages"
+        }
+      ],
+      "default": "all",
+      "description": "How much of the request this rule reads at the input hook.\n\n`all` (the default) scans every message the caller sent, including replayed history and system prompts. `latest_turn` scans only the messages after the last assistant message, with system messages excluded — the current user message plus any tool results answering it. It exists for clients that resend the whole conversation on every call, where a rule that matched one earlier message would otherwise keep refusing the rest of the session.\n\nThe narrowing governs everything the rule does on the request: under `latest_turn` a masking rule rewrites only the current turn, and messages outside it reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`.\n\nIgnored at the output hook, which always reads the whole response."
     },
     "name": {
       "description": "Operator-facing name that surfaces in metric labels and error reasons.",

--- a/tests/e2e/src/cases/guardrail-input-messages-latest-turn-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-input-messages-latest-turn-e2e.test.ts
@@ -86,6 +86,7 @@ describe("guardrail input_messages: latest_turn (AISIX-Cloud#1558)", () => {
   const scriptLatest: Lane = { model: "lt-script-latest" };
   const scriptAll: Lane = { model: "lt-script-all" };
   const maskLatest: Lane = { model: "lt-mask-latest" };
+  const piiLatest: Lane = { model: "lt-pii-latest" };
 
   beforeAll(async () => {
     const etcd = new EtcdClient();
@@ -163,6 +164,18 @@ describe("guardrail input_messages: latest_turn (AISIX-Cloud#1558)", () => {
       timeout_ms: 5000,
     });
 
+    // The sync mask channel (`redact_input_text`) is a different code path
+    // from the segment one above — per-member filtering rather than slot
+    // splicing — and it is the one a real PII mask rule uses.
+    await lane(piiLatest, {
+      name: "lt-pii-latest-row",
+      enabled: true,
+      hook_point: "input",
+      input_messages: "latest_turn",
+      kind: "pii",
+      detectors: [{ type: "email", action: "mask" }],
+    });
+
     // Seeded last: this key authenticating implies every resource above it
     // is already in the gateway's snapshot.
     await seed.createApiKey({
@@ -173,6 +186,7 @@ describe("guardrail input_messages: latest_turn (AISIX-Cloud#1558)", () => {
         scriptLatest.model,
         scriptAll.model,
         maskLatest.model,
+        piiLatest.model,
       ],
     });
   });
@@ -581,6 +595,43 @@ describe("guardrail input_messages: latest_turn (AISIX-Cloud#1558)", () => {
   );
 
   // ── masking follows the same window ───────────────────────────────────
+
+  test(
+    "a `pii` mask row on `latest_turn` leaves history's PII untouched",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+      const HISTORY_MAIL = "history.person@example.com";
+      const CURRENT_MAIL = "current.person@example.com";
+
+      await waitConfigPropagation(async () => {
+        const before = upstream!.receivedRequests.length;
+        await chat(piiLatest.model, [
+          { role: "user", content: `probe ${CURRENT_MAIL}` },
+        ]);
+        return upstream!.receivedRequests
+          .slice(before)
+          .some((r) => !r.body.includes(CURRENT_MAIL));
+      });
+
+      const before = upstream.receivedRequests.length;
+      await chat(piiLatest.model, [
+        { role: "user", content: `earlier ${HISTORY_MAIL}` },
+        { role: "assistant", content: "understood" },
+        { role: "user", content: `now ${CURRENT_MAIL}` },
+      ]);
+      const sent = upstream.receivedRequests.slice(before);
+      expect(sent.length).toBeGreaterThan(0);
+      const body = sent[sent.length - 1].body;
+      expect(body, "history PII is forwarded as the caller sent it").toContain(
+        HISTORY_MAIL,
+      );
+      expect(body, "the current turn is masked").not.toContain(CURRENT_MAIL);
+    },
+    60_000,
+  );
 
   test(
     "a masking row on `latest_turn` rewrites the current turn and forwards history byte-identical",

--- a/tests/e2e/src/cases/guardrail-input-messages-latest-turn-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-input-messages-latest-turn-e2e.test.ts
@@ -608,20 +608,25 @@ describe("guardrail input_messages: latest_turn (AISIX-Cloud#1558)", () => {
 
       await waitConfigPropagation(async () => {
         const before = upstream!.receivedRequests.length;
-        await chat(piiLatest.model, [
+        const probe = await chat(piiLatest.model, [
           { role: "user", content: `probe ${CURRENT_MAIL}` },
         ]);
+        if (!probe.ok) return false;
         return upstream!.receivedRequests
           .slice(before)
           .some((r) => !r.body.includes(CURRENT_MAIL));
       });
 
       const before = upstream.receivedRequests.length;
-      await chat(piiLatest.model, [
+      const res = await chat(piiLatest.model, [
         { role: "user", content: `earlier ${HISTORY_MAIL}` },
         { role: "assistant", content: "understood" },
         { role: "user", content: `now ${CURRENT_MAIL}` },
       ]);
+      // A mask row never refuses, so anything but a success here means the
+      // request took a path this case is not describing — and the upstream
+      // body below would then be evidence about the wrong request.
+      expect(res.status, "a masking row must not refuse the request").toBe(200);
       const sent = upstream.receivedRequests.slice(before);
       expect(sent.length).toBeGreaterThan(0);
       const body = sent[sent.length - 1].body;
@@ -644,22 +649,23 @@ describe("guardrail input_messages: latest_turn (AISIX-Cloud#1558)", () => {
       // upstream rather than on a refusal.
       await waitConfigPropagation(async () => {
         const before = upstream!.receivedRequests.length;
-        await chat(maskLatest.model, [
+        const probe = await chat(maskLatest.model, [
           { role: "user", content: `probe ${SECRET}` },
         ]);
-        const forwarded = upstream!.receivedRequests
+        if (!probe.ok) return false;
+        return upstream!.receivedRequests
           .slice(before)
           .some((r) => r.body.includes(MASKED));
-        return forwarded;
       });
 
       const before = upstream.receivedRequests.length;
-      await chat(maskLatest.model, [
+      const res = await chat(maskLatest.model, [
         { role: "system", content: `system holds ${SECRET}` },
         { role: "user", content: `earlier turn holds ${SECRET}` },
         { role: "assistant", content: "understood" },
         { role: "user", content: `this turn holds ${SECRET}` },
       ]);
+      expect(res.status, "a masking row must not refuse the request").toBe(200);
       const sent = upstream.receivedRequests.slice(before);
       expect(sent.length, "the request must reach the upstream").toBeGreaterThan(0);
       const body = JSON.parse(sent[sent.length - 1].body) as {

--- a/tests/e2e/src/cases/guardrail-input-messages-latest-turn-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-input-messages-latest-turn-e2e.test.ts
@@ -548,6 +548,38 @@ describe("guardrail input_messages: latest_turn (AISIX-Cloud#1558)", () => {
     60_000,
   );
 
+  test(
+    "/v1/responses: a model turn carrying no readable text still opens the window",
+    async (ctx) => {
+      if (!etcdReachable || !app) {
+        ctx.skip();
+        return;
+      }
+      await waitForLane(kwLatest.model);
+      await waitForLane(scriptLatest.model);
+
+      // What an agent client replays when reasoning summaries are off:
+      // the item's only payload is provider ciphertext, so it carries no
+      // text to scan — but it is still the model's turn, and both halves
+      // of the window rule have to agree that the marker before it is
+      // history.
+      const input = [
+        { role: "user", content: `earlier ${MARKER}` },
+        { type: "reasoning", encrypted_content: "opaque-provider-blob" },
+        { role: "user", content: "a clean new question" },
+      ];
+      expect(
+        await blocked(responses(kwLatest.model, input)),
+        "check pass: the marker sits before the model's turn",
+      ).toBe(false);
+      expect(
+        await blocked(responses(scriptLatest.model, input)),
+        "segment pass must agree with the check pass",
+      ).toBe(false);
+    },
+    60_000,
+  );
+
   // ── masking follows the same window ───────────────────────────────────
 
   test(

--- a/tests/e2e/src/cases/guardrail-input-messages-latest-turn-e2e.test.ts
+++ b/tests/e2e/src/cases/guardrail-input-messages-latest-turn-e2e.test.ts
@@ -1,0 +1,604 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+// E2E: `input_messages: latest_turn` narrows an input guardrail to the part
+// of the conversation the model has not answered yet (AISIX-Cloud#1558).
+//
+// The reported problem: IDE and agent clients replay the whole conversation
+// on every call, so a rule that matched one message keeps refusing every
+// later request in the session even though the new prompt is clean. The
+// window is "everything after the last assistant message, system excluded" —
+// this turn's user message plus the tool results answering it.
+//
+// Two boundaries are pinned per protocol, deliberately, because the gateway
+// answers the question twice and in two representations:
+//
+//   * the CHECK pass reads the parsed ChatFormat, so a `keyword` row
+//     exercises `aisix_guardrails::latest_turn_view`;
+//   * the SEGMENT pass rewrites raw wire slots and never sees a parsed
+//     view, so a `custom` row — which moderates via the segment hooks —
+//     exercises the per-shape walkers in `aisix-proxy::redact`.
+//
+// A `custom` row runs its script in-process, so the segment half needs no
+// external service. The two must agree; a drift between them is exactly
+// what these cases exist to catch.
+//
+// Reference:
+//   - <https://platform.openai.com/docs/api-reference/chat/create>
+//   - <https://docs.anthropic.com/en/api/messages>
+//   - <https://platform.openai.com/docs/api-reference/responses/create>
+
+const CALLER = "sk-latest-turn-e2e-caller";
+const HASH = createHash("sha256").update(CALLER).digest("hex");
+
+/** The pattern every guardrail below refuses. */
+const MARKER = "latestturnforbiddenmarker";
+/** Masked rather than blocked, by the mask row only. */
+const SECRET = "latestturnsecretvalue";
+const MASKED = "[REDACTED]";
+
+/** Blocks whenever the text it is given contains the marker. */
+const BLOCK_SCRIPT = `
+export async function checkInput(ctx) {
+  if (ctx.text.indexOf("${MARKER}") !== -1) {
+    return { action: "block", reason_code: "LT-1" };
+  }
+  return { action: "none" };
+}
+`;
+
+/** Rewrites the secret out of every slot it is offered. */
+const MASK_SCRIPT = `
+export async function checkInput(ctx) {
+  return {
+    action: "mask",
+    segments: ctx.segments.map(function (s) {
+      return s.split("${SECRET}").join("${MASKED}");
+    }),
+  };
+}
+`;
+
+interface Lane {
+  /** Model display name, also the model a request addresses. */
+  model: string;
+}
+
+describe("guardrail input_messages: latest_turn (AISIX-Cloud#1558)", () => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  // One model per (guardrail kind × window) so the rows never share scope:
+  // a guardrail's scope is its attachments and nothing else, so attaching
+  // each to its own model keeps the lanes independent on one gateway.
+  const kwLatest: Lane = { model: "lt-kw-latest" };
+  const kwAll: Lane = { model: "lt-kw-all" };
+  const scriptLatest: Lane = { model: "lt-script-latest" };
+  const scriptAll: Lane = { model: "lt-script-all" };
+  const maskLatest: Lane = { model: "lt-mask-latest" };
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp();
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+
+    const pk = await seed.createProviderKey({
+      display_name: "lt-pk",
+      secret: "sk-mock",
+      api_base: `${upstream.baseUrl}/v1`,
+    });
+
+    const lane = async (
+      lane: Lane,
+      guardrail: Record<string, unknown>,
+    ): Promise<void> => {
+      const model = await seed.createModel({
+        display_name: lane.model,
+        provider: "openai",
+        model_name: "gpt-4o-mini",
+        provider_key_id: pk.id,
+      });
+      const gr = await seed.createGuardrail(guardrail, { attach: false });
+      await seed.attachGuardrailToModel(gr.id, model.id);
+    };
+
+    await lane(kwLatest, {
+      name: "lt-kw-latest-row",
+      enabled: true,
+      hook_point: "input",
+      input_messages: "latest_turn",
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: MARKER }],
+    });
+    await lane(kwAll, {
+      name: "lt-kw-all-row",
+      enabled: true,
+      hook_point: "input",
+      // `input_messages` deliberately unset: the default must stay `all`,
+      // so this lane also pins that no existing configuration changed.
+      kind: "keyword",
+      patterns: [{ kind: "literal", value: MARKER }],
+    });
+    await lane(scriptLatest, {
+      name: "lt-script-latest-row",
+      enabled: true,
+      hook_point: "input",
+      input_messages: "latest_turn",
+      fail_open: false,
+      kind: "custom",
+      script: BLOCK_SCRIPT,
+      timeout_ms: 5000,
+    });
+    await lane(scriptAll, {
+      name: "lt-script-all-row",
+      enabled: true,
+      hook_point: "input",
+      fail_open: false,
+      kind: "custom",
+      script: BLOCK_SCRIPT,
+      timeout_ms: 5000,
+    });
+    await lane(maskLatest, {
+      name: "lt-mask-latest-row",
+      enabled: true,
+      hook_point: "input",
+      input_messages: "latest_turn",
+      fail_open: false,
+      kind: "custom",
+      script: MASK_SCRIPT,
+      timeout_ms: 5000,
+    });
+
+    // Seeded last: this key authenticating implies every resource above it
+    // is already in the gateway's snapshot.
+    await seed.createApiKey({
+      key_hash: HASH,
+      allowed_models: [
+        kwLatest.model,
+        kwAll.model,
+        scriptLatest.model,
+        scriptAll.model,
+        maskLatest.model,
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  // ── request builders, one per protocol ────────────────────────────────
+
+  const post = (path: string, body: unknown): Promise<Response> =>
+    fetch(`${app!.proxyUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${CALLER}`,
+        "x-api-key": CALLER,
+      },
+      body: JSON.stringify(body),
+    });
+
+  const chat = (model: string, messages: unknown[]) =>
+    post("/v1/chat/completions", { model, messages });
+
+  const anthropic = (
+    model: string,
+    messages: unknown[],
+    system?: string,
+  ) =>
+    post("/v1/messages", {
+      model,
+      max_tokens: 64,
+      ...(system === undefined ? {} : { system }),
+      messages,
+    });
+
+  const responses = (model: string, input: unknown[], instructions?: string) =>
+    post("/v1/responses", {
+      model,
+      ...(instructions === undefined ? {} : { instructions }),
+      input,
+    });
+
+  /** 422 is the guardrail refusal; anything else is "not blocked". */
+  const blocked = async (r: Promise<Response>): Promise<boolean> =>
+    (await r).status === 422;
+
+  /**
+   * Gate on the lane's guardrail being loaded AND in force, using the one
+   * shape every window agrees on: the marker in the CURRENT user message.
+   * A positive condition, so a transient 401 while the caller key is still
+   * propagating cannot be mistaken for a guardrail verdict.
+   */
+  async function waitForLane(model: string): Promise<void> {
+    await waitConfigPropagation(async () => {
+      if (await blocked(chat(model, [{ role: "user", content: "probe" }]))) {
+        return false;
+      }
+      return blocked(
+        chat(model, [{ role: "user", content: `probe ${MARKER}` }]),
+      );
+    });
+  }
+
+  // ── the four boundary cases, per protocol × per pass ──────────────────
+  //
+  // Each builder returns a body whose marker sits in exactly one place.
+
+  const chatBodies = {
+    // Replayed history the model has already answered.
+    history: () => [
+      { role: "system", content: "be helpful" },
+      { role: "user", content: `earlier ${MARKER}` },
+      { role: "assistant", content: "understood" },
+      { role: "user", content: "a clean new question" },
+    ],
+    // This turn's user message.
+    latest: () => [
+      { role: "user", content: "earlier" },
+      { role: "assistant", content: "understood" },
+      { role: "user", content: `now do ${MARKER}` },
+    ],
+    // This turn's tool result: it follows the assistant turn that asked
+    // for it, so it is inside the window.
+    toolResult: () => [
+      { role: "user", content: "look it up" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "lookup", arguments: "{}" },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: "call_1", content: `found ${MARKER}` },
+    ],
+    system: () => [
+      { role: "system", content: `policy mentions ${MARKER}` },
+      { role: "user", content: "earlier" },
+      { role: "assistant", content: "understood" },
+      { role: "user", content: "a clean new question" },
+    ],
+  };
+
+  const anthropicBodies = {
+    history: (): [unknown[], string | undefined] => [
+      [
+        { role: "user", content: `earlier ${MARKER}` },
+        { role: "assistant", content: "understood" },
+        { role: "user", content: "a clean new question" },
+      ],
+      "be helpful",
+    ],
+    latest: (): [unknown[], string | undefined] => [
+      [
+        { role: "user", content: "earlier" },
+        { role: "assistant", content: "understood" },
+        { role: "user", content: `now do ${MARKER}` },
+      ],
+      undefined,
+    ],
+    // A tool_use turn is an assistant message, so it is the boundary; the
+    // tool_result answering it rides the FINAL user message.
+    toolResult: (): [unknown[], string | undefined] => [
+      [
+        { role: "user", content: "look it up" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "tu_1", name: "lookup", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tu_1",
+              content: `found ${MARKER}`,
+            },
+          ],
+        },
+      ],
+      undefined,
+    ],
+    system: (): [unknown[], string | undefined] => [
+      [
+        { role: "user", content: "earlier" },
+        { role: "assistant", content: "understood" },
+        { role: "user", content: "a clean new question" },
+      ],
+      `policy mentions ${MARKER}`,
+    ],
+  };
+
+  const assistantMessageItem = (text: string) => ({
+    type: "message",
+    role: "assistant",
+    content: [{ type: "output_text", text }],
+  });
+
+  const responsesBodies = {
+    history: (): [unknown[], string | undefined] => [
+      [
+        { role: "user", content: `earlier ${MARKER}` },
+        assistantMessageItem("understood"),
+        { role: "user", content: "a clean new question" },
+      ],
+      "be helpful",
+    ],
+    latest: (): [unknown[], string | undefined] => [
+      [
+        { role: "user", content: "earlier" },
+        assistantMessageItem("understood"),
+        { role: "user", content: `now do ${MARKER}` },
+      ],
+      undefined,
+    ],
+    // `function_call` is the model's turn (no `role` on this wire) and so
+    // the boundary; the `function_call_output` answering it is inside.
+    toolResult: (): [unknown[], string | undefined] => [
+      [
+        { role: "user", content: "look it up" },
+        {
+          type: "function_call",
+          call_id: "call_1",
+          name: "lookup",
+          arguments: "{}",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: `found ${MARKER}`,
+        },
+      ],
+      undefined,
+    ],
+    system: (): [unknown[], string | undefined] => [
+      [
+        { role: "user", content: "earlier" },
+        assistantMessageItem("understood"),
+        { role: "user", content: "a clean new question" },
+      ],
+      `policy mentions ${MARKER}`,
+    ],
+  };
+
+  const send = {
+    chat: (model: string, which: keyof typeof chatBodies) =>
+      chat(model, chatBodies[which]()),
+    messages: (model: string, which: keyof typeof anthropicBodies) => {
+      const [msgs, system] = anthropicBodies[which]();
+      return anthropic(model, msgs, system);
+    },
+    responses: (model: string, which: keyof typeof responsesBodies) => {
+      const [input, instructions] = responsesBodies[which]();
+      return responses(model, input, instructions);
+    },
+  };
+
+  const protocols = ["chat", "messages", "responses"] as const;
+  const passes = [
+    { pass: "check pass (keyword)", latest: kwLatest, all: kwAll },
+    { pass: "segment pass (custom script)", latest: scriptLatest, all: scriptAll },
+  ];
+
+  for (const { pass, latest, all } of passes) {
+    for (const protocol of protocols) {
+      const drive = send[protocol];
+
+      test(
+        `${pass} / ${protocol}: a marker in replayed history blocks under \`all\` and passes under \`latest_turn\``,
+        async (ctx) => {
+          if (!etcdReachable || !app) {
+            ctx.skip();
+            return;
+          }
+          await waitForLane(all.model);
+          await waitForLane(latest.model);
+
+          expect(
+            await blocked(drive(all.model, "history")),
+            "`all` must still read the whole conversation",
+          ).toBe(true);
+          expect(
+            await blocked(drive(latest.model, "history")),
+            "`latest_turn` must not read a message the model already answered",
+          ).toBe(false);
+        },
+        60_000,
+      );
+
+      test(
+        `${pass} / ${protocol}: a marker in the current user message blocks under \`latest_turn\``,
+        async (ctx) => {
+          if (!etcdReachable || !app) {
+            ctx.skip();
+            return;
+          }
+          await waitForLane(latest.model);
+          expect(await blocked(drive(latest.model, "latest"))).toBe(true);
+        },
+        60_000,
+      );
+
+      test(
+        `${pass} / ${protocol}: a marker in this turn's tool result blocks under \`latest_turn\``,
+        async (ctx) => {
+          if (!etcdReachable || !app) {
+            ctx.skip();
+            return;
+          }
+          await waitForLane(latest.model);
+          expect(
+            await blocked(drive(latest.model, "toolResult")),
+            "the tool result answering this turn is inside the window",
+          ).toBe(true);
+        },
+        60_000,
+      );
+
+      test(
+        `${pass} / ${protocol}: a marker in the system prompt blocks under \`all\` and passes under \`latest_turn\``,
+        async (ctx) => {
+          if (!etcdReachable || !app) {
+            ctx.skip();
+            return;
+          }
+          await waitForLane(all.model);
+          await waitForLane(latest.model);
+
+          expect(await blocked(drive(all.model, "system"))).toBe(true);
+          expect(
+            await blocked(drive(latest.model, "system")),
+            "system messages are never inside the window",
+          ).toBe(false);
+        },
+        60_000,
+      );
+    }
+  }
+
+  // ── /v1/responses: the model's turn is a typed item, not a role ───────
+
+  test(
+    "/v1/responses: a replayed function_call's arguments are scanned under `all` and excluded once answered",
+    async (ctx) => {
+      if (!etcdReachable || !app) {
+        ctx.skip();
+        return;
+      }
+      await waitForLane(kwAll.model);
+      await waitForLane(kwLatest.model);
+
+      const input = [
+        { role: "user", content: "look it up" },
+        {
+          type: "function_call",
+          call_id: "call_1",
+          name: "lookup",
+          arguments: JSON.stringify({ q: MARKER }),
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: "nothing found",
+        },
+        assistantMessageItem("all done"),
+        { role: "user", content: "a clean new question" },
+      ];
+
+      expect(
+        await blocked(responses(kwAll.model, input)),
+        "a replayed tool call's arguments are caller-supplied text entering the model",
+      ).toBe(true);
+      expect(
+        await blocked(responses(kwLatest.model, input)),
+        "the whole loop sits before the last assistant message",
+      ).toBe(false);
+    },
+    60_000,
+  );
+
+  test(
+    "/v1/responses: a function_call_output with no later assistant item blocks under `latest_turn`",
+    async (ctx) => {
+      if (!etcdReachable || !app) {
+        ctx.skip();
+        return;
+      }
+      await waitForLane(kwLatest.model);
+
+      const input = [
+        { role: "user", content: "look it up" },
+        {
+          type: "function_call",
+          call_id: "call_1",
+          name: "lookup",
+          arguments: "{}",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: `found ${MARKER}`,
+        },
+      ];
+      expect(await blocked(responses(kwLatest.model, input))).toBe(true);
+    },
+    60_000,
+  );
+
+  // ── masking follows the same window ───────────────────────────────────
+
+  test(
+    "a masking row on `latest_turn` rewrites the current turn and forwards history byte-identical",
+    async (ctx) => {
+      if (!etcdReachable || !app || !upstream) {
+        ctx.skip();
+        return;
+      }
+      // This lane never blocks, so gate it on the request reaching the
+      // upstream rather than on a refusal.
+      await waitConfigPropagation(async () => {
+        const before = upstream!.receivedRequests.length;
+        await chat(maskLatest.model, [
+          { role: "user", content: `probe ${SECRET}` },
+        ]);
+        const forwarded = upstream!.receivedRequests
+          .slice(before)
+          .some((r) => r.body.includes(MASKED));
+        return forwarded;
+      });
+
+      const before = upstream.receivedRequests.length;
+      await chat(maskLatest.model, [
+        { role: "system", content: `system holds ${SECRET}` },
+        { role: "user", content: `earlier turn holds ${SECRET}` },
+        { role: "assistant", content: "understood" },
+        { role: "user", content: `this turn holds ${SECRET}` },
+      ]);
+      const sent = upstream.receivedRequests.slice(before);
+      expect(sent.length, "the request must reach the upstream").toBeGreaterThan(0);
+      const body = JSON.parse(sent[sent.length - 1].body) as {
+        messages: Array<{ role: string; content: string | null }>;
+      };
+      const byRole = (role: string, index: number) =>
+        body.messages.filter((m) => m.role === role)[index]?.content ?? "";
+
+      expect(
+        byRole("system", 0),
+        "a system message is outside the window",
+      ).toContain(SECRET);
+      expect(
+        byRole("user", 0),
+        "history the model already answered is forwarded as the caller sent it",
+      ).toContain(SECRET);
+      expect(
+        byRole("user", 1),
+        "the current turn is rewritten",
+      ).toContain(MASKED);
+      expect(byRole("user", 1)).not.toContain(SECRET);
+    },
+    60_000,
+  );
+});

--- a/tests/e2e/src/cases/model-reference-ids-e2e.test.ts
+++ b/tests/e2e/src/cases/model-reference-ids-e2e.test.ts
@@ -667,9 +667,23 @@ describe("model references by resource id", () => {
     await scoped("mr-beta", { embedding_model: DANGLING });
     // Fail-closed is the default, so a benign prompt is refused too —
     // that is what makes the two spellings comparable on one request.
+    //
+    // Wait for BOTH rows. The two guardrails and their two attachments are
+    // four separate etcd keys, so the snapshot can carry `mr-alpha`'s pair
+    // while `mr-beta`'s attachment is not yet applied — and a guardrail
+    // with no attachment in force governs nothing, so `mr-beta` answers
+    // 200 and the comparison below fails on a request that was never
+    // screened. Gating on one of the two made that a scheduler-dependent
+    // race (it reproduced on the work-stealing leg while the
+    // thread-per-core leg passed on identical code). The gate is still a
+    // real check: if either spelling stopped failing closed it would never
+    // be satisfied and the test times out.
     await waitConfigPropagation(async () => {
-      const r = await chat("mr-alpha", "what is the weather");
-      return r.status === 422;
+      const [a, b] = await Promise.all([
+        chat("mr-alpha", "what is the weather"),
+        chat("mr-beta", "what is the weather"),
+      ]);
+      return a.status === 422 && b.status === 422;
     });
     const byId = await chat("mr-alpha", "what is the weather");
     const byName = await chat("mr-beta", "what is the weather");


### PR DESCRIPTION
## Problem

IDE and agent clients replay the whole conversation on every call. An input guardrail therefore re-reads every earlier message on every request, so a rule that matched one message keeps refusing the rest of the session even though the new prompt is clean. A customer's regex rule is stuck this way today: the only way out is to start a new conversation or drop the rule.

## What this adds

A new optional top-level field on the guardrail resource, common to all twelve kinds:

```yaml
input_messages: all | latest_turn   # optional, default "all"
```

- **`all`** — today's behaviour, unchanged. Every message in the request is read: system, user, assistant, tool.
- **`latest_turn`** — only the messages after the last assistant message, with system messages excluded. A *trailing* assistant message does not count: that is a prefill, text the caller wrote for the model to continue rather than a turn the model has answered, so it belongs to the current turn and is scanned with it. "Trailing" is measured against the last non-system message, since system messages sit outside the window wherever they are — an assistant message followed only by system ones has still answered nothing. In practice that is this turn's user message plus the tool results answering it (`role: "tool"` on the chat wire, `tool_result` blocks on `/v1/messages`, `function_call_output` items on `/v1/responses`). A request with no assistant message narrows to every non-system message. Messages the model has already replied to are neither screened nor rewritten.

The field is inert at the output hook, which always reads the whole response.

**The default is unchanged**, and a row that does not carry the field behaves exactly as before.

## How it is wired

The narrowing governs **both** input passes, and the window is per row — a chain that mixes an `all` row with a `latest_turn` row gives each what it asked for.

- **Block/allow check.** Every endpoint already converts its request into one `ChatFormat` and calls the same trait method, so the narrowing lives in the chain fold: each member is handed either the request or a narrowed view of it. No endpoint-side change, and the single-input surfaces (embeddings, rerank, images, audio, MCP, passthrough, …) are a natural no-op.
- **Masking.** The mask passes rewrite raw wire slots and have no parsed view to index against, so each input walker in `aisix-proxy::redact` answers the same boundary question for its own shape and tags every slot it offers. The chain then hands a narrowed row only the in-window slots and splices its reply back onto the positions it was given; a row on `all` still sees and rewrites everything. The per-kind segment hooks are untouched — a kind never learns its own window.

The boundary is therefore stated twice, once per representation. Both halves are pinned per protocol in the e2e suite, deliberately, because a drift between them is the failure this design can have.

## Behaviour changes

**Masking under `latest_turn` does not rewrite history.** Messages outside the window reach the upstream exactly as the caller sent them. A rule whose job is to mask the whole conversation belongs on `all`. This is stated in the field description too.

**`/v1/responses` now scans a replayed tool call's `name` and `arguments`, under `all` as well.** That API spells a model turn as a typed item carrying no `role`, so the input translator read an agent's whole tool loop as user text — and dropped `function_call` items entirely, because they carry none of the keys the scan used to read. A block rule that fires on `/v1/chat/completions`, where the same replayed call rides `extra["tool_calls"]` and has always been scanned, was bypassable by moving the payload into a tool call on this surface. The mask walker already rewrote both keys, so the two passes now read the same slots.

The item mapping is now:

| `input[]` item | role |
| --- | --- |
| `role: "assistant"` message | assistant |
| `function_call`, `custom_tool_call` | assistant (`name` + `arguments`/`input` scanned) |
| `reasoning` | assistant |
| `function_call_output`, `custom_tool_call_output` | tool |
| `role: "system"` / `"developer"`, `instructions` | system |
| everything else | user |

An operator running a block rule on `/v1/responses` whose pattern appears in a replayed tool call's arguments will start seeing refusals that previously passed. That is the gap being closed, not a regression.

**Two kinds stop screening replayed tool results on `/v1/responses`.** `semantic` and `azure_content_safety_text_moderation` read only user-role messages under their default `text_source` (`user_messages` / `concatenate_user_content`). A `function_call_output` used to be mislabelled as a user message, so they happened to scan it; now that it is correctly a tool result, they do not — exactly as a `role: "tool"` message already sits outside what they read on `/v1/chat/completions`. This is the two surfaces agreeing rather than a new gap, but it is a coverage reduction for an existing rule with unchanged configuration, so: an operator who wants tool results screened by either kind sets `text_source` to its all-messages value, on either surface. A unit test names the behaviour so it is not rediscovered as a bug.

The same translator also stops dropping any item that carries no readable text. It used to drop them, which removed the very boundary the window opens after: a `reasoning` item whose only payload is `encrypted_content` has nothing to scan, so the check pass saw no model turn and widened back to the whole conversation while the mask walkers correctly treated the messages before it as history. Agent clients replay that shape on every turn when reasoning summaries are off. The parsed view is now one message per `input[]` item whatever the item carries, which is what keeps it aligned with the wire the walkers read; an empty message contributes nothing to any kind's scan.

`redact_responses_item` also gained the custom-tool arms — `custom_tool_call`'s `input` and `custom_tool_call_output`'s `output` — which the scan reads and the mask walk did not, so a Mask rule reported a hit there and forwarded the match unmasked. A tool `name` is still scanned and never rewritten, matching `/v1/chat/completions`, where a tool-call name is treated as structural.

## Tests

`tests/e2e/src/cases/guardrail-input-messages-latest-turn-e2e.test.ts` (29 cases) drives a real gateway + etcd + mock upstream. For each of `/v1/chat/completions`, `/v1/messages` and `/v1/responses`, four boundary cases — marker in replayed history, in the current user message, in this turn's tool result, in the system prompt — run twice: once with a `keyword` row (which answers from the check pass) and once with a `custom` script row (which answers from the segment pass), so each half of the boundary rule is pinned independently. Plus three `/v1/responses` cases for the typed model items — including one where the model's turn carries no readable text and both halves must still agree — and two mask cases asserting the mock upstream received the history byte-identical while the current turn was rewritten — one per channel, since the segment channel narrows by splicing a slot subset and the sync channel (`kind: pii`) narrows by filtering chain members.

Unit tests additionally pin the trailing-prefill rule on both halves, the mixed-window mask composition (one row on `all`, one on `latest_turn`, rewriting the same slot list), and the Responses role mapping.

Each half was mutation-checked: disabling the chain narrowing reds exactly the seven check-pass cases, disabling the wire-level windowing reds exactly the seven segment/mask cases, and dropping `name`/`arguments` from the Responses scan reds exactly the tool-call case. Unit tests pin the two boundary functions and the Responses role mapping directly. The existing `guardrail-keyword-message-locations-e2e` suite, which asserts whole-history scanning, stays green under the default.

## Control plane

This is a user-configurable surface, so it is not reachable until the control plane exposes it: `cp-admin.yaml` schema + Go model/validation/projection, the dashboard form, and CP↔DP integration tests. Tracked on api7/AISIX-Cloud#1558.

Two notes for that side. The control plane should reject `hook_point: output` together with `input_messages: latest_turn` — the gateway accepts the pair and simply ignores the field there, so nothing breaks, but it is a configuration the operator did not mean. And this is a new optional field rather than a new value on an existing one, so a gateway older than this release ignores it and keeps scanning the whole conversation: the feature is unavailable there, never fail-open, and needs no compatibility gate.

Fixes api7/AISIX-Cloud#1558

🤖 Generated with [Claude Code](https://claude.com/claude-code)