### PR TITLE
perf: reduce configuration overhead and preserve concurrent metric samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "crossbeam-queue",
  "flate2",
  "futures",
  "hex",
@@ -1668,6 +1669,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e8bd762f7479489c70ed6c768ddca99d7296857de437a68dcb2a94365b3fae"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "jsonschema",
  "once_cell",
  "regex",
+ "ring",
  "schemars 0.8.22",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt",
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
 metrics-util = { version = "0.19", default-features = false, features = ["registry"] }
+crossbeam-queue = "0.3"
 quanta = "0.12"
 
 # Errors / utilities

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ percent-encoding = "2"
 
 # Crypto (M6 v3 CP register flow + ApiKey hash auth)
 sha2 = "0.10"
+ring = "0.17"
 sha1 = "0.10"
 hmac = "0.12"
 rcgen = { version = "0.13", default-features = false, features = ["pem", "ring"] }

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -151,6 +151,7 @@ managed:
   dp_id_file: "/var/lib/aisix/dp_id"
   # Optional recovery across restarts while the configuration store is
   # unavailable. Each instance needs its own writable cache location.
+  # The cache contains unencrypted credentials; restrict directory access.
   snapshot_cache_enabled: false
   snapshot_cache_path: "/var/lib/aisix/config_cache.json"
 

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -149,11 +149,9 @@ managed:
   # bake secrets into the image.
   mtls_dir: "/var/lib/aisix/mtls"
   dp_id_file: "/var/lib/aisix/dp_id"
-  # On-disk snapshot cache (prd-09 §9.7.2). The supervisor writes the
-  # last-known etcd contents here on every successful resync / put /
-  # delete, and re-loads it at boot before opening the etcd connection
-  # — so the proxy stays up across CP outages and full restarts.
-  # Set to "" to disable.
+  # Optional recovery across restarts while the configuration store is
+  # unavailable. Each instance needs its own writable cache location.
+  snapshot_cache_enabled: false
   snapshot_cache_path: "/var/lib/aisix/config_cache.json"
 
   # Heartbeat interval, in seconds. The DP POSTs a heartbeat to

--- a/crates/aisix-core/Cargo.toml
+++ b/crates/aisix-core/Cargo.toml
@@ -28,6 +28,7 @@ once_cell.workspace = true
 # proxy uses to compare an incoming Authorization: Bearer <plaintext>
 # against the snapshot's `key_hash` column.
 sha2.workspace = true
