### PR TITLE
feat(proxy): scope URL rewrites by host before all routing

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -114,8 +114,12 @@ proxy:
   # AISIX_PROXY__URL_REWRITES='[{"match":"...","rewrite":"..."}]'
   # Example: serve per-server MCP URLs like /mcp-servers/github/mcp on
   # the /mcp/{server} endpoint.
+  # Runs before ALL routing, including host-matched passthrough routes.
+  # Optional hosts restrict a rule to those inbound hosts; omit for all hosts.
+  # Host matching ignores case/port; *.example.com matches one extra label.
   # url_rewrites:
   #   - name: per-server-mcp-compat
+  #     hosts: ["gateway.example.com"]
   #     match: "^/mcp-servers/([^/]+)/mcp$"
   #     rewrite: "/mcp/$1"
 

--- a/config.managed.yaml
+++ b/config.managed.yaml
@@ -87,8 +87,12 @@ proxy:
   # legacy URL shapes, e.g. per-server MCP paths served on the
   # /mcp/{server} endpoint. When configuring through env vars only, set
   # one JSON array: AISIX_PROXY__URL_REWRITES='[{"match":"...","rewrite":"..."}]'
+  # Runs before ALL routing, including host-matched passthrough routes.
+  # Optional hosts restrict a rule to those inbound hosts; omit for all hosts.
+  # Host matching ignores case/port; *.example.com matches one extra label.
   # url_rewrites:
   #   - name: per-server-mcp-compat
