### PR TITLE
fix(jwt): share in-flight JWKS and discovery fetches

### DIFF
--- a/crates/aisix-proxy/src/jwt.rs
+++ b/crates/aisix-proxy/src/jwt.rs
@@ -762,19 +762,23 @@ fn usable_for_verification(jwk: &jsonwebtoken::jwk::Jwk, alg: Algorithm) -> bool
 
 // ── JWKS fetch + cache ───────────────────────────────────────────────
 
+#[derive(Default)]
 struct JwksEntry {
     /// The last successfully fetched key set and when it landed.
     jwks: Option<(Arc<JwkSet>, Instant)>,
-    /// Last fetch attempt, success or failure — the rate-limit clock.
+    /// Completion of the last fetch, success or failure — the rate-limit clock.
     last_attempt: Option<Instant>,
+    fetch_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 /// One issuer's resolved discovery result plus its rate-limit clock.
+#[derive(Default)]
 struct DiscoveryEntry {
     /// The resolved `jwks_uri` and when discovery last succeeded.
     resolved: Option<(String, Instant)>,
-    /// Last discovery attempt, success or failure.
+    /// Completion of the last discovery attempt, success or failure.
     last_attempt: Option<Instant>,
+    fetch_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 /// Read a poisoned-lock-tolerant guard. A panic while some other request
@@ -790,8 +794,8 @@ fn write_recover<T>(lock: &RwLock<T>) -> std::sync::RwLockWriteGuard<'_, T> {
 }
 
 /// Process-global JWKS cache keyed by URL. Guards are held only for map
-/// lookups/inserts, never across an await; concurrent misses may fetch in
-/// parallel (each result is valid — last insert wins).
+/// lookups/inserts, never across an await. Each entry's async lock lets
+/// concurrent misses share the completed fetch, across serving runtimes.
 fn jwks_cache() -> &'static RwLock<HashMap<String, JwksEntry>> {
     static CACHE: OnceLock<RwLock<HashMap<String, JwksEntry>>> = OnceLock::new();
     CACHE.get_or_init(|| RwLock::new(HashMap::new()))
@@ -833,6 +837,31 @@ async fn resolve_jwks_url(prov: &OidcProvider) -> Result<String, String> {
         }
         return Ok(u.clone());
     }
