### PR TITLE
perf(metrics): preallocate warmed scrape output

### DIFF
--- a/crates/aisix-obs/src/prometheus.rs
+++ b/crates/aisix-obs/src/prometheus.rs
@@ -5,7 +5,10 @@
 use std::{
     collections::HashMap,
     fmt::Write,
-    sync::{atomic::Ordering, Arc, Mutex, OnceLock},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex, OnceLock,
+    },
 };
 
 use crossbeam_queue::SegQueue;
@@ -236,6 +239,7 @@ impl metrics_util::registry::Storage<Key> for Storage {
 pub(crate) struct Recorder {
     registry: Registry<Key, Storage>,
     descriptions: Mutex<HashMap<String, SharedString>>,
+    previous_render_bytes: AtomicUsize,
 }
 
 impl Recorder {
@@ -243,6 +247,7 @@ impl Recorder {
         Self {
             registry: Registry::new(Storage { distributions }),
             descriptions: Mutex::new(HashMap::new()),
+            previous_render_bytes: AtomicUsize::new(0),
         }
     }
 
@@ -261,7 +266,10 @@ impl Recorder {
             .lock()
             .expect("metric descriptions")
             .clone();
-        let mut output = String::new();
+        // A warmed high-cardinality scrape can be hundreds of MiB. Leave
+        // room for growing counters without copying that buffer on every scrape.
+        let previous_bytes = self.previous_render_bytes.load(Ordering::Relaxed);
+        let mut output = String::with_capacity(previous_bytes.saturating_add(previous_bytes / 8));
         let mut scalars = Vec::new();
         self.registry
             .visit_counters(|_, value| scalars.push(Arc::clone(value)));
@@ -314,6 +322,8 @@ impl Recorder {
             );
             value.render(&mut output);
         }
+        self.previous_render_bytes
+            .store(output.len(), Ordering::Relaxed);
         output
     }
 


### PR DESCRIPTION
Large Prometheus scrapes repeatedly grow an empty output buffer, copying hundreds of megabytes on each render. Remember the previous rendered length and reserve that size plus 12.5% headroom for the next scrape. The estimate is updated after every render; normal buffer growth still handles larger registries. Metric contents, default labels, summary windows, concurrent scrape sharing and cancellation behavior are unchanged.

A single-core release ABBA recorder benchmark with jemalloc, 53,260 synthetic keys and a 723 MB exposition reduced warmed render CPU time from 1.328 s to 0.792 s (40.35%). All 24 canonicalized outputs matched. The first render has no estimate, so its cost and the process peak that includes it are essentially unchanged. This measures recorder allocation costs, not full gateway stability.

Coverage uses the existing exporter-equivalence/rolling-window/concurrent-recording tests and both serving modes of the concurrent/cancelled scrape and histogram-bucket E2E cases. No timing assertion is added: allocator and host scheduling variability make a unit-test time limit unsuitable for this optimization.

Fixes api7/AISIX-Cloud#1589


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Prometheus metrics rendering efficiency by reusing the previously observed output size to better prepare subsequent renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->