### PR TITLE
fix: report the build version in outbound User-Agent headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,11 @@ jobs:
           name: coverage-unit
           path: lcov-unit.info
           retention-days: 7
+      - name: exporter User-Agent uses the release version
+        env:
+          # Differ from Cargo's version so the old source cannot pass.
+          AISIX_BUILD_VERSION: 0.0.0-ci
+        run: cargo test -p aisix-obs --lib otlp_http_sink::tests::otlp_sink_posts_one_request_with_all_spans -- --exact
 
   build-bin:
     name: build aisix (instrumented)
@@ -305,6 +310,7 @@ jobs:
     env:
       RUSTFLAGS: "-C instrument-coverage"
       LLVM_PROFILE_FILE: "coverage/aisix-%p-%m.profraw"
+      AISIX_BUILD_VERSION: 0.0.0-ci
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/aisix-gateway/src/upstream_http.rs
+++ b/crates/aisix-gateway/src/upstream_http.rs
@@ -131,12 +131,12 @@ pub fn config() -> &'static UpstreamHttpConfig {
     CONFIG.get_or_init(UpstreamHttpConfig::default)
 }
 
-/// A `reqwest::ClientBuilder` with the connection settings **and the
-/// deployment's outbound TLS trust** applied. Callers add their own
-/// `user_agent` and `build()`.
+/// A `reqwest::ClientBuilder` with the connection settings, deployment's
+/// outbound TLS trust, and versioned `aisix` user agent applied.
 pub fn client_builder() -> reqwest::ClientBuilder {
     let cfg = config();
     let mut b = reqwest::Client::builder()
+        .user_agent(format!("aisix/{}", aisix_core::BUILD_VERSION))
         .pool_idle_timeout(cfg.pool_idle_timeout)
         .tcp_keepalive(cfg.tcp_keepalive);
     if let Some(d) = cfg.connect_timeout {
@@ -447,9 +447,8 @@ mod tests {
     }
 
     /// On a thread-per-core worker every dispatch runs on that worker's
-    /// own pool, and that one pool stands in for all of the clients
-    /// below — so it is built with a single user agent
-    /// (`upstream_tls::DISPATCH_USER_AGENT`).
+    /// own pool, and that one pool stands in for all dispatch clients.
+    /// They must inherit the same user agent from `client_builder`.
     ///
     /// That substitution is only invisible while the clients it replaces
     /// agree on the user agent. Give one bridge its own and the header
@@ -460,30 +459,32 @@ mod tests {
     #[test]
     fn every_dispatch_client_presents_the_same_user_agent() {
         let crates_dir = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/.."));
-        // Only literals: the telemetry, heartbeat, and OTLP clients build
-        // theirs from a version string or a named constant, and none of
-        // them talks to a model provider or reaches the per-worker pool.
-        const NEEDLE: &str = ".user_agent(\"";
         let mut offenders = Vec::new();
         for file in rust_sources(crates_dir) {
+            // These clients never reach the dispatch pools; their
+            // existing control-plane/exporter identities are separate.
+            if [
+                "aisix-gateway/src/upstream_http.rs",
+                "aisix-server/src/telemetry.rs",
+                "aisix-server/src/heartbeat.rs",
+                "aisix-obs/src/otlp_http_sink.rs",
+            ]
+            .iter()
+            .any(|path| file.ends_with(path))
+            {
+                continue;
+            }
             let src = std::fs::read_to_string(&file).expect("read source");
             for (n, line) in production_half(&src).lines().enumerate() {
-                let Some(rest) = line.split_once(NEEDLE).map(|(_, r)| r) else {
-                    continue;
-                };
-                let Some((agent, _)) = rest.split_once('"') else {
-                    continue;
-                };
-                if agent != crate::upstream_tls::DISPATCH_USER_AGENT {
-                    offenders.push(format!("{}:{}: {agent}", file.display(), n + 1));
+                if line.contains(".user_agent(") {
+                    offenders.push(format!("{}:{}", file.display(), n + 1));
                 }
             }
         }
         assert!(
             offenders.is_empty(),
-            "these dispatch clients present a user agent the per-worker \
-             pool would replace with `{}`:\n{}",
-            crate::upstream_tls::DISPATCH_USER_AGENT,
+            "these clients override the user agent inherited from \
+             `client_builder`, which the per-worker pool also uses:\n{}",
             offenders.join("\n"),
         );
     }

--- a/crates/aisix-gateway/src/upstream_tls.rs
+++ b/crates/aisix-gateway/src/upstream_tls.rs
@@ -212,13 +212,6 @@ static PK_CLIENTS: OnceLock<dashmap::DashMap<ProviderKeyTls, reqwest::Client>> =
 
 // ─── per-worker pools ────────────────────────────────────────────────
 
-/// The user agent every dispatch-path client is built with.
-///
-/// A worker's pool stands in for those clients, so it has to present the
-/// same identity upstream. `every_dispatch_client_presents_the_same_user_agent`
-/// holds them in step.
-pub(crate) const DISPATCH_USER_AGENT: &str = "aisix/0.1";
-
 thread_local! {
     /// Whether this thread serves proxy traffic on its own runtime.
     static IS_WORKER_THREAD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
@@ -256,20 +249,15 @@ fn worker_client() -> Option<reqwest::Client> {
         return None;
     }
     WORKER_CLIENT.with(|cell| {
-        cell.get_or_init(|| {
-            match crate::upstream_http::client_builder()
-                .user_agent(DISPATCH_USER_AGENT)
-                .build()
-            {
-                Ok(client) => Some(client),
-                Err(e) => {
-                    tracing::error!(
-                        error = %e,
-                        "per-worker upstream pool could not be built; this worker \
-                         dispatches on the shared pool"
-                    );
-                    None
-                }
+        cell.get_or_init(|| match crate::upstream_http::client_builder().build() {
+            Ok(client) => Some(client),
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    "per-worker upstream pool could not be built; this worker \
+                     dispatches on the shared pool"
+                );
+                None
             }
         })
         .clone()
@@ -321,7 +309,7 @@ fn build_provider_key_client(tls: &ProviderKeyTls) -> Result<reqwest::Client, St
     // than replacing them: a deployment CA and a per-key CA are both
     // trust roots, and a client presenting the deployment's mTLS
     // identity must keep presenting it.
-    let mut builder = crate::upstream_http::client_builder().user_agent(PROVIDER_KEY_USER_AGENT);
+    let mut builder = crate::upstream_http::client_builder();
     if let Some(pem) = tls.ca_cert.as_ref().filter(|p| !p.trim().is_empty()) {
         let roots = reqwest::Certificate::from_pem_bundle(pem.as_bytes())
             .map_err(|e| format!("provider_key.tls.ca_cert: {e}"))?;
@@ -337,10 +325,6 @@ fn build_provider_key_client(tls: &ProviderKeyTls) -> Result<reqwest::Client, St
     }
     builder.build().map_err(|e| e.to_string())
 }
-
-/// Matches the agent every bridge sets on its shared client, so a
-/// per-key client is indistinguishable upstream from the shared one.
-const PROVIDER_KEY_USER_AGENT: &str = "aisix/0.1";
 
 // ─── raw rustls (Realtime WebSocket) ─────────────────────────────────
 
@@ -560,15 +544,6 @@ mod tests {
         params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
         let kp = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
         params.self_signed(&kp).unwrap().pem().into_bytes()
-    }
-
-    /// The literal scan in `upstream_http` cannot see named constants, so
-    /// the per-key client's agent is pinned to the dispatch agent here —
-    /// a per-key client must stay indistinguishable upstream from the
-    /// shared (or per-worker) one.
-    #[test]
-    fn provider_key_clients_present_the_dispatch_user_agent() {
-        assert_eq!(PROVIDER_KEY_USER_AGENT, DISPATCH_USER_AGENT);
     }
 
     #[test]

--- a/crates/aisix-obs/src/otlp_http_sink.rs
+++ b/crates/aisix-obs/src/otlp_http_sink.rs
@@ -65,10 +65,6 @@ use crate::usage::UsageEvent;
 /// tasks for a wedged user receiver.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// `User-Agent` header so vendor receivers can attribute traces back
-/// to AISIX in their own analytics. Not a contract; informational.
-const USER_AGENT: &str = concat!("aisix-dp/", env!("CARGO_PKG_VERSION"));
-
 /// Fans usage events out to every configured observability exporter — any
 /// [`ExporterKind`], dispatched per kind to the matching
 /// [`crate::sink::ObservabilitySink`] — each via its own
@@ -120,7 +116,7 @@ impl OtlpHttpFanOut {
     fn build(metrics: Option<Metrics>) -> Self {
         let client = aisix_gateway::client_builder()
             .timeout(REQUEST_TIMEOUT)
-            .user_agent(USER_AGENT)
+            .user_agent(format!("aisix-dp/{}", aisix_core::BUILD_VERSION))
             .build()
             // The client builder only fails on illegal TLS roots; the
             // default config is always valid.
@@ -2172,7 +2168,7 @@ mod tests {
             "test-exp",
             format!("{}/v1/traces", server.uri()),
             BTreeMap::new(),
-            otlp_test_client(),
+            OtlpHttpFanOut::new().inner.client.clone(),
         );
 
         let ack = sink
@@ -2183,6 +2179,10 @@ mod tests {
 
         let reqs = server.received_requests().await.unwrap();
         assert_eq!(reqs.len(), 1, "one batched request, not three spawns");
+        assert_eq!(
+            reqs[0].headers["user-agent"],
+            format!("aisix-dp/{}", aisix_core::BUILD_VERSION)
+        );
         let body: Value = serde_json::from_slice(&reqs[0].body).unwrap();
         let spans = body["resourceSpans"][0]["scopeSpans"][0]["spans"]
             .as_array()

--- a/crates/aisix-provider-anthropic/src/bridge.rs
+++ b/crates/aisix-provider-anthropic/src/bridge.rs
@@ -79,7 +79,6 @@ impl Default for AnthropicBridge {
 
 fn default_client() -> Client {
     aisix_gateway::client_builder()
-        .user_agent("aisix/0.1")
         .build()
         .unwrap_or_else(|_| Client::new())
 }

--- a/crates/aisix-provider-azure-openai/src/bridge.rs
+++ b/crates/aisix-provider-azure-openai/src/bridge.rs
@@ -187,7 +187,6 @@ impl Default for AzureOpenAiBridge {
 
 fn default_client() -> Client {
     aisix_gateway::client_builder()
-        .user_agent("aisix/0.1")
         .build()
         .unwrap_or_else(|_| Client::new())
 }

--- a/crates/aisix-provider-openai/src/bridge.rs
+++ b/crates/aisix-provider-openai/src/bridge.rs
@@ -160,7 +160,6 @@ impl Default for OpenAiBridge {
 
 fn default_client() -> Client {
     aisix_gateway::client_builder()
-        .user_agent("aisix/0.1")
         .build()
         .unwrap_or_else(|_| Client::new())
 }

--- a/crates/aisix-provider-vertex/src/bridge.rs
+++ b/crates/aisix-provider-vertex/src/bridge.rs
@@ -275,7 +275,6 @@ impl Default for VertexBridge {
 
 fn default_client() -> Client {
     aisix_gateway::client_builder()
-        .user_agent("aisix/0.1")
         .build()
         .unwrap_or_else(|_| Client::new())
 }

--- a/crates/aisix-proxy/src/http_client.rs
+++ b/crates/aisix-proxy/src/http_client.rs
@@ -15,7 +15,6 @@ pub fn client() -> &'static Client {
     static CLIENT: OnceLock<Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
         aisix_gateway::client_builder()
-            .user_agent("aisix/0.1")
             .build()
             .unwrap_or_else(|_| Client::new())
     })

--- a/tests/e2e/src/cases/upstream-user-agent-e2e.test.ts
+++ b/tests/e2e/src/cases/upstream-user-agent-e2e.test.ts
@@ -1,0 +1,109 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+const CALLER_KEY = "sk-user-agent-e2e";
+const routes = [
+  {
+    path: "/v1/chat/completions",
+    body: { messages: [{ role: "user", content: "hi" }] },
+  },
+  {
+    path: "/v1/messages",
+    body: { max_tokens: 16, messages: [{ role: "user", content: "hi" }] },
+  },
+  {
+    path: "/v1/responses",
+    body: { input: "hi" },
+  },
+];
+
+describe.each([false, true])("upstream User-Agent (threadPerCore=%s)", (threadPerCore) => {
+  let app: SpawnedApp | undefined;
+  let upstream: OpenAiUpstream | undefined;
+  let version: string;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    if (!(await etcd.ping())) return;
+
+    const binary =
+      process.env.AISIX_BIN ?? join(process.cwd(), "../../target/debug/aisix");
+    const { stdout } = await promisify(execFile)(binary, ["--version"]);
+    expect(stdout.trim()).toMatch(/^aisix \S+$/);
+    version = stdout.trim().slice("aisix ".length);
+
+    upstream = await startOpenAiUpstream();
+    app = await spawnApp({ threadPerCore });
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    for (const pool of ["default", "provider-key"]) {
+      const pk = await seed.createProviderKey({
+        display_name: `ua-${pool}`,
+        secret: "sk-mock",
+        api_base: `${upstream.baseUrl}/v1`,
+        // Select the per-key client even on loopback HTTP.
+        ...(pool === "provider-key" ? { tls: { verify: false } } : {}),
+      });
+      await seed.createModel({
+        display_name: `ua-${pool}`,
+        provider: "openai",
+        model_name: "mock-model",
+        provider_key_id: pk.id,
+      });
+    }
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update(CALLER_KEY).digest("hex"),
+      allowed_models: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${CALLER_KEY}` },
+      });
+      await res.arrayBuffer();
+      return res.status === 200;
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await upstream?.close();
+  });
+
+  describe.each(["default", "provider-key"])("%s pool", (pool) => {
+    test.for(routes)("$path reports the binary's version upstream", async (route, ctx) => {
+      if (!app || !upstream) {
+        ctx.skip();
+        return;
+      }
+      const before = upstream.receivedRequests.length;
+      const res = await fetch(`${app.proxyUrl}${route.path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${CALLER_KEY}`,
+          "anthropic-version": "2023-06-01",
+          "user-agent": "test-client/1.0",
+        },
+        body: JSON.stringify({ model: `ua-${pool}`, ...route.body }),
+      });
+      await res.arrayBuffer();
+      expect(res.status).toBe(200);
+      expect(res.headers.get("server")).toBe(`AISIX/${version}`);
+      expect(upstream.receivedRequests).toHaveLength(before + 1);
+      expect(upstream.receivedRequests[before].headers["user-agent"]).toBe(
+        `aisix/${version}`,
+      );
+    });
+  });
+});

--- a/tests/e2e/src/cases/upstream-user-agent-e2e.test.ts
+++ b/tests/e2e/src/cases/upstream-user-agent-e2e.test.ts
@@ -16,22 +16,30 @@ import {
 const CALLER_KEY = "sk-user-agent-e2e";
 const routes = [
   {
+    provider: "openai",
     path: "/v1/chat/completions",
     body: { messages: [{ role: "user", content: "hi" }] },
   },
   {
+    provider: "openai",
     path: "/v1/messages",
     body: { max_tokens: 16, messages: [{ role: "user", content: "hi" }] },
   },
   {
+    provider: "openai",
     path: "/v1/responses",
     body: { input: "hi" },
+  },
+  {
+    provider: "anthropic",
+    path: "/v1/chat/completions",
+    body: { messages: [{ role: "user", content: "hi" }] },
   },
 ];
 
 describe.each([false, true])("upstream User-Agent (threadPerCore=%s)", (threadPerCore) => {
   let app: SpawnedApp | undefined;
-  let upstream: OpenAiUpstream | undefined;
+  const upstreams: Record<string, OpenAiUpstream> = {};
   let version: string;
 
   beforeAll(async () => {
@@ -44,23 +52,39 @@ describe.each([false, true])("upstream User-Agent (threadPerCore=%s)", (threadPe
     expect(stdout.trim()).toMatch(/^aisix \S+$/);
     version = stdout.trim().slice("aisix ".length);
 
-    upstream = await startOpenAiUpstream();
+    upstreams.openai = await startOpenAiUpstream();
+    upstreams.anthropic = await startOpenAiUpstream({
+      nonStreamBody: {
+        id: "msg-user-agent",
+        type: "message",
+        role: "assistant",
+        model: "mock-model",
+        content: [{ type: "text", text: "hi" }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 5, output_tokens: 1 },
+      },
+    });
     app = await spawnApp({ threadPerCore });
     const seed = new SeedClient(etcd, app.etcdPrefix);
-    for (const pool of ["default", "provider-key"]) {
-      const pk = await seed.createProviderKey({
-        display_name: `ua-${pool}`,
-        secret: "sk-mock",
-        api_base: `${upstream.baseUrl}/v1`,
-        // Select the per-key client even on loopback HTTP.
-        ...(pool === "provider-key" ? { tls: { verify: false } } : {}),
-      });
-      await seed.createModel({
-        display_name: `ua-${pool}`,
-        provider: "openai",
-        model_name: "mock-model",
-        provider_key_id: pk.id,
-      });
+    for (const [provider, upstream] of Object.entries(upstreams)) {
+      for (const pool of ["default", "provider-key"]) {
+        const pk = await seed.createProviderKey({
+          display_name: `ua-${provider}-${pool}`,
+          provider,
+          adapter: provider,
+          secret: "sk-mock",
+          api_base: upstream.baseUrl + (provider === "openai" ? "/v1" : ""),
+          // Select the per-key client even on loopback HTTP.
+          ...(pool === "provider-key" ? { tls: { verify: false } } : {}),
+        });
+        await seed.createModel({
+          display_name: `ua-${provider}-${pool}`,
+          provider,
+          model_name: "mock-model",
+          provider_key_id: pk.id,
+        });
+      }
     }
     await seed.createApiKey({
       key_hash: createHash("sha256").update(CALLER_KEY).digest("hex"),
@@ -77,11 +101,12 @@ describe.each([false, true])("upstream User-Agent (threadPerCore=%s)", (threadPe
 
   afterAll(async () => {
     await app?.exit();
-    await upstream?.close();
+    await Promise.all(Object.values(upstreams).map((upstream) => upstream.close()));
   });
 
   describe.each(["default", "provider-key"])("%s pool", (pool) => {
-    test.for(routes)("$path reports the binary's version upstream", async (route, ctx) => {
+    test.for(routes)("$provider $path reports the binary's version upstream", async (route, ctx) => {
+      const upstream = upstreams[route.provider];
       if (!app || !upstream) {
         ctx.skip();
         return;
@@ -95,7 +120,7 @@ describe.each([false, true])("upstream User-Agent (threadPerCore=%s)", (threadPe
           "anthropic-version": "2023-06-01",
           "user-agent": "test-client/1.0",
         },
-        body: JSON.stringify({ model: `ua-${pool}`, ...route.body }),
+        body: JSON.stringify({ model: `ua-${route.provider}-${pool}`, ...route.body }),
       });
       await res.arrayBuffer();
       expect(res.status).toBe(200);


### PR DESCRIPTION
Upstream requests advertise `aisix/0.1` even when the gateway is running a newer release. Set the default `User-Agent` in the shared HTTP client builder to `aisix/<build version>`, using the same release-aware version source as `aisix --version` and the `Server` response header.

Remove the fixed values from the OpenAI, Anthropic, Azure OpenAI and Vertex bridges, the proxy HTTP client, and the worker and Provider Key TLS pools. Clients using this shared builder now inherit the versioned default; heartbeat and telemetry retain their existing identities. The exporter client keeps its `aisix-dp/` prefix but also uses the release build version instead of the Cargo package version. No configuration change is required.

Regression coverage sends real requests through the gateway and etcd to a local upstream across chat completions, Anthropic messages and Responses, with both OpenAI and Anthropic upstreams and in both serving modes and with both default and Provider Key TLS pools. Each case checks the outgoing UA against the binary's own version. The source guard also rejects dispatch clients that override the shared default. The OTLP HTTP test exercises the production exporter client and checks the version received over HTTP.

CI stamps the E2E binary and the targeted exporter test with a version different from the Cargo package version, so accidentally reverting to the package version fails the regression checks.