+    {
+        let map = read_recover(discovery_cache());
+        if let Some((url, at)) = map.get(&prov.issuer).and_then(|e| e.resolved.as_ref()) {
+            if at.elapsed() < JWKS_TTL {
+                return Ok(url.clone());
+            }
+        }
+    }
+    let fetch_lock = write_recover(discovery_cache())
+        .entry(prov.issuer.clone())
+        .or_default()
+        .fetch_lock
+        .clone();
+    let _fetch = match fetch_lock.try_lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            if let Some((url, _)) = read_recover(discovery_cache())
+                .get(&prov.issuer)
+                .and_then(|e| e.resolved.as_ref())
+            {
+                return Ok(url.clone());
+            }
+            fetch_lock.lock().await
+        }
+    };
     let now = Instant::now();
     let (stale, attempted_recently) = {
         let map = read_recover(discovery_cache());
@@ -860,20 +889,18 @@ async fn resolve_jwks_url(prov: &OidcProvider) -> Result<String, String> {
             .ok_or_else(|| "OIDC discovery suppressed by the refresh interval".to_string());
     }
 
-    // Stamp the attempt before awaiting so concurrent misses don't stampede.
-    write_recover(discovery_cache())
-        .entry(prov.issuer.clone())
-        .or_insert(DiscoveryEntry {
-            resolved: None,
-            last_attempt: None,
-        })
-        .last_attempt = Some(now);
-
     let discovery_url = format!(
         "{}/.well-known/openid-configuration",
         prov.issuer.trim_end_matches('/')
     );
-    match fetch_json(&discovery_url).await {
+    let result = fetch_json(&discovery_url).await;
+    // Only completed attempts consume the interval. Cancellation drops the
+    // fetch lock so a waiting request can take over instead of failing cold.
+    write_recover(discovery_cache())
+        .entry(prov.issuer.clone())
+        .or_default()
+        .last_attempt = Some(Instant::now());
+    match result {
         Ok(doc) => {
             // §4.3: the document must claim the issuer we asked about.
             if doc.get("issuer").and_then(|v| v.as_str()) != Some(prov.issuer.as_str()) {
@@ -897,11 +924,8 @@ async fn resolve_jwks_url(prov: &OidcProvider) -> Result<String, String> {
             }
             write_recover(discovery_cache())
                 .entry(prov.issuer.clone())
-                .or_insert(DiscoveryEntry {
-                    resolved: None,
-                    last_attempt: Some(now),
-                })
-                .resolved = Some((jwks_uri.clone(), now));
+                .or_default()
+                .resolved = Some((jwks_uri.clone(), Instant::now()));
             Ok(jwks_uri)
         }
         Err(e) => {
@@ -963,70 +987,81 @@ fn same_origin(base: &str, candidate: &str) -> bool {
 /// failed re-fetch keeps serving the stale set; with nothing cached the
 /// error propagates and the request fails closed as retryable.
 async fn get_jwks(url: &str) -> Result<Arc<JwkSet>, String> {
-    let now = Instant::now();
-    let (stale, attempted_recently) = {
+    {
         let map = read_recover(jwks_cache());
-        match map.get(url) {
-            Some(entry) => {
-                if let Some((jwks, fetched_at)) = &entry.jwks {
-                    if now.duration_since(*fetched_at) < JWKS_TTL {
-                        return Ok(jwks.clone());
-                    }
-                }
-                (
-                    entry.jwks.as_ref().map(|(j, _)| j.clone()),
-                    entry
-                        .last_attempt
-                        .is_some_and(|at| now.duration_since(at) < JWKS_REFRESH_MIN_INTERVAL),
-                )
+        if let Some((jwks, at)) = map.get(url).and_then(|e| e.jwks.as_ref()) {
+            if at.elapsed() < JWKS_TTL {
+                return Ok(jwks.clone());
             }
-            None => (None, false),
         }
-    };
-    if attempted_recently {
-        return stale.ok_or_else(|| "JWKS fetch suppressed by the refresh interval".to_string());
     }
-    refresh_jwks(url).await
+    refresh_jwks(url, false).await
 }
 
 /// One fetch for an unknown `kid`, suppressed inside
 /// [`JWKS_REFRESH_MIN_INTERVAL`] of the previous attempt.
 async fn refresh_jwks_rate_limited(url: &str) -> Option<Arc<JwkSet>> {
-    let now = Instant::now();
-    if let Some(entry) = read_recover(jwks_cache()).get(url) {
-        if let Some(at) = entry.last_attempt {
-            if now.duration_since(at) < JWKS_REFRESH_MIN_INTERVAL {
-                return None;
+    refresh_jwks(url, true).await.ok()
+}
+
+async fn refresh_jwks(url: &str, unknown_kid: bool) -> Result<Arc<JwkSet>, String> {
+    let fetch_lock = write_recover(jwks_cache())
+        .entry(url.to_string())
+        .or_default()
+        .fetch_lock
+        .clone();
+    let _fetch = match fetch_lock.try_lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            if !unknown_kid {
+                if let Some((stale, _)) = read_recover(jwks_cache())
+                    .get(url)
+                    .and_then(|e| e.jwks.as_ref())
+                {
+                    return Ok(stale.clone());
+                }
+            }
+            fetch_lock.lock().await
+        }
+    };
+    {
+        let map = read_recover(jwks_cache());
+        if let Some(entry) = map.get(url) {
+            if !unknown_kid {
+                if let Some((jwks, at)) = &entry.jwks {
+                    if at.elapsed() < JWKS_TTL {
+                        return Ok(jwks.clone());
+                    }
+                }
+            }
+            if entry
+                .last_attempt
+                .is_some_and(|at| at.elapsed() < JWKS_REFRESH_MIN_INTERVAL)
+            {
+                return entry
+                    .jwks
+                    .as_ref()
+                    .map(|(j, _)| j.clone())
+                    .ok_or_else(|| "JWKS fetch suppressed by the refresh interval".to_string());
             }
         }
     }
-    refresh_jwks(url).await.ok()
-}
-
-async fn refresh_jwks(url: &str) -> Result<Arc<JwkSet>, String> {
-    // Stamp the attempt before awaiting so a slow endpoint is not
-    // hammered by concurrent refreshes.
-    {
-        let mut map = write_recover(jwks_cache());
-        map.entry(url.to_string())
-            .or_insert(JwksEntry {
-                jwks: None,
-                last_attempt: None,
-            })
-            .last_attempt = Some(Instant::now());
-    }
-    match fetch_json(url).await.and_then(|v| {
+    let result = fetch_json(url).await.and_then(|v| {
         serde_json::from_value::<JwkSet>(v).map_err(|e| format!("not a JWKS document: {e}"))
-    }) {
+    });
+    // The lock covers in-flight requests; the interval covers completed
+    // attempts, including failures slower than the interval itself.
+    write_recover(jwks_cache())
+        .entry(url.to_string())
+        .or_default()
+        .last_attempt = Some(Instant::now());
+    match result {
         Ok(set) => {
             let arc = Arc::new(set);
             write_recover(jwks_cache())
                 .entry(url.to_string())
-                .and_modify(|e| e.jwks = Some((arc.clone(), Instant::now())))
-                .or_insert(JwksEntry {
-                    jwks: Some((arc.clone(), Instant::now())),
-                    last_attempt: Some(Instant::now()),
-                });
+                .or_default()
+                .jwks = Some((arc.clone(), Instant::now()));
             Ok(arc)
         }
         Err(e) => {
@@ -1082,6 +1117,160 @@ mod tests {
     use super::*;
     use aisix_core::resource::ResourceEntry;
     use jsonwebtoken::{encode, EncodingKey, Header};
+
+    struct FetchServer {
+        url: String,
+        hold: Arc<std::sync::atomic::AtomicBool>,
+        fail: Arc<std::sync::atomic::AtomicBool>,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl Drop for FetchServer {
+        fn drop(&mut self) {
+            self.release.notify_waiters();
+            self.task.abort();
+        }
+    }
+
+    async fn fetch_server(discovery: bool) -> FetchServer {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let hold = Arc::new(AtomicBool::new(false));
+        let fail = Arc::new(AtomicBool::new(false));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let handler = {
+            let (hold, fail, calls, entered, release) = (
+                hold.clone(),
+                fail.clone(),
+                calls.clone(),
+                entered.clone(),
+                release.clone(),
+            );
+            let body = if discovery {
+                serde_json::json!({"issuer": url, "jwks_uri": format!("{url}/jwks")}).to_string()
+            } else {
+                TEST_JWKS.to_string()
+            };
+            move || {
+                let (hold, fail, calls, entered, release, body) = (
+                    hold.clone(),
+                    fail.clone(),
+                    calls.clone(),
+                    entered.clone(),
+                    release.clone(),
+                    body.clone(),
+                );
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    if hold.load(Ordering::SeqCst) {
+                        let released = release.notified();
+                        tokio::pin!(released);
+                        released.as_mut().enable();
+                        entered.notify_one();
+                        released.await;
+                    }
+                    let status = if fail.load(Ordering::SeqCst) {
+                        axum::http::StatusCode::SERVICE_UNAVAILABLE
+                    } else {
+                        axum::http::StatusCode::OK
+                    };
+                    (status, body)
+                }
+            }
+        };
+        let router = axum::Router::new().fallback(handler);
+        let task = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        FetchServer {
+            url,
+            hold,
+            fail,
+            calls,
+            entered,
+            release,
+            task,
+        }
+    }
+
+    async fn cached_fetch(url: &str, discovery: bool) -> Result<(), String> {
+        if discovery {
+            let mut provider = base_provider();
+            provider.issuer = url.to_string();
+            resolve_jwks_url(&provider).await.map(|_| ())
+        } else {
+            get_jwks(url).await.map(|_| ())
+        }
+    }
+
+    async fn assert_cancelled_fetch_can_retry(discovery: bool) {
+        use std::sync::atomic::Ordering;
+        let server = fetch_server(discovery).await;
+        server.hold.store(true, Ordering::SeqCst);
+        let url = server.url.clone();
+        let first = tokio::spawn(async move { cached_fetch(&url, discovery).await });
+        server.entered.notified().await;
+        first.abort();
+        assert!(first.await.unwrap_err().is_cancelled());
+        server.hold.store(false, Ordering::SeqCst);
+        server.release.notify_waiters();
+        assert_eq!(cached_fetch(&server.url, discovery).await, Ok(()));
+        assert_eq!(server.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn cancelled_jwks_fetch_can_retry() {
+        assert_cancelled_fetch_can_retry(false).await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_discovery_fetch_can_retry() {
+        assert_cancelled_fetch_can_retry(true).await;
+    }
+
+    #[tokio::test]
+    async fn expired_trust_material_stays_available_during_refresh_and_outage() {
+        use std::sync::atomic::Ordering;
+        for discovery in [false, true] {
+            let server = fetch_server(discovery).await;
+            assert_eq!(cached_fetch(&server.url, discovery).await, Ok(()));
+            let past = Instant::now() - JWKS_TTL - Duration::from_secs(1);
+            if discovery {
+                let mut cache = write_recover(discovery_cache());
+                let entry = cache.get_mut(&server.url).unwrap();
+                entry.resolved.as_mut().unwrap().1 = past;
+                entry.last_attempt = Some(past);
+            } else {
+                let mut cache = write_recover(jwks_cache());
+                let entry = cache.get_mut(&server.url).unwrap();
+                entry.jwks.as_mut().unwrap().1 = past;
+                entry.last_attempt = Some(past);
+            }
+            server.hold.store(true, Ordering::SeqCst);
+            server.fail.store(true, Ordering::SeqCst);
+            let url = server.url.clone();
+            let refresh = tokio::spawn(async move { cached_fetch(&url, discovery).await });
+            server.entered.notified().await;
+            // A known key / discovery URL must not wait behind an outage.
+            assert_eq!(
+                tokio::time::timeout(
+                    Duration::from_millis(100),
+                    cached_fetch(&server.url, discovery)
+                )
+                .await
+                .unwrap(),
+                Ok(())
+            );
+            server.release.notify_waiters();
+            assert_eq!(refresh.await.unwrap(), Ok(()));
+            assert_eq!(cached_fetch(&server.url, discovery).await, Ok(()));
+            assert_eq!(server.calls.load(Ordering::SeqCst), 2);
+        }
+    }
 
     /// Test-only RSA keypair. The private PEM signs fixture tokens; the
     /// JWK below is its public half (kid `test-kid-1`).

--- a/tests/e2e/src/cases/jwt-fetch-concurrency-e2e.test.ts
+++ b/tests/e2e/src/cases/jwt-fetch-concurrency-e2e.test.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { once } from "node:events";
 import { createServer } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
 import { expect, test } from "vitest";
@@ -7,9 +8,14 @@ import {
   startMockIdp, waitConfigPropagation,
 } from "../harness/index.js";
 
+// JWT key refreshes are limited to once per second.
+const REFRESH_INTERVAL_MS = 1000;
+
 async function fixture(ctx: { onTestFinished: (fn: () => Promise<void>) => void }) {
   const signer = await startMockIdp();
+  ctx.onTestFinished(() => signer.close());
   const app = await spawnApp({});
+  ctx.onTestFinished(() => app.exit());
   const etcd = new EtcdClient();
   const seed = new SeedClient(etcd, app.etcdPrefix);
   const port = await pickFreePort();
@@ -33,14 +39,16 @@ async function fixture(ctx: { onTestFinished: (fn: () => Promise<void>) => void 
     res.end(JSON.stringify(path === "/.well-known/openid-configuration"
       ? { issuer, jwks_uri: `${issuer}/jwks` } : keys));
   });
-  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
   ctx.onTestFinished(async () => {
     release();
-    await app.exit();
     server.closeAllConnections();
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-    await signer.close();
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
+    }
   });
+  const listening = once(server, "listening");
+  server.listen(port, "127.0.0.1");
+  await listening;
   const provider = {
     name: randomUUID(), issuer, audiences: ["aisix-gateway"],
     identity_claim: "sub", jwks_uri: `${issuer}/jwks`,
@@ -92,7 +100,7 @@ for (const stage of ["jwks", "discovery", "uri-change", "rotation"] as const) {
     if (stage === "uri-change" || stage === "rotation") {
       expect((await f.request(f.token())).status).toBe(200);
       if (stage === "uri-change") await f.configure(false, "?new-keys=1");
-      else { await f.rotate(); await sleep(1100); }
+      else { await f.rotate(); await sleep(REFRESH_INTERVAL_MS + 100); }
     }
     const path = stage === "discovery" ? "/.well-known/openid-configuration" : "/jwks";
     const before = f.counts.get(path) ?? 0;
@@ -113,8 +121,8 @@ for (const stage of ["jwks", "discovery", "uri-change", "rotation"] as const) {
 for (const { discovery, delay } of [
   { discovery: false, delay: 100 },
   { discovery: true, delay: 100 },
-  { discovery: false, delay: 1200 },
-  { discovery: true, delay: 1200 },
+  { discovery: false, delay: REFRESH_INTERVAL_MS + 200 },
+  { discovery: true, delay: REFRESH_INTERVAL_MS + 200 },
 ]) {
   test(`failed ${discovery ? "discovery" : "JWKS"} fetch (${delay}ms) is shared and remains rate limited`, async (ctx) => {
     if (!(await new EtcdClient().ping())) { ctx.skip(); return; }

--- a/tests/e2e/src/cases/jwt-fetch-concurrency-e2e.test.ts
+++ b/tests/e2e/src/cases/jwt-fetch-concurrency-e2e.test.ts
@@ -1,0 +1,139 @@
+import { createHash, randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import { setTimeout as sleep } from "node:timers/promises";
+import { expect, test } from "vitest";
+import {
+  agentClaims, EtcdClient, pickFreePort, ProxyClient, SeedClient, spawnApp,
+  startMockIdp, waitConfigPropagation,
+} from "../harness/index.js";
+
+async function fixture(ctx: { onTestFinished: (fn: () => Promise<void>) => void }) {
+  const signer = await startMockIdp();
+  const app = await spawnApp({});
+  const etcd = new EtcdClient();
+  const seed = new SeedClient(etcd, app.etcdPrefix);
+  const port = await pickFreePort();
+  const issuer = `http://127.0.0.1:${port}`;
+  let keys = await (await fetch(signer.jwksUrl)).json();
+  let release = () => {};
+  let arrived = () => {};
+  let heldPath = "";
+  let hold = Promise.resolve();
+  let status = 200;
+  const counts = new Map<string, number>();
+  const server = createServer(async (req, res) => {
+    const path = (req.url ?? "").split("?")[0];
+    counts.set(path, (counts.get(path) ?? 0) + 1);
+    if (path === heldPath) {
+      arrived();
+      await hold;
+    }
+    res.setHeader("content-type", "application/json");
+    res.statusCode = status;
+    res.end(JSON.stringify(path === "/.well-known/openid-configuration"
+      ? { issuer, jwks_uri: `${issuer}/jwks` } : keys));
+  });
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  ctx.onTestFinished(async () => {
+    release();
+    await app.exit();
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await signer.close();
+  });
+  const provider = {
+    name: randomUUID(), issuer, audiences: ["aisix-gateway"],
+    identity_claim: "sub", jwks_uri: `${issuer}/jwks`,
+  };
+  const id = randomUUID();
+  async function barrier() {
+    const bearer = `sk-ready-${randomUUID()}`;
+    await seed.createApiKey({
+      key_hash: createHash("sha256").update(bearer).digest("hex"), allowed_models: [],
+    });
+    const proxy = new ProxyClient(app.proxyUrl, bearer);
+    await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);
+  }
+  async function configure(discovery = false, suffix = "") {
+    await etcd.put(`${app.etcdPrefix}/oidc_providers/${id}`, JSON.stringify({
+      ...provider, jwks_uri: discovery ? undefined : `${issuer}/jwks${suffix}`,
+    }));
+    await barrier();
+  }
+  await seed.createApiKey({
+    key_hash: createHash("sha256").update(`sk-bound-${id}`).digest("hex"),
+    allowed_models: [], jwt_provider: provider.name, jwt_subject: "agent-1",
+  });
+  return {
+    app, configure, counts,
+    token: () => signer.sign(agentClaims(issuer)),
+    request: (token: string) => fetch(`${app.proxyUrl}/v1/models`, {
+      headers: { authorization: `Bearer ${token}` },
+    }).then(async (response) => ({ status: response.status, body: await response.json() })),
+    hold(path: string) {
+      heldPath = path;
+      hold = new Promise<void>((resolve) => { release = resolve; });
+      const entered = new Promise<void>((resolve) => { arrived = resolve; });
+      return { entered, release: () => release() };
+    },
+    fail() { status = 503; },
+    async rotate() {
+      signer.rotate();
+      keys = await (await fetch(signer.jwksUrl)).json();
+    },
+  };
+}
+
+for (const stage of ["jwks", "discovery", "uri-change", "rotation"] as const) {
+  test(`concurrent JWT requests share an in-flight ${stage} fetch`, async (ctx) => {
+    if (!(await new EtcdClient().ping())) { ctx.skip(); return; }
+    const f = await fixture(ctx);
+    await f.configure(stage === "discovery");
+    if (stage === "uri-change" || stage === "rotation") {
+      expect((await f.request(f.token())).status).toBe(200);
+      if (stage === "uri-change") await f.configure(false, "?new-keys=1");
+      else { await f.rotate(); await sleep(1100); }
+    }
+    const path = stage === "discovery" ? "/.well-known/openid-configuration" : "/jwks";
+    const before = f.counts.get(path) ?? 0;
+    const gate = f.hold(path);
+    const token = f.token();
+    const first = f.request(token);
+    await gate.entered;
+    const followers = Array.from({ length: 8 }, () => f.request(token));
+    await sleep(100);
+    gate.release();
+    const results = await Promise.all([first, ...followers]);
+    expect(results.map((r) => ({ status: r.status, code: r.body.error?.code })))
+      .toEqual(Array.from({ length: 9 }, () => ({ status: 200, code: undefined })));
+    expect((f.counts.get(path) ?? 0) - before).toBe(1);
+  });
+}
+
+for (const { discovery, delay } of [
+  { discovery: false, delay: 100 },
+  { discovery: true, delay: 100 },
+  { discovery: false, delay: 1200 },
+  { discovery: true, delay: 1200 },
+]) {
+  test(`failed ${discovery ? "discovery" : "JWKS"} fetch (${delay}ms) is shared and remains rate limited`, async (ctx) => {
+    if (!(await new EtcdClient().ping())) { ctx.skip(); return; }
+    const f = await fixture(ctx);
+    await f.configure(discovery);
+    f.fail();
+    const path = discovery ? "/.well-known/openid-configuration" : "/jwks";
+    const gate = f.hold(path);
+    const token = f.token();
+    const first = f.request(token);
+    await gate.entered;
+    const followers = Array.from({ length: 8 }, () => f.request(token));
+    await sleep(delay);
+    gate.release();
+    for (const response of await Promise.all([first, ...followers])) {
+      expect(response.status).toBe(503);
+      expect(response.body.error.code).toBe("jwks_unavailable");
+    }
+    expect((await f.request(token)).status).toBe(503);
+    expect(f.counts.get(path)).toBe(1);
+  });
+}


### PR DESCRIPTION
Concurrent JWT requests could fail authentication while a valid JWKS or OIDC discovery fetch was still in flight. The refresh interval was recorded before a result existed, so cold-cache callers were rejected and requests using a newly rotated key could miss the ongoing refresh.

Serialize fetches per JWKS URL or issuer and recheck the cache after waiting. Keep fresh-cache reads fast and serve existing stale trust material during refresh or an outage. Start the retry interval when an attempt completes; cancelling a fetch releases its lock so another caller can take over. Signature and claim validation, fetch deadlines, response limits, and configuration remain unchanged.

Add real HTTP/etcd E2E coverage for concurrent cold fetches, discovery, URI changes, key rotation, and short/slow failures, plus focused Rust coverage for cancellation and expired-cache fallback.

Fixes api7/AISIX-Cloud#1591


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JWT authentication metadata fetching to prevent duplicate concurrent requests.
  - Failed or cancelled fetches can now be retried appropriately while remaining rate-limited.
  - Existing cached signing keys and discovery information remain available during refreshes or temporary outages.
  - Authentication continues to fail safely when no valid cached metadata is available.

- **Tests**
  - Added coverage for concurrent fetches, retries, failures, key rotation, URI changes, and stale cached metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->