### PR TITLE
test(cache): wait for all seeded cache policies

### DIFF
--- a/tests/e2e/src/cases/cache-edges-model-and-disabled-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-edges-model-and-disabled-e2e.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
   EtcdClient,
+  ProxyClient,
   SeedClient,
   spawnApp,
   startOpenAiUpstream,
@@ -90,14 +91,6 @@ describe("cache edges: model in fingerprint + enabled:false bypass", () => {
       model_name: "gpt-4o-mini",
       provider_key_id: pk.id,
     });
-    await seed.createApiKey({
-      key_hash: CALLER_KEY_HASH,
-      allowed_models: [
-        "cache-edges-A",
-        "cache-edges-B",
-        "cache-edges-disabled",
-      ],
-    });
     // Two enabled policies scoped narrowly to A and B respectively
     // so test (1) has caching ON for those Models, plus one
     // disabled policy scoped to the third Model. Crucially the
@@ -119,6 +112,17 @@ describe("cache edges: model in fingerprint + enabled:false bypass", () => {
       enabled: false,
       applies_to: "model:cache-edges-disabled",
     });
+    // The final caller key gates all three policies, not just model A's.
+    await seed.createApiKey({
+      key_hash: CALLER_KEY_HASH,
+      allowed_models: [
+        "cache-edges-A",
+        "cache-edges-B",
+        "cache-edges-disabled",
+      ],
+    });
+    const proxy = new ProxyClient(app.proxyUrl, CALLER_PLAINTEXT);
+    await waitConfigPropagation(async () => (await proxy.listModels()).status === 200);
   });
 
   afterAll(async () => {

--- a/tests/e2e/src/cases/cache-env-namespace-e2e.test.ts
+++ b/tests/e2e/src/cases/cache-env-namespace-e2e.test.ts
@@ -120,16 +120,17 @@ async function seed(etcdRoot: string, upstreamBase: string) {
     model_name: "gpt-4o-mini",
     provider_key_id: pk.id,
   });
-  await seed.createApiKey({
-    key_hash: CALLER_KEY_HASH,
-    allowed_models: [MODEL],
-  });
   await seed.createCachePolicy({
     name: `${MODEL}-redis-policy`,
     enabled: true,
     backend: "redis",
     ttl_seconds: 300,
     applies_to: "all",
+  });
+  // Authenticating this final row also proves the cache policy has arrived.
+  await seed.createApiKey({
+    key_hash: CALLER_KEY_HASH,
+    allowed_models: [MODEL],
   });
 }
 


### PR DESCRIPTION
The shared-Redis environment isolation test could authenticate its caller before the cache policy arrived, then assert cache behavior against an incomplete configuration. The model-isolation test had the same gap: readiness covered model A's policy while subsequent assertions also required model B's policy.

Seed each caller key after all cache policies and wait for that key to authenticate before the assertions run. The shared environment helper covers both gateways; the model fixture now waits for all three policies, including the disabled one. Production code, cache behavior, test assertions, deadlines and retry rules are unchanged.

The existing end-to-end cases cover both fixes: delaying the later policy notifications exposes the failures without changing their assertions. No additional scenario is needed.

Fixes api7/AISIX-Cloud#1594


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end coverage for cache policy configuration and propagation.
  - Updated test setup sequencing to ensure cache policies are established before API credentials are created.
  - Added readiness validation for configuration propagation, improving confidence in cache behavior across environments and namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->