### PR TITLE
perf(etcd): adapt watch coalescing to configuration apply cost

### DIFF
--- a/crates/aisix-etcd/src/supervisor.rs
+++ b/crates/aisix-etcd/src/supervisor.rs
@@ -1663,6 +1663,7 @@ impl<P: ConfigProvider> Supervisor<P> {
         // stream). Held here so the next loop iteration handles it
         // exactly as if it had just arrived.
         let mut pushed_back: Option<Option<Watched>> = None;
+        let mut apply_timing = ApplyTiming::default();
 
         loop {
             if *cancel.borrow() {
@@ -1708,8 +1709,8 @@ impl<P: ConfigProvider> Supervisor<P> {
                     // Coalesce: hold the batch open for a short bounded
                     // window and apply the whole run as one
                     // copy-on-write cycle. The window closes on the first
-                    // of three conditions — COALESCE_QUIET_PERIOD with no
-                    // new event, COALESCE_MAX_WAIT since the first event,
+                    // of three conditions — the quiet period with no new
+                    // event, COALESCE_MAX_WAIT since the first event,
                     // or MAX_APPLY_BATCH events — so a bulk edit costs a
                     // bounded number of whole-configuration passes no
                     // matter how the source spaces its deliveries
@@ -1718,6 +1719,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                     // endpoint happened to batch its watch deliveries and
                     // on how long the previous apply took.
                     let mut batch = vec![first];
+                    let quiet_period = apply_timing.quiet_period();
                     let deadline = tokio::time::Instant::now() + COALESCE_MAX_WAIT;
                     while batch.len() < MAX_APPLY_BATCH {
                         // Checked here as well as in the select: with a
@@ -1750,7 +1752,7 @@ impl<P: ConfigProvider> Supervisor<P> {
                             _ = wait_for_cancel(cancel.clone()) => break,
                             item = stream.next() => item,
                             _ = tokio::time::sleep_until(deadline) => break,
-                            _ = tokio::time::sleep(COALESCE_QUIET_PERIOD) => break,
+                            _ = tokio::time::sleep(quiet_period) => break,
                         };
                         match item {
                             Some(Watched::Event(Ok(
@@ -1791,7 +1793,9 @@ impl<P: ConfigProvider> Supervisor<P> {
                             }
                         })
                         .collect();
+                    let started = std::time::Instant::now();
                     self.apply_events(&staged);
+                    apply_timing.record(started.elapsed());
                 }
             }
         }
@@ -1871,15 +1875,7 @@ async fn wait_for_cancel(mut rx: tokio::sync::watch::Receiver<bool>) {
 /// snapshot arbitrarily stale.
 const MAX_APPLY_BATCH: usize = 512;
 
-/// How long a coalescing window stays open after the last event before
-/// the batch is applied.
-///
-/// This is the delay a lone write pays in full — measured, it moves the
-/// etcd-write-to-`applied_revision` median from 21 ms to 42 ms — so it
-/// buys nothing by being larger than it has to be. It only has to clear
-/// the gap between consecutive deliveries of one control-plane burst,
-/// which measured 1–3 ms against a local etcd and stays in single-digit
-/// milliseconds for an outbox relay writing a row per transaction.
+/// Quiet period for cheap applies and the first write after an idle interval.
 const COALESCE_QUIET_PERIOD: Duration = Duration::from_millis(20);
 
 /// Hard cap on how long the first event of a batch waits for company.
@@ -1893,6 +1889,29 @@ const COALESCE_QUIET_PERIOD: Duration = Duration::from_millis(20);
 /// less: a 1500-row burst costs 12 applies here and would cost 9 at the
 /// 200 ms this was picked under.
 const COALESCE_MAX_WAIT: Duration = Duration::from_millis(150);
+
+#[derive(Default)]
+struct ApplyTiming {
+    previous: Option<(tokio::time::Instant, Duration)>,
+}
+
+impl ApplyTiming {
+    fn quiet_period(&self) -> Duration {
+        match self.previous {
+            // Expensive applies need to amortize their configuration-wide
+            // work across spaced writes too. Forget that cost after an idle
+            // interval so a later isolated write keeps its short wait.
+            Some((finished, cost)) if finished.elapsed() < COALESCE_MAX_WAIT => {
+                cost.clamp(COALESCE_QUIET_PERIOD, COALESCE_MAX_WAIT)
+            }
+            _ => COALESCE_QUIET_PERIOD,
+        }
+    }
+
+    fn record(&mut self, cost: Duration) {
+        self.previous = Some((tokio::time::Instant::now(), cost));
+    }
+}
 
 /// One watch event staged for a coalesced apply.
 enum PendingEvent<'a> {
@@ -3438,6 +3457,25 @@ mod tests {
                 self.rx.lock().unwrap().take().expect("watched twice"),
             ))
         }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn coalescing_cost_expires_and_never_extends_the_maximum_wait() {
+        let mut timing = ApplyTiming::default();
+        assert_eq!(timing.quiet_period(), Duration::from_millis(20));
+
+        timing.record(Duration::from_millis(90));
+        tokio::time::advance(Duration::from_millis(70)).await;
+        assert_eq!(timing.quiet_period(), Duration::from_millis(90));
+
+        timing.record(Duration::from_secs(1));
+        assert_eq!(timing.quiet_period(), Duration::from_millis(150));
+        tokio::time::advance(Duration::from_millis(150)).await;
+        assert_eq!(timing.quiet_period(), Duration::from_millis(20));
+
+        timing.record(Duration::from_millis(90));
+        timing.record(Duration::from_millis(1));
+        assert_eq!(timing.quiet_period(), Duration::from_millis(20));
     }
 
     /// A burst that arrives one event at a time — how the control plane's

--- a/tests/e2e/src/cases/batch-files-finetuning-e2e.test.ts
+++ b/tests/e2e/src/cases/batch-files-finetuning-e2e.test.ts
@@ -186,10 +186,6 @@ describe("jobs e2e: /v1/files + /v1/batches + /v1/fine_tuning/jobs (#720)", () =
     seed = new SeedClient(etcd, app.etcdPrefix);
     upstream = await startJobsUpstream();
 
-    await seed.createApiKey({
-      key_hash: CALLER_KEY_HASH,
-      allowed_models: ["*"],
-    });
     const pk = await seed.createProviderKey({
       display_name: "jobs-e2e-pk",
       secret: "sk-upstream-jobs",
@@ -220,6 +216,10 @@ describe("jobs e2e: /v1/files + /v1/batches + /v1/fine_tuning/jobs (#720)", () =
       provider: "openai",
       model_name: "gpt-4o",
       provider_key_id: hdrPk.id,
+    });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["*"],
     });
 
     // Gate on the DP snapshot, not the store: /v1/models only lists the

--- a/tests/e2e/src/cases/cache-hit-output-guardrail-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-hit-output-guardrail-e2e.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  ProxyClient,
   SeedClient,
   spawnApp,
   startOpenAiUpstream,
@@ -48,12 +49,14 @@ describe("cache hit runs output guardrails (#448)", () => {
       model_name: "gpt-4o-mini",
       provider_key_id: pk.id,
     });
-    await seed.createApiKey({ key_hash: HASH, allowed_models: ["cache-gr"] });
     await seed.createCachePolicy({
       name: "cache-gr-policy",
       enabled: true,
       applies_to: "all",
     });
+    await seed.createApiKey({ key_hash: HASH, allowed_models: ["cache-gr"] });
+    const proxy = new ProxyClient(app.proxyUrl, CALLER);
+    await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);
   });
 
   afterAll(async () => {
@@ -73,9 +76,6 @@ describe("cache hit runs output guardrails (#448)", () => {
       ctx.skip();
       return;
     }
-
-    // Wait until model+key+pk+cache are live (clean prompt → 200 + cache miss).
-    await waitConfigPropagation(async () => (await chat("ready-probe")).ok);
 
     // 1) Cache the response BEFORE any output guardrail exists.
     const first = await chat(CACHED_PROMPT);

--- a/tests/e2e/src/cases/cache-policy-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-policy-e2e.test.ts
@@ -3,6 +3,7 @@ import OpenAI from "openai";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  ProxyClient,
   SeedClient,
   spawnApp,
   startOpenAiUpstream,
@@ -58,10 +59,6 @@ describe("cache policy e2e: identical request hits cache", () => {
       model_name: "gpt-4o-mini",
       provider_key_id: pk.id,
     });
-    await seed.createApiKey({
-      key_hash: CALLER_KEY_HASH,
-      allowed_models: ["cache-e2e"],
-    });
     // A policy requires `name`, `enabled`, and `applies_to` to take
     // effect.
     await seed.createCachePolicy({
@@ -69,6 +66,12 @@ describe("cache policy e2e: identical request hits cache", () => {
       enabled: true,
       applies_to: "all",
     });
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: ["cache-e2e"],
+    });
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);
   });
 
   afterAll(async () => {
@@ -87,22 +90,6 @@ describe("cache policy e2e: identical request hits cache", () => {
       baseURL: `${app.proxyUrl}/v1`,
     });
 
-    // Wait for the snapshot to carry the Model + ProviderKey + ApiKey
-    // + CachePolicy. The probe uses a distinct message so it doesn't
-    // pollute the cache fingerprint we're about to test against.
-    await waitConfigPropagation(async () => {
-      try {
-        await client.chat.completions.create({
-          model: "cache-e2e",
-          messages: [{ role: "user", content: "ready-probe" }],
-        });
-        return true;
-      } catch {
-        return false;
-      }
-    });
-
-    // Baseline includes the probe (and any retries during propagation).
     const baseline = upstream.receivedRequests.length;
 
     // First call with a fresh fingerprint — cache miss, upstream hit.

--- a/tests/e2e/src/cases/config-last-known-good-e2e.test.ts
+++ b/tests/e2e/src/cases/config-last-known-good-e2e.test.ts
@@ -120,13 +120,10 @@ describe("config last-known-good: rejected updates keep serving across resync an
     }
 
     {
-      await waitConfigPropagation(async () => {
-        const cfg = await getStatusConfig(app!);
-        return (cfg.applied?.resource_counts.models ?? 0) >= 1;
-      });
+      const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+      await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);
 
       // Baseline: the model serves.
-      const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
       const before = await proxy.chat({
         model: "lkg-model",
         messages: [{ role: "user", content: "baseline" }],

--- a/tests/e2e/src/cases/forward-client-headers-e2e.test.ts
+++ b/tests/e2e/src/cases/forward-client-headers-e2e.test.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  ProxyClient,
   SeedClient,
   spawnApp,
   startA2aUpstream,
@@ -361,13 +362,7 @@ describe("forward_client_headers e2e: one capability across every proxy face", (
       enabled: true,
     });
 
-    const callerKey = await seed.createApiKey({
-      key_hash: CALLER_HASH,
-      allowed_models: ["*"],
-      allowed_routes: ["*"],
-      allowed_agents: ["*"],
-      mcp_access: { allow: ["*"] },
-    });
+    const callerKeyId = randomUUID();
 
     // A route that names its OWN gateway-credential slot, and one that
     // names none. `x-*` is the same pattern on both: what differs is
@@ -404,18 +399,21 @@ describe("forward_client_headers e2e: one capability across every proxy face", (
       path_prefix: `${ROUTE_PREFIX}-anon`,
       target_url: upstream.baseUrl,
       auth_mode: "anonymous",
-      anonymous_key_id: callerKey.id,
+      anonymous_key_id: callerKeyId,
       source_cidrs: ["127.0.0.0/8", "::1/128"],
       credential_mode: "inject",
       provider_key_id: slotPk.id,
       forward_client_headers: ["x-*"],
     });
-
-    await waitConfigPropagation(async () => {
-      const res = await chat(FORWARD_MODEL);
-      await res.text();
-      return res.status === 200;
+    await seed.update("api_keys", callerKeyId, {
+      key_hash: CALLER_HASH,
+      allowed_models: ["*"],
+      allowed_routes: ["*"],
+      allowed_agents: ["*"],
+      mcp_access: { allow: ["*"] },
     });
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_KEY);
+    await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);
   }, 120_000);
 
   afterAll(async () => {

--- a/tests/e2e/src/cases/provider-key-tls-e2e.test.ts
+++ b/tests/e2e/src/cases/provider-key-tls-e2e.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  ProxyClient,
   SeedClient,
   spawnApp,
   startOpenAiUpstream,
@@ -124,10 +125,6 @@ describe("provider_key.tls (#860)", () => {
     // Provider Keys themselves.
     app = await spawnApp();
     const seed = new SeedClient(new EtcdClient(), app.etcdPrefix);
-    await seed.createApiKey({
-      key_hash: CALLER_KEY_HASH,
-      allowed_models: [MODEL_TRUSTED, MODEL_WRONG_CA, MODEL_NO_VERIFY],
-    });
 
     const cases: Array<[string, Record<string, unknown>]> = [
       [MODEL_TRUSTED, { ca_cert: caA.certPem }],
@@ -148,6 +145,12 @@ describe("provider_key.tls (#860)", () => {
         provider_key_id: pk.id,
       });
     }
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [MODEL_TRUSTED, MODEL_WRONG_CA, MODEL_NO_VERIFY],
+    });
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);
   });
 
   afterAll(async () => {
@@ -172,15 +175,6 @@ describe("provider_key.tls (#860)", () => {
       ctx.skip();
       return;
     }
-    await waitConfigPropagation(async () => {
-      try {
-        const { status } = await chat(MODEL_TRUSTED);
-        return status === 200 || status === 502;
-      } catch {
-        return false;
-      }
-    });
-
     const { status, body } = await chat(MODEL_TRUSTED);
     expect(status).toBe(200);
     expect(JSON.parse(body).choices[0].message.content).toBe("trusted");

--- a/tests/e2e/src/cases/status-config-hash-e2e.test.ts
+++ b/tests/e2e/src/cases/status-config-hash-e2e.test.ts
@@ -131,6 +131,20 @@ test("configuration digests match the written rows through updates, rejection, d
     await put(modelKey(257), model(257));
     await check();
 
+    // Spaced updates and key deletion must publish the same final bytes
+    // regardless of how many watch events the gateway groups together.
+    for (let i = 0; i < 24; i++) {
+      await put(modelKey(i), JSON.stringify({ ...JSON.parse(model(i)), model_name: "gpt-4o" }));
+      await new Promise((resolve) => setTimeout(resolve, 40));
+    }
+    const callerConfig = rows.get(caller)!;
+    await remove(caller);
+    await check();
+    expect((await proxy().listModels()).status).toBe(401);
+    await put(caller, callerConfig);
+    await check();
+    expect((await proxy().listModels()).status).toBe(200);
+
     await app.stop();
     await remove(modelKey(0));
     await put(modelKey(128), JSON.stringify({ ...JSON.parse(model(128)), model_name: "gpt-4o" }));


### PR DESCRIPTION
Spaced configuration updates can repeatedly clone and hash a large snapshot because each gap exceeds the fixed 20 ms quiet period. Adapt that period to the previous apply's processing cost, within the existing 150 ms maximum coalescing wait. Cheap applies and writes following an idle interval retain the 20 ms wait.

The event cap, validation, last-known-good handling, canonical hash format and per-batch revision publication stay unchanged; no configuration changes are required. Regression coverage pins the quiet-period cap and idle reset, and exercises spaced model updates followed by API-key revocation and restoration against a real gateway and etcd. CPU savings are measured separately from functional E2E assertions to avoid timing-dependent tests.

Fixture readiness now waits for caller keys written after their dependencies, so separately delivered watch batches cannot start jobs, TLS, cache, last-known-good or header-forwarding assertions with a partial fixture.

Fixes api7/AISIX-Cloud#1569


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Configuration updates now adapt batching delays based on recent processing time, helping manage expensive updates while keeping routine changes responsive.
  - Adaptive timing is bounded and resets after inactivity for more predictable update behavior.

- **Tests**
  - Expanded end-to-end coverage for configuration propagation, API-key authorization, caching, TLS access, and last-known-good configuration handling.
  - Test setup now more reliably waits for configuration changes to become available before validating requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->