### PR TITLE
test(harness): preserve complete startup failure diagnostics

### DIFF
--- a/tests/e2e/src/harness/app-output.test.ts
+++ b/tests/e2e/src/harness/app-output.test.ts
@@ -1,0 +1,64 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+
+const dirs: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function failingProcess(source: string) {
+  const dir = await mkdtemp(join(tmpdir(), "aisix-harness-output-"));
+  dirs.push(dir);
+  const executable = join(dir, "process.cjs");
+  await writeFile(executable, `#!/usr/bin/env node\n${source}`);
+  await chmod(executable, 0o755);
+  vi.stubEnv("AISIX_BIN", executable);
+  vi.resetModules();
+  return (await import("./app.js")).spawnApp;
+}
+
+test("startup assertions retain an error between long logs and a backtrace", async () => {
+  const spawnApp = await failingProcess(`
+    const { writeFileSync } = require("node:fs");
+    writeFileSync(2, "startup warning\\n".repeat(300));
+    writeFileSync(2, 'Error: unsupported variable "request_id"\\n');
+    writeFileSync(2, "backtrace frame\\n".repeat(300));
+    process.exit(1);
+  `);
+  await expect(spawnApp({ resourcesFile: '_format_version: "1"\n' })).rejects.toThrow(/unsupported variable.*request_id/);
+});
+
+test("startup failure includes output drained after the child exits", async () => {
+  const spawnApp = await failingProcess(`
+    const { spawn } = require("node:child_process");
+    spawn(process.execPath, ["-e", 'setTimeout(() => require("node:fs").writeFileSync(2, "final startup diagnostic\\\\n"), 100)'], {
+      stdio: ["ignore", "inherit", "inherit"],
+    }).unref();
+    process.exit(1);
+  `);
+  await expect(spawnApp({ resourcesFile: '_format_version: "1"\n' })).rejects.toThrow("final startup diagnostic");
+});
+
+test("a real gateway startup error survives surrounding output", async () => {
+  const binary = process.env.AISIX_BIN ?? join(process.cwd(), "..", "..", "target", "debug", "aisix");
+  const spawnApp = await failingProcess(`
+    const { writeFileSync } = require("node:fs");
+    const { spawnSync } = require("node:child_process");
+    writeFileSync(2, "startup warning\\n".repeat(300));
+    const result = spawnSync(${JSON.stringify(binary)}, process.argv.slice(2), {
+      encoding: "utf8", timeout: 5000,
+    });
+    writeFileSync(1, result.stdout ?? "");
+    writeFileSync(2, result.stderr ?? "");
+    writeFileSync(2, "shutdown diagnostic\\n".repeat(300));
+    process.exit(result.status ?? 2);
+  `);
+  await expect(spawnApp({ resourcesFile: '_format_version: "1"\n', extraEnv: {
+    AISIX_OBSERVABILITY__METRICS__LABELS: JSON.stringify({ aisix_request_ttft_seconds: ["request_id"] }),
+  } })).rejects.toThrow(/unsupported variable.*request_id/);
+});

--- a/tests/e2e/src/harness/app.ts
+++ b/tests/e2e/src/harness/app.ts
@@ -410,6 +410,7 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
     stdio: ["ignore", "pipe", "pipe"],
     env: childEnv,
   });
+  const closed = new Promise<void>((resolve) => child.once("close", () => resolve()));
 
   let stderrBuf = "";
   child.stderr?.on("data", (c: Buffer) => {
@@ -478,17 +479,13 @@ async function spawnAppOnce(overrides: AppOverrides = {}): Promise<SpawnedApp> {
     }
   } catch (err) {
     const detail = exitErr ?? "still running";
-    // Keep the head too — a startup error (anyhow's `Error: …` line)
-    // prints before its backtrace, and a tail-only excerpt used to cut
-    // exactly the line that says what went wrong.
-    const stderr =
-      stderrBuf.length <= 3000
-        ? stderrBuf
-        : `${stderrBuf.slice(0, 1500)}\n  […]\n${stderrBuf.slice(-1500)}`;
     await terminate(child);
+    // `exit` can precede the final pipe data. Assertions need the full
+    // diagnostic, including an error between startup logs and a backtrace.
+    await closed;
     await cleanup(fileMode ? undefined : etcd, etcdPrefix, dir);
     throw new Error(
-      `${(err as Error).message}\n  binary state: ${detail}\n  stderr:\n${stderr}`,
+      `${(err as Error).message}\n  binary state: ${detail}\n  stderr:\n${stderrBuf}`,
     );
   }
 


### PR DESCRIPTION
Startup failures can lose their diagnostic when the E2E harness keeps only the first and last 1,500 characters of output. A configuration error between startup warnings and a backtrace then fails an otherwise valid error assertion. Reading output at process exit can also miss data still in the stdout/stderr pipes.

Wait for the pipes to close and include the complete captured output in startup exceptions. Existing scenarios, expected errors, readiness deadlines and retry rules remain unchanged; gateway runtime code is unaffected.

Regression tests cover errors surrounded by long output, output delivered after process exit, and an invalid metrics configuration rejected by a real gateway binary. The harness-only cases use real child processes to exercise pipe lifecycle without mocking Node internals.

Fixes api7/AISIX-Cloud#1592