+ring.workspace = true
 hex.workspace = true
 # Trusted-proxy CIDR parsing/validation for proxy.real_ip (#492)
 ipnet.workspace = true

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -286,21 +286,15 @@ pub struct ManagedConfig {
     #[serde(default = "ManagedConfig::default_dp_id_file")]
     pub dp_id_file: String,
 
-    /// Optional path to the on-disk snapshot cache the DP keeps as a
-    /// fallback when etcd is unreachable (prd-09 §9.7.2). When set, the
-    /// supervisor flushes every applied resync / put / delete to this
-    /// file and re-loads it at boot before opening the etcd connection,
-    /// so the proxy can serve traffic from cached config across CP
-    /// outages and full container restarts.
-    ///
-    /// When the field is omitted, managed mode uses
-    /// `/var/lib/aisix/config_cache.json` and self-hosted etcd mode
-    /// leaves persistence off (unchanged defaults). Setting a path
-    /// enables the cache in either mode — self-hosted etcd deployments
-    /// gain the same offline resilience by opting in. Empty string
-    /// disables persistence everywhere — useful for ephemeral test runs
-    /// where you don't want a stale cache to mask a real failure. A
-    /// bare `snapshot_cache_path:` (YAML null) is treated as omitted.
+    /// Enable on-disk configuration snapshots for recovery across restarts
+    /// when etcd is unavailable. Disabled by default in both managed and
+    /// self-hosted etcd modes; in-memory last-known-good serving is unaffected.
+    #[serde(default)]
+    pub snapshot_cache_enabled: bool,
+
+    /// Cache location when `snapshot_cache_enabled` is true. Omitted or
+    /// null uses `/var/lib/aisix/config_cache.json`; an empty string also
+    /// disables persistence. A path alone does not enable the cache.
     #[serde(default)]
     pub snapshot_cache_path: Option<String>,
 
@@ -337,20 +331,18 @@ impl ManagedConfig {
         has_pem || has_file
     }
 
-    /// Resolve the snapshot-cache path per the field docs: an explicit
-    /// path wins in any mode, an explicit empty string disables, and an
-    /// omitted field means "the default path in managed mode, disabled
-    /// in self-hosted etcd mode".
+    /// Resolve the optional cache only after the operator enables it.
     pub fn effective_snapshot_cache_path(&self) -> Option<&str> {
+        if !self.snapshot_cache_enabled {
+            return None;
+        }
         match self.snapshot_cache_path.as_deref() {
             Some("") => None,
             Some(path) => Some(path),
-            None if self.is_managed() => Some(Self::DEFAULT_SNAPSHOT_CACHE_PATH),
-            None => None,
+            None => Some(Self::DEFAULT_SNAPSHOT_CACHE_PATH),
         }
     }
 
-    /// Default on-disk snapshot cache location for managed mode.
     pub const DEFAULT_SNAPSHOT_CACHE_PATH: &'static str = "/var/lib/aisix/config_cache.json";
 
     fn default_mtls_dir() -> String {
@@ -3407,50 +3399,53 @@ managed:
         assert!(cfg.managed.is_managed());
         assert_eq!(cfg.managed.mtls_dir, "/var/lib/aisix/mtls");
         assert_eq!(cfg.managed.dp_id_file, "/var/lib/aisix/dp_id");
-        // Default snapshot cache path keeps offline-resilience on by
-        // default in managed mode; operators opt out by setting the
-        // field to "".
-        assert_eq!(
-            cfg.managed.effective_snapshot_cache_path(),
-            Some("/var/lib/aisix/config_cache.json"),
-        );
+        assert_eq!(cfg.managed.effective_snapshot_cache_path(), None);
         // CP URL comes from env at runtime — empty here is fine.
         assert!(cfg.managed.cp_base_url.is_none());
     }
 
-    /// #871: the snapshot cache resolves per mode — managed defaults on,
-    /// self-hosted etcd defaults off, an explicit path enables either,
-    /// an explicit "" disables either.
     #[test]
     fn snapshot_cache_path_resolution_per_mode() {
-        let mut managed = ManagedConfig {
-            enabled: true,
-            ..Default::default()
-        };
-        assert_eq!(
-            managed.effective_snapshot_cache_path(),
-            Some(ManagedConfig::DEFAULT_SNAPSHOT_CACHE_PATH),
-        );
-        managed.snapshot_cache_path = Some(String::new());
-        assert_eq!(managed.effective_snapshot_cache_path(), None);
-        managed.snapshot_cache_path = Some("/tmp/cache.json".into());
-        assert_eq!(
-            managed.effective_snapshot_cache_path(),
-            Some("/tmp/cache.json"),
-        );
-
-        let mut self_hosted = ManagedConfig {
-            enabled: false,
-            ..Default::default()
-        };
-        assert_eq!(self_hosted.effective_snapshot_cache_path(), None);
-        self_hosted.snapshot_cache_path = Some("/tmp/cache.json".into());
-        assert_eq!(
-            self_hosted.effective_snapshot_cache_path(),
-            Some("/tmp/cache.json"),
-        );
-        self_hosted.snapshot_cache_path = Some(String::new());
-        assert_eq!(self_hosted.effective_snapshot_cache_path(), None);
+        for enabled in [false, true] {
+            for toggle in [
+                "",
+                "snapshot_cache_enabled: false",
+                "snapshot_cache_enabled: true",
+            ] {
+                for (setting, when_enabled) in [
+                    ("", Some(ManagedConfig::DEFAULT_SNAPSHOT_CACHE_PATH)),
+                    (
+                        "snapshot_cache_path: null",
+                        Some(ManagedConfig::DEFAULT_SNAPSHOT_CACHE_PATH),
+                    ),
+                    ("snapshot_cache_path: \"\"", None),
+                    (
+                        "snapshot_cache_path: /tmp/cache.json",
+                        Some("/tmp/cache.json"),
+                    ),
+                ] {
+                    let managed: ManagedConfig = config::Config::builder()
+                        .add_source(config::File::from_str(
+                            &format!("enabled: {enabled}\n{toggle}\n{setting}\n"),
+                            config::FileFormat::Yaml,
+                        ))
+                        .build()
+                        .unwrap()
+                        .try_deserialize()
+                        .unwrap();
+                    let expected = if toggle.ends_with("true") {
+                        when_enabled
+                    } else {
+                        None
+                    };
+                    assert_eq!(
+                        managed.effective_snapshot_cache_path(),
+                        expected,
+                        "{enabled}: {toggle}: {setting}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -289,6 +289,7 @@ pub struct ManagedConfig {
     /// Enable on-disk configuration snapshots for recovery across restarts
     /// when etcd is unavailable. Disabled by default in both managed and
     /// self-hosted etcd modes; in-memory last-known-good serving is unaffected.
+    /// Snapshots include unencrypted credentials; restrict cache directory access.
     #[serde(default)]
     pub snapshot_cache_enabled: bool,
 

--- a/crates/aisix-core/src/config_status.rs
+++ b/crates/aisix-core/src/config_status.rs
@@ -48,8 +48,8 @@
 //!   rejected reload the applied hash stays at the last-good file's hash.
 
 use chrono::{DateTime, SecondsFormat, Utc};
+use ring::digest::{Context, SHA256};
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::watch;
@@ -516,13 +516,13 @@ impl ConfigStatus {
         let identity_hash = if all_rejected.is_empty() {
             None
         } else {
-            let mut hasher = Sha256::new();
+            let mut hasher = Context::new(&SHA256);
             hasher.update(b"aisix-runtime-rejections-v1\0");
             for identity in all_rejected.keys() {
                 hasher.update(identity.as_bytes());
-                hasher.update([b'\n']);
+                hasher.update(b"\n");
             }
-            Some(hex(hasher.finalize().as_slice()))
+            Some(hex(hasher.finish().as_ref()))
         };
 
         let mut merged = BTreeMap::new();
@@ -671,12 +671,12 @@ impl ConfigStatusInner {
         let Some(identity_hash) = self.build_rejected_identity_hash.as_ref() else {
             return Some(base.clone());
         };
-        let mut hasher = Sha256::new();
+        let mut hasher = Context::new(&SHA256);
         hasher.update(b"aisix-runtime-filtered-v1\0");
         hasher.update(base.as_bytes());
-        hasher.update([0u8]);
+        hasher.update(&[0u8]);
         hasher.update(identity_hash.as_bytes());
-        Some(hex(hasher.finalize().as_slice()))
+        Some(hex(hasher.finish().as_ref()))
     }
 
     fn effective_resource_counts(&self) -> BTreeMap<String, usize> {
@@ -946,18 +946,18 @@ where
     I: IntoIterator<Item = R>,
     R: AsRef<[u8]>,
 {
-    let mut hasher = Sha256::new();
+    let mut hasher = Context::new(&SHA256);
     for record in records {
         hasher.update(record.as_ref());
     }
-    hex(hasher.finalize().as_slice())
+    hex(hasher.finish().as_ref())
 }
 
 /// Hash raw file bytes: `sha256` hex.
 pub fn hash_bytes(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
+    let mut hasher = Context::new(&SHA256);
     hasher.update(bytes);
-    hex(hasher.finalize().as_slice())
+    hex(hasher.finish().as_ref())
 }
 
 /// Serialize a JSON value with object keys sorted recursively and no
@@ -1782,6 +1782,19 @@ mod tests {
     /// so the two digests differ.
     const HASH_FIXTURE_ACCEPTED: &str =
         "f0b4b0cdc9ae4da988e11b3e64b47e802212859e6ed2d08b64434967a9d41308";
+
+    #[test]
+    fn hash_backend_matches_sha256_across_chunk_boundaries() {
+        use sha2::{Digest, Sha256};
+        for len in [0, 1, 55, 56, 63, 64, 65, 127, 128, 129, 4096, 65537] {
+            let bytes: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+            let expected = hex(Sha256::digest(&bytes).as_slice());
+            assert_eq!(hash_bytes(&bytes), expected);
+            for chunk in [1, 7, 64, 1024] {
+                assert_eq!(hash_records(bytes.chunks(chunk)), expected);
+            }
+        }
+    }
 
     #[test]
     fn hash_entries_output_is_pinned() {

--- a/crates/aisix-etcd/src/snapshot_cache.rs
+++ b/crates/aisix-etcd/src/snapshot_cache.rs
@@ -22,15 +22,14 @@
 //! Atomicity: `store` writes to `<path>.tmp` first, fsyncs, then
 //! renames over the destination. A torn write never corrupts the
 //! committed file. Disabled when [`SnapshotCache::disabled`] is used
-//! (passed when `managed.snapshot_cache_path` is empty so operators
-//! can opt out).
+//! (the default unless `managed.snapshot_cache_enabled` is true).
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::sync::Mutex;
 
 use crate::provider::RawEntry;
@@ -58,12 +57,9 @@ struct Inner {
     /// so they also commit in order. Reads are unguarded — they go
     /// through OS caches and the rename is atomic.
     ///
-    /// The ordering half matters because [`Self::store`] serialises its
-    /// snapshot BEFORE taking this lock: the supervisor spawns one write
-    /// per apply and never waits for it, so two writes racing that work
-    /// can reach the lock in the opposite order to the applies that
-    /// produced them, and the older snapshot lands last. `i64::MIN`
-    /// until the first write, so a revision of `0` still commits.
+    /// Applies spawn independent tasks, so a newer revision may acquire
+    /// the lock first. Never let a late older task replace it. `i64::MIN`
+    /// until the first write so revision zero also commits.
     write_lock: Mutex<i64>,
 }
 
@@ -135,6 +131,10 @@ impl SnapshotCache {
         }
     }
 
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.inner.path.is_some()
+    }
+
     /// Read the cached snapshot, or `None` if no usable file exists.
     /// "Usable" means: the file is present, parses as JSON, declares a
     /// recognised [`FORMAT_VERSION`], and every entry's value decodes.
@@ -180,13 +180,15 @@ impl SnapshotCache {
             .stale
             .into_iter()
             .map(|s| {
-                B64.decode(&s.value_b64).map(|value| StaleServing {
-                    entry: RawEntry {
-                        key: s.key,
-                        value,
-                        revision: s.revision,
-                    },
-                    since_unix_secs: s.since_unix_secs,
+                B64.decode(&s.value_b64).map(|value| {
+                    StaleServing::new(
+                        RawEntry {
+                            key: s.key,
+                            value,
+                            revision: s.revision,
+                        },
+                        s.since_unix_secs,
+                    )
                 })
             })
             .collect();
@@ -208,36 +210,22 @@ impl SnapshotCache {
     /// cache is not worth blowing up an otherwise-healthy DP — at worst
     /// the next restart rebuilds from etcd.
     pub async fn store(&self, entries: &[RawEntry], revision: i64, stale: &[StaleServing]) {
-        let Some(path) = self.inner.path.clone() else {
+        if !self.is_enabled() {
             return;
-        };
-        let cached = CachedFile {
-            version: FORMAT_VERSION,
-            revision,
-            entries: entries
-                .iter()
-                .map(|e| CachedEntry {
-                    key: e.key.clone(),
-                    value_b64: B64.encode(&e.value),
-                    revision: e.revision,
-                })
-                .collect(),
-            stale: stale
-                .iter()
-                .map(|s| CachedStaleEntry {
-                    key: s.entry.key.clone(),
-                    value_b64: B64.encode(&s.entry.value),
-                    revision: s.entry.revision,
-                    since_unix_secs: s.since_unix_secs,
-                })
-                .collect(),
-        };
-        let bytes = match serde_json::to_vec(&cached) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::warn!(error = %e, "snapshot cache serialise failed");
-                return;
-            }
+        }
+        let entries: Vec<_> = entries.iter().map(encode_entry).collect();
+        let stale: Vec<_> = stale.iter().map(encode_stale).collect();
+        self.store_encoded(&entries, revision, &stale).await;
+    }
+
+    pub(crate) async fn store_encoded(
+        &self,
+        entries: &[Arc<[u8]>],
+        revision: i64,
+        stale: &[Arc<[u8]>],
+    ) {
+        let Some(path) = self.inner.path.as_ref() else {
+            return;
         };
         let mut committed = self.inner.write_lock.lock().await;
         // A write that lost the serialisation race to a NEWER apply has
@@ -249,7 +237,7 @@ impl SnapshotCache {
         if revision < *committed {
             return;
         }
-        if let Err(e) = atomic_write(&path, &bytes).await {
+        if let Err(e) = atomic_write(path, entries, revision, stale).await {
             tracing::warn!(error = %e, path = %path.display(), "snapshot cache write failed");
             return;
         }
@@ -257,9 +245,35 @@ impl SnapshotCache {
     }
 }
 
-/// Write `bytes` to `path` atomically: write to a sibling tmp file,
-/// fsync, rename. Survives crashes between any two of those steps.
-async fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+pub(crate) fn encode_entry(entry: &RawEntry) -> Arc<[u8]> {
+    serde_json::to_vec(&CachedEntry {
+        key: entry.key.clone(),
+        value_b64: B64.encode(&entry.value),
+        revision: entry.revision,
+    })
+    .expect("snapshot entries contain only strings and integers")
+    .into()
+}
+
+pub(crate) fn encode_stale(stale: &StaleServing) -> Arc<[u8]> {
+    serde_json::to_vec(&CachedStaleEntry {
+        key: stale.entry.key.clone(),
+        value_b64: B64.encode(&stale.entry.value),
+        revision: stale.entry.revision,
+        since_unix_secs: stale.since_unix_secs,
+    })
+    .expect("stale entries contain only strings and integers")
+    .into()
+}
+
+/// Preserve the v1 JSON envelope while writing shared records through a
+/// bounded buffer. No full-snapshot byte buffer is assembled per apply.
+async fn atomic_write(
+    path: &Path,
+    entries: &[Arc<[u8]>],
+    revision: i64,
+    stale: &[Arc<[u8]>],
+) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             tokio::fs::create_dir_all(parent).await?;
@@ -267,11 +281,34 @@ async fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     }
     let tmp = path.with_extension("tmp");
     {
-        let mut f = tokio::fs::File::create(&tmp).await?;
-        f.write_all(bytes).await?;
-        f.sync_all().await?;
+        let mut writer = BufWriter::with_capacity(64 * 1024, tokio::fs::File::create(&tmp).await?);
+        writer
+            .write_all(
+                format!(r#"{{"version":{FORMAT_VERSION},"revision":{revision},"entries":["#)
+                    .as_bytes(),
+            )
+            .await?;
+        write_records(&mut writer, entries).await?;
+        writer.write_all(b"],\"stale\":[").await?;
+        write_records(&mut writer, stale).await?;
+        writer.write_all(b"]}").await?;
+        writer.flush().await?;
+        writer.get_ref().sync_all().await?;
     }
     tokio::fs::rename(&tmp, path).await
+}
+
+async fn write_records(
+    writer: &mut BufWriter<tokio::fs::File>,
+    records: &[Arc<[u8]>],
+) -> std::io::Result<()> {
+    for (index, record) in records.iter().enumerate() {
+        if index > 0 {
+            writer.write_all(b",").await?;
+        }
+        writer.write_all(record).await?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -355,10 +392,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let cache = SnapshotCache::new(dir.path().join("snap.json"));
         let entries = vec![entry("/aisix/models/m-1", br#"{"bad":true}"#, 9)];
-        let stale = vec![StaleServing {
-            entry: entry("/aisix/models/m-1", br#"{"name":"last-good"}"#, 7),
-            since_unix_secs: 1_770_000_000,
-        }];
+        let stale = vec![StaleServing::new(
+            entry("/aisix/models/m-1", br#"{"name":"last-good"}"#, 7),
+            1_770_000_000,
+        )];
         cache.store(&entries, 9, &stale).await;
 
         let cached = cache.load().expect("cache file exists");

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -26,7 +26,7 @@ use futures::StreamExt;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 
@@ -34,7 +34,7 @@ use crate::backoff::ExpBackoff;
 use crate::key::{PrefixScope, PrefixSet, WatchedPrefix};
 use crate::loader::{self, BuildStats, PartialCompatEntry, PartialCompatRow, RejectedEntry};
 use crate::provider::{ConfigProvider, ProviderError, RawEntry, WatchEvent};
-use crate::snapshot_cache::SnapshotCache;
+use crate::snapshot_cache::{encode_entry, encode_stale, SnapshotCache};
 use std::sync::atomic::AtomicBool;
 
 /// Cheap clonable handle for the watch supervisor's freshness state —
@@ -176,11 +176,34 @@ const CACHE_WRITE_DRAIN: Duration = Duration::from_secs(5);
 /// not truncate a report. The map is bounded by the number of rows that
 /// ever loaded successfully — a subset of the served snapshot, which is
 /// itself uncapped.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct StaleServing {
     pub entry: RawEntry,
     pub since_unix_secs: u64,
+    cache_record: OnceLock<Arc<[u8]>>,
 }
+
+impl StaleServing {
+    pub(crate) fn new(entry: RawEntry, since_unix_secs: u64) -> Self {
+        Self {
+            entry,
+            since_unix_secs,
+            cache_record: OnceLock::new(),
+        }
+    }
+
+    fn cache_record(&self) -> Arc<[u8]> {
+        self.cache_record.get_or_init(|| encode_stale(self)).clone()
+    }
+}
+
+impl PartialEq for StaleServing {
+    fn eq(&self, other: &Self) -> bool {
+        self.entry == other.entry && self.since_unix_secs == other.since_unix_secs
+    }
+}
+
+impl Eq for StaleServing {}
 
 /// One observed etcd entry plus the bytes it contributes to the config
 /// digests, computed once when the entry is stored.
@@ -191,12 +214,23 @@ struct StateEntry {
     /// function of `(key, value)`, so it is valid for exactly as long as
     /// this map holds these bytes.
     record: Arc<[u8]>,
+    cache_record: OnceLock<Arc<[u8]>>,
 }
 
 impl StateEntry {
     fn new(entry: RawEntry) -> Self {
         let record: Arc<[u8]> = hash_record(&entry.key, &entry.value).into();
-        Self { entry, record }
+        Self {
+            entry,
+            record,
+            cache_record: OnceLock::new(),
+        }
+    }
+
+    fn cache_record(&self) -> Arc<[u8]> {
+        self.cache_record
+            .get_or_init(|| encode_entry(&self.entry))
+            .clone()
     }
 }
 
@@ -940,10 +974,7 @@ impl<P: ConfigProvider> Supervisor<P> {
             .lock()
             .unwrap()
             .entry(key_str.to_string())
-            .or_insert_with(|| StaleServing {
-                entry: good,
-                since_unix_secs: now_unix_secs(),
-            });
+            .or_insert_with(|| StaleServing::new(good, now_unix_secs()));
     }
 
     /// Apply a single Put event on top of the current snapshot.
@@ -1302,10 +1333,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                 if let Some(good) = prev_state.get(&r.key) {
                     stale.insert(
                         r.key.clone(),
-                        StaleServing {
-                            entry: good.clone(),
-                            since_unix_secs: now_unix_secs(),
-                        },
+                        StaleServing::new(good.clone(), now_unix_secs()),
                     );
                 }
             }
@@ -1394,26 +1422,29 @@ impl<P: ConfigProvider> Supervisor<P> {
     /// don't drive the cache), the write is silently dropped which is
     /// the desired no-op.
     fn flush_cache(&self) {
-        let entries: Vec<RawEntry> = {
+        if !self.cache.is_enabled() {
+            return;
+        }
+        let entries: Vec<Arc<[u8]>> = {
             let state = self.state.lock().unwrap();
-            state.values().map(|e| e.entry.clone()).collect()
+            state.values().map(StateEntry::cache_record).collect()
         };
-        let stale: Vec<StaleServing> = {
+        let stale: Vec<Arc<[u8]>> = {
             let guard = self.stale_serving.lock().unwrap();
-            guard.values().cloned().collect()
+            guard.values().map(StaleServing::cache_record).collect()
         };
         let revision = *self.revision.lock().unwrap();
         let cache = self.cache.clone();
         // Spawn the actual write so the apply path stays sync. If we
-        // aren't inside a runtime (cache::disabled() tests), just skip.
+        // aren't inside a runtime, just skip.
         // Track the JoinHandle so [`Self::run`] can drain it at shutdown,
         // and so tests can deterministically await the write via
         // [`Self::await_pending_cache_writes`] instead of leaning on
         // `tokio::time::sleep`, which under CI load raced the spawn
         // (~50ms wasn't enough on heavily loaded GitHub Actions runners).
         if let Ok(rt_handle) = tokio::runtime::Handle::try_current() {
-            let join =
-                rt_handle.spawn(async move { cache.store(&entries, revision, &stale).await });
+            let join = rt_handle
+                .spawn(async move { cache.store_encoded(&entries, revision, &stale).await });
             let mut pending = self.pending_writes.lock().unwrap();
             // Only writes still in flight are worth draining, and only
             // those may be retained: the list is appended to on every
@@ -2205,7 +2236,7 @@ mod tests {
     use crate::provider::{RawEntry, WatchEvent};
     use async_trait::async_trait;
     use futures::stream;
-    use std::sync::Mutex;
+    use std::sync::{Mutex, OnceLock};
 
     struct FakeProvider {
         entries: Mutex<Vec<RawEntry>>,
@@ -3013,6 +3044,75 @@ mod tests {
         assert_eq!(snap.guardrails.len(), 1);
     }
 
+    #[tokio::test]
+    async fn disabled_cache_skips_encoding_and_background_writes() {
+        let provider = Arc::new(FakeProvider::new(
+            vec![entry("/aisix/models/m-1", VALID_MODEL, 1)],
+            1,
+        ));
+        let sup = Supervisor::new(provider, "/aisix");
+        sup.load_once().await.unwrap();
+        assert!(sup.pending_writes.lock().unwrap().is_empty());
+        assert!(sup
+            .state
+            .lock()
+            .unwrap()
+            .values()
+            .all(|row| row.cache_record.get().is_none()));
+
+        sup.apply_put(&entry("/aisix/models/m-1", b"not json", 2));
+        assert_eq!(sup.handle().load().models.len(), 1);
+        assert_eq!(sup.stale_serving.lock().unwrap().len(), 1);
+        assert!(sup
+            .stale_serving
+            .lock()
+            .unwrap()
+            .values()
+            .all(|row| row.cache_record.get().is_none()));
+        sup.apply_delete("/aisix/models/m-1");
+        assert_eq!(sup.handle().load().models.len(), 0);
+        assert!(sup.pending_writes.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cache_records_are_shared_until_their_entry_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = SnapshotCache::new(dir.path().join("snap.json"));
+        let provider = Arc::new(FakeProvider::new(
+            vec![
+                entry("/aisix/models/m-1", VALID_MODEL, 1),
+                entry("/aisix/api_keys/k-1", VALID_APIKEY, 1),
+            ],
+            1,
+        ));
+        let sup = Supervisor::with_cache(provider, "/aisix", cache.clone());
+        sup.load_once().await.unwrap();
+        let records = || {
+            let state = sup.state.lock().unwrap();
+            (
+                state["/aisix/models/m-1"].cache_record(),
+                state["/aisix/api_keys/k-1"].cache_record(),
+            )
+        };
+        let before = records();
+        sup.apply_put(&entry("/aisix/models/m-1", b"not json", 2));
+        let after = records();
+        assert!(!Arc::ptr_eq(&before.0, &after.0));
+        assert!(Arc::ptr_eq(&before.1, &after.1));
+        let pinned = sup.stale_serving.lock().unwrap()["/aisix/models/m-1"].cache_record();
+        sup.apply_put(&entry("/aisix/api_keys/k-1", VALID_APIKEY, 3));
+        assert!(Arc::ptr_eq(
+            &pinned,
+            &sup.stale_serving.lock().unwrap()["/aisix/models/m-1"].cache_record()
+        ));
+        sup.await_pending_cache_writes().await;
+        let cached = cache.load().unwrap();
+        assert_eq!(cached.revision, 3);
+        assert_eq!(cached.entries.len(), 2);
+        assert_eq!(cached.stale.len(), 1);
+        assert_eq!(cached.stale[0].entry.value, VALID_MODEL);
+    }
+
     /// A delete for a key the gateway never held changes what
     /// `/status/config` reports (the revision floor moved) and nothing
     /// about the observed entry set — so it must not rewrite the on-disk
@@ -3020,7 +3120,12 @@ mod tests {
     #[tokio::test]
     async fn a_delete_of_an_unknown_key_publishes_status_without_writing_the_cache() {
         let provider = Arc::new(FakeProvider::new(vec![], 0));
-        let sup = Supervisor::new(provider, "/aisix");
+        let dir = tempfile::tempdir().unwrap();
+        let sup = Supervisor::with_cache(
+            provider,
+            "/aisix",
+            SnapshotCache::new(dir.path().join("snap.json")),
+        );
         sup.load_once().await.unwrap();
         sup.await_pending_cache_writes().await;
 

--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -2236,7 +2236,7 @@ mod tests {
     use crate::provider::{RawEntry, WatchEvent};
     use async_trait::async_trait;
     use futures::stream;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::Mutex;
 
     struct FakeProvider {
         entries: Mutex<Vec<RawEntry>>,

--- a/crates/aisix-obs/Cargo.toml
+++ b/crates/aisix-obs/Cargo.toml
@@ -19,6 +19,7 @@ tracing-subscriber.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 metrics-util.workspace = true
+crossbeam-queue.workspace = true
 quanta.workspace = true
 bytes.workspace = true
 regex.workspace = true

--- a/crates/aisix-obs/src/prometheus.rs
+++ b/crates/aisix-obs/src/prometheus.rs
@@ -1,6 +1,6 @@
 //! Per-series storage keeps scrape work off the recording path. Labels are
-//! escaped once on the first scrape; histogram samples use the existing lock-free
-//! bucket and the exporter's existing distribution/quantile implementation.
+//! escaped once on the first scrape; histogram samples use a concurrent queue
+//! and the exporter's existing distribution/quantile implementation.
 
 use std::{
     collections::HashMap,
@@ -8,6 +8,7 @@ use std::{
     sync::{atomic::Ordering, Arc, Mutex, OnceLock},
 };
 
+use crossbeam_queue::SegQueue;
 use metrics::{
     atomics::AtomicU64, Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName,
     Metadata, Recorder as MetricsRecorder, SharedString, Unit,
@@ -16,7 +17,7 @@ use metrics_exporter_prometheus::{
     formatting::{sanitize_label_key, sanitize_metric_name, write_help_line, write_type_line},
     Distribution, DistributionBuilder,
 };
-use metrics_util::{registry::Registry, storage::AtomicBucket};
+use metrics_util::registry::Registry;
 use quanta::Instant;
 
 struct Labels {
@@ -124,7 +125,7 @@ impl GaugeFn for Scalar {
 struct DistributionSeries {
     labels: Labels,
     kind: &'static str,
-    pending: AtomicBucket<(f64, Instant)>,
+    pending: SegQueue<(f64, Instant)>,
     distribution: Mutex<Distribution>,
 }
 
@@ -135,19 +136,37 @@ impl HistogramFn for DistributionSeries {
 }
 
 impl DistributionSeries {
+    fn drain(&self, distribution: &mut Distribution) {
+        // Bound this drain to the current backlog so ongoing writers cannot
+        // keep a scrape busy indefinitely. New samples stay queued for next time.
+        let count = self.pending.len();
+        let mut samples = Vec::with_capacity(count.min(64));
+        for _ in 0..count {
+            let Some(sample) = self.pending.pop() else {
+                break;
+            };
+            samples.push(sample);
+            if samples.len() == 64 {
+                distribution.record_samples(&samples);
+                samples.clear();
+            }
+        }
+        if !samples.is_empty() {
+            distribution.record_samples(&samples);
+        }
+    }
+
     fn upkeep(&self) {
         if self.pending.is_empty() {
             return;
         }
         let mut distribution = self.distribution.lock().expect("metric distribution");
-        self.pending
-            .clear_with(|samples| distribution.record_samples(samples));
+        self.drain(&mut distribution);
     }
 
     fn render(&self, output: &mut String) {
         let mut distribution = self.distribution.lock().expect("metric distribution");
-        self.pending
-            .clear_with(|samples| distribution.record_samples(samples));
+        self.drain(&mut distribution);
         let (sum, count) = match &*distribution {
             Distribution::Summary(summary, quantiles, sum) => {
                 let snapshot = summary.snapshot(Instant::now());
@@ -208,7 +227,7 @@ impl metrics_util::registry::Storage<Key> for Storage {
         Arc::new(DistributionSeries {
             labels: Labels::new(key),
             kind,
-            pending: AtomicBucket::new(),
+            pending: SegQueue::new(),
             distribution: Mutex::new(distribution),
         })
     }
@@ -494,6 +513,7 @@ mod tests {
         let recorder = Arc::new(Recorder::new(distributions()));
         let metadata = Metadata::new("test", metrics::Level::INFO, None);
         let histogram = recorder.register_histogram(&Key::from_name("latency"), &metadata);
+        let summary = recorder.register_histogram(&Key::from_name("duration"), &metadata);
         let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let maintenance = {
             let recorder = Arc::clone(&recorder);
@@ -508,9 +528,11 @@ mod tests {
         let writers = (0..4)
             .map(|_| {
                 let histogram = histogram.clone();
+                let summary = summary.clone();
                 std::thread::spawn(move || {
                     for _ in 0..10_000 {
                         histogram.record(0.5);
+                        summary.record(0.5);
                     }
                 })
             })
@@ -529,6 +551,8 @@ mod tests {
             assert_eq!(sample(&output, "latency_bucket{le=\"+Inf\"} "), count);
             assert_eq!(sample(&output, "latency_bucket{le=\"0.5\"} "), count);
             assert_eq!(sample(&output, "latency_sum "), count * 0.5);
+            let count = sample(&output, "duration_count ");
+            assert_eq!(sample(&output, "duration_sum "), count * 0.5);
         }
         for writer in writers {
             writer.join().unwrap();
@@ -538,5 +562,7 @@ mod tests {
         let output = recorder.render();
         assert_eq!(sample(&output, "latency_count "), 40_000.0);
         assert_eq!(sample(&output, "latency_sum "), 20_000.0);
+        assert_eq!(sample(&output, "duration_count "), 40_000.0);
+        assert_eq!(sample(&output, "duration_sum "), 20_000.0);
     }
 }

--- a/crates/aisix-server/src/main.rs
+++ b/crates/aisix-server/src/main.rs
@@ -797,11 +797,7 @@ async fn run(mut cfg: Config) -> anyhow::Result<()> {
                     cfg.etcd.request_timeout(),
                 ))
             };
-            // Snapshot cache: persist to disk so the DP can serve traffic
-            // from the last-known config across CP outages and restarts.
-            // Managed mode defaults to /var/lib/aisix/config_cache.json;
-            // self-hosted etcd mode enables it only when the operator sets
-            // a path explicitly; "" disables it in either mode.
+            // Disk recovery is opt-in in both managed and self-hosted modes.
             let snapshot_cache = match cfg.managed.effective_snapshot_cache_path() {
                 Some(path) => SnapshotCache::new(path),
                 None => SnapshotCache::disabled(),

--- a/tests/e2e/src/cases/config-last-known-good-e2e.test.ts
+++ b/tests/e2e/src/cases/config-last-known-good-e2e.test.ts
@@ -111,169 +111,156 @@ describe("config last-known-good: rejected updates keep serving across resync an
     if (cacheDir) await rm(cacheDir, { recursive: true, force: true });
   });
 
-  test("a rejected update leaves the old value serving real traffic, with staleness reported", async (ctx) => {
+  test("last-good lifecycle: reject, restore, disable persistence, and delete", async (ctx) => {
     if (!etcdReachable || !app || !etcd) {
       ctx.skip();
       return;
     }
 
-    await waitConfigPropagation(async () => {
-      const cfg = await getStatusConfig(app!);
-      return (cfg.applied?.resource_counts.models ?? 0) >= 1;
-    });
-
-    // Baseline: the model serves.
-    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
-    const before = await proxy.chat({
-      model: "lkg-model",
-      messages: [{ role: "user", content: "baseline" }],
-    });
-    expect(before.status, JSON.stringify(before.body)).toBe(200);
-
-    // A newer control plane (or a bug) replaces the document with bytes
-    // this DP rejects: empty display_name violates the schema (RED).
-    await etcd.put(
-      modelKey,
-      JSON.stringify({
-        display_name: "",
-        provider: "openai",
-        model_name: "gpt-4o-mini",
-      }),
-    );
-
-    let cfg: StatusConfig | undefined;
-    await waitConfigPropagation(async () => {
-      cfg = await getStatusConfig(app!);
-      return cfg.rejected.some((r) => r.resource_id === modelId);
-    });
-
-    // The old value keeps serving REAL traffic — the user journey the
-    // cliff used to break.
-    const during = await proxy.chat({
-      model: "lkg-model",
-      messages: [{ role: "user", content: "still serving?" }],
-    });
-    expect(during.status, JSON.stringify(during.body)).toBe(200);
-
-    // The rejection is reported with the staleness attached.
-    expect(cfg!.state).toBe("degraded");
-    const rejection = cfg!.rejected.find((r) => r.resource_id === modelId)!;
-    expect(rejection.resource_kind).toBe("models");
-    expect(rejection.serving_stale_since).toBeTypeOf("string");
-    expect(rejection.serving_stale_age_seconds).toBeTypeOf("number");
-    staleSinceBeforeRestart = rejection.serving_stale_since;
-    // The served row keeps counting.
-    expect(cfg!.applied?.resource_counts.models).toBe(1);
-
-    // And the per-kind gauge on the metrics listener.
-    const text = await scrape(app);
-    expect(text).toMatch(/aisix_config_stale_served_resources\{kind="models"\} 1/);
-  });
-
-  test("the last known good survives a restart (cache replay + live resync against rejected bytes)", async (ctx) => {
-    if (!etcdReachable || !app || !etcd) {
-      ctx.skip();
-      return;
-    }
-
-    // Full process restart on the same etcd prefix + snapshot cache.
-    stoppedApps.push(app);
-    await app.stop();
-    app = await spawnApp({
-      etcdPrefix,
-      snapshotCachePath: join(cacheDir!, "config_cache.json"),
-    });
-
-    // Prove the LIVE etcd read completed (not just the cache replay):
-    // a sentinel written after the restart can only appear via the new
-    // process's load_all/watch. By then the boot resync has re-read the
-    // rejected bytes for the model key — the exact path that used to
-    // drop the row.
-    await etcd.put(
-      `${etcdPrefix}/api_keys/${randomUUID()}`,
-      JSON.stringify({
-        key_hash: createHash("sha256").update(`sentinel-${randomUUID()}`).digest("hex"),
-        allowed_models: [],
-      }),
-    );
-    await waitConfigPropagation(async () => {
-      const cfg = await getStatusConfig(app!);
-      return (cfg.applied?.resource_counts.api_keys ?? 0) >= 2;
-    });
-
-    // The model still serves real traffic from its pinned value.
-    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
-    const after = await proxy.chat({
-      model: "lkg-model",
-      messages: [{ role: "user", content: "post-restart" }],
-    });
-    expect(after.status, JSON.stringify(after.body)).toBe(200);
-
-    // The rejection + staleness survive, and the stale-since instant is
-    // CONTINUOUS across the restart (persisted in the snapshot cache),
-    // so the age keeps growing instead of resetting.
-    const cfg = await getStatusConfig(app);
-    const rejection = cfg.rejected.find((r) => r.resource_id === modelId)!;
-    expect(rejection).toBeDefined();
-    expect(rejection.serving_stale_since).toBe(staleSinceBeforeRestart);
-    expect(rejection.serving_stale_age_seconds).toBeTypeOf("number");
-    expect(cfg.applied?.resource_counts.models).toBe(1);
-
-    const text = await scrape(app);
-    expect(text).toMatch(/aisix_config_stale_served_resources\{kind="models"\} 1/);
-  });
-
-  test("disabling persistence does not restore the last good configuration on restart", async (ctx) => {
-    if (!etcdReachable || !app || !etcd) {
-      ctx.skip();
-      return;
-    }
-
-    const uncached = await spawnApp({ etcdPrefix, snapshotCachePath: "" });
-    stoppedApps.push(uncached);
-    try {
+    {
       await waitConfigPropagation(async () => {
-        const cfg = await getStatusConfig(uncached);
-        return cfg.rejected.some((row) => row.resource_id === modelId);
+        const cfg = await getStatusConfig(app!);
+        return (cfg.applied?.resource_counts.models ?? 0) >= 1;
       });
-      const cfg = await getStatusConfig(uncached);
-      expect(cfg.applied?.resource_counts.models ?? 0).toBe(0);
-      expect(cfg.rejected.find((row) => row.resource_id === modelId)?.serving_stale_since).toBeUndefined();
-      const proxy = new ProxyClient(uncached.proxyUrl, CALLER_PLAINTEXT);
-      const response = await proxy.chat({
+
+      // Baseline: the model serves.
+      const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+      const before = await proxy.chat({
         model: "lkg-model",
-        messages: [{ role: "user", content: "no disk recovery" }],
+        messages: [{ role: "user", content: "baseline" }],
       });
-      expect(response.status, JSON.stringify(response.body)).toBe(404);
-    } finally {
-      await uncached.stop();
+      expect(before.status, JSON.stringify(before.body)).toBe(200);
+
+      // A newer control plane (or a bug) replaces the document with bytes
+      // this DP rejects: empty display_name violates the schema (RED).
+      await etcd.put(
+        modelKey,
+        JSON.stringify({
+          display_name: "",
+          provider: "openai",
+          model_name: "gpt-4o-mini",
+        }),
+      );
+
+      let cfg: StatusConfig | undefined;
+      await waitConfigPropagation(async () => {
+        cfg = await getStatusConfig(app!);
+        return cfg.rejected.some((r) => r.resource_id === modelId);
+      });
+
+      // The old value keeps serving REAL traffic — the user journey the
+      // cliff used to break.
+      const during = await proxy.chat({
+        model: "lkg-model",
+        messages: [{ role: "user", content: "still serving?" }],
+      });
+      expect(during.status, JSON.stringify(during.body)).toBe(200);
+
+      // The rejection is reported with the staleness attached.
+      expect(cfg!.state).toBe("degraded");
+      const rejection = cfg!.rejected.find((r) => r.resource_id === modelId)!;
+      expect(rejection.resource_kind).toBe("models");
+      expect(rejection.serving_stale_since).toBeTypeOf("string");
+      expect(rejection.serving_stale_age_seconds).toBeTypeOf("number");
+      staleSinceBeforeRestart = rejection.serving_stale_since;
+      // The served row keeps counting.
+      expect(cfg!.applied?.resource_counts.models).toBe(1);
+
+      // And the per-kind gauge on the metrics listener.
+      const text = await scrape(app);
+      expect(text).toMatch(/aisix_config_stale_served_resources\{kind="models"\} 1/);
     }
-  });
 
-  test("deleting the etcd key kills the pinned value — no zombie config", async (ctx) => {
-    if (!etcdReachable || !app || !etcd) {
-      ctx.skip();
-      return;
+    {
+      // Full process restart on the same etcd prefix + snapshot cache.
+      stoppedApps.push(app);
+      await app.stop();
+      app = await spawnApp({
+        etcdPrefix,
+        snapshotCachePath: join(cacheDir!, "config_cache.json"),
+      });
+
+      // Prove the LIVE etcd read completed (not just the cache replay):
+      // a sentinel written after the restart can only appear via the new
+      // process's load_all/watch. By then the boot resync has re-read the
+      // rejected bytes for the model key — the exact path that used to
+      // drop the row.
+      await etcd.put(
+        `${etcdPrefix}/api_keys/${randomUUID()}`,
+        JSON.stringify({
+          key_hash: createHash("sha256").update(`sentinel-${randomUUID()}`).digest("hex"),
+          allowed_models: [],
+        }),
+      );
+      await waitConfigPropagation(async () => {
+        const cfg = await getStatusConfig(app!);
+        return (cfg.applied?.resource_counts.api_keys ?? 0) >= 2;
+      });
+
+      // The model still serves real traffic from its pinned value.
+      const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+      const after = await proxy.chat({
+        model: "lkg-model",
+        messages: [{ role: "user", content: "post-restart" }],
+      });
+      expect(after.status, JSON.stringify(after.body)).toBe(200);
+
+      // The rejection + staleness survive, and the stale-since instant is
+      // CONTINUOUS across the restart (persisted in the snapshot cache),
+      // so the age keeps growing instead of resetting.
+      const cfg = await getStatusConfig(app);
+      const rejection = cfg.rejected.find((r) => r.resource_id === modelId)!;
+      expect(rejection).toBeDefined();
+      expect(rejection.serving_stale_since).toBe(staleSinceBeforeRestart);
+      expect(rejection.serving_stale_age_seconds).toBeTypeOf("number");
+      expect(cfg.applied?.resource_counts.models).toBe(1);
+
+      const text = await scrape(app);
+      expect(text).toMatch(/aisix_config_stale_served_resources\{kind="models"\} 1/);
     }
 
-    await etcd.delete(modelKey);
-    await waitConfigPropagation(async () => {
-      const cfg = await getStatusConfig(app!);
-      return (cfg.applied?.resource_counts.models ?? 0) === 0;
-    });
+    {
+      const uncached = await spawnApp({ etcdPrefix, snapshotCachePath: "" });
+      stoppedApps.push(uncached);
+      try {
+        await waitConfigPropagation(async () => {
+          const cfg = await getStatusConfig(uncached);
+          return cfg.rejected.some((row) => row.resource_id === modelId);
+        });
+        const cfg = await getStatusConfig(uncached);
+        expect(cfg.applied?.resource_counts.models ?? 0).toBe(0);
+        expect(cfg.rejected.find((row) => row.resource_id === modelId)?.serving_stale_since).toBeUndefined();
+        const proxy = new ProxyClient(uncached.proxyUrl, CALLER_PLAINTEXT);
+        const response = await proxy.chat({
+          model: "lkg-model",
+          messages: [{ role: "user", content: "no disk recovery" }],
+        });
+        expect(response.status, JSON.stringify(response.body)).toBe(404);
+      } finally {
+        await uncached.stop();
+      }
+    }
 
-    // The resource is gone for real traffic...
-    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
-    const gone = await proxy.chat({
-      model: "lkg-model",
-      messages: [{ role: "user", content: "should be gone" }],
-    });
-    expect(gone.status, JSON.stringify(gone.body)).toBe(404);
+    {
+      await etcd.delete(modelKey);
+      await waitConfigPropagation(async () => {
+        const cfg = await getStatusConfig(app!);
+        return (cfg.applied?.resource_counts.models ?? 0) === 0;
+      });
 
-    // ...and every stale/rejected signal clears with it.
-    const cfg = await getStatusConfig(app);
-    expect(cfg.rejected).toHaveLength(0);
-    const text = await scrape(app);
-    expect(text).toMatch(/aisix_config_stale_served_resources\{kind="models"\} 0/);
+      // The resource is gone for real traffic...
+      const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+      const gone = await proxy.chat({
+        model: "lkg-model",
+        messages: [{ role: "user", content: "should be gone" }],
+      });
+      expect(gone.status, JSON.stringify(gone.body)).toBe(404);
+
+      // ...and every stale/rejected signal clears with it.
+      const cfg = await getStatusConfig(app);
+      expect(cfg.rejected).toHaveLength(0);
+      const text = await scrape(app);
+      expect(text).toMatch(/aisix_config_stale_served_resources\{kind="models"\} 0/);
+    }
   });
 });

--- a/tests/e2e/src/cases/config-last-known-good-e2e.test.ts
+++ b/tests/e2e/src/cases/config-last-known-good-e2e.test.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
@@ -219,8 +219,14 @@ describe("config last-known-good: rejected updates keep serving across resync an
       expect(text).toMatch(/aisix_config_stale_served_resources\{kind="models"\} 1/);
     }
 
-    {
-      const uncached = await spawnApp({ etcdPrefix, snapshotCachePath: "" });
+    const persisted = await readFile(join(cacheDir!, "config_cache.json"));
+    const disabledPath = join(cacheDir!, "disabled-cache.json");
+    await writeFile(disabledPath, persisted);
+    for (const toggle of [{}, { snapshot_cache_enabled: false }]) {
+      const uncached = await spawnApp({
+        etcdPrefix,
+        extra: { managed: { snapshot_cache_path: disabledPath, ...toggle } },
+      });
       stoppedApps.push(uncached);
       try {
         await waitConfigPropagation(async () => {
@@ -239,6 +245,7 @@ describe("config last-known-good: rejected updates keep serving across resync an
       } finally {
         await uncached.stop();
       }
+      expect(await readFile(disabledPath)).toEqual(persisted);
     }
 
     {

--- a/tests/e2e/src/cases/config-last-known-good-e2e.test.ts
+++ b/tests/e2e/src/cases/config-last-known-good-e2e.test.ts
@@ -8,6 +8,7 @@ import {
   ProxyClient,
   SeedClient,
   spawnApp,
+  startEtcdRelay,
   startOpenAiUpstream,
   waitConfigPropagation,
   type OpenAiUpstream,
@@ -35,6 +36,7 @@ const CALLER_KEY_HASH = createHash("sha256").update(CALLER_PLAINTEXT).digest("he
 
 interface StatusConfig {
   state: string;
+  source: { connected: boolean };
   applied?: { resource_counts: Record<string, number> };
   rejected: Array<{
     resource_kind: string;
@@ -220,6 +222,33 @@ describe("config last-known-good: rejected updates keep serving across resync an
     }
 
     const persisted = await readFile(join(cacheDir!, "config_cache.json"));
+    const offlinePath = join(cacheDir!, "offline-cache.json");
+    await writeFile(offlinePath, persisted);
+    const relay = await startEtcdRelay();
+    let offline: SpawnedApp | undefined;
+    try {
+      await relay.refuse();
+      offline = await spawnApp({
+        etcdPrefix,
+        snapshotCachePath: offlinePath,
+        extra: { etcd: { endpoints: [relay.endpoint], prefix: etcdPrefix } },
+      });
+      stoppedApps.push(offline);
+      await waitConfigPropagation(async () => (await getStatusConfig(offline!)).source.connected === false);
+      const proxy = new ProxyClient(offline.proxyUrl, CALLER_PLAINTEXT);
+      const response = await proxy.chat({
+        model: "lkg-model",
+        messages: [{ role: "user", content: "offline restart" }],
+      });
+      expect(response.status, JSON.stringify(response.body)).toBe(200);
+      const cfg = await getStatusConfig(offline);
+      expect(cfg.rejected.find((row) => row.resource_id === modelId)?.serving_stale_since)
+        .toBe(staleSinceBeforeRestart);
+    } finally {
+      await offline?.stop();
+      await relay.stop();
+    }
+
     const disabledPath = join(cacheDir!, "disabled-cache.json");
     await writeFile(disabledPath, persisted);
     for (const toggle of [{}, { snapshot_cache_enabled: false }]) {

--- a/tests/e2e/src/cases/config-last-known-good-e2e.test.ts
+++ b/tests/e2e/src/cases/config-last-known-good-e2e.test.ts
@@ -59,7 +59,7 @@ async function scrape(app: SpawnedApp): Promise<string> {
 
 describe("config last-known-good: rejected updates keep serving across resync and restart", () => {
   let app: SpawnedApp | undefined;
-  let stoppedApp: SpawnedApp | undefined;
+  const stoppedApps: SpawnedApp[] = [];
   let upstream: OpenAiUpstream | undefined;
   let etcd: EtcdClient | undefined;
   let etcdReachable = false;
@@ -106,7 +106,7 @@ describe("config last-known-good: rejected updates keep serving across resync an
     await app?.exit();
     // The pre-restart app was stop()ped without cleanup; exit() is
     // idempotent on the dead process and reclaims its tmp dir.
-    await stoppedApp?.exit();
+    for (const stopped of stoppedApps) await stopped.exit();
     await upstream?.close();
     if (cacheDir) await rm(cacheDir, { recursive: true, force: true });
   });
@@ -177,7 +177,7 @@ describe("config last-known-good: rejected updates keep serving across resync an
     }
 
     // Full process restart on the same etcd prefix + snapshot cache.
-    stoppedApp = app;
+    stoppedApps.push(app);
     await app.stop();
     app = await spawnApp({
       etcdPrefix,
@@ -221,6 +221,33 @@ describe("config last-known-good: rejected updates keep serving across resync an
 
     const text = await scrape(app);
     expect(text).toMatch(/aisix_config_stale_served_resources\{kind="models"\} 1/);
+  });
+
+  test("disabling persistence does not restore the last good configuration on restart", async (ctx) => {
+    if (!etcdReachable || !app || !etcd) {
+      ctx.skip();
+      return;
+    }
+
+    const uncached = await spawnApp({ etcdPrefix, snapshotCachePath: "" });
+    stoppedApps.push(uncached);
+    try {
+      await waitConfigPropagation(async () => {
+        const cfg = await getStatusConfig(uncached);
+        return cfg.rejected.some((row) => row.resource_id === modelId);
+      });
+      const cfg = await getStatusConfig(uncached);
+      expect(cfg.applied?.resource_counts.models ?? 0).toBe(0);
+      expect(cfg.rejected.find((row) => row.resource_id === modelId)?.serving_stale_since).toBeUndefined();
+      const proxy = new ProxyClient(uncached.proxyUrl, CALLER_PLAINTEXT);
+      const response = await proxy.chat({
+        model: "lkg-model",
+        messages: [{ role: "user", content: "no disk recovery" }],
+      });
+      expect(response.status, JSON.stringify(response.body)).toBe(404);
+    } finally {
+      await uncached.stop();
+    }
   });
 
   test("deleting the etcd key kills the pinned value — no zombie config", async (ctx) => {

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -370,8 +370,13 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
     // specs rely on. Drain immediately here; the drain spec sets its own
     // window through `extra`.
     shutdown: { min_drain_secs: 0 },
-    ...(overrides.snapshotCachePath
-      ? { managed: { snapshot_cache_path: overrides.snapshotCachePath } }
+    ...(overrides.snapshotCachePath !== undefined
+      ? {
+          managed: {
+            snapshot_cache_enabled: overrides.snapshotCachePath !== "",
+            snapshot_cache_path: overrides.snapshotCachePath,
+          },
+        }
       : {}),
     ...(overrides.extra ?? {}),
   };


### PR DESCRIPTION
Configuration updates repeatedly hash the full configuration and, when disk recovery is enabled, copy and re-encode every resource. Use ring for byte-identical SHA-256 digests, cache each entry's JSON/base64 encoding, share unchanged encodings between writes, and stream the existing v1 snapshot format through a bounded buffer before fsync and atomic replacement.

Add `managed.snapshot_cache_enabled`, defaulting to `false` in both managed and self-hosted etcd modes. Disabled caches skip reads, encoding, full-state copies, and background writes. Upgrades that need disk recovery must explicitly set it to `true`; an existing `snapshot_cache_path` alone no longer enables persistence. In-memory last-known-good serving is unchanged. The existing snapshot format, revision guard, and shutdown drain are retained; this change does not introduce a new persistence scheduler or journal.

Concurrent histogram recording and scrape/upkeep drains can also lose samples in the previous pending bucket. Replace it with a per-series concurrent queue and drain only the backlog observed at the start, in bounded batches. Recording remains independent of distribution aggregation and text rendering; histogram and summary formats and defaults are unchanged.

Coverage includes cross-backend SHA-256 parity and fixed digest fixtures, disabled-path and encoding-reuse regression tests, existing disk ordering/recovery/shutdown tests, and real-binary/etcd E2E coverage for enabled recovery and disabled persistence. Concurrent sample-count and sum coverage exercises both histograms and summaries, with existing real-binary scrape/cancellation and histogram-bucket coverage retained. The hash backend change preserves behavior, so it uses parity coverage rather than a behavior test that fails on the old implementation.

Equal-revision write ordering is an existing limitation retained by this change and tracked separately in api7/AISIX-Cloud#1574 for the deferred persistence redesign.

Fixes api7/AISIX-Cloud#1569

Fixes api7/AISIX-Cloud#1575