+  #     hosts: ["gateway.example.com"]
   #     match: "^/mcp-servers/([^/]+)/mcp$"
   #     rewrite: "/mcp/$1"
 

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -1661,6 +1661,7 @@ impl Config {
         // otherwise surface at runtime as silently mis-routed or 404ing
         // legacy traffic, which is much harder to trace back to a typo in
         // one line of config.
+        let host_pattern = regex::Regex::new(crate::host::HOST_PATTERN).expect("host pattern is valid");
         for (i, rule) in self.proxy.url_rewrites.iter().enumerate() {
             let ctx = || {
                 rule.name
@@ -1668,9 +1669,7 @@ impl Config {
                     .unwrap_or_else(|| format!("proxy.url_rewrites[{i}]"))
             };
             if let Some(hosts) = &rule.hosts {
-                let pattern =
-                    regex::Regex::new(crate::host::HOST_PATTERN).expect("host pattern is valid");
-                if hosts.is_empty() || hosts.iter().any(|host| !pattern.is_match(host)) {
+                if hosts.is_empty() || hosts.iter().any(|host| !host_pattern.is_match(host)) {
                     return Err(BootstrapError::Config(format!(
                         "{}: hosts must be a non-empty list of hostnames or single-label \
                          wildcards such as *.example.com (no scheme, port, or path)",

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -1661,7 +1661,8 @@ impl Config {
         // otherwise surface at runtime as silently mis-routed or 404ing
         // legacy traffic, which is much harder to trace back to a typo in
         // one line of config.
-        let host_pattern = regex::Regex::new(crate::host::HOST_PATTERN).expect("host pattern is valid");
+        let host_pattern =
+            regex::Regex::new(crate::host::HOST_PATTERN).expect("host pattern is valid");
         for (i, rule) in self.proxy.url_rewrites.iter().enumerate() {
             let ctx = || {
                 rule.name

--- a/crates/aisix-core/src/config.rs
+++ b/crates/aisix-core/src/config.rs
@@ -507,9 +507,10 @@ pub struct ProxyConfig {
     #[serde(default)]
     pub workers: Option<usize>,
     /// Entry-level URL rewrite rules, applied to every proxy-listener
-    /// request **before** routing (the admin and metrics listeners are
-    /// unaffected). The first rule whose `match` regex matches the request
-    /// path rewrites it — once, no cascading — and the request then flows
+    /// request **before** all routing, including host-based passthrough
+    /// (the admin and metrics listeners are unaffected). The first rule
+    /// whose optional `hosts` and path `match` both match rewrites it —
+    /// once, no cascading — and the request then flows
     /// through the normal endpoint (auth, ACL, quota, …) as if the client
     /// had sent the rewritten path. Lets operators map legacy URL shapes
     /// onto AISIX endpoints, e.g. per-server MCP paths onto
@@ -553,6 +554,11 @@ pub struct UrlRewriteRule {
     /// Optional name, used in logs when the rule fires.
     #[serde(default)]
     pub name: Option<String>,
+    /// Optional inbound hosts. Omitted means all hosts; an explicit list
+    /// must be non-empty. Host and path must both match. Matching ignores
+    /// case and the request's port; `*.` matches one additional label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hosts: Option<Vec<String>>,
     /// Regex matched against the **raw, percent-encoded** request path
     /// (never the query string) — no decoding, no normalization. Anchor
     /// with `^`/`$` to match the whole path; an unanchored pattern matches
@@ -1661,6 +1667,17 @@ impl Config {
                     .clone()
                     .unwrap_or_else(|| format!("proxy.url_rewrites[{i}]"))
             };
+            if let Some(hosts) = &rule.hosts {
+                let pattern =
+                    regex::Regex::new(crate::host::HOST_PATTERN).expect("host pattern is valid");
+                if hosts.is_empty() || hosts.iter().any(|host| !pattern.is_match(host)) {
+                    return Err(BootstrapError::Config(format!(
+                        "{}: hosts must be a non-empty list of hostnames or single-label \
+                         wildcards such as *.example.com (no scheme, port, or path)",
+                        ctx()
+                    )));
+                }
+            }
             let regex = match regex::Regex::new(&rule.pattern) {
                 Ok(regex) => regex,
                 Err(e) => {
@@ -2164,6 +2181,47 @@ admin:
     }
 
     #[test]
+    fn url_rewrites_validate_optional_hosts() {
+        let load = |hosts: serde_json::Value| {
+            let f = write_yaml(
+                &serde_json::json!({
+                    "etcd": {"endpoints": ["http://127.0.0.1:2379"]},
+                    "admin": {"addr": "127.0.0.1:3001", "admin_keys": ["test"]},
+                    "proxy": {"addr": "127.0.0.1:3000", "url_rewrites": [{
+                        "name": "host-scoped-chat", "hosts": hosts,
+                        "match": "^/chat$", "rewrite": "/v1/chat/completions"
+                    }]}
+                })
+                .to_string(),
+            );
+            Config::load_from_path(Some(f.path()))
+        };
+        for hosts in [
+            serde_json::json!(["GW.Example.com", "*.example.com"]),
+            serde_json::json!(["localhost", "127.0.0.1"]),
+        ] {
+            let cfg = load(hosts.clone()).unwrap();
+            assert_eq!(serde_json::json!(cfg.proxy.url_rewrites[0].hosts), hosts);
+        }
+        for hosts in [
+            serde_json::json!([]),
+            serde_json::json!([""]),
+            serde_json::json!(["*"]),
+            serde_json::json!(["*.com"]),
+            serde_json::json!(["https://gw.example.com"]),
+            serde_json::json!(["gw.example.com:8080"]),
+            serde_json::json!(["gw.example.com/chat"]),
+            serde_json::json!(["gw.example.com", "bad host"]),
+        ] {
+            let err = load(hosts.clone()).unwrap_err().to_string();
+            assert!(
+                err.contains("host-scoped-chat") && err.contains("hosts"),
+                "{hosts}: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn loads_url_rewrites_and_rejects_an_invalid_regex() {
         let f = write_yaml(
             r#"
@@ -2184,6 +2242,7 @@ admin:
         let cfg = Config::load_from_path(Some(f.path())).unwrap();
         assert_eq!(cfg.proxy.url_rewrites.len(), 1);
         assert_eq!(cfg.proxy.url_rewrites[0].replacement, "/mcp/$1");
+        assert!(cfg.proxy.url_rewrites[0].hosts.is_none());
 
         let f = write_yaml(
             r#"
@@ -2377,7 +2436,7 @@ admin:
             ),
             (
                 "AISIX_PROXY__URL_REWRITES",
-                r#"[{"name":"c","match":"^/a$","rewrite":"/b"}]"#,
+                r#"[{"name":"c","hosts":["gw.example.com"],"match":"^/a$","rewrite":"/b"}]"#,
             ),
             (
                 "AISIX_OBSERVABILITY__METRICS__CLIENT_TYPE_RULES",
@@ -2415,6 +2474,10 @@ admin:
         }
 
         let cfg = Config::load_from_path(None).unwrap();
+        assert_eq!(
+            cfg.proxy.url_rewrites[0].hosts.as_deref(),
+            Some(["gw.example.com".to_string()].as_slice())
+        );
         assert_eq!(
             cfg.proxy.real_ip.trusted_proxies,
             vec!["10.0.0.0/8".to_string(), "127.0.0.1/32".to_string()],

--- a/crates/aisix-core/src/host.rs
+++ b/crates/aisix-core/src/host.rs
@@ -1,0 +1,23 @@
+//! Host patterns shared by entry-level rewrites and passthrough routes.
+
+/// Exact host, or a single-label wildcard with at least two literal labels.
+pub const HOST_PATTERN: &str = r"^(\*\.)?([A-Za-z0-9-]+\.)+[A-Za-z0-9-]+$|^[A-Za-z0-9-]+$";
+
+/// Match a normalized host (lowercase, no port) against configured patterns.
+pub fn matches(hosts: &[String], host: &str) -> bool {
+    hosts.iter().any(|pattern| {
+        let p = pattern.to_ascii_lowercase();
+        if let Some(suffix) = p.strip_prefix("*.") {
+            match host.strip_suffix(suffix) {
+                Some(head) => {
+                    head.ends_with('.')
+                        && !head[..head.len() - 1].is_empty()
+                        && !head[..head.len() - 1].contains('.')
+                }
+                None => false,
+            }
+        } else {
+            p == host
+        }
+    })
+}

--- a/crates/aisix-core/src/lib.rs
+++ b/crates/aisix-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod error;
 pub mod filesource;
 pub mod forwarded_headers;
 pub mod header_template;
+pub mod host;
 pub mod models;
 pub mod resource;
 pub mod similarity;

--- a/crates/aisix-core/src/models/passthrough_route.rs
+++ b/crates/aisix-core/src/models/passthrough_route.rs
@@ -248,22 +248,7 @@ impl PassthroughRoute {
         let Some(hosts) = &self.hosts else {
             return false;
         };
-        hosts.iter().any(|pattern| {
-            let p = pattern.to_ascii_lowercase();
-            if let Some(suffix) = p.strip_prefix("*.") {
-                match host.strip_suffix(suffix) {
-                    // `label.` + suffix, with exactly one label consumed.
-                    Some(head) => {
-                        head.ends_with('.')
-                            && !head[..head.len() - 1].is_empty()
-                            && !head[..head.len() - 1].contains('.')
-                    }
-                    None => false,
-                }
-            } else {
-                p == host
-            }
-        })
+        crate::host::matches(hosts, host)
     }
 }
 
@@ -313,7 +298,7 @@ pub fn passthrough_route_coupling() -> Value {
                 "type": "array", "minItems": 1,
                 "items": {
                     "type": "string", "minLength": 1,
-                    "pattern": "^(\\*\\.)?([A-Za-z0-9-]+\\.)+[A-Za-z0-9-]+$|^[A-Za-z0-9-]+$"
+                    "pattern": crate::host::HOST_PATTERN
                 }
             } } }
         },

--- a/crates/aisix-proxy/src/host.rs
+++ b/crates/aisix-proxy/src/host.rs
@@ -1,0 +1,25 @@
+//! Inbound authority shared by URL rewriting and passthrough routing.
+
+use axum::extract::Request;
+use axum::http::header;
+
+/// The request's inbound host: the `Host` header (origin-form requests),
+/// falling back to the URI authority (absolute-form requests from a
+/// chained proxy). Lowercased, `:port` stripped.
+pub(crate) fn inbound_host(req: &Request) -> Option<String> {
+    let raw = req
+        .headers()
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .or_else(|| req.uri().authority().map(|a| a.as_str()))?;
+    let no_port = raw.rsplit_once(':').map_or(raw, |(head, port)| {
+        // Only treat the suffix as a port when it is all digits — an
+        // IPv6 literal's last group would otherwise be truncated.
+        if port.chars().all(|c| c.is_ascii_digit()) {
+            head
+        } else {
+            raw
+        }
+    });
+    Some(no_port.trim_end_matches('.').to_ascii_lowercase())
+}

--- a/crates/aisix-proxy/src/host.rs
+++ b/crates/aisix-proxy/src/host.rs
@@ -3,15 +3,15 @@
 use axum::extract::Request;
 use axum::http::header;
 
-/// The request's inbound host: the `Host` header (origin-form requests),
-/// falling back to the URI authority (absolute-form requests from a
-/// chained proxy). Lowercased, `:port` stripped.
+/// The URI authority takes precedence over `Host` for absolute-form requests
+/// (RFC 9112 section 3.2.2). Origin-form requests use `Host`.
+/// Lowercased, `:port` stripped.
 pub(crate) fn inbound_host(req: &Request) -> Option<String> {
-    let raw = req
-        .headers()
-        .get(header::HOST)
-        .and_then(|v| v.to_str().ok())
-        .or_else(|| req.uri().authority().map(|a| a.as_str()))?;
+    let raw = req.uri().authority().map(|a| a.as_str()).or_else(|| {
+        req.headers()
+            .get(header::HOST)
+            .and_then(|v| v.to_str().ok())
+    })?;
     let no_port = raw.rsplit_once(':').map_or(raw, |(head, port)| {
         // Only treat the suffix as a port when it is all digits — an
         // IPv6 literal's last group would otherwise be truncated.

--- a/crates/aisix-proxy/src/lib.rs
+++ b/crates/aisix-proxy/src/lib.rs
@@ -50,6 +50,7 @@ mod guardrail_coverage;
 mod guardrail_embedder;
 mod guardrail_stream;
 pub mod health;
+mod host;
 mod http_client;
 mod images;
 mod images_edits;
@@ -242,6 +243,24 @@ pub fn build_router(state: ProxyState) -> Router {
     )
     .with_state(state.clone());
 
+    // Host-based passthrough-route dispatch. A request whose `Host`
+    // matches an enabled route's `hosts` was never addressed to this
+    // gateway's own API (forward-proxy traffic delivered with the
+    // original host), so it must not fall into a typed route that
+    // happens to share the path. URL rewriting runs before this dispatch,
+    // so both host and path routes see the rewritten URI.
+    // Wrapped unconditionally: routes arrive dynamically via the
+    // snapshot, and the per-request probe is one arc-swap load plus a
+    // scan of the (typically tiny) route table. Matched requests go to
+    // `host_entry_stack`, which carries the same shared layers as the
+    // main stack (see above).
+    let router = Router::new()
+        .fallback_service(router)
+        .layer(middleware::from_fn_with_state(
+            (state.clone(), host_entry_stack),
+            passthrough_route::host_dispatch,
+        ));
+
     // Pre-routing URL rewriting (`proxy.url_rewrites`). `Router::layer`
     // middleware runs AFTER route matching, so a URI rewritten there could
     // never change which route matches. Wrapping the whole router as the
@@ -260,24 +279,6 @@ pub fn build_router(state: ProxyState) -> Router {
                 rewrite::rewrite_request_uri,
             ))
     };
-
-    // Host-based passthrough-route dispatch. A request whose `Host`
-    // matches an enabled route's `hosts` was never addressed to this
-    // gateway's own API (forward-proxy traffic delivered with the
-    // original host), so it must not fall into a typed route that
-    // happens to share the path — this seat is pre-routing AND outside
-    // the rewrite layer, so `url_rewrites` never touches foreign-host
-    // paths. Wrapped unconditionally: routes arrive dynamically via the
-    // snapshot, and the per-request probe is one arc-swap load plus a
-    // scan of the (typically tiny) route table. Matched requests go to
-    // `host_entry_stack`, which carries the same shared layers as the
-    // main stack (see above).
-    let router = Router::new()
-        .fallback_service(router)
-        .layer(middleware::from_fn_with_state(
-            (state.clone(), host_entry_stack),
-            passthrough_route::host_dispatch,
-        ));
 
     // Outermost: mint the request id into the request extensions
     // before any handler/extractor runs — including the rewrite layer,

--- a/crates/aisix-proxy/src/passthrough_route.rs
+++ b/crates/aisix-proxy/src/passthrough_route.rs
@@ -33,7 +33,7 @@
 //!   route can never shadow `/v1/*`, `/mcp`, or `/a2a`. A no-match request
 //!   keeps the pre-existing plain 404, `/passthrough/*` included — that
 //!   namespace is claimed by explicit routes like any other.
-//! - [`host_dispatch`] — a **pre-routing** middleware (outermost wrap in
+//! - [`host_dispatch`] — a **pre-routing** middleware (after URL rewriting in
 //!   `build_router`). A request whose `Host` matches an enabled route's
 //!   `hosts` was never addressed to this gateway's own API, so it must not
 //!   fall into a typed route that happens to share the path (forward-proxy
@@ -74,6 +74,7 @@ use aisix_core::{PassthroughAuthMode, PassthroughCredentialMode, PassthroughRout
 
 use crate::auth::AuthenticatedKey;
 use crate::error::ProxyError;
+use crate::host::inbound_host;
 use crate::state::ProxyState;
 
 /// Bounded `model` metric label for passthrough-route requests. Route
@@ -135,27 +136,6 @@ fn has_host_match(snapshot: &aisix_core::AisixSnapshot, host: Option<&str>) -> b
         .entries()
         .iter()
         .any(|e| e.value.enabled && e.value.matches_host(host))
-}
-
-/// The request's inbound host: the `Host` header (origin-form requests),
-/// falling back to the URI authority (absolute-form requests from a
-/// chained proxy). Lowercased, `:port` stripped.
-fn inbound_host(req: &Request) -> Option<String> {
-    let raw = req
-        .headers()
-        .get(header::HOST)
-        .and_then(|v| v.to_str().ok())
-        .or_else(|| req.uri().authority().map(|a| a.as_str()))?;
-    let no_port = raw.rsplit_once(':').map_or(raw, |(head, port)| {
-        // Only treat the suffix as a port when it is all digits — an
-        // IPv6 literal's last group would otherwise be truncated.
-        if port.chars().all(|c| c.is_ascii_digit()) {
-            head
-        } else {
-            raw
-        }
-    });
-    Some(no_port.trim_end_matches('.').to_ascii_lowercase())
 }
 
 /// Pre-routing middleware: dispatch foreign-host traffic to the entry

--- a/crates/aisix-proxy/src/rewrite.rs
+++ b/crates/aisix-proxy/src/rewrite.rs
@@ -266,6 +266,12 @@ mod tests {
                 "http://gw.example.com/legacy/health",
                 Some("other.example.com"),
                 None,
+                200,
+            ),
+            (
+                "http://other.example.com/legacy/health",
+                Some("gw.example.com"),
+                None,
                 404,
             ),
             ("/legacy/other", Some("gw.example.com"), None, 404),

--- a/crates/aisix-proxy/src/rewrite.rs
+++ b/crates/aisix-proxy/src/rewrite.rs
@@ -2,7 +2,7 @@
 //!
 //! Applied to every proxy-listener request **before** route matching (the
 //! admin and metrics listeners never see this layer): the first rule whose
-//! `match` regex matches the request path rewrites it — once, no cascading —
+//! host condition and `match` regex match rewrites it — once, no cascading —
 //! and the request then flows through the normal endpoint (auth, ACL, quota,
 //! metrics labelling) as if the client had sent the rewritten path. A miss
 //! leaves the request untouched.
@@ -31,6 +31,7 @@ use crate::state::ProxyState;
 /// One boot-compiled rewrite rule.
 pub struct CompiledRewrite {
     name: Option<String>,
+    hosts: Option<Vec<String>>,
     pattern: Regex,
     replacement: String,
 }
@@ -60,6 +61,7 @@ pub fn compile(rules: &[UrlRewriteRule]) -> Arc<[CompiledRewrite]> {
         .iter()
         .map(|rule| CompiledRewrite {
             name: rule.name.clone(),
+            hosts: rule.hosts.clone(),
             pattern: Regex::new(&rule.pattern)
                 .expect("proxy.url_rewrites pattern is validated at config load"),
             replacement: rule.replacement.clone(),
@@ -73,7 +75,16 @@ pub async fn rewrite_request_uri(
     mut request: Request,
     next: Next,
 ) -> Response {
+    let host = crate::host::inbound_host(&request);
     let fired = state.url_rewrites.iter().find_map(|rule| {
+        if let Some(hosts) = &rule.hosts {
+            if !host
+                .as_deref()
+                .is_some_and(|host| aisix_core::host::matches(hosts, host))
+            {
+                return None;
+            }
+        }
         let path = request.uri().path();
         rule.apply(path).map(|to| (rule, path.to_owned(), to))
     });
@@ -119,6 +130,7 @@ mod tests {
     fn rule(pattern: &str, replacement: &str) -> UrlRewriteRule {
         UrlRewriteRule {
             name: None,
+            hosts: None,
             pattern: pattern.to_string(),
             replacement: replacement.to_string(),
         }
@@ -219,6 +231,59 @@ mod tests {
         assert_eq!(get(router.clone(), "/legacy/other").await, 404);
         // The canonical path keeps working alongside the legacy one.
         assert_eq!(get(router, "/livez").await, 200);
+    }
+
+    #[tokio::test]
+    async fn host_scoping_uses_inbound_authority_and_first_complete_match_once() {
+        use tower::ServiceExt;
+
+        let mut scoped = rule("^/legacy/health$", "/livez");
+        scoped.hosts = Some(vec!["GW.Example.com".into(), "*.tenant.example.com".into()]);
+        let router = router_with_rules(vec![
+            scoped,
+            rule("^/legacy/health$", "/nonexistent"),
+            rule("^/livez$", "/must-not-cascade"),
+        ]);
+        for (uri, host, forwarded, expected) in [
+            ("/legacy/health", Some("gW.example.COM:8443"), None, 200),
+            ("/legacy/health", Some("one.tenant.example.com"), None, 200),
+            ("/legacy/health", Some("tenant.example.com"), None, 404),
+            (
+                "/legacy/health",
+                Some("two.one.tenant.example.com"),
+                None,
+                404,
+            ),
+            (
+                "/legacy/health",
+                Some("other.example.com"),
+                Some("gw.example.com"),
+                404,
+            ),
+            ("/legacy/health", None, Some("gw.example.com"), 404),
+            ("http://gw.example.com:8080/legacy/health", None, None, 200),
+            (
+                "http://gw.example.com/legacy/health",
+                Some("other.example.com"),
+                None,
+                404,
+            ),
+            ("/legacy/other", Some("gw.example.com"), None, 404),
+        ] {
+            let mut req = http::Request::get(uri);
+            if let Some(host) = host {
+                req = req.header(http::header::HOST, host);
+            }
+            if let Some(forwarded) = forwarded {
+                req = req.header("x-forwarded-host", forwarded);
+            }
+            let response = router
+                .clone()
+                .oneshot(req.body(axum::body::Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), expected, "uri={uri} host={host:?}");
+        }
     }
 
     #[tokio::test]

--- a/tests/e2e/src/cases/url-rewrite-e2e.test.ts
+++ b/tests/e2e/src/cases/url-rewrite-e2e.test.ts
@@ -14,7 +14,7 @@ import {
 // gateway + etcd + a real MCP upstream.
 //
 // Pinned contract:
-//   - the first rule whose `match` regex matches the path rewrites it; the
+//   - the first rule whose host and path conditions match rewrites it; the
 //     request then flows through the normal endpoint (auth, ACL, quota) as
 //     if the client had sent the rewritten path;
 //   - the flagship scenario: a client keeping its legacy per-server MCP URL
@@ -136,6 +136,7 @@ describe("url rewrite e2e: proxy.url_rewrites", () => {
       urlRewrites: [
         {
           name: "per-server-mcp-compat",
+          hosts: ["127.0.0.1"],
           match: "^/mcp-servers/([^/]+)/mcp$",
           rewrite: "/mcp/$1",
         },
@@ -158,11 +159,11 @@ describe("url rewrite e2e: proxy.url_rewrites", () => {
     });
 
     await waitConfigPropagation(async () => {
-      const listed = await listToolNames("/mcp-servers/alpha/mcp");
-      return (
-        listed.status === 200 &&
-        JSON.stringify(listed.names) === JSON.stringify(["echo", "reverse"])
-      );
+      const res = await fetch(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${KEY}` },
+      });
+      await res.text();
+      return res.status === 200;
     });
   }, 60_000);
 

--- a/tests/e2e/src/cases/url-rewrite-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/url-rewrite-routing-e2e.test.ts
@@ -1,0 +1,156 @@
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { harnessRequest } from "../harness/http.js";
+import {
+  EtcdClient,
+  SeedClient,
+  spawnApp,
+  startOpenAiUpstream,
+  waitConfigPropagation,
+  type OpenAiUpstream,
+  type SpawnedApp,
+} from "../harness/index.js";
+
+const KEY = "sk-url-rewrite-routing";
+const BODY = { model: "chat-alias", messages: [{ role: "user", content: "hello" }] };
+
+describe("URL rewrite precedes every route and respects host scope", () => {
+  let app: SpawnedApp | undefined;
+  let agent: OpenAiUpstream | undefined;
+  let llm: OpenAiUpstream | undefined;
+  let etcdReachable = false;
+
+  beforeAll(async () => {
+    const etcd = new EtcdClient();
+    etcdReachable = await etcd.ping();
+    if (!etcdReachable) return;
+
+    agent = await startOpenAiUpstream({ nonStreamBody: { servedBy: "agent" } });
+    llm = await startOpenAiUpstream();
+    app = await spawnApp({
+      extraEnv: {
+        AISIX_PROXY__URL_REWRITES: JSON.stringify([
+          { hosts: ["gw.example.com"], match: "^/(?:pjt/)?chat$", rewrite: "/v1/chat/completions" },
+          { hosts: ["*.tenant.example.com"], match: "^/chat$", rewrite: "/rewritten/chat" },
+          { match: "^/legacy/(.*)$", rewrite: "/rewritten/$1" },
+          { match: "^/rewritten/.*$", rewrite: "/must-not-cascade" },
+        ]),
+      },
+    });
+    const seed = new SeedClient(etcd, app.etcdPrefix);
+    const pk = await seed.createProviderKey({
+      display_name: "rewrite-provider", api_key: "upstream-secret", api_base: `${llm.baseUrl}/v1`,
+    });
+    await seed.createModel({
+      display_name: "chat-alias", provider: "openai", model_name: "upstream-model",
+      provider_key_id: pk.id,
+    });
+    for (const [prefix, mount] of [["/pjt", "/path"], ["/rewritten", "/path"], ["/chat", "/unchanged"]]) {
+      await seed.createPassthroughRoute({
+        name: `path-${prefix.slice(1)}`, path_prefix: prefix,
+        target_url: `${agent.baseUrl}${mount}`, credential_mode: "forward_client",
+      });
+    }
+    await seed.createPassthroughRoute({
+      name: "host-route",
+      hosts: ["relay.example.com", "other.example.com", "*.tenant.example.com"],
+      target_url: `${agent.baseUrl}/host`, credential_mode: "forward_client",
+    });
+    await seed.createPassthroughRoute({
+      name: "combined-route", hosts: ["combo.example.com"], path_prefix: "/rewritten",
+      target_url: `${agent.baseUrl}/combined`, credential_mode: "forward_client",
+    });
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update(KEY).digest("hex"),
+      allowed_models: ["*"], allowed_routes: ["*"],
+    });
+    await waitConfigPropagation(async () => {
+      const res = await harnessRequest(`${app!.proxyUrl}/v1/models`, {
+        headers: { authorization: `Bearer ${KEY}` },
+      });
+      await res.body.text();
+      return res.statusCode === 200;
+    });
+  });
+
+  afterAll(async () => {
+    await app?.exit();
+    await agent?.close();
+    await llm?.close();
+  });
+
+  for (const path of ["/chat", "/pjt/chat"]) {
+    test(`${path} on the gateway host uses the standard Chat pipeline`, async (ctx) => {
+      if (!etcdReachable || !app || !agent || !llm) return ctx.skip();
+      const beforeAgent = agent.receivedRequests.length;
+      const beforeLlm = llm.receivedRequests.length;
+      const res = await harnessRequest(`${app.proxyUrl}${path}`, {
+        method: "POST",
+        headers: {
+          host: "GW.Example.COM:8443", authorization: `Bearer ${KEY}`,
+          "content-type": "application/json", "x-aisix-request-id": "rewrite-chat",
+        },
+        body: JSON.stringify(BODY),
+      });
+      const responseBody = await res.body.json();
+      expect(res.statusCode, JSON.stringify(responseBody)).toBe(200);
+      expect(responseBody).toMatchObject({
+        choices: [{ message: { content: "mock reply" } }],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      });
+      expect(res.headers["x-aisix-request-id"]).toBe("rewrite-chat");
+      expect(agent.receivedRequests).toHaveLength(beforeAgent);
+      expect(llm.receivedRequests).toHaveLength(beforeLlm + 1);
+      expect(llm.receivedRequests.at(-1)).toMatchObject({
+        path: "/v1/chat/completions",
+        headers: { authorization: "Bearer upstream-secret" },
+      });
+      expect(JSON.parse(llm.receivedRequests.at(-1)!.body)).toMatchObject({ model: "upstream-model" });
+    });
+
+  }
+
+  for (const [host, path, expected] of [
+    ["relay.example.com", "/legacy/item?probe=a%2Fb", "/host/rewritten/item?probe=a%2Fb"],
+    ["combo.example.com", "/legacy/item?probe=1", "/combined/item?probe=1"],
+    ["gw.example.com", "/legacy/item", "/path/item"],
+    ["other.example.com", "/chat", "/host/chat"],
+    ["other.example.com", "/pjt/chat", "/host/pjt/chat"],
+    ["A.tenant.EXAMPLE.com:8080", "/chat", "/host/rewritten/chat"],
+    ["tenant.example.com", "/chat", "/unchanged"],
+    ["two.one.tenant.example.com", "/chat", "/unchanged"],
+  ]) {
+    test(`${host}${path} reaches the expected passthrough path`, async (ctx) => {
+      if (!etcdReachable || !app || !agent || !llm) return ctx.skip();
+      const beforeAgent = agent.receivedRequests.length;
+      const beforeLlm = llm.receivedRequests.length;
+      const res = await harnessRequest(`${app.proxyUrl}${path}`, {
+        method: "POST",
+        headers: { host, authorization: `Bearer ${KEY}`, "content-type": "application/json" },
+        body: JSON.stringify(BODY),
+      });
+      expect(res.statusCode).toBe(200);
+      expect(await res.body.json()).toEqual({ servedBy: "agent" });
+      expect(llm.receivedRequests).toHaveLength(beforeLlm);
+      expect(agent.receivedRequests).toHaveLength(beforeAgent + 1);
+      expect(agent.receivedRequests.at(-1)).toMatchObject({ path: expected, body: JSON.stringify(BODY) });
+    });
+
+  }
+
+  test("rewritten Chat and host passthrough requests still require authentication", async (ctx) => {
+    if (!etcdReachable || !app || !agent || !llm) return ctx.skip();
+    const beforeAgent = agent.receivedRequests.length;
+    const beforeLlm = llm.receivedRequests.length;
+    for (const [host, path] of [["gw.example.com", "/chat"], ["relay.example.com", "/legacy/chat"]]) {
+      const res = await harnessRequest(`${app.proxyUrl}${path}`, {
+        method: "POST", headers: { host, "content-type": "application/json" },
+        body: JSON.stringify(BODY),
+      });
+      await res.body.text();
+      expect(res.statusCode).toBe(401);
+    }
+    expect(agent.receivedRequests).toHaveLength(beforeAgent);
+    expect(llm.receivedRequests).toHaveLength(beforeLlm);
+  });
+});

--- a/tests/e2e/src/cases/url-rewrite-routing-e2e.test.ts
+++ b/tests/e2e/src/cases/url-rewrite-routing-e2e.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { request as httpRequest } from "node:http";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { harnessRequest } from "../harness/http.js";
 import {
@@ -13,6 +14,24 @@ import {
 
 const KEY = "sk-url-rewrite-routing";
 const BODY = { model: "chat-alias", messages: [{ role: "user", content: "hello" }] };
+
+function absoluteRequest(proxyUrl: string, authority: string, host: string) {
+  return new Promise<{ status: number | undefined; body: string }>((resolve, reject) => {
+    const req = httpRequest(proxyUrl, {
+      method: "POST", path: `http://${authority}/chat`, agent: false,
+      signal: AbortSignal.timeout(5000),
+      headers: { host, authorization: `Bearer ${KEY}`, "content-type": "application/json" },
+    }, (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => { body += chunk; });
+      res.on("end", () => resolve({ status: res.statusCode, body }));
+      res.on("error", reject);
+    });
+    req.on("error", reject);
+    req.end(JSON.stringify(BODY));
+  });
+}
 
 describe("URL rewrite precedes every route and respects host scope", () => {
   let app: SpawnedApp | undefined;
@@ -137,6 +156,30 @@ describe("URL rewrite precedes every route and respects host scope", () => {
     });
 
   }
+
+  test("absolute-form authority overrides a conflicting Host for Chat rewriting", async (ctx) => {
+    if (!etcdReachable || !app || !agent || !llm) return ctx.skip();
+    const beforeAgent = agent.receivedRequests.length;
+    const beforeLlm = llm.receivedRequests.length;
+    const res = await absoluteRequest(app.proxyUrl, "GW.example.com:8443", "other.example.com");
+    expect(res.status, res.body).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ choices: [{ message: { content: "mock reply" } }] });
+    expect(agent.receivedRequests).toHaveLength(beforeAgent);
+    expect(llm.receivedRequests).toHaveLength(beforeLlm + 1);
+    expect(llm.receivedRequests.at(-1)?.path).toBe("/v1/chat/completions");
+  });
+
+  test("absolute-form authority controls both rewriting and host passthrough dispatch", async (ctx) => {
+    if (!etcdReachable || !app || !agent || !llm) return ctx.skip();
+    const beforeAgent = agent.receivedRequests.length;
+    const beforeLlm = llm.receivedRequests.length;
+    const res = await absoluteRequest(app.proxyUrl, "A.tenant.example.com:8080", "gw.example.com");
+    expect(res.status, res.body).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ servedBy: "agent" });
+    expect(llm.receivedRequests).toHaveLength(beforeLlm);
+    expect(agent.receivedRequests).toHaveLength(beforeAgent + 1);
+    expect(agent.receivedRequests.at(-1)?.path).toBe("/host/rewritten/chat");
+  });
 
   test("rewritten Chat and host passthrough requests still require authentication", async (ctx) => {
     if (!etcdReachable || !app || !agent || !llm) return ctx.skip();

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -54,7 +54,7 @@ export interface AppOverrides {
    * rewriting: first matching rule wins, `rewrite` replaces the matched
    * portion of the path.
    */
-  urlRewrites?: Array<{ name?: string; match: string; rewrite: string }>;
+  urlRewrites?: Array<{ name?: string; hosts?: string[]; match: string; rewrite: string }>;
   /**
    * `proxy.request_body_limit_bytes`. A dedicated override (like
    * `realIp`) because `extra` replaces whole top-level blocks and the


### PR DESCRIPTION
URL rewrite rules now run before host-based passthrough dispatch as well as built-in endpoints and path-prefix passthrough routes. This makes rewriting a consistent entry-stage operation. Existing rules without `hosts` now also affect host-matched passthrough requests.

Add optional `hosts` to restrict a rule to inbound hostnames. Host and path must both match; the first matching rule applies once. Host matching shares passthrough semantics: case-insensitive exact names or single-label wildcards, ignoring the inbound port. Absolute-form requests use their URI authority ahead of a conflicting Host header; origin-form requests use Host. Empty lists and invalid patterns fail startup. Rules remain startup configuration in `config.yaml` or the existing JSON environment variable, including Helm-managed deployments.

Regression coverage exercises a real gateway, etcd, and HTTP/MCP upstreams: custom Chat aliases retain model mapping and authentication, other hosts retain their passthrough paths, and host-only, path-only, and combined passthrough routes all see the rewritten path. Configuration and router tests cover environment loading, wildcard boundaries, missing authority, and first-match behavior. HTTP/1.1 regression cases cover conflicting absolute-form authority and Host values for both Chat and passthrough dispatch.

Documentation: api7/docs#2379 and api7/docs.apiseven.com#625.
