### PR TITLE
test(jwt): await every identity binding before authentication cases

### DIFF
--- a/tests/e2e/src/cases/jwt-auth-e2e.test.ts
+++ b/tests/e2e/src/cases/jwt-auth-e2e.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   agentClaims,
   EtcdClient,
+  ProxyClient,
   SeedClient,
   spawnApp,
   startMockIdp,
@@ -170,11 +171,14 @@ describe("jwt auth e2e: OIDC trust providers + jwt_subject key binding", () => {
       disabled: true,
     });
 
-    await waitConfigPropagation(async () => {
-      const res = await chat(app!, idp!.sign(validClaims()));
-      await res.text();
-      return res.status === 200;
+    // The final key proves all JWT bindings are applied without testing JWT auth.
+    const readyKey = "sk-jwt-ready-probe";
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update(readyKey).digest("hex"),
+      allowed_models: [],
     });
+    const proxy = new ProxyClient(app.proxyUrl, readyKey);
+    await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
The JWT fixture waited for the first bound identity to authenticate even though later identities, including the disabled key, could still be pending in the etcd watch. That allowed the disabled-key assertion to observe `jwt_identity_unmapped` instead of `api_key_disabled`.

Seed a dedicated ordinary API key after all JWT resources and wait for its `/v1/models` request to succeed. This makes readiness cover every preceding binding without exercising JWT authentication in setup. Existing authentication assertions and timeouts remain unchanged; there is no product behavior or configuration change.

Fixes api7/AISIX-Cloud#1590


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end authentication test coverage by verifying configuration readiness before test execution.
  - Added validation that API access is available and supported models can be listed successfully.
  - Updated test setup to provide more reliable checks of authentication and service availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->